### PR TITLE
feat: Persist debug variable flags and compileOnly setting

### DIFF
--- a/src/renderer/components/_features/[workspace]/editor/device/configuration/board.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/configuration/board.tsx
@@ -23,7 +23,9 @@ const STATS_POLL_INTERVAL_MS = 2500
 
 const Board = memo(function () {
   const {
-    deviceDefinitions: { compileOnly },
+    deviceDefinitions: {
+      configuration: { compileOnly },
+    },
     deviceAvailableOptions: { availableBoards },
     project: {
       data: { pous, servers, remoteDevices },

--- a/src/renderer/components/_molecules/global-variables-table/selectable-cell.tsx
+++ b/src/renderer/components/_molecules/global-variables-table/selectable-cell.tsx
@@ -415,13 +415,14 @@ const SelectableClassCell = ({
 }
 
 const SelectableDebugCell = ({ getValue, row: { index }, column: { id }, table }: ISelectableCellProps) => {
-  const initialValue = getValue<boolean>()
+  const initialValue = getValue<boolean | undefined>() ?? false
 
   const [cellValue, setCellValue] = useState(initialValue)
 
   const onClick = () => {
-    setCellValue(!cellValue)
-    table.options.meta?.updateData(index, id, !cellValue)
+    const newValue = !cellValue
+    setCellValue(newValue)
+    table.options.meta?.updateData(index, id, newValue)
   }
 
   useEffect(() => {

--- a/src/renderer/hooks/use-store-selectors.ts
+++ b/src/renderer/hooks/use-store-selectors.ts
@@ -53,7 +53,7 @@ const deviceSelectors = {
 }
 
 const compileOnlySelectors = {
-  useCompileOnly: () => useOpenPLCStore((state) => state.deviceDefinitions.compileOnly),
+  useCompileOnly: () => useOpenPLCStore((state) => state.deviceDefinitions.configuration.compileOnly),
   useSetCompileOnly: () => useOpenPLCStore((state) => state.deviceActions.setCompileOnly),
 }
 

--- a/src/renderer/store/slices/device/data/constants.ts
+++ b/src/renderer/store/slices/device/data/constants.ts
@@ -5,6 +5,7 @@ export const defaultDeviceConfiguration: DeviceConfiguration = {
   deviceBoard: 'OpenPLC Runtime v3',
   communicationPort: '',
   runtimeIpAddress: '',
+  compileOnly: false,
   communicationConfiguration: {
     modbusRTU: {
       rtuInterface: 'Serial',

--- a/src/renderer/store/slices/device/slice.ts
+++ b/src/renderer/store/slices/device/slice.ts
@@ -26,7 +26,6 @@ const createDeviceSlice: StateCreator<DeviceSlice, [], [], DeviceSlice> = (setSt
       pins: [],
       currentSelectedPinTableRow: -1,
     },
-    compileOnly: true, // This flag indicates if the device is set to compile only (no deployment)
   },
   deviceUpdated: {
     updated: false,
@@ -73,7 +72,6 @@ const createDeviceSlice: StateCreator<DeviceSlice, [], [], DeviceSlice> = (setSt
             pins: [],
             currentSelectedPinTableRow: -1,
           }
-          deviceDefinitions.compileOnly = true
         }),
       )
     },
@@ -439,7 +437,7 @@ const createDeviceSlice: StateCreator<DeviceSlice, [], [], DeviceSlice> = (setSt
       setState(
         produce(({ deviceDefinitions, deviceUpdated }: DeviceSlice) => {
           deviceUpdated.updated = true
-          deviceDefinitions.compileOnly = compileOnly
+          deviceDefinitions.configuration.compileOnly = compileOnly
         }),
       )
     },
@@ -496,6 +494,7 @@ function mergeDeviceConfigWithDefaults(
   return {
     deviceBoard: provided.deviceBoard || defaults.deviceBoard,
     communicationPort: provided.communicationPort ?? defaults.communicationPort,
+    compileOnly: provided.compileOnly ?? defaults.compileOnly,
     communicationConfiguration: {
       modbusRTU: {
         ...defaults.communicationConfiguration.modbusRTU,

--- a/src/renderer/store/slices/device/types.ts
+++ b/src/renderer/store/slices/device/types.ts
@@ -106,7 +106,6 @@ const deviceStateSchema = z.object({
   deviceDefinitions: z.object({
     configuration: deviceConfigurationSchema,
     pinMapping: devicePinMappingSchema,
-    compileOnly: z.boolean().default(true),
     temporaryDhcpIp: z.string().optional(),
   }),
   deviceUpdated: z.object({

--- a/src/types/PLC/devices/configuration.ts
+++ b/src/types/PLC/devices/configuration.ts
@@ -19,6 +19,7 @@ const deviceConfigurationSchema = z.object({
   deviceBoard: z.string(),
   communicationPort: z.string(),
   runtimeIpAddress: z.string().optional(),
+  compileOnly: z.boolean().default(false),
   communicationConfiguration: z.object({
     modbusRTU: z.object({
       rtuInterface: z.enum(interfaceOptions), // This will be an enumerated that will be associated with the device board selected - Validation will be added further.

--- a/src/types/PLC/open-plc.ts
+++ b/src/types/PLC/open-plc.ts
@@ -154,7 +154,7 @@ const PLCVariableSchema = z.object({
   location: z.string(),
   initialValue: z.string().or(z.null()).optional(),
   documentation: z.string(),
-  debug: z.boolean(),
+  debug: z.boolean().optional(),
 })
 
 type PLCVariable = z.infer<typeof PLCVariableSchema>
@@ -360,12 +360,27 @@ const PLCRemoteDeviceSchema = z.object({
 })
 type PLCRemoteDevice = z.infer<typeof PLCRemoteDeviceSchema>
 
+/**
+ * Schema for storing debug variable flags.
+ * Since POU variables are saved as text files (IEC 61131-3 format) which don't support debug flags,
+ * we store the debug flags separately in project.json.
+ */
+const PLCDebugVariablesSchema = z
+  .object({
+    global: z.array(z.string()).optional(),
+    pous: z.record(z.string(), z.array(z.string())).optional(),
+  })
+  .optional()
+
+type PLCDebugVariables = z.infer<typeof PLCDebugVariablesSchema>
+
 const PLCProjectDataSchema = z.object({
   dataTypes: z.array(PLCDataTypeSchema),
   pous: z.array(PLCPouSchema),
   configuration: PLCConfigurationSchema,
   servers: z.array(PLCServerSchema).optional(),
   remoteDevices: z.array(PLCRemoteDeviceSchema).optional(),
+  debugVariables: PLCDebugVariablesSchema,
   deletedPous: z
     .array(
       z.object({
@@ -421,6 +436,7 @@ export {
   PLCArrayDatatypeSchema,
   PLCConfigurationSchema,
   PLCDataTypeSchema,
+  PLCDebugVariablesSchema,
   PLCEnumeratedDatatypeSchema,
   PLCFunctionBlockSchema,
   PLCFunctionSchema,
@@ -454,6 +470,7 @@ export type {
   PLCArrayDatatype,
   PLCConfiguration,
   PLCDataType,
+  PLCDebugVariables,
   PLCEnumeratedDatatype,
   PLCFunction,
   PLCFunctionBlock,


### PR DESCRIPTION
## Summary
- Add `debugVariables` schema to store debug flags for all variables (global and POU) in `project.json`
- Move `compileOnly` setting to device configuration for persistence, defaulting to `false`
- Restore debug flags when loading a project, gracefully skipping deleted variables

## Details

Since POU variables are saved as text files (IEC 61131-3 format) which don't support debug flags, we store them separately in `project.json` under `debugVariables`:

```json
{
  "debugVariables": {
    "global": ["varName1", "varName2"],
    "pous": {
      "main": ["localVar1", "counter"],
      "myFunction": ["inputParam"]
    }
  }
}
```

## Test plan
- [ ] Create a new project and verify `compileOnly` defaults to unchecked
- [ ] Check `compileOnly`, save project, close, reopen - verify setting persists
- [ ] Mark global variables for debug, save project, close, reopen - verify debug icons persist
- [ ] Mark POU variables for debug, save project, close, reopen - verify debug icons persist
- [ ] Delete a variable that has debug enabled, save, reopen - verify no errors occur

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Debug variable settings for global and POU variables are now persisted and restored when saving and opening projects, ensuring your debug configurations survive project serialization.

* **Bug Fixes**
  * Improved handling of optional debug values and cell state synchronization to prevent data inconsistencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->