### PR TITLE
fix: Allow custom data types in FBD variable nodes

### DIFF
--- a/src/renderer/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
@@ -85,14 +85,12 @@ const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProp
           return {
             values: restrictions.values.length > 0 ? restrictions.values : undefined,
             definition: restrictions.definition.length > 0 ? restrictions.definition : undefined,
-            limitations: ['derived'],
           }
         }
         default:
           return {
             values: undefined,
             definition: undefined,
-            limitations: undefined,
           }
       }
     }, [pou])
@@ -103,9 +101,7 @@ const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProp
             (variable) =>
               variable.name.toLowerCase().includes(valueToSearch.toLowerCase()) &&
               (variableRestrictions.values === undefined ||
-                variableRestrictions.values.includes(variable.type.value.toLowerCase())) &&
-              (variableRestrictions.limitations === undefined ||
-                !variableRestrictions.limitations.includes(variable.type.definition)),
+                variableRestrictions.values.includes(variable.type.value.toLowerCase())),
           )
           .sort((a, b) => {
             const aNumber = extractNumberAtEnd(a.name).number

--- a/src/renderer/components/_atoms/graphical-editor/fbd/utils/utils.ts
+++ b/src/renderer/components/_atoms/graphical-editor/fbd/utils/utils.ts
@@ -38,7 +38,15 @@ export const getFBDPouVariablesRungNodeAndEdges = (
         return undefined
       case 'comment':
         return undefined
+      case 'input-variable':
+      case 'output-variable':
+      case 'inout-variable':
+        // Variable nodes - allow all types including derived (user-defined types)
+        return (node.data as BasicNodeData).variable.name !== undefined
+          ? variable.name.toLowerCase() === (node.data as BasicNodeData).variable.name.toLowerCase()
+          : variable.name === data.variableName
       default:
+        // Other node types - only allow base types (not derived/user-defined)
         return (
           ((node.data as BasicNodeData).variable.name !== undefined
             ? variable.name.toLowerCase() === (node.data as BasicNodeData).variable.name.toLowerCase()

--- a/src/renderer/components/_atoms/graphical-editor/fbd/variable.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/fbd/variable.tsx
@@ -19,7 +19,7 @@ import { HighlightedTextArea } from '../../highlighted-textarea'
 import { Label } from '../../label'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../tooltip'
 import { BlockVariant } from '../types/block'
-import { getVariableByName, validateVariableType } from '../utils'
+import { validateVariableType } from '../utils'
 import { FBDBlockAutoComplete } from './autocomplete'
 import { BlockNode } from './block'
 import { buildHandle, CustomHandle } from './handle'
@@ -323,9 +323,10 @@ const VariableElement = (block: VariableProps) => {
     if (!pou || !rung || !node) return
     const variableNode = node as VariableNode
 
-    let variable: PLCVariable | { name: string } | undefined = getVariableByName(
-      pou.data.variables as PLCVariable[],
-      variableNameToSubmit,
+    // For variable nodes, allow all types including derived (user-defined types)
+    // Don't use getVariableByName here as it filters out derived types
+    let variable: PLCVariable | { name: string } | undefined = (pou.data.variables as PLCVariable[]).find(
+      (v) => v.name.toLowerCase() === variableNameToSubmit.toLowerCase(),
     )
     if (!variable) {
       setIsAVariable(false)


### PR DESCRIPTION
## Summary
Applies the same custom data type fixes from LD (PR #514) to FBD variable nodes.

## Changes
1. **getFBDPouVariablesRungNodeAndEdges**: Added cases for `input-variable`, `output-variable`, `inout-variable` to allow derived/user-defined types in variable lookup
2. **FBD autocomplete**: Removed `limitations: ['derived']` from variable restrictions to allow custom types in the dropdown
3. **FBD variable.tsx**: Replaced `getVariableByName` with direct lookup that allows derived types

## Test plan
- [ ] Create a custom data type (struct, enum, etc.)
- [ ] Open FBD editor and add a block that expects the custom data type
- [ ] Add an input/output variable node and connect it to the block
- [ ] Type a variable name and press Enter to create a new variable
- [ ] Verify the variable is created with the correct custom type
- [ ] Verify the variable name is not shown in red/yellow (validation passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Derived and user-defined type variables now appear in FBD graphical editor autocomplete for input/output/inout variable nodes.
  * Variable name matching is case-insensitive for more reliable lookup across the editor.

* **Bug Fixes**
  * Autocomplete filtering no longer incorrectly excludes valid variables for those variable node types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->