### PR TITLE
DOPE-131 implement compile only option

### DIFF
--- a/resources/sources/boards/hals.json
+++ b/resources/sources/boards/hals.json
@@ -674,7 +674,7 @@
     "default_dout": "02, 04, 05, 12, 13, 14, 15",
     "define": "BOARD_ESP32",
     "extra_libraries": [],
-    "platform": "esp32:esp32:esp32wrover:UploadSpeed=230400,PartitionScheme=huge_app,FlashMode=qio,FlashFreq=40,PSRAM=enabled",
+    "platform": "esp32:esp32:esp32wrover:UploadSpeed=230400,PartitionScheme=huge_app,FlashMode=qio,FlashFreq=40",
     "preview": "esp32.png",
     "source": "esp32.cpp",
     "specs": {

--- a/src/main/modules/compiler/compiler-module.ts
+++ b/src/main/modules/compiler/compiler-module.ts
@@ -887,7 +887,7 @@ class CompilerModule {
       buildProjectFlags = [
         ...buildProjectFlags,
         '--build-property',
-        `compiler.cxx.extra_flags=${boardHalsContent['cxx_flags'].map((f) => f).join(' ')}`,
+        `compiler.cpp.extra_flags=${boardHalsContent['cxx_flags'].map((f) => f).join(' ')}`,
       ]
     }
 

--- a/src/main/modules/compiler/compiler-module.ts
+++ b/src/main/modules/compiler/compiler-module.ts
@@ -939,8 +939,13 @@ class CompilerModule {
     const { communicationPort: port } =
       await CompilerModule.readJSONFile<DeviceConfiguration>(devicesConfigurationFilePath)
     const baremetalPath = join(compilationPath, 'examples', 'Baremetal')
+
+    if (!port) {
+      handleOutputData('No communication port specified', 'error')
+      return
+    }
+
     return new Promise<MethodsResult<string | Buffer>>((resolve, reject) => {
-      if (!port) reject(new Error('No communication port specified in device configuration'))
       const child = this.#executeArduinoCliCommand([
         'upload',
         '--port',

--- a/src/main/modules/compiler/compiler-module.ts
+++ b/src/main/modules/compiler/compiler-module.ts
@@ -879,7 +879,7 @@ class CompilerModule {
       buildProjectFlags = [
         ...buildProjectFlags,
         '--build-property',
-        `${boardHalsContent['c_flags'].map((f) => f).join(' ')}`,
+        `compiler.c.extra_flags=${boardHalsContent['c_flags'].map((f) => f).join(' ')}`,
       ]
     }
 
@@ -887,7 +887,7 @@ class CompilerModule {
       buildProjectFlags = [
         ...buildProjectFlags,
         '--build-property',
-        `${boardHalsContent['cxx_flags'].map((f) => f).join(' ')}`,
+        `compiler.cxx.extra_flags=${boardHalsContent['cxx_flags'].map((f) => f).join(' ')}`,
       ]
     }
 

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -121,7 +121,7 @@ const rendererProcessBridge = {
   // =================== Work in Progress ===================
   // This method is a placeholder for running the compile program.
   runCompileProgram: (
-    compileProgramArgs: Array<string | null | ProjectState['data']>,
+    compileProgramArgs: Array<string | boolean | null | ProjectState['data']>,
     callback: (args: any) => void,
   ) => {
     // Create a MessageChannel to communicate between the renderer and main process

--- a/src/renderer/components/_features/[workspace]/editor/device/configuration/board.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/configuration/board.tsx
@@ -1,15 +1,19 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { boardSelectors, pinSelectors } from '@hooks/use-store-selectors'
+import { boardSelectors, compileOnlySelectors, pinSelectors } from '@hooks/use-store-selectors'
 import { MinusIcon, PlusIcon, RefreshIcon } from '@root/renderer/assets'
-import { Label, Select, SelectContent, SelectItem, SelectTrigger } from '@root/renderer/components/_atoms'
+import { Checkbox, Label, Select, SelectContent, SelectItem, SelectTrigger } from '@root/renderer/components/_atoms'
 import TableActions from '@root/renderer/components/_atoms/table-actions'
 import { DeviceEditorSlot } from '@root/renderer/components/_templates/[editors]'
+import { useOpenPLCStore } from '@root/renderer/store'
 import { cn } from '@root/utils'
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { PinMappingTable } from './components/pin-mapping-table'
 
 const Board = memo(function () {
+  const {
+    deviceDefinitions: { compileOnly },
+  } = useOpenPLCStore()
   const availableBoards = boardSelectors.useAvailableBoards()
   const availableCommunicationPorts = boardSelectors.useAvailableCommunicationPorts()
   const deviceBoard = boardSelectors.useDeviceBoard()
@@ -19,6 +23,8 @@ const Board = memo(function () {
   const setAvailableOptions = boardSelectors.useSetAvailableOptions()
   const currentSelectedPinTableRow = pinSelectors.useCurrentSelectedPinTableRow()
   const setCurrentSelectedPinTableRow = pinSelectors.useSelectPinTableRow()
+
+  const setCompileOnly = compileOnlySelectors.useSetCompileOnly()
 
   const pins = pinSelectors.usePins()
   const createNewPin = pinSelectors.useCreateNewPin()
@@ -89,6 +95,7 @@ const Board = memo(function () {
     },
     [setAvailableOptions],
   )
+  console.log('compileOnly', compileOnly)
 
   const handleSetDeviceBoard = useCallback(
     (board: string) => {
@@ -100,8 +107,24 @@ const Board = memo(function () {
   )
   const handleRowClick = (row: HTMLTableRowElement) => setCurrentSelectedPinTableRow(parseInt(row.id))
 
+  const handleCompileOnly = () => {
+    setCompileOnly(!memoizedCompileOnly)
+  }
+  const memoizedCompileOnly = useMemo(() => compileOnly, [compileOnly])
+
   return (
     <DeviceEditorSlot heading='Board Settings'>
+      <div id='compile-only-container' className='flex select-none items-center gap-2'>
+        <Label htmlFor='compile-only-checkbox' className='w-fit text-xs text-neutral-950 dark:text-white'>
+          Compile Only
+        </Label>
+        <Checkbox
+          id='compile-only-checkbox'
+          className={compileOnly ? 'h-[14px] w-[14px] border-brand' : 'h-[14px] w-[14px] border-neutral-300'}
+          checked={compileOnly}
+          onCheckedChange={handleCompileOnly}
+        />
+      </div>
       <div id='board-selection-container' className='flex h-2/5 min-h-[325px] w-full justify-between'>
         <div
           id='board-preferences-container'

--- a/src/renderer/components/_features/[workspace]/editor/device/configuration/board.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/configuration/board.tsx
@@ -95,7 +95,6 @@ const Board = memo(function () {
     },
     [setAvailableOptions],
   )
-  console.log('compileOnly', compileOnly)
 
   const handleSetDeviceBoard = useCallback(
     (board: string) => {

--- a/src/renderer/components/_features/[workspace]/editor/device/configuration/board.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/configuration/board.tsx
@@ -13,8 +13,8 @@ import { PinMappingTable } from './components/pin-mapping-table'
 const Board = memo(function () {
   const {
     deviceDefinitions: { compileOnly },
+    deviceAvailableOptions: { availableBoards },
   } = useOpenPLCStore()
-  const availableBoards = boardSelectors.useAvailableBoards()
   const availableCommunicationPorts = boardSelectors.useAvailableCommunicationPorts()
   const deviceBoard = boardSelectors.useDeviceBoard()
   const communicationPort = boardSelectors.useCommunicationPort()

--- a/src/renderer/components/_organisms/console/index.tsx
+++ b/src/renderer/components/_organisms/console/index.tsx
@@ -1,11 +1,11 @@
-import { useOpenPLCStore } from '@root/renderer/store'
+import { consoleSelectors } from '@root/renderer/hooks'
 import { debounce } from 'lodash'
-import { useEffect, useRef } from 'react'
+import { memo, useEffect, useRef } from 'react'
 
 import { LogComponent } from './log'
 
-const Console = () => {
-  const { logs } = useOpenPLCStore()
+const Console = memo(() => {
+  const logs = consoleSelectors.useLogs()
   const bottomLogRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
@@ -36,5 +36,5 @@ const Console = () => {
       <div ref={bottomLogRef} id='bottom-log' />
     </div>
   )
-}
+})
 export { Console }

--- a/src/renderer/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/renderer/components/_organisms/workspace-activity-bar/default.tsx
@@ -1,3 +1,4 @@
+import { compileOnlySelectors } from '@root/renderer/hooks'
 import { useOpenPLCStore } from '@root/renderer/store'
 import { BufferToStringArray, cn } from '@root/utils'
 import { useState } from 'react'
@@ -32,10 +33,12 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
 
   const disabledButtonClass = 'disabled cursor-not-allowed opacity-50 [&>*:first-child]:hover:bg-transparent'
 
+  const compileOnly = compileOnlySelectors.useCompileOnly()
+
   const handleRequest = () => {
     const boardCore = availableBoards.get(deviceDefinitions.configuration.deviceBoard)?.core || null
     window.bridge.runCompileProgram(
-      [projectMeta.path, deviceDefinitions.configuration.deviceBoard, boardCore, projectData],
+      [projectMeta.path, deviceDefinitions.configuration.deviceBoard, boardCore, compileOnly, projectData],
       (data: { logLevel?: 'info' | 'error' | 'warning'; message: string | Buffer; closePort?: boolean }) => {
         setIsCompiling(true)
         if (typeof data.message === 'string') {

--- a/src/renderer/hooks/use-store-selectors.ts
+++ b/src/renderer/hooks/use-store-selectors.ts
@@ -46,9 +46,14 @@ const pinSelectors = {
     useOpenPLCStore((state) => state.deviceDefinitions.pinMapping.currentSelectedPinTableRow),
 }
 
-export const deviceSelectors = {
+const deviceSelectors = {
   useDeviceUpdated: () => useOpenPLCStore((state) => state.deviceUpdated.updated),
   useResetDeviceUpdated: () => useOpenPLCStore((state) => state.deviceActions.resetDeviceUpdated),
+}
+
+const compileOnlySelectors = {
+  useCompileOnly: () => useOpenPLCStore((state) => state.deviceDefinitions.compileOnly),
+  useSetCompileOnly: () => useOpenPLCStore((state) => state.deviceActions.setCompileOnly),
 }
 
 const communicationSelectors = {
@@ -104,7 +109,9 @@ const consoleSelectors = {
 export {
   boardSelectors,
   communicationSelectors,
+  compileOnlySelectors,
   consoleSelectors,
+  deviceSelectors,
   editorSelectors,
   pinSelectors,
   rtuSelectors,

--- a/src/renderer/screens/start-screen.tsx
+++ b/src/renderer/screens/start-screen.tsx
@@ -43,13 +43,6 @@ const StartScreen = () => {
   }, [])
 
   useEffect(() => {
-    const getAvailableBoardOptions = async () => {
-      const boards = await window.bridge.getAvailableBoards()
-      setAvailableOptions({ availableBoards: boards })
-    }
-    void getAvailableBoardOptions()
-  }, [])
-  useEffect(() => {
     const getAvailableCommunicationPortsOptions = async () => {
       const ports = await window.bridge.getAvailableCommunicationPorts()
       setAvailableOptions({ availableCommunicationPorts: ports })

--- a/src/renderer/screens/workspace-screen.tsx
+++ b/src/renderer/screens/workspace-screen.tsx
@@ -29,6 +29,7 @@ const WorkspaceScreen = () => {
     workspace: { isCollapsed },
     editor,
     workspaceActions: { toggleCollapse },
+    deviceActions: { setAvailableOptions },
     searchResults,
   } = useOpenPLCStore()
 
@@ -75,7 +76,13 @@ const WorkspaceScreen = () => {
       }
     })
   }, [isCollapsed])
-
+  useEffect(() => {
+    const getAvailableBoardOptions = async () => {
+      const boards = await window.bridge.getAvailableBoards()
+      setAvailableOptions({ availableBoards: boards })
+    }
+    void getAvailableBoardOptions()
+  }, [])
   const [isSwitchingPerspective, setIsSwitchingPerspective] = useState(false)
 
   const handleSwitchPerspective = () => {

--- a/src/renderer/store/slices/device/slice.ts
+++ b/src/renderer/store/slices/device/slice.ts
@@ -26,6 +26,7 @@ const createDeviceSlice: StateCreator<DeviceSlice, [], [], DeviceSlice> = (setSt
       pins: [],
       currentSelectedPinTableRow: -1,
     },
+    compileOnly: true, // This flag indicates if the device is set to compile only (no deployment)
   },
   deviceUpdated: {
     updated: false, // This flag is used to track if the device has been updated
@@ -423,6 +424,14 @@ const createDeviceSlice: StateCreator<DeviceSlice, [], [], DeviceSlice> = (setSt
           if (staticHostConfiguration.subnet !== undefined)
             deviceDefinitions.configuration.communicationConfiguration.modbusTCP.tcpStaticHostConfiguration.subnet =
               staticHostConfiguration.subnet
+        }),
+      )
+    },
+    setCompileOnly: (compileOnly): void => {
+      setState(
+        produce(({ deviceDefinitions, deviceUpdated }: DeviceSlice) => {
+          deviceUpdated.updated = true // Mark device as updated when setting compile only
+          deviceDefinitions.compileOnly = compileOnly
         }),
       )
     },

--- a/src/renderer/store/slices/device/slice.ts
+++ b/src/renderer/store/slices/device/slice.ts
@@ -66,6 +66,7 @@ const createDeviceSlice: StateCreator<DeviceSlice, [], [], DeviceSlice> = (setSt
             pins: [],
             currentSelectedPinTableRow: -1,
           }
+          deviceDefinitions.compileOnly = true
         }),
       )
     },

--- a/src/renderer/store/slices/device/types.ts
+++ b/src/renderer/store/slices/device/types.ts
@@ -58,7 +58,7 @@ const deviceStateSchema = z.object({
   deviceDefinitions: z.object({
     configuration: deviceConfigurationSchema,
     pinMapping: devicePinMappingSchema,
-    compileOnly: z.boolean(),
+    compileOnly: z.boolean().default(true),
   }),
   deviceUpdated: z.object({
     updated: z.boolean(),

--- a/src/renderer/store/slices/device/types.ts
+++ b/src/renderer/store/slices/device/types.ts
@@ -58,6 +58,7 @@ const deviceStateSchema = z.object({
   deviceDefinitions: z.object({
     configuration: deviceConfigurationSchema,
     pinMapping: devicePinMappingSchema,
+    compileOnly: z.boolean(),
   }),
   deviceUpdated: z.object({
     updated: z.boolean(),
@@ -130,6 +131,7 @@ const deviceActionSchema = z.object({
     .args(z.object({ tcpWifiSSID: z.string(), tcpWifiPassword: z.string() }).partial())
     .returns(z.void()),
   setStaticHostConfiguration: z.function().args(staticHostConfigurationSchema.partial()).returns(z.void()),
+  setCompileOnly: z.function().args(z.boolean()).returns(z.void()),
 })
 
 type DeviceActions = z.infer<typeof deviceActionSchema>

--- a/src/renderer/store/slices/shared/index.ts
+++ b/src/renderer/store/slices/shared/index.ts
@@ -10,6 +10,7 @@ import {
 } from '@root/types/PLC/open-plc'
 import { StateCreator } from 'zustand'
 
+import { ConsoleSlice } from '../console'
 import { DeviceSlice } from '../device'
 import { EditorSlice } from '../editor'
 import { FBDFlowSlice, FBDFlowType } from '../fbd'
@@ -79,6 +80,7 @@ export const createSharedSlice: StateCreator<
     WorkspaceSlice &
     DeviceSlice &
     HistorySlice &
+    ConsoleSlice &
     SharedSlice,
   [],
   [],
@@ -232,6 +234,7 @@ export const createSharedSlice: StateCreator<
       getState().ladderFlowActions.clearLadderFlows()
       getState().projectActions.clearProjects()
       getState().deviceActions.clearDeviceDefinitions()
+      getState().consoleActions.clearLogs()
       window.bridge.rebuildMenu()
     },
 


### PR DESCRIPTION
# Pull request info

## References

### Link to Jira task

*[DOPE-131](https://autonomylogic.atlassian.net/browse/DOPE-131?atlOrigin=eyJpIjoiZmQwZDI2N2Y0NDA3NGFlZGFlMDNjOGJmNmUyMjEwYmYiLCJwIjoiaiJ9)*

## Description of the changes proposed

- Implement the functionality to upload a builded program to arduino boars

## DOD checklist

- [x] The code is complete and according to developers’ standards.
- [x] I have performed a self-review of my code.
- [x] Meet the acceptance criteria.
- [x] Changes were communicated and updated in the ticket description.
- [x] Reviewed and accepted by the Product Owner.


[DOPE-131]: https://autonomylogic.atlassian.net/browse/DOPE-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Compile Only” toggle in Board Settings (default: on) and wired into the activity bar.
  * Compile workflow accepts a compile-only option to skip uploading to the board.

* **Improvements**
  * When upload is enabled, the app uploads to the connected board and streams progress/output to the UI.
  * Upload requires a configured communication port and shows clear error messages if missing.
  * Workspace now initializes available boards on load.
  * Console rendering switched to hook-based logs and memoized component for smoother updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->