### PR TITLE
fix: add cpp and python language support to search tree components

### DIFF
--- a/src/renderer/components/_features/[workspace]/search/display/tree-view.tsx
+++ b/src/renderer/components/_features/[workspace]/search/display/tree-view.tsx
@@ -1,6 +1,7 @@
 import {
   ArrayIcon,
   ArrowIcon,
+  CppIcon,
   DataTypeIcon,
   DeviceIcon,
   EnumIcon,
@@ -11,6 +12,7 @@ import {
   LDIcon,
   PLCIcon,
   ProgramIcon,
+  PythonIcon,
   ResourceIcon,
   SFCIcon,
   STIcon,
@@ -209,7 +211,7 @@ const ProjectSearchTreeNestedBranch = ({
 
 type IProjectSearchTreeLeafProps = ComponentPropsWithoutRef<'li'> & {
   nested?: boolean
-  leafLang: 'il' | 'st' | 'fbd' | 'sfc' | 'ld' | 'arr' | 'enum' | 'str' | 'res'
+  leafLang: 'il' | 'st' | 'python' | 'cpp' | 'fbd' | 'sfc' | 'ld' | 'arr' | 'enum' | 'str' | 'res'
   label?: string
   children?: ReactNode
 }
@@ -217,6 +219,8 @@ type IProjectSearchTreeLeafProps = ComponentPropsWithoutRef<'li'> & {
 const LeafSources = {
   il: { LeafIcon: ILIcon },
   st: { LeafIcon: STIcon },
+  python: { LeafIcon: PythonIcon },
+  cpp: { LeafIcon: CppIcon },
   fbd: { LeafIcon: FBDIcon },
   sfc: { LeafIcon: SFCIcon },
   ld: { LeafIcon: LDIcon },

--- a/src/renderer/components/_features/[workspace]/search/index.tsx
+++ b/src/renderer/components/_features/[workspace]/search/index.tsx
@@ -21,7 +21,7 @@ interface _SearchResult {
       'program' | 'function' | 'function-block',
       Array<{
         name: string
-        language: 'ld' | 'sfc' | 'fbd' | 'il' | 'st'
+        language: 'ld' | 'sfc' | 'fbd' | 'il' | 'st' | 'python' | 'cpp'
         pouType: 'program' | 'function' | 'function-block'
         body: string
         variable: string | null

--- a/src/renderer/store/slices/search/type.ts
+++ b/src/renderer/store/slices/search/type.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 const pouSchema = z.object({
   name: z.string(),
-  language: z.enum(['ld', 'sfc', 'fbd', 'il', 'st']),
+  language: z.enum(['ld', 'sfc', 'fbd', 'il', 'st', 'python', 'cpp']),
   pouType: z.enum(['program', 'function', 'function-block']),
   body: z.string(),
   variable: z.string().nullable(),


### PR DESCRIPTION
## Summary
- Fixes app crash when searching for variables in C++ or Python function block POUs
- The `LeafSources` object in the search tree view was missing entries for `cpp` and `python` languages, causing a destructuring error when trying to access icons for these languages
- Added the missing language support to all relevant type definitions and icon mappings

## Changes
- Added `CppIcon` and `PythonIcon` imports to `tree-view.tsx`
- Added `cpp` and `python` entries to `LeafSources` object
- Updated `leafLang` type definitions to include `'python' | 'cpp'`
- Updated search type schema language enum in `type.ts`

## Root Cause
When a user searched for a variable in a C++ function block, the search results contained a POU with `language: 'cpp'`. The component attempted to access `LeafSources['cpp']` which was `undefined`, causing the destructuring `const { LeafIcon } = LeafSources[leafLang]` to fail and crash the app.

## Test Plan
- [ ] Search for a variable defined in a C++ function block POU
- [ ] Search for a variable defined in a Python function block POU
- [ ] Verify the search results display correctly without crashing
- [ ] Verify the correct icons are shown for C++ and Python POUs in search results

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Python and C++ programming languages in search results with corresponding language icons and visual indicators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->