### PR TITLE
fix: Enable text selection in Console and PLC Logs tabs

### DIFF
--- a/src/renderer/components/_organisms/console/index.tsx
+++ b/src/renderer/components/_organisms/console/index.tsx
@@ -30,7 +30,7 @@ const Console = memo(() => {
   return (
     <div
       aria-label='Console'
-      className='relative h-full w-full overflow-auto text-cp-base font-semibold text-brand-dark focus:outline-none dark:text-neutral-50'
+      className='relative h-full w-full select-text overflow-auto text-cp-base font-semibold text-brand-dark focus:outline-none dark:text-neutral-50'
     >
       {logs.length > 0 &&
         logs.map((log) => (

--- a/src/renderer/components/_organisms/plc-logs/index.tsx
+++ b/src/renderer/components/_organisms/plc-logs/index.tsx
@@ -65,7 +65,7 @@ const PlcLogs = memo(() => {
   return (
     <div
       aria-label='PLC Logs'
-      className='relative h-full w-full overflow-auto text-cp-base font-semibold text-brand-dark focus:outline-none dark:text-neutral-50'
+      className='relative h-full w-full select-text overflow-auto text-cp-base font-semibold text-brand-dark focus:outline-none dark:text-neutral-50'
     >
       {isV4
         ? v4DisplayLogs.map((entry, index) => (


### PR DESCRIPTION
## Summary
- Added `select-text` Tailwind class to Console and PlcLogs container divs
- Overrides the global `user-select: none` applied to the body element
- Restores ability to select and copy text from log messages

## Problem
Text selection was inadvertently disabled in the Console and PLC Logs tabs when the UI was locked to prevent text selection. The global CSS sets `user-select: none` on the body, and only re-enables it for `input`, `textarea`, and `[contenteditable='true']` elements. Since log messages are rendered as `<p>` tags, they inherit the disabled selection.

## Solution
Apply `select-text` class to the container divs in both components, which sets `user-select: text` and allows users to select and copy log text.

## Files Changed
- `src/renderer/components/_organisms/console/index.tsx`
- `src/renderer/components/_organisms/plc-logs/index.tsx`

## Test plan
- [ ] Open a project and view the Console tab
- [ ] Verify text can be selected with mouse drag
- [ ] Verify selected text can be copied (Cmd/Ctrl+C)
- [ ] Connect to a PLC runtime and view the PLC Logs tab
- [ ] Verify text selection works in PLC Logs as well

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced Console and PLC Logs components to allow text selection, improving user ability to copy and interact with displayed content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->