### PR TITLE
fix: Close autocomplete when Enter pressed with no 'add' option available

### DIFF
--- a/src/renderer/components/_atoms/graphical-editor/autocomplete/index.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/autocomplete/index.tsx
@@ -128,6 +128,9 @@ export const GraphicalEditorAutocomplete = forwardRef<HTMLDivElement, GraphicalE
             const addVariableOption = selectableValues.find((item) => item.type === 'add')
             if (addVariableOption) {
               submitAutocompletion({ variable: addVariableOption.variable })
+            } else {
+              // No 'add' option available; close the autocomplete to provide clear feedback
+              closeModal()
             }
           } else {
             submitAutocompletion({


### PR DESCRIPTION
## Summary
Addresses Copilot review feedback from PR #133 (openplc-web) - applies the same fix to openplc-editor for consistency.

When Enter is pressed with nothing selected and `canCreateNewVariable` is false, the autocomplete now closes to provide clear feedback instead of doing nothing.

## Changes
- Added else clause to close the modal when no 'add' option is available in the autocomplete

## Test plan
- [ ] Open autocomplete in a context where `canCreateNewVariable` is false
- [ ] Press Enter without selecting anything
- [ ] Verify the autocomplete closes instead of staying open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Autocomplete modal now properly closes when pressing Enter/Tab with no item selected and no variable option available, providing clearer feedback to users instead of remaining open.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->