### PR TITLE
fix: Close autocomplete when Enter pressed with no 'add' option avail…

### DIFF
--- a/src/renderer/components/_atoms/graphical-editor/autocomplete/index.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/autocomplete/index.tsx
@@ -128,6 +128,9 @@ export const GraphicalEditorAutocomplete = forwardRef<HTMLDivElement, GraphicalE
             const addVariableOption = selectableValues.find((item) => item.type === 'add')
             if (addVariableOption) {
               submitAutocompletion({ variable: addVariableOption.variable })
+            } else {
+              // No 'add' option available; close the autocomplete to provide clear feedback
+              closeModal()
             }
           } else {
             submitAutocompletion({


### PR DESCRIPTION
When Enter is pressed with nothing selected and canCreateNewVariable is false, close the modal to provide clear feedback instead of doing nothing.

# Pull request info

## References

### If applicable substitute the issue reference to the one that this PR refers

This PR resolve the *#issue_number*.

### Link to Jira task

*[jira task](link to jira)*

## Description of the changes proposed

- ...
- ...

## DOD checklist

- [ ] The code is complete and according to developers’ standards.
- [ ] I have performed a self-review of my code.
- [ ] Meet the acceptance criteria.
- [ ] Unit tests are written and green.
- [ ] Test coverage: __ %.
- [ ] Integration tests are written and green.
- [ ] Changes were communicated and updated in the ticket description.
- [ ] Reviewed and accepted by the Product Owner.
- [ ] End-to-end test are successful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved autocomplete functionality - the autocomplete menu now properly closes when users press Enter or Tab without selecting an available option, providing clearer visual feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->