### PR TITLE
fixing minor issue with variable code editor height

### DIFF
--- a/src/renderer/components/_organisms/variables-editor/index.tsx
+++ b/src/renderer/components/_organisms/variables-editor/index.tsx
@@ -1018,7 +1018,7 @@ const VariablesEditor = () => {
         {editorVariables.display === 'code' && (
           <div
             aria-label='Variables editor code container'
-            className='mb-1 h-80 overflow-y-auto'
+            className='mb-1 h-full overflow-y-auto'
             style={{ scrollbarGutter: 'stable' }}
           >
             <VariablesCodeEditor code={editorCode} onCodeChange={setEditorCode} shouldUseDarkMode={shouldUseDarkMode} />


### PR DESCRIPTION
# Pull request info

Small css issue with the variable editor in code view, simply changing the tailwind height from h-80 to h-full makes it look as I would expect

## References

https://github.com/user-attachments/assets/22b23b41-68c4-4486-a5e3-1600f4cf79bc

### If applicable substitute the issue reference to the one that this PR refers

n/a

### Link to Jira task

n/a

## Description of the changes proposed

- change the editor container height class form h-80 to h-full

## DOD checklist

- [ ] The code is complete and according to developers’ standards.
- [ ] I have performed a self-review of my code.
- [ ] Meet the acceptance criteria.
- [ ] Unit tests are written and green.
- [ ] Test coverage: __ %.
- [ ] Integration tests are written and green.
- [ ] Changes were communicated and updated in the ticket description.
- [ ] Reviewed and accepted by the Product Owner.
- [ ] End-to-end test are successful.
