### PR TITLE
fix: Resolve keyboard navigation for Add Variable in Ladder editor

### DIFF
--- a/src/renderer/components/_atoms/graphical-editor/autocomplete/index.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/autocomplete/index.tsx
@@ -92,8 +92,25 @@ export const GraphicalEditorAutocomplete = forwardRef<HTMLDivElement, GraphicalE
         },
         isFocused: autocompleteFocus,
         selectedVariable: selectedVariable,
+        /**
+         * Synchronously triggers the submit action.
+         * Used by parent components to bypass the async keyPressed → keyDown useEffect chain
+         * which can cause race conditions when the autocomplete unmounts on blur.
+         */
+        triggerSubmit: () => {
+          if (selectedVariable.positionInArray === -1) {
+            const addVariableOption = selectableValues.find((item) => item.type === 'add')
+            if (addVariableOption) {
+              submitAutocompletion({ variable: addVariableOption.variable })
+            } else {
+              closeModal()
+            }
+          } else {
+            submitAutocompletion({ variable: selectedVariable.variable })
+          }
+        },
       }
-    }, [selectedVariable, popoverRef, autocompleteFocus])
+    }, [selectedVariable, selectableValues, popoverRef, autocompleteFocus])
 
     useEffect(() => {
       switch (keyDown) {

--- a/src/renderer/components/_atoms/graphical-editor/ladder/coil.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/ladder/coil.tsx
@@ -196,6 +196,7 @@ export const Coil = (block: CoilProps) => {
       focus: () => void
       isFocused: boolean
       selectedVariable: { positionInArray: number; variableName: string }
+      triggerSubmit?: () => void
     }
   >(null)
 
@@ -487,8 +488,13 @@ export const Coil = (block: CoilProps) => {
             onChange={onChangeHandler}
             onKeyDown={(e) => {
               if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Tab') e.preventDefault()
-              if (e.key === 'Enter' && autocompleteRef.current?.selectedVariable.positionInArray !== -1) {
+              if (e.key === 'Enter' && openAutocomplete) {
+                e.preventDefault()
+                // Call triggerSubmit synchronously before blur to avoid race condition
+                // where autocomplete unmounts before processing the Enter key
+                autocompleteRef.current?.triggerSubmit?.()
                 inputVariableRef.current?.blur({ submit: false })
+                return
               }
               setKeyPressedAtTextarea(e.key)
             }}

--- a/src/renderer/components/_atoms/graphical-editor/ladder/contact.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/ladder/contact.tsx
@@ -163,6 +163,7 @@ export const Contact = (block: ContactProps) => {
       focus: () => void
       isFocused: boolean
       selectedVariable: { positionInArray: number; variableName: string }
+      triggerSubmit?: () => void
     }
   >(null)
 
@@ -457,8 +458,13 @@ export const Contact = (block: ContactProps) => {
             onChange={onChangeHandler}
             onKeyDown={(e) => {
               if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Tab') e.preventDefault()
-              if (e.key === 'Enter' && autocompleteRef.current?.selectedVariable.positionInArray !== -1) {
+              if (e.key === 'Enter' && openAutocomplete) {
+                e.preventDefault()
+                // Call triggerSubmit synchronously before blur to avoid race condition
+                // where autocomplete unmounts before processing the Enter key
+                autocompleteRef.current?.triggerSubmit?.()
                 inputVariableRef.current?.blur({ submit: false })
+                return
               }
               setKeyPressedAtTextarea(e.key)
             }}

--- a/src/renderer/components/_atoms/graphical-editor/ladder/variable.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/ladder/variable.tsx
@@ -78,6 +78,7 @@ const VariableElement = (block: VariableProps) => {
       focus: () => void
       isFocused: boolean
       selectedVariable: { positionInArray: number; variableName: string }
+      triggerSubmit?: () => void
     }
   >(null)
 
@@ -488,8 +489,13 @@ const VariableElement = (block: VariableProps) => {
           onChange={onChangeHandler}
           onKeyDown={(e) => {
             if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Tab') e.preventDefault()
-            if (e.key === 'Enter' && (autocompleteRef.current?.selectedVariable?.positionInArray ?? -1) !== -1) {
+            if (e.key === 'Enter' && openAutocomplete) {
+              e.preventDefault()
+              // Call triggerSubmit synchronously before blur to avoid race condition
+              // where autocomplete unmounts before processing the Enter key
+              autocompleteRef.current?.triggerSubmit?.()
               inputVariableRef.current?.blur({ submit: false })
+              return
             }
             setKeyPressedAtTextarea(e.key)
           }}


### PR DESCRIPTION
## Summary
- Fixed race condition in Ladder editor autocomplete where "Add variable" option was not working when selected via keyboard navigation (arrow keys + Enter)
- Added `triggerSubmit()` method to autocomplete ref for synchronous submission
- Updated Ladder components (variable, contact, coil) to call `triggerSubmit()` directly on Enter key press

## Root Cause
The autocomplete component would unmount (due to `onFocusOutside` triggering `closeModal`) before the async useEffect chain could process the Enter key press. This caused the variable creation to never execute.

## Solution
Instead of relying on the async `keyPressed` prop → `keyDown` state → useEffect chain (which takes 2 render cycles), the parent components now call `triggerSubmit()` synchronously before the blur occurs, ensuring the submit action completes before any unmount.

## Test plan
- [ ] Open Ladder editor
- [ ] Add a contact, coil, or variable block
- [ ] Type a new variable name in the input field
- [ ] Use arrow keys to navigate to "Add variable" option
- [ ] Press Enter
- [ ] Verify the variable is created and assigned to the block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autocomplete behavior in the graphical editor when pressing Enter, resolving potential race conditions during variable submission.
  * Enhanced keyboard navigation by refining the trigger conditions for autocomplete submission across editor components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->