### PR TITLE
DOPE-97: Create POUs inside the editor

### DIFF
--- a/src/main/contracts/types/modules/ipc/main.ts
+++ b/src/main/contracts/types/modules/ipc/main.ts
@@ -2,7 +2,7 @@ import MenuBuilder from '@root/main/menu'
 import { CompilerService } from '@root/main/services/compiler-service'
 import { BrowserWindow, IpcMain } from 'electron/main'
 
-import { HardwareService, ProjectService } from '../../../../services'
+import { HardwareService, PouService, ProjectService } from '../../../../services'
 import { TStoreType } from '../store'
 
 export type MainIpcModule = {
@@ -27,4 +27,5 @@ export type MainIpcModuleConstructor = {
   store: TStoreType
   menuBuilder: InstanceType<typeof MenuBuilder>
   hardwareService: InstanceType<typeof HardwareService>
+  pouService: InstanceType<typeof PouService>
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -19,7 +19,7 @@ import { MainIpcModuleConstructor } from './contracts/types/modules/ipc/main'
 import MenuBuilder from './menu'
 import MainProcessBridge from './modules/ipc/main'
 import { store } from './modules/store'
-import { HardwareService, ProjectService, UserService } from './services'
+import { HardwareService, PouService, ProjectService, UserService } from './services'
 import { CompilerService } from './services/compiler-service'
 import { resolveHtmlPath } from './utils'
 
@@ -278,6 +278,11 @@ const createMainWindow = async () => {
   const projectService = new ProjectService(mainWindow)
 
   /**
+   * Creates a singleton instance for POU service, which will be used across the entire application
+   */
+  const pouService = new PouService()
+
+  /**
    * Creates a singleton instance for compiler service, which will be used across the entire application
    */
   const compilerService = new CompilerService()
@@ -292,6 +297,7 @@ const createMainWindow = async () => {
     store,
     menuBuilder,
     hardwareService,
+    pouService,
   } as unknown as MainIpcModuleConstructor)
   mainIpcModule.setupMainIpcListener()
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -81,7 +81,7 @@ export default class MenuBuilder {
   }
 
   handleDeletePou() {
-    this.mainWindow.webContents.send('workspace:delete-pou-accelerator')
+    this.mainWindow.webContents.send('workspace:delete-file-accelerator')
   }
 
   handleSwitchPerspective() {

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -150,7 +150,14 @@ class MainProcessBridge implements MainIpcModule {
       return response
     } catch (error) {
       console.error('Error creating POU file:', error)
-      return { ok: false, error }
+      return {
+        success: false,
+        error: {
+          title: 'Error creating POU file',
+          description: 'Please try again',
+          error,
+        },
+      }
     }
   }
   handleDeletePouFile = async (_event: IpcMainInvokeEvent, filePath: string) => {
@@ -159,7 +166,14 @@ class MainProcessBridge implements MainIpcModule {
       return response
     } catch (error) {
       console.error('Error deleting POU file:', error)
-      return { ok: false, error }
+      return {
+        success: false,
+        error: {
+          title: 'Error deleting POU file',
+          description: 'Please try again',
+          error,
+        },
+      }
     }
   }
 

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -63,6 +63,7 @@ class MainProcessBridge implements MainIpcModule {
 
     // Pou-related handlers
     this.ipcMain.handle('pou:create', this.handleCreatePouFile)
+    this.ipcMain.handle('pou:delete', this.handleDeletePouFile)
 
     // App and system handlers
     this.ipcMain.handle('open-external-link', this.handleOpenExternalLink)
@@ -146,11 +147,18 @@ class MainProcessBridge implements MainIpcModule {
   handleCreatePouFile = async (_event: IpcMainInvokeEvent, props: CreatePouFileProps) => {
     try {
       const response = await this.pouService.createPouFile(props)
-      this.mainWindow?.webContents.send('pou:create-pou-file-accelerator', { ok: true, data: response })
       return response
     } catch (error) {
       console.error('Error creating POU file:', error)
-      this.mainWindow?.webContents.send('pou:create-pou-file-accelerator', { ok: false, error })
+      return { ok: false, error }
+    }
+  }
+  handleDeletePouFile = async (_event: IpcMainInvokeEvent, filePath: string) => {
+    try {
+      const response = await this.pouService.deletePouFile(filePath)
+      return response
+    } catch (error) {
+      console.error('Error deleting POU file:', error)
       return { ok: false, error }
     }
   }

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -41,6 +41,8 @@ const rendererProcessBridge = {
     ipcRenderer.invoke('project:create', data),
   createProjectAccelerator: (callback: IpcRendererCallbacks) =>
     ipcRenderer.on('project:create-accelerator', (_event) => callback(_event)),
+  deleteFileAccelerator: (callback: IpcRendererCallbacks) =>
+    ipcRenderer.on('workspace:delete-file-accelerator', callback),
   findInProjectAccelerator: (callback: IpcRendererCallbacks) =>
     ipcRenderer.on('project:find-in-project-accelerator', callback),
   handleOpenProjectRequest: (callback: IpcRendererCallbacks) =>
@@ -55,6 +57,7 @@ const rendererProcessBridge = {
   removeCloseProjectListener: () => ipcRenderer.removeAllListeners('workspace:close-project-accelerator'),
   removeCloseTabListener: () => ipcRenderer.removeAllListeners('workspace:close-tab-accelerator'),
   removeCreateProjectAccelerator: () => ipcRenderer.removeAllListeners('project:create-accelerator'),
+  removeDeleteFileListener: () => ipcRenderer.removeAllListeners('workspace:delete-file-accelerator'),
   removeOpenProjectAccelerator: () => ipcRenderer.removeAllListeners('project:open-project-request'),
   removeOpenRecentListener: () => ipcRenderer.removeAllListeners('project:open-recent-accelerator'),
   removeSaveProjectAccelerator: () => ipcRenderer.removeAllListeners('project:save-accelerator'),
@@ -67,9 +70,6 @@ const rendererProcessBridge = {
   // ===================== POU METHODS =====================
   createPouFile: (props: CreatePouFileProps): Promise<PouServiceResponse> => ipcRenderer.invoke('pou:create', props),
   deletePouFile: (filePath: string): Promise<PouServiceResponse> => ipcRenderer.invoke('pou:delete', filePath),
-  deletePouAccelerator: (callback: IpcRendererCallbacks) =>
-    ipcRenderer.on('workspace:delete-pou-accelerator', callback),
-  removeDeletePouListener: () => ipcRenderer.removeAllListeners('workspace:delete-pou-accelerator'),
 
   // ===================== APP & SYSTEM METHODS =====================
   darwinAppIsClosing: (callback: IpcRendererCallbacks) => ipcRenderer.on('app:darwin-is-closing', callback),

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -66,6 +66,7 @@ const rendererProcessBridge = {
 
   // ===================== POU METHODS =====================
   createPouFile: (props: CreatePouFileProps): Promise<PouServiceResponse> => ipcRenderer.invoke('pou:create', props),
+  deletePouFile: (filePath: string): Promise<PouServiceResponse> => ipcRenderer.invoke('pou:delete', filePath),
   deletePouAccelerator: (callback: IpcRendererCallbacks) =>
     ipcRenderer.on('workspace:delete-pou-accelerator', callback),
   removeDeletePouListener: () => ipcRenderer.removeAllListeners('workspace:delete-pou-accelerator'),

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return */
+import { CreatePouFileProps, PouServiceResponse } from '@root/types/IPC/pou-service'
 import { CreateProjectFileProps, IProjectServiceResponse } from '@root/types/IPC/project-service'
 import { DeviceConfiguration, DevicePin } from '@root/types/PLC/devices'
 import { ipcRenderer, IpcRendererEvent } from 'electron'
@@ -40,8 +41,6 @@ const rendererProcessBridge = {
     ipcRenderer.invoke('project:create', data),
   createProjectAccelerator: (callback: IpcRendererCallbacks) =>
     ipcRenderer.on('project:create-accelerator', (_event) => callback(_event)),
-  deletePouAccelerator: (callback: IpcRendererCallbacks) =>
-    ipcRenderer.on('workspace:delete-pou-accelerator', callback),
   findInProjectAccelerator: (callback: IpcRendererCallbacks) =>
     ipcRenderer.on('project:find-in-project-accelerator', callback),
   handleOpenProjectRequest: (callback: IpcRendererCallbacks) =>
@@ -56,7 +55,6 @@ const rendererProcessBridge = {
   removeCloseProjectListener: () => ipcRenderer.removeAllListeners('workspace:close-project-accelerator'),
   removeCloseTabListener: () => ipcRenderer.removeAllListeners('workspace:close-tab-accelerator'),
   removeCreateProjectAccelerator: () => ipcRenderer.removeAllListeners('project:create-accelerator'),
-  removeDeletePouListener: () => ipcRenderer.removeAllListeners('workspace:delete-pou-accelerator'),
   removeOpenProjectAccelerator: () => ipcRenderer.removeAllListeners('project:open-project-request'),
   removeOpenRecentListener: () => ipcRenderer.removeAllListeners('project:open-recent-accelerator'),
   removeSaveProjectAccelerator: () => ipcRenderer.removeAllListeners('project:save-accelerator'),
@@ -65,6 +63,12 @@ const rendererProcessBridge = {
   saveProjectAccelerator: (callback: IpcRendererCallbacks) => ipcRenderer.on('project:save-accelerator', callback),
   switchPerspective: (callback: IpcRendererCallbacks) =>
     ipcRenderer.on('workspace:switch-perspective-accelerator', callback),
+
+  // ===================== POU METHODS =====================
+  createPouFile: (props: CreatePouFileProps): Promise<PouServiceResponse> => ipcRenderer.invoke('pou:create', props),
+  deletePouAccelerator: (callback: IpcRendererCallbacks) =>
+    ipcRenderer.on('workspace:delete-pou-accelerator', callback),
+  removeDeletePouListener: () => ipcRenderer.removeAllListeners('workspace:delete-pou-accelerator'),
 
   // ===================== APP & SYSTEM METHODS =====================
   darwinAppIsClosing: (callback: IpcRendererCallbacks) => ipcRenderer.on('app:darwin-is-closing', callback),

--- a/src/main/services/index.ts
+++ b/src/main/services/index.ts
@@ -1,5 +1,6 @@
 export * from './compiler-service'
 export * from './hardware/hardware-service'
 export * from './logger-service'
+export * from './pou-service'
 export * from './project-service'
 export * from './user-service'

--- a/src/main/services/pou-service/index.ts
+++ b/src/main/services/pou-service/index.ts
@@ -16,6 +16,17 @@ class PouService {
       return { success: false, error: { title: 'POU Creation Error', description: 'Failed to create POU file', error } }
     }
   }
+
+  async deletePouFile(filePath: string): Promise<PouServiceResponse> {
+    try {
+      console.log('Deleting POU file at:', filePath)
+      await UserService.deleteFile(filePath)
+      return { success: true }
+    } catch (error) {
+      console.error('Error deleting POU file:', error)
+      return { success: false, error: { title: 'POU Deletion Error', description: 'Failed to delete POU file', error } }
+    }
+  }
 }
 
 export { PouService }

--- a/src/main/services/pou-service/index.ts
+++ b/src/main/services/pou-service/index.ts
@@ -1,0 +1,21 @@
+import { CreatePouFileProps, PouServiceResponse } from '@root/types/IPC/pou-service'
+
+import { UserService } from '../user-service'
+
+class PouService {
+  constructor() {}
+
+  async createPouFile(props: CreatePouFileProps): Promise<PouServiceResponse> {
+    try {
+      const filePath = props.path
+      await UserService.createJSONFileIfNotExists(filePath, props.pou)
+
+      return { success: true, data: { pou: props.pou } }
+    } catch (error) {
+      console.error('Error creating POU file:', error)
+      return { success: false, error: { title: 'POU Creation Error', description: 'Failed to create POU file', error } }
+    }
+  }
+}
+
+export { PouService }

--- a/src/main/services/project-service/utils/create-project.ts
+++ b/src/main/services/project-service/utils/create-project.ts
@@ -167,6 +167,7 @@ const createProjectDefaultStructure = (
   const pouPath = `${basePath}/pous/${pou.type}s`
 
   try {
+    if (!fileOrDirectoryExists(pouPath)) createDirectory(pouPath)
     CreateJSONFile(pouPath, JSON.stringify(pou, null, 2), pou.data.name)
   } catch (error) {
     return {
@@ -179,7 +180,7 @@ const createProjectDefaultStructure = (
     }
   }
 
-  content.project?.data.pous.push(pou)
+  if (content.project) content.project?.data.pous.push(pou)
 
   return {
     success: true,

--- a/src/main/services/user-service/index.ts
+++ b/src/main/services/user-service/index.ts
@@ -1,7 +1,6 @@
 import { exec } from 'child_process'
 import { app } from 'electron'
-import { rm } from 'fs'
-import { access, constants, mkdir, writeFile } from 'fs/promises'
+import { access, constants, mkdir, rm, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { promisify } from 'util'
 
@@ -67,6 +66,14 @@ class UserService {
       } else {
         console.error(`Error creating file at ${filePath}: ${String(err)}`)
       }
+    }
+  }
+
+  static async deleteFile(filePath: string): Promise<void> {
+    try {
+      await rm(filePath, { recursive: true, force: true })
+    } catch (err) {
+      console.error(`Error deleting file at ${filePath}: ${String(err)}`)
     }
   }
 

--- a/src/renderer/components/_molecules/graphical-editor/ladder/rung/header.tsx
+++ b/src/renderer/components/_molecules/graphical-editor/ladder/rung/header.tsx
@@ -8,6 +8,7 @@ import { CloseIcon } from '@root/renderer/assets'
 import { DragHandleIcon } from '@root/renderer/assets/icons/interface/DragHandle'
 import { DuplicateIcon } from '@root/renderer/assets/icons/interface/Duplicate'
 import { StickArrowIcon } from '@root/renderer/assets/icons/interface/StickArrow'
+import { pouSelectors, projectSelectors } from '@root/renderer/hooks'
 import { useOpenPLCStore } from '@root/renderer/store'
 import { RungLadderState } from '@root/renderer/store/slices'
 import { cn } from '@root/utils'
@@ -30,6 +31,9 @@ export const RungHeader = ({ rung, isOpen, draggableHandleProps, className, onCl
     modalActions: { openModal },
   } = useOpenPLCStore()
 
+  const pou = pouSelectors.usePous(editor.meta.name)
+  const projectPath = projectSelectors.useProjectPath()
+
   const editorName = editor.meta.name
 
   const containerRef = useRef<HTMLDivElement>(null)
@@ -48,7 +52,13 @@ export const RungHeader = ({ rung, isOpen, draggableHandleProps, className, onCl
   }, [rung.comment])
 
   const handleRemoveRung = () => {
-    openModal('confirm-delete-element', rung)
+    openModal('confirm-delete-element', {
+      type: 'ladder-rung',
+      file: editor.meta.name,
+      path: `${projectPath}/pous/${pou.type}s/${pou.data.name}.json`,
+      pou,
+      rung,
+    })
   }
 
   return (

--- a/src/renderer/components/_molecules/graphical-editor/ladder/rung/header.tsx
+++ b/src/renderer/components/_molecules/graphical-editor/ladder/rung/header.tsx
@@ -54,7 +54,7 @@ export const RungHeader = ({ rung, isOpen, draggableHandleProps, className, onCl
   const handleRemoveRung = () => {
     openModal('confirm-delete-element', {
       type: 'ladder-rung',
-      file: editor.meta.name,
+      file: pou.data.name,
       path: `${projectPath}/pous/${pou.type}s/${pou.data.name}.json`,
       pou,
       rung,

--- a/src/renderer/components/_molecules/modal/index.tsx
+++ b/src/renderer/components/_molecules/modal/index.tsx
@@ -30,6 +30,7 @@ const ModalContent = forwardRef<
   ComponentPropsWithoutRef<typeof PrimitiveDialog.Content> & { onClose?: () => void }
 >(({ className, onClose, ...props }, ref) => (
   <ModalPortal>
+    <PrimitiveDialog.Title /> {/* This is to ensure the title is rendered correctly */}
     <ModalOverlay />
     <PrimitiveDialog.Content
       ref={ref}

--- a/src/renderer/components/_molecules/tabs/index.tsx
+++ b/src/renderer/components/_molecules/tabs/index.tsx
@@ -13,7 +13,6 @@ const Tabs = () => {
     editor,
     tabsActions: { sortTabs },
     editorActions: { setEditor, getEditorFromEditors },
-    modalActions: { openModal },
   } = useOpenPLCStore()
   const { handleRemoveTab, selectedTab, setSelectedTab } = useHandleRemoveTab()
   const hasTabs = tabs.length > 0
@@ -42,10 +41,6 @@ const Tabs = () => {
     setEditor(candidate)
   }
 
-  const handleDeletePou = () => {
-    openModal('confirm-delete-element', null)
-  }
-
   const handleDragStart = ({ tab, idx }: { tab: TabsProps; idx: number }) => {
     dndTab.current = idx
     setSelectedTab(tab.name)
@@ -59,14 +54,10 @@ const Tabs = () => {
     setSelectedTab(editor.meta.name)
   }, [editor.meta.name])
 
-  useEffect(() => {}, [tabs])
-
   useEffect(() => {
     window.bridge.closeTabAccelerator((_event) => handleRemoveTab(selectedTab))
-    window.bridge.deletePouAccelerator((_event) => handleDeletePou())
     return () => {
       void window.bridge.removeCloseTabListener()
-      void window.bridge.removeDeletePouListener()
     }
   })
 

--- a/src/renderer/components/_organisms/modals/delete-confirmation-modal.tsx
+++ b/src/renderer/components/_organisms/modals/delete-confirmation-modal.tsx
@@ -5,138 +5,162 @@ import { useHandleRemoveTab } from '@root/renderer/hooks'
 import { useOpenPLCStore } from '@root/renderer/store'
 import { RungLadderState } from '@root/renderer/store/slices'
 import { PLCVariable } from '@root/types/PLC'
-import { useEffect } from 'react'
+import { PLCPou } from '@root/types/PLC/open-plc'
 
 import { Modal, ModalContent } from '../../_molecules/modal'
 
-type ModalData = {
-  leafLang: string
-  label: string
+export type DeletePou = {
+  type: 'pou'
+  file: string
+  path: string
+  pou: PLCPou
 }
 
-type ConfirmDeleteElementProps = {
-  rung?: RungLadderState | null
+export type DeleteDatatype = {
+  type: 'datatype'
+  file: string
+  path: string
+}
+
+export type DeleteLadderRung = {
+  type: 'ladder-rung'
+  file: string
+  path: string
+  pou: PLCPou
+  rung: RungLadderState
+}
+
+export type ConfirmDeleteModalProps = {
   isOpen: boolean
-  validationContext: string | null
-  modalData?: ModalData
+  data: DeletePou | DeleteDatatype | DeleteLadderRung
 }
 
-const ConfirmDeleteElementModal = ({
-  rung,
-  modalData,
-  isOpen,
-  validationContext,
-  ...rest
-}: ConfirmDeleteElementProps) => {
+const ConfirmDeleteElementModal = ({ isOpen, data, ...rest }: ConfirmDeleteModalProps) => {
   const {
     editor,
-    projectActions: { deletePou, deleteDatatype, deleteVariable },
-    ladderFlowActions: { removeLadderFlow, removeRung },
+    projectActions: { deleteVariable },
+    ladderFlowActions: { removeRung },
     editorActions: { updateModelVariables },
-    libraryActions: { removeUserLibrary },
     modalActions: { onOpenChange, closeModal },
-    project: {
-      data: { pous },
-    },
+    pouActions: { delete: deletePouAction },
+    datatypeActions: { delete: deleteDatatypeAction },
   } = useOpenPLCStore()
 
   const { handleRemoveTab } = useHandleRemoveTab()
-  const editorName = editor.meta.name
-  const pou = pous.find((pou) => pou.data.name === editorName)
 
-  useEffect(() => {}, [modalData, editor])
+  const handleDeleteLadderRung = (data: DeleteLadderRung) => {
+    const { pou, rung } = data
+    if (Array.isArray(rung.nodes)) {
+      /**
+       * Remove the variable associated with the block node
+       * If the editor is a graphical editor and the variable display is set to table, update the model variables
+       * If the variable is the selected row, set the selected row to -1
+       *
+       * !IMPORTANT: This function must be used inside of components, because the functions deleteVariable and updateModelVariables are just available at the useOpenPLCStore hook
+       * -- This block of code references at project:
+       *    -- src/renderer/components/_molecules/rung/body.tsx
+       *    -- src/renderer/components/_molecules/menu-bar/modals/delete-confirmation-modal.tsx
+       *    -- src/renderer/components/_organisms/workspace-activity-bar/ladder-toolbox.tsx
+       *    -- src/renderer/components/_molecules/graphical-editor/fbd/index.tsx
+       */
+      const blockNodes = rung.nodes.filter((node) => node.type === 'block')
+
+      if (blockNodes.length > 0) {
+        let variables: PLCVariable[] = []
+        if (pou) variables = [...pou.data.variables] as PLCVariable[]
+
+        blockNodes.forEach((blockNode) => {
+          const variableData = (blockNode.data as BasicNodeData)?.variable
+          const variableIndex = variables.findIndex((variable) => variable.id === variableData?.id)
+
+          if (variableIndex !== -1) {
+            deleteVariable({
+              variableId: variableData?.id,
+              scope: 'local',
+              associatedPou: editor.meta.name,
+            })
+            variables.splice(variableIndex, 1)
+          }
+
+          if (
+            editor.type === 'plc-graphical' &&
+            editor.variable.display === 'table' &&
+            parseInt(editor.variable.selectedRow, 10) === variableIndex
+          ) {
+            updateModelVariables({ display: 'table', selectedRow: -1 })
+          }
+        })
+      }
+
+      removeRung(editor.meta.name, rung.id)
+
+      toast({
+        title: 'Rung deleted success!',
+        description: 'Your rung was successfully deleted.',
+        variant: 'default',
+      })
+    }
+  }
+
+  const handleDeleteDatatype = (data: DeleteDatatype) => {
+    const { file: targetLabel } = data
+
+    const res = deleteDatatypeAction(data)
+    if (!res.success) {
+      toast({
+        title: res.error?.title || 'Error deleting datatype',
+        description: res.error?.description || 'An error occurred while deleting the datatype. Please try again.',
+        variant: 'fail',
+      })
+      return
+    }
+
+    handleRemoveTab(targetLabel)
+    toast({
+      title: 'Datatype deleted success!',
+      description: `Datatype "${targetLabel}" was successfully deleted.`,
+      variant: 'default',
+    })
+  }
+
+  const handleDeletePou = (data: DeletePou) => {
+    const { file: targetLabel } = data
+
+    const res = deletePouAction(data)
+    if (!res.success) {
+      toast({
+        title: res.error?.title || 'Error deleting POU',
+        description: res.error?.description || 'An error occurred while deleting the POU. Please try again.',
+        variant: 'fail',
+      })
+      return
+    }
+
+    handleRemoveTab(targetLabel)
+    toast({
+      title: 'POU deleted success!',
+      description: `POU "${targetLabel}" was successfully deleted.`,
+      variant: 'default',
+    })
+  }
 
   const handleDeleteElement = (): void => {
     try {
-      if (rung && Array.isArray(rung.nodes)) {
-        /**
-         * Remove the variable associated with the block node
-         * If the editor is a graphical editor and the variable display is set to table, update the model variables
-         * If the variable is the selected row, set the selected row to -1
-         *
-         * !IMPORTANT: This function must be used inside of components, because the functions deleteVariable and updateModelVariables are just available at the useOpenPLCStore hook
-         * -- This block of code references at project:
-         *    -- src/renderer/components/_molecules/rung/body.tsx
-         *    -- src/renderer/components/_molecules/menu-bar/modals/delete-confirmation-modal.tsx
-         *    -- src/renderer/components/_organisms/workspace-activity-bar/ladder-toolbox.tsx
-         *    -- src/renderer/components/_molecules/graphical-editor/fbd/index.tsx
-         */
-        const blockNodes = rung.nodes.filter((node) => node.type === 'block')
-
-        if (blockNodes.length > 0) {
-          let variables: PLCVariable[] = []
-          if (pou) variables = [...pou.data.variables] as PLCVariable[]
-
-          blockNodes.forEach((blockNode) => {
-            const variableData = (blockNode.data as BasicNodeData)?.variable
-            const variableIndex = variables.findIndex((variable) => variable.id === variableData?.id)
-
-            if (variableIndex !== -1) {
-              deleteVariable({
-                variableId: variableData?.id,
-                scope: 'local',
-                associatedPou: editor.meta.name,
-              })
-              variables.splice(variableIndex, 1)
-            }
-
-            if (
-              editor.type === 'plc-graphical' &&
-              editor.variable.display === 'table' &&
-              parseInt(editor.variable.selectedRow, 10) === variableIndex
-            ) {
-              updateModelVariables({ display: 'table', selectedRow: -1 })
-            }
-          })
+      switch (data.type) {
+        case 'pou': {
+          handleDeletePou(data)
+          break
         }
-
-        removeRung(editor.meta.name, rung.id)
-
-        toast({
-          title: 'Rung deleted success!',
-          description: 'Your rung was successfully deleted.',
-          variant: 'default',
-        })
-        closeModal()
-        return
-      }
-
-      if (editor.type === 'plc-datatype') {
-        const targetLabel = modalData?.label
-        if (!targetLabel) {
-          throw new Error('No label found for datatype deletion.')
+        case 'datatype': {
+          handleDeleteDatatype(data)
+          break
         }
-
-        deleteDatatype(targetLabel)
-        removeLadderFlow(targetLabel)
-        removeUserLibrary(targetLabel)
-        handleRemoveTab(targetLabel)
-
-        toast({
-          title: 'Datatype deleted success!',
-          description: `Datatype "${targetLabel}" was successfully deleted.`,
-          variant: 'default',
-        })
-        closeModal()
-        return
-      }
-
-      if (editor.type === 'plc-textual' || editor.type === 'plc-graphical') {
-        const targetLabel = modalData?.label
-        if (!targetLabel) {
-          throw new Error('No label found for POU deletion.')
+        case 'ladder-rung': {
+          handleDeleteLadderRung(data)
+          break
         }
-        deletePou(targetLabel)
-        removeLadderFlow(targetLabel)
-        removeUserLibrary(targetLabel)
-        handleRemoveTab(targetLabel)
-        toast({
-          title: 'Pou deleted success!',
-          description: `POU "${targetLabel}" was successfully deleted.`,
-          variant: 'default',
-        })
-        closeModal()
-        return
+        default:
+          throw new Error('Unknown element type')
       }
     } catch (_error) {
       toast({
@@ -145,7 +169,8 @@ const ConfirmDeleteElementModal = ({
         variant: 'fail',
       })
     }
-    closeModal()
+
+    handleCloseModal()
   }
 
   const handleCloseModal = () => {

--- a/src/renderer/components/_organisms/modals/delete-confirmation-modal.tsx
+++ b/src/renderer/components/_organisms/modals/delete-confirmation-modal.tsx
@@ -123,10 +123,10 @@ const ConfirmDeleteElementModal = ({ isOpen, data, ...rest }: ConfirmDeleteModal
     })
   }
 
-  const handleDeletePou = (data: DeletePou) => {
+  const handleDeletePou = async (data: DeletePou) => {
     const { file: targetLabel } = data
 
-    const res = deletePouAction(data)
+    const res = await deletePouAction(data)
     if (!res.success) {
       toast({
         title: res.error?.title || 'Error deleting POU',
@@ -148,7 +148,7 @@ const ConfirmDeleteElementModal = ({ isOpen, data, ...rest }: ConfirmDeleteModal
     try {
       switch (data.type) {
         case 'pou': {
-          handleDeletePou(data)
+          void handleDeletePou(data)
           break
         }
         case 'datatype': {

--- a/src/renderer/components/_templates/accelerator-handler.tsx
+++ b/src/renderer/components/_templates/accelerator-handler.tsx
@@ -261,7 +261,7 @@ const AcceleratorHandler = () => {
   }, [project, deviceDefinitions])
 
   /**
-   * ==== POU Related Accelerators ====
+   * -- Delete files
    */
   useEffect(() => {
     const handleDelete = () => {
@@ -281,14 +281,18 @@ const AcceleratorHandler = () => {
       }
     }
 
-    window.bridge.deletePouAccelerator((_event) => {
+    window.bridge.deleteFileAccelerator((_event) => {
       handleDelete()
     })
 
     return () => {
-      window.bridge.removeDeletePouListener()
+      window.bridge.removeDeleteFileListener()
     }
   }, [selectedProjectLeft])
+
+  /**
+   * ==== POU Related Accelerators ====
+   */
 
   /**
    * ==== Window Related Accelerators ====

--- a/src/renderer/components/_templates/accelerator-handler.tsx
+++ b/src/renderer/components/_templates/accelerator-handler.tsx
@@ -1,5 +1,5 @@
 import type { ISaveDataResponse } from '@root/main/modules/ipc/renderer'
-import { useCompiler } from '@root/renderer/hooks'
+import { useCompiler, workspaceSelectors } from '@root/renderer/hooks'
 import { useQuitApp } from '@root/renderer/hooks/use-quit-app'
 import { useOpenPLCStore } from '@root/renderer/store'
 import type { DeviceState, ModalTypes, ProjectState } from '@root/renderer/store/slices'
@@ -114,9 +114,13 @@ const AcceleratorHandler = () => {
     modalActions: { openModal },
     sharedWorkspaceActions: { closeProject, openProject, openRecentProject },
     workspaceActions: { setEditingState, switchAppTheme, toggleMaximizedWindow },
+    pouActions: { deleteRequest: deletePouRequest },
+    datatypeActions: { deleteRequest: deleteDatatypeRequest },
   } = useOpenPLCStore()
 
   const { handleWindowClose, handleAppIsClosingDarwin } = useQuitApp()
+
+  const selectedProjectLeft = workspaceSelectors.useSelectedProjectTreeLeaf()
 
   /**
    * Compiler Related Accelerators
@@ -255,6 +259,36 @@ const AcceleratorHandler = () => {
       window.bridge.removeSaveProjectAccelerator()
     }
   }, [project, deviceDefinitions])
+
+  /**
+   * ==== POU Related Accelerators ====
+   */
+  useEffect(() => {
+    const handleDelete = () => {
+      const { label, type } = selectedProjectLeft
+
+      if (type === 'pou') {
+        deletePouRequest(label)
+      } else if (type === 'datatype') {
+        deleteDatatypeRequest(label)
+      } else {
+        toast({
+          title: 'Error',
+          description: 'This element cannot be deleted.',
+          variant: 'fail',
+        })
+        return
+      }
+    }
+
+    window.bridge.deletePouAccelerator((_event) => {
+      handleDelete()
+    })
+
+    return () => {
+      window.bridge.removeDeletePouListener()
+    }
+  }, [selectedProjectLeft])
 
   /**
    * ==== Window Related Accelerators ====

--- a/src/renderer/components/_templates/app-layout.tsx
+++ b/src/renderer/components/_templates/app-layout.tsx
@@ -1,7 +1,6 @@
-import { SaveChangeModalProps } from '@root/renderer/components/_organisms/modals'
+import { ConfirmDeleteModalProps, SaveChangeModalProps } from '@root/renderer/components/_organisms/modals'
 import { TitleBar } from '@root/renderer/components/_organisms/title-bar'
 import { useOpenPLCStore } from '@root/renderer/store'
-import { RungLadderState } from '@root/renderer/store/slices'
 import { cn } from '@root/utils'
 import { ComponentPropsWithoutRef, ReactNode, useEffect, useState } from 'react'
 
@@ -17,10 +16,7 @@ const AppLayout = ({ children, ...rest }: AppLayoutProps): ReactNode => {
     modals,
     workspaceActions: { setSystemConfigs, setRecent },
   } = useOpenPLCStore()
-  type ModalData = {
-    leafLang: string
-    label: string
-  }
+
   useEffect(() => {
     const getUserSystemProps = async () => {
       const { OS, architecture, prefersDarkMode, isWindowMaximized } = await window.bridge.getSystemInfo()
@@ -66,9 +62,7 @@ const AppLayout = ({ children, ...rest }: AppLayoutProps): ReactNode => {
         {modals?.['confirm-delete-element']?.open === true && (
           <ConfirmDeleteElementModal
             isOpen={modals['confirm-delete-element'].open}
-            validationContext={modals['confirm-delete-element'].data as string}
-            rung={modals['confirm-delete-element'].data as RungLadderState}
-            modalData={modals['confirm-delete-element'].data as ModalData}
+            data={modals['confirm-delete-element'].data as ConfirmDeleteModalProps['data']}
           />
         )}
         <AcceleratorHandler />

--- a/src/renderer/hooks/use-store-selectors.ts
+++ b/src/renderer/hooks/use-store-selectors.ts
@@ -1,4 +1,5 @@
 import { useOpenPLCStore } from '@root/renderer/store'
+import { PLCPou } from '@root/types/PLC/open-plc'
 
 // ===================== Device screen selectors. =====================
 const rtuSelectors = {
@@ -68,7 +69,7 @@ const communicationSelectors = {
   useSetCommunicationPreferences: () => useOpenPLCStore((state) => state.deviceActions.setCommunicationPreferences),
 }
 
-// ===================== Project search selectors. =====================
+// ===================== Search selectors. =====================
 const searchSelectors = {
   useSearchQuery: () => useOpenPLCStore((state) => state.searchQuery),
   useSearchResults: () => useOpenPLCStore((state) => state.searchResults),
@@ -84,13 +85,25 @@ const editorSelectors = {
   useEditorState: () => useOpenPLCStore((state) => state.editor),
 }
 
+// ===================== Pous selectors. =====================
+const pouSelectors = {
+  usePous: (fileName: string) =>
+    useOpenPLCStore((state) => state.project.data.pous.find((pou) => pou.data.name === fileName) as PLCPou),
+}
+
+// ===================== Project selectors. =====================
+const projectSelectors = {
+  useProjectPath: () => useOpenPLCStore((state) => state.project.meta.path),
+}
+
 /**
- * Workspace selectors.
+ * ====================== Workspace selectors. =====================
  */
 const workspaceSelectors = {
   useWorkspace: () => useOpenPLCStore((state) => state.workspace),
   useEditingState: () => useOpenPLCStore((state) => state.workspace.editingState),
   useSetEditingState: () => useOpenPLCStore((state) => state.workspaceActions.setEditingState),
+  useSelectedProjectTreeLeaf: () => useOpenPLCStore((state) => state.workspace.selectedProjectTreeLeaf),
 }
 
 // ===================== Console selectors. =====================
@@ -107,6 +120,8 @@ export {
   consoleSelectors,
   editorSelectors,
   pinSelectors,
+  pouSelectors,
+  projectSelectors,
   rtuSelectors,
   searchSelectors,
   staticHostSelectors,

--- a/src/renderer/store/slices/workspace/slice.ts
+++ b/src/renderer/store/slices/workspace/slice.ts
@@ -21,6 +21,10 @@ const createWorkspaceSlice: StateCreator<WorkspaceSlice, [], [], WorkspaceSlice>
       app: false,
       appDarwin: false,
     },
+    selectedProjectTreeLeaf: {
+      label: '',
+      type: null,
+    },
   },
 
   workspaceActions: {
@@ -105,6 +109,13 @@ const createWorkspaceSlice: StateCreator<WorkspaceSlice, [], [], WorkspaceSlice>
           } else {
             workspace.isModalOpen.push({ modalName, modalState })
           }
+        }),
+      )
+    },
+    setSelectedProjectTreeLeaf: (selectedProjectTreeLeaf): void => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.selectedProjectTreeLeaf = selectedProjectTreeLeaf
         }),
       )
     },

--- a/src/renderer/store/slices/workspace/types.ts
+++ b/src/renderer/store/slices/workspace/types.ts
@@ -21,6 +21,10 @@ const workspaceStateSchema = z.object({
       app: z.boolean(),
       appDarwin: z.boolean(),
     }),
+    selectedProjectTreeLeaf: z.object({
+      label: z.string(),
+      type: z.enum(['pou', 'datatype', 'file']).nullable(),
+    }),
   }),
 })
 type WorkspaceState = z.infer<typeof workspaceStateSchema>
@@ -43,6 +47,15 @@ const workspaceActionsSchema = z.object({
   toggleMaximizedWindow: z.function().returns(z.void()),
   toggleCollapse: z.function().returns(z.void()),
   setModalOpen: z.function().args(z.string(), z.boolean()).returns(z.void()),
+  setSelectedProjectTreeLeaf: z
+    .function()
+    .args(
+      z.object({
+        label: z.string(),
+        type: z.enum(['pou', 'datatype', 'file']).nullable(),
+      }),
+    )
+    .returns(z.void()),
 })
 type WorkspaceActions = z.infer<typeof workspaceActionsSchema>
 

--- a/src/types/IPC/pou-service/create-pou-file.ts
+++ b/src/types/IPC/pou-service/create-pou-file.ts
@@ -1,0 +1,8 @@
+import { PLCPou } from '@root/types/PLC/open-plc'
+
+type CreatePouFileProps = {
+  path: string
+  pou: PLCPou
+}
+
+export { CreatePouFileProps }

--- a/src/types/IPC/pou-service/index.ts
+++ b/src/types/IPC/pou-service/index.ts
@@ -1,0 +1,16 @@
+import { PLCPou } from '@root/types/PLC/open-plc'
+
+export * from './create-pou-file'
+
+export type PouServiceResponse = {
+  success: boolean
+  error?: {
+    title: string
+    description: string
+    error: unknown
+  }
+  message?: string
+  data?: {
+    pou: PLCPou
+  }
+}

--- a/src/types/PLC/pous/language.ts
+++ b/src/types/PLC/pous/language.ts
@@ -1,0 +1,9 @@
+import z from 'zod'
+
+const pousLanguageSchema = z.object({
+  textual: z.enum(['il', 'st']),
+  graphical: z.enum(['ld', 'sfc', 'fbd']),
+})
+type PousLanguage = z.infer<typeof pousLanguageSchema>
+
+export { PousLanguage, pousLanguageSchema }

--- a/src/types/PLC/pous/language.ts
+++ b/src/types/PLC/pous/language.ts
@@ -6,4 +6,9 @@ const pousLanguageSchema = z.object({
 })
 type PousLanguage = z.infer<typeof pousLanguageSchema>
 
-export { PousLanguage, pousLanguageSchema }
+const pousAllLanguages = [
+  ...pousLanguageSchema.shape.textual.options,
+  ...pousLanguageSchema.shape.graphical.options,
+] as const
+
+export { pousAllLanguages, PousLanguage, pousLanguageSchema }


### PR DESCRIPTION
# Pull request info

## References

### Link to Jira task

*[DOPE-97: Create POUs inside the editor](https://autonomylogic.atlassian.net/browse/DOPE-97)*

## Description of the changes proposed

- Create a POU inside the project
- Refector delete confirmation modal
- Delete POU file when deleting a POU

## To test it:
1. Open/Create a project
2. Press the "+" button at the explorer and check if the `POU` will be created 
  a. Also check if the POU is created at the correct folder at the project directory
3. Press the "+" button at the explorer and check if the `Datatype` will be created
4. Try deleting the `POU` clicking the "X" button at the explorer (will appear when hover the POU)
  a. Also check if the POU file will be deleted at project directory
6. Try deleting the `Datatype` clicking the "X" button at the explorer (will appear when hover the Datatype)
7. Do the same two latest steps (6 and 7), but this time using the delete accelerator (Edit > Delete POU/Datatype - ctrl + shift + del)

_Disclaimer: we cannot save the project. Those are the next steps, so check if any of these are merged:_
> _[DOPE-94: Save project](https://autonomylogic.atlassian.net/browse/DOPE-94)_
> _[DOPE-95: Save file](https://autonomylogic.atlassian.net/browse/DOPE-95)_

## DOD checklist

- [x] The code is complete and according to developers’ standards.
- [x] I have performed a self-review of my code.
- [ ] Meet the acceptance criteria.
- [ ] Unit tests are written and green.
- [ ] Test coverage: __ %.
- [ ] Integration tests are written and green.
- [x] Changes were communicated and updated in the ticket description.
- [ ] Reviewed and accepted by the Product Owner.
- [ ] End-to-end test are successful.


[DOPE-94]: https://autonomylogic.atlassian.net/browse/DOPE-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ