### PR TITLE
DOPE-91: Open project with the new structure

### DIFF
--- a/src/main/services/project-service/utils/read-project.ts
+++ b/src/main/services/project-service/utils/read-project.ts
@@ -46,13 +46,16 @@ function checkIfDirectoryIsAValidProjectDirectory(basePath: string): {
     }
   }
 
-  const entries = readdirSync(basePath, { withFileTypes: true })
+  const entries = readdirSync(basePath, { withFileTypes: true, recursive: true })
   let isValidProject = true
   let hasProjectFile = false
   for (const entry of entries) {
     // If any entry is a file, it should be one of the expected project files
     if (entry.isFile()) {
-      console.log(`Found file: ${entry.name}`)
+      if (entry.path.includes('pous') || entry.path.includes('build')) {
+        continue // Skip POU files for now, they will be handled separately
+      }
+
       if (entry.name === 'project.json') {
         hasProjectFile = true
       }
@@ -64,7 +67,6 @@ function checkIfDirectoryIsAValidProjectDirectory(basePath: string): {
 
     // If any entry is a directory, it should be one of the expected directories
     if (entry.isDirectory()) {
-      console.log(`Found directory: ${entry.name}`)
       if (!projectDefaultDirectoriesValidation.some((dir) => dir.includes(entry.name))) {
         return {
           success: false,

--- a/src/types/IPC/project-service/project-files-schema.ts
+++ b/src/types/IPC/project-service/project-files-schema.ts
@@ -9,6 +9,7 @@ export const projectDefaultFilesMapSchema = {
 export type ProjectDefaultFilesMapKeys = keyof typeof projectDefaultFilesMapSchema
 export type ProjectDefaultFilesMapValues = (typeof projectDefaultFilesMapSchema)[ProjectDefaultFilesMapKeys]
 
-export const projectDefaultDirectories = ['devices'] as const
+export const projectPouDirectories = ['pous/functions', 'pous/function-blocks', 'pous/programs'] as const
+export const projectDefaultDirectories = ['devices', ...projectPouDirectories] as const
 export const projectDefaultDirectoriesValidation = [...projectDefaultDirectories, 'build'] as readonly string[]
 export type ProjectDefaultDirectories = (typeof projectDefaultDirectories)[number]

--- a/src/types/PLC/open-plc.ts
+++ b/src/types/PLC/open-plc.ts
@@ -85,7 +85,7 @@ const PLCStructureVariableSchema = z.object({
     }),
     z.object({
       /**
-       * This should be ommited at variable table type options
+       * This should be omitted at variable table type options
        */
       definition: z.literal('derived'),
       value: z.string(),


### PR DESCRIPTION
# Pull request info

## References

### Link to Jira task

*[DOPE-91: Open project with the new structure](https://autonomylogic.atlassian.net/jira/software/c/projects/DOPE/boards/68?selectedIssue=DOPE-91)*

## Description of the changes proposed

- Import POUs that aren't inside of project.json file.
- Add `pous` subdirectory that contains functions, function-blocks and programas files separated

## To test it:
1. Manually create a project that contains files inside of the `pous` directory that aren't inside of project.json. Example:
<img width="2037" height="1371" alt="image" src="https://github.com/user-attachments/assets/f50be5a5-1472-4317-a582-ee73a6be1d53" />

2. Try opening this project.
> It should load the project with all the POUs loaded

_Disclaimer: we cannot create project and save it. Those are the next steps, so check if any of these were merged:_
> _[DOPE-92](https://autonomylogic.atlassian.net/browse/DOPE-92)_
> _[DOPE-94](https://autonomylogic.atlassian.net/browse/DOPE-94)_
> _[DOPE-95](https://autonomylogic.atlassian.net/browse/DOPE-95)_

## DOD checklist

- [x] The code is complete and according to developers’ standards.
- [x] I have performed a self-review of my code.
- [] Meet the acceptance criteria.
- [ ] Unit tests are written and green.
- [ ] Test coverage: __ %.
- [ ] Integration tests are written and green.
- [x] Changes were communicated and updated in the ticket description.
- [ ] Reviewed and accepted by the Product Owner.
- [ ] End-to-end test are successful.
