### PR TITLE
fix: Prevent type dropdown from blocking array modal

### DIFF
--- a/src/renderer/components/_atoms/dimensions-modal/index.tsx
+++ b/src/renderer/components/_atoms/dimensions-modal/index.tsx
@@ -30,6 +30,7 @@ interface DimensionsModalProps {
   onRearrangeDimensions: (index: number, direction: 'up' | 'down') => void
   onInputClick: (id: string) => void
   onUpdateDimension: (index: number, value: string) => { ok: boolean }
+  hideTrigger?: boolean
 }
 
 export const DimensionsModal = ({
@@ -48,15 +49,18 @@ export const DimensionsModal = ({
   onUpdateDimension,
   libraryTypes,
   variableTypes,
+  hideTrigger = false,
 }: DimensionsModalProps) => {
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
-      <ModalTrigger
-        onClick={() => onOpenChange(true)}
-        className='flex h-8 w-full cursor-pointer items-center justify-center py-1 outline-none hover:bg-neutral-100 data-[state=open]:bg-neutral-100 dark:hover:bg-neutral-900 data-[state=open]:dark:bg-neutral-900'
-      >
-        <span className='font-caption text-xs font-normal text-neutral-700 dark:text-neutral-500'>Array</span>
-      </ModalTrigger>
+      {!hideTrigger && (
+        <ModalTrigger
+          onClick={() => onOpenChange(true)}
+          className='flex h-8 w-full cursor-pointer items-center justify-center py-1 outline-none hover:bg-neutral-100 data-[state=open]:bg-neutral-100 dark:hover:bg-neutral-900 data-[state=open]:dark:bg-neutral-900'
+        >
+          <span className='font-caption text-xs font-normal text-neutral-700 dark:text-neutral-500'>Array</span>
+        </ModalTrigger>
+      )}
       <ModalContent
         onEscapeKeyDown={onCancel}
         onPointerDownOutside={onCancel}

--- a/src/renderer/components/_molecules/data-types/structure/table/elements/array-modal.tsx
+++ b/src/renderer/components/_molecules/data-types/structure/table/elements/array-modal.tsx
@@ -205,6 +205,7 @@ export const ArrayModal = ({
       onUpdateDimension={handleUpdateDimension}
       variableTypes={VariableTypes}
       libraryTypes={LibraryTypes}
+      hideTrigger
     />
   )
 }

--- a/src/renderer/components/_molecules/data-types/structure/table/selectable-cell.tsx
+++ b/src/renderer/components/_molecules/data-types/structure/table/selectable-cell.tsx
@@ -94,143 +94,154 @@ const SelectableTypeCell = ({
   }))
 
   return (
-    <PrimitiveDropdown.Root onOpenChange={setPoppoverIsOpen} open={poppoverIsOpen}>
-      <PrimitiveDropdown.Trigger asChild disabled={!editable}>
-        <div
-          className={cn('flex h-full w-full cursor-pointer justify-center p-2 outline-none', {
-            'pointer-events-none': !editable,
-            'cursor-default': !editable || definition === 'derived',
-          })}
-        >
-          <span className='line-clamp-1 font-caption text-xs font-normal text-neutral-700 dark:text-neutral-500'>
-            {cellValue === null
-              ? ''
-              : definition === 'array' || definition === 'derived'
-                ? cellValue
-                : _.upperCase(cellValue as unknown as string)}
-          </span>
-        </div>
-      </PrimitiveDropdown.Trigger>
-      <PrimitiveDropdown.Portal>
-        <PrimitiveDropdown.Content
-          side='bottom'
-          sideOffset={-20}
-          className='box h-fit w-[200px] overflow-hidden rounded-lg bg-white outline-none dark:bg-neutral-950'
-        >
-          {filteredVariableValues.map((scope) => (
-            <PrimitiveDropdown.Sub
-              key={scope.definition}
-              onOpenChange={() => setVariableFilters((prev) => ({ ...prev, [scope.definition]: '' }))}
+    <>
+      <ArrayModal
+        variableName={variableName}
+        VariableRow={index}
+        arrayModalIsOpen={arrayModalIsOpen}
+        setArrayModalIsOpen={setArrayModalIsOpen}
+        closeContainer={() => setPoppoverIsOpen(false)}
+      />
+      <PrimitiveDropdown.Root onOpenChange={setPoppoverIsOpen} open={poppoverIsOpen}>
+        <PrimitiveDropdown.Trigger asChild disabled={!editable}>
+          <div
+            className={cn('flex h-full w-full cursor-pointer justify-center p-2 outline-none', {
+              'pointer-events-none': !editable,
+              'cursor-default': !editable || definition === 'derived',
+            })}
+          >
+            <span className='line-clamp-1 font-caption text-xs font-normal text-neutral-700 dark:text-neutral-500'>
+              {cellValue === null
+                ? ''
+                : definition === 'array' || definition === 'derived'
+                  ? cellValue
+                  : _.upperCase(cellValue as unknown as string)}
+            </span>
+          </div>
+        </PrimitiveDropdown.Trigger>
+        <PrimitiveDropdown.Portal>
+          <PrimitiveDropdown.Content
+            side='bottom'
+            sideOffset={-20}
+            className='box h-fit w-[200px] overflow-hidden rounded-lg bg-white outline-none dark:bg-neutral-950'
+          >
+            {filteredVariableValues.map((scope) => (
+              <PrimitiveDropdown.Sub
+                key={scope.definition}
+                onOpenChange={() => setVariableFilters((prev) => ({ ...prev, [scope.definition]: '' }))}
+              >
+                <PrimitiveDropdown.SubTrigger asChild>
+                  <div className='relative flex h-8 w-full cursor-pointer items-center justify-center py-1 outline-none hover:bg-neutral-100 dark:hover:bg-neutral-900'>
+                    <span className='text-xs text-neutral-700 dark:text-neutral-500'>
+                      {_.startCase(scope.definition)}
+                    </span>
+                    <ArrowIcon size='md' direction='right' className='absolute right-1' />
+                  </div>
+                </PrimitiveDropdown.SubTrigger>
+                <PrimitiveDropdown.Portal>
+                  <PrimitiveDropdown.SubContent
+                    sideOffset={5}
+                    className='box max-h-[300px] w-[200px] overflow-y-auto rounded-lg bg-white dark:bg-neutral-950'
+                  >
+                    <div className='sticky top-0 z-10 bg-white p-2 dark:bg-neutral-950'>
+                      <InputWithRef
+                        type='text'
+                        placeholder='Search...'
+                        className='w-full rounded-md border border-neutral-200 px-2 py-1 text-xs text-neutral-700 outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-500'
+                        value={variableFilters[scope.definition]}
+                        onChange={(e) =>
+                          setVariableFilters((prev) => ({
+                            ...prev,
+                            [scope.definition]: e.target.value,
+                          }))
+                        }
+                        onKeyDown={(e) => e.stopPropagation()}
+                      />
+                    </div>
+                    {scope.values.length > 0 ? (
+                      scope.values.map((value) => (
+                        <PrimitiveDropdown.Item
+                          key={value}
+                          onSelect={() =>
+                            onSelect(scope.definition as PLCStructureVariable['type']['definition'], value)
+                          }
+                          className='flex h-8 items-center justify-center hover:bg-neutral-100 dark:hover:bg-neutral-900'
+                        >
+                          <span className='text-xs text-neutral-700 dark:text-neutral-500'>{_.upperCase(value)}</span>
+                        </PrimitiveDropdown.Item>
+                      ))
+                    ) : (
+                      <div className='flex h-8 items-center justify-center'>
+                        <span className='text-xs text-neutral-700 dark:text-neutral-500'>
+                          No {_.startCase(scope.definition)} found
+                        </span>
+                      </div>
+                    )}
+                  </PrimitiveDropdown.SubContent>
+                </PrimitiveDropdown.Portal>
+              </PrimitiveDropdown.Sub>
+            ))}
+
+            {filteredLibraryValues.map((scope) => (
+              <PrimitiveDropdown.Sub key={scope.definition} onOpenChange={() => setInputFilter('')}>
+                <PrimitiveDropdown.SubTrigger asChild>
+                  <div className='relative flex h-8 w-full cursor-pointer items-center justify-center py-1 outline-none hover:bg-neutral-100 dark:hover:bg-neutral-900'>
+                    <span className='text-xs text-neutral-700 dark:text-neutral-500'>
+                      {_.startCase(scope.definition)}
+                    </span>
+                    <ArrowIcon size='md' direction='right' className='absolute right-1' />
+                  </div>
+                </PrimitiveDropdown.SubTrigger>
+                <PrimitiveDropdown.Portal>
+                  <PrimitiveDropdown.SubContent
+                    sideOffset={5}
+                    className='box max-h-[300px] w-[200px] overflow-y-auto rounded-lg bg-white dark:bg-neutral-950'
+                  >
+                    <div className='sticky top-0 z-10 bg-white p-2 dark:bg-neutral-950'>
+                      <InputWithRef
+                        type='text'
+                        placeholder='Search...'
+                        className='w-full rounded-md border border-neutral-200 px-2 py-1 text-xs text-neutral-700 outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-500'
+                        value={inputFilter}
+                        onChange={(e) => setInputFilter(e.target.value)}
+                        onKeyDown={(e) => e.stopPropagation()}
+                      />
+                    </div>
+                    {scope.values.length > 0 ? (
+                      scope.values.map((value) => (
+                        <PrimitiveDropdown.Item
+                          key={value}
+                          onSelect={() => onSelect('derived', value)}
+                          className='flex h-8 items-center justify-center hover:bg-neutral-100 dark:hover:bg-neutral-900'
+                        >
+                          <span className='text-xs text-neutral-700 dark:text-neutral-500'>{_.upperCase(value)}</span>
+                        </PrimitiveDropdown.Item>
+                      ))
+                    ) : (
+                      <div className='flex h-8 items-center justify-center'>
+                        <span className='text-xs text-neutral-700 dark:text-neutral-500'>
+                          No {_.startCase(scope.definition)} found
+                        </span>
+                      </div>
+                    )}
+                  </PrimitiveDropdown.SubContent>
+                </PrimitiveDropdown.Portal>
+              </PrimitiveDropdown.Sub>
+            ))}
+
+            <PrimitiveDropdown.Item
+              onSelect={() => {
+                setArrayModalIsOpen(true)
+                setPoppoverIsOpen(false)
+              }}
+              className='flex h-8 w-full cursor-pointer items-center justify-center py-1 outline-none hover:bg-neutral-100 data-[state=open]:bg-neutral-100 dark:hover:bg-neutral-900 data-[state=open]:dark:bg-neutral-900'
             >
-              <PrimitiveDropdown.SubTrigger asChild>
-                <div className='relative flex h-8 w-full cursor-pointer items-center justify-center py-1 outline-none hover:bg-neutral-100 dark:hover:bg-neutral-900'>
-                  <span className='text-xs text-neutral-700 dark:text-neutral-500'>
-                    {_.startCase(scope.definition)}
-                  </span>
-                  <ArrowIcon size='md' direction='right' className='absolute right-1' />
-                </div>
-              </PrimitiveDropdown.SubTrigger>
-              <PrimitiveDropdown.Portal>
-                <PrimitiveDropdown.SubContent
-                  sideOffset={5}
-                  className='box max-h-[300px] w-[200px] overflow-y-auto rounded-lg bg-white dark:bg-neutral-950'
-                >
-                  <div className='sticky top-0 z-10 bg-white p-2 dark:bg-neutral-950'>
-                    <InputWithRef
-                      type='text'
-                      placeholder='Search...'
-                      className='w-full rounded-md border border-neutral-200 px-2 py-1 text-xs text-neutral-700 outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-500'
-                      value={variableFilters[scope.definition]}
-                      onChange={(e) =>
-                        setVariableFilters((prev) => ({
-                          ...prev,
-                          [scope.definition]: e.target.value,
-                        }))
-                      }
-                      onKeyDown={(e) => e.stopPropagation()}
-                    />
-                  </div>
-                  {scope.values.length > 0 ? (
-                    scope.values.map((value) => (
-                      <PrimitiveDropdown.Item
-                        key={value}
-                        onSelect={() => onSelect(scope.definition as PLCStructureVariable['type']['definition'], value)}
-                        className='flex h-8 items-center justify-center hover:bg-neutral-100 dark:hover:bg-neutral-900'
-                      >
-                        <span className='text-xs text-neutral-700 dark:text-neutral-500'>{_.upperCase(value)}</span>
-                      </PrimitiveDropdown.Item>
-                    ))
-                  ) : (
-                    <div className='flex h-8 items-center justify-center'>
-                      <span className='text-xs text-neutral-700 dark:text-neutral-500'>
-                        No {_.startCase(scope.definition)} found
-                      </span>
-                    </div>
-                  )}
-                </PrimitiveDropdown.SubContent>
-              </PrimitiveDropdown.Portal>
-            </PrimitiveDropdown.Sub>
-          ))}
-
-          {filteredLibraryValues.map((scope) => (
-            <PrimitiveDropdown.Sub key={scope.definition} onOpenChange={() => setInputFilter('')}>
-              <PrimitiveDropdown.SubTrigger asChild>
-                <div className='relative flex h-8 w-full cursor-pointer items-center justify-center py-1 outline-none hover:bg-neutral-100 dark:hover:bg-neutral-900'>
-                  <span className='text-xs text-neutral-700 dark:text-neutral-500'>
-                    {_.startCase(scope.definition)}
-                  </span>
-                  <ArrowIcon size='md' direction='right' className='absolute right-1' />
-                </div>
-              </PrimitiveDropdown.SubTrigger>
-              <PrimitiveDropdown.Portal>
-                <PrimitiveDropdown.SubContent
-                  sideOffset={5}
-                  className='box max-h-[300px] w-[200px] overflow-y-auto rounded-lg bg-white dark:bg-neutral-950'
-                >
-                  <div className='sticky top-0 z-10 bg-white p-2 dark:bg-neutral-950'>
-                    <InputWithRef
-                      type='text'
-                      placeholder='Search...'
-                      className='w-full rounded-md border border-neutral-200 px-2 py-1 text-xs text-neutral-700 outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-500'
-                      value={inputFilter}
-                      onChange={(e) => setInputFilter(e.target.value)}
-                      onKeyDown={(e) => e.stopPropagation()}
-                    />
-                  </div>
-                  {scope.values.length > 0 ? (
-                    scope.values.map((value) => (
-                      <PrimitiveDropdown.Item
-                        key={value}
-                        onSelect={() => onSelect('derived', value)}
-                        className='flex h-8 items-center justify-center hover:bg-neutral-100 dark:hover:bg-neutral-900'
-                      >
-                        <span className='text-xs text-neutral-700 dark:text-neutral-500'>{_.upperCase(value)}</span>
-                      </PrimitiveDropdown.Item>
-                    ))
-                  ) : (
-                    <div className='flex h-8 items-center justify-center'>
-                      <span className='text-xs text-neutral-700 dark:text-neutral-500'>
-                        No {_.startCase(scope.definition)} found
-                      </span>
-                    </div>
-                  )}
-                </PrimitiveDropdown.SubContent>
-              </PrimitiveDropdown.Portal>
-            </PrimitiveDropdown.Sub>
-          ))}
-
-          <PrimitiveDropdown.Item asChild>
-            <ArrayModal
-              variableName={variableName}
-              VariableRow={index}
-              arrayModalIsOpen={arrayModalIsOpen}
-              setArrayModalIsOpen={setArrayModalIsOpen}
-              closeContainer={() => setPoppoverIsOpen(false)}
-            />
-          </PrimitiveDropdown.Item>
-        </PrimitiveDropdown.Content>
-      </PrimitiveDropdown.Portal>
-    </PrimitiveDropdown.Root>
+              <span className='font-caption text-xs font-normal text-neutral-700 dark:text-neutral-500'>Array</span>
+            </PrimitiveDropdown.Item>
+          </PrimitiveDropdown.Content>
+        </PrimitiveDropdown.Portal>
+      </PrimitiveDropdown.Root>
+    </>
   )
 }
 

--- a/src/renderer/components/_molecules/variables-table/elements/array-modal.tsx
+++ b/src/renderer/components/_molecules/variables-table/elements/array-modal.tsx
@@ -191,6 +191,7 @@ export const ArrayModal = ({
       onUpdateDimension={handleUpdateDimension}
       variableTypes={VariableTypes}
       libraryTypes={LibraryTypes}
+      hideTrigger
     />
   )
 }

--- a/src/renderer/components/_molecules/variables-table/selectable-cell.tsx
+++ b/src/renderer/components/_molecules/variables-table/selectable-cell.tsx
@@ -262,6 +262,15 @@ const SelectableTypeCell = ({
             />
           )
         })()}
+      {language !== 'python' && language !== 'cpp' && (
+        <ArrayModal
+          variableName={variableName}
+          VariableRow={index}
+          arrayModalIsOpen={arrayModalIsOpen}
+          setArrayModalIsOpen={setArrayModalIsOpen}
+          closeContainer={() => setPoppoverIsOpen(false)}
+        />
+      )}
       <PrimitiveDropdown.Root onOpenChange={setPoppoverIsOpen} open={poppoverIsOpen}>
         <PrimitiveDropdown.Trigger
           asChild
@@ -352,14 +361,14 @@ const SelectableTypeCell = ({
             })}
 
             {language !== 'python' && language !== 'cpp' && (
-              <PrimitiveDropdown.Item asChild>
-                <ArrayModal
-                  variableName={variableName}
-                  VariableRow={index}
-                  arrayModalIsOpen={arrayModalIsOpen}
-                  setArrayModalIsOpen={setArrayModalIsOpen}
-                  closeContainer={() => setPoppoverIsOpen(false)}
-                />
+              <PrimitiveDropdown.Item
+                onSelect={() => {
+                  setArrayModalIsOpen(true)
+                  setPoppoverIsOpen(false)
+                }}
+                className='flex h-8 w-full cursor-pointer items-center justify-center py-1 outline-none hover:bg-neutral-100 data-[state=open]:bg-neutral-100 dark:hover:bg-neutral-900 data-[state=open]:dark:bg-neutral-900'
+              >
+                <span className='font-caption text-xs font-normal text-neutral-700 dark:text-neutral-500'>Array</span>
               </PrimitiveDropdown.Item>
             )}
 


### PR DESCRIPTION
## Summary
- Fix UI bug where the type dropdown remained visible on top of the array type definition modal
- Move ArrayModal rendering outside of the dropdown component so the modal persists when the dropdown closes
- Add `hideTrigger` prop to DimensionsModal to support external trigger control

## Test plan
- [ ] Create a new variable in the variables table
- [ ] Click on the Type column to open the type selector dropdown
- [ ] Select "Array" from the dropdown
- [ ] Verify the dropdown closes and the array type definition modal appears without obstruction
- [ ] Verify the modal is fully interactive (can add dimensions, select base type, save/cancel)
- [ ] Test the same flow in the data-types structure table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional control to hide dimension modal triggers, improving UI customization.
  * Enhanced array modal integration with improved positioning and state management for better user interaction flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->