### PR TITLE
fix: Preserve runtimeIpAddress in device config merge

### DIFF
--- a/src/renderer/store/slices/device/slice.ts
+++ b/src/renderer/store/slices/device/slice.ts
@@ -492,8 +492,9 @@ function mergeDeviceConfigWithDefaults(
   defaults: DeviceConfiguration,
 ): DeviceConfiguration {
   return {
-    deviceBoard: provided.deviceBoard || defaults.deviceBoard,
+    deviceBoard: provided.deviceBoard ?? defaults.deviceBoard,
     communicationPort: provided.communicationPort ?? defaults.communicationPort,
+    runtimeIpAddress: provided.runtimeIpAddress ?? defaults.runtimeIpAddress,
     compileOnly: provided.compileOnly ?? defaults.compileOnly,
     communicationConfiguration: {
       modbusRTU: {


### PR DESCRIPTION
## Summary
- Add missing `runtimeIpAddress` field to `mergeDeviceConfigWithDefaults` function
- Prevents losing runtime IP configuration when merging device configs
- Use nullish coalescing (`??`) for `deviceBoard` for consistency with other fields

This addresses the CodeRabbit review comment on PR #523.

## Test plan
- [ ] Set a runtime IP address in device configuration
- [ ] Save and reload the project
- [ ] Verify runtime IP address is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of device configuration defaults to ensure all device settings are properly applied.

* **New Features**
  * Added support for runtime IP address configuration in device settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->