### PR TITLE
fix: enable vertical scrolling in device editor template

### DIFF
--- a/src/renderer/components/_templates/[editors]/device-editor-template.tsx
+++ b/src/renderer/components/_templates/[editors]/device-editor-template.tsx
@@ -4,7 +4,7 @@ type DeviceEditorTemplateProps = ComponentPropsWithoutRef<'div'>
 
 const DeviceEditorTemplate = (props: DeviceEditorTemplateProps) => {
   return (
-    <div id='device-editor-template' className='flex h-full w-full overflow-hidden' {...props}>
+    <div id='device-editor-template' className='flex h-full w-full overflow-y-auto' {...props}>
       {props.children}
     </div>
   )


### PR DESCRIPTION
## Summary
- Changed `overflow-hidden` to `overflow-y-auto` in the device editor template container
- Enables vertical scrolling when form fields extend beyond the visible viewport
- Fixes the issue where WiFi parameters (password, DNS, subnet) were off screen with no way to access them

## Test plan
- [ ] Open the device editor with WiFi configuration
- [ ] Verify that password, DNS, and subnet fields are now accessible via scrolling
- [ ] Confirm scrolling works smoothly without affecting horizontal layout

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled vertical scrolling in the device editor interface, allowing users to view and navigate all content without overflow constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->