### PR TITLE
fix: Enable force values for non-boolean types in debugger

### DIFF
--- a/src/renderer/components/_molecules/variables-panel/index.tsx
+++ b/src/renderer/components/_molecules/variables-panel/index.tsx
@@ -67,6 +67,11 @@ const VariablesPanel = ({
   } | null>(null)
   const [forceValueModalOpen, setForceValueModalOpen] = useState<boolean>(false)
   const [forceValue, setForceValue] = useState<string>('')
+  const [pendingForceContext, setPendingForceContext] = useState<{
+    compositeKey: string
+    lookupKey: string
+    variableType: string
+  } | null>(null)
 
   const getValue = (compositeKey: string): string | undefined => {
     return debugVariableValues?.get(compositeKey)
@@ -194,24 +199,35 @@ const VariablesPanel = ({
     (e: React.MouseEvent) => {
       e.preventDefault()
       e.stopPropagation()
+      // Save context before popover closes (popover auto-closes on click)
+      if (contextMenuState) {
+        setPendingForceContext({
+          compositeKey: contextMenuState.compositeKey,
+          lookupKey: contextMenuState.lookupKey,
+          variableType: contextMenuState.variableType,
+        })
+      }
       setForceValueModalOpen(true)
-      handleCloseContextMenu()
     },
-    [handleCloseContextMenu],
+    [contextMenuState],
   )
 
   const handleForceValueConfirm = useCallback(() => {
-    if (!contextMenuState || !forceValue.trim() || !onForceVariable) {
+    const closeModal = () => {
       setForceValueModalOpen(false)
       setForceValue('')
+      setPendingForceContext(null)
+    }
+
+    if (!pendingForceContext || !forceValue.trim() || !onForceVariable) {
+      closeModal()
       return
     }
 
-    const variableType = contextMenuState.variableType
+    const variableType = pendingForceContext.variableType
     const typeInfo = getVariableTypeInfo(variableType)
     if (!typeInfo) {
-      setForceValueModalOpen(false)
-      setForceValue('')
+      closeModal()
       return
     }
 
@@ -225,8 +241,7 @@ const VariablesPanel = ({
     if (isStringType) {
       const parsedStringValue: string | null = parseStringValue(forceValue)
       if (parsedStringValue === null) {
-        setForceValueModalOpen(false)
-        setForceValue('')
+        closeModal()
         return
       }
       valueBuffer = stringToBuffer(parsedStringValue)
@@ -234,8 +249,7 @@ const VariablesPanel = ({
     } else if (isFloatType) {
       const parsedFloatValue = parseFloatValue(forceValue, typeInfo.byteSize)
       if (parsedFloatValue === null) {
-        setForceValueModalOpen(false)
-        setForceValue('')
+        closeModal()
         return
       }
       valueBuffer = floatToBuffer(parsedFloatValue, typeInfo.byteSize)
@@ -243,8 +257,7 @@ const VariablesPanel = ({
     } else {
       const parsedIntValue = parseIntegerValue(forceValue, typeInfo)
       if (parsedIntValue === null) {
-        setForceValueModalOpen(false)
-        setForceValue('')
+        closeModal()
         return
       }
       valueBuffer = integerToBuffer(parsedIntValue, typeInfo.byteSize, typeInfo.signed)
@@ -252,26 +265,27 @@ const VariablesPanel = ({
     }
 
     void onForceVariable(
-      contextMenuState.compositeKey,
+      pendingForceContext.compositeKey,
       variableType,
       forcedValueForState,
       valueBuffer,
-      contextMenuState.lookupKey,
+      pendingForceContext.lookupKey,
     )
 
-    setForceValueModalOpen(false)
-    setForceValue('')
-  }, [contextMenuState, forceValue, onForceVariable])
+    closeModal()
+  }, [pendingForceContext, forceValue, onForceVariable])
 
   const handleForceValueCancel = useCallback(() => {
     setForceValueModalOpen(false)
     setForceValue('')
+    setPendingForceContext(null)
   }, [])
 
   const handleForceValueModalChange = useCallback((open: boolean) => {
     setForceValueModalOpen(open)
     if (!open) {
       setForceValue('')
+      setPendingForceContext(null)
     }
   }, [])
 
@@ -457,7 +471,7 @@ const VariablesPanel = ({
           <ModalTitle className='mb-4 text-lg font-semibold'>Force Value</ModalTitle>
 
           <p className='mb-6 text-center text-sm text-neutral-600 dark:text-neutral-400'>
-            Enter the value to force for {contextMenuState?.compositeKey.split(':')[1] || 'this variable'}
+            Enter the value to force for {pendingForceContext?.compositeKey.split(':')[1] || 'this variable'}
           </p>
 
           <div className='flex w-full flex-col gap-4'>

--- a/src/renderer/screens/workspace-screen.tsx
+++ b/src/renderer/screens/workspace-screen.tsx
@@ -1555,7 +1555,8 @@ const WorkspaceScreen = () => {
     const variableIndex = debugVariableIndexes.get(keyForIndexLookup)
     if (variableIndex === undefined) return
 
-    if (value === undefined) {
+    if (value === undefined && valueBuffer === undefined) {
+      // Release force
       const result = await window.bridge.debuggerSetVariable(variableIndex, false)
       if (result.success) {
         const newForcedVariables = new Map(Array.from(debugForcedVariables))
@@ -1563,11 +1564,12 @@ const WorkspaceScreen = () => {
         setDebugForcedVariables(newForcedVariables)
       }
     } else {
-      const buffer = valueBuffer || new Uint8Array([value ? 1 : 0])
+      // Set force - use valueBuffer for non-boolean types, fallback to boolean conversion
+      const buffer = valueBuffer ?? new Uint8Array([value ? 1 : 0])
       const result = await window.bridge.debuggerSetVariable(variableIndex, true, buffer)
       if (result.success) {
         const newForcedVariables = new Map(Array.from(debugForcedVariables))
-        newForcedVariables.set(compositeKey, value)
+        newForcedVariables.set(compositeKey, value ?? true)
         setDebugForcedVariables(newForcedVariables)
       }
     }


### PR DESCRIPTION
## Summary
- Fixed force value functionality not working for integer, float, and string types in the debugger's VariablesPanel
- The Popover component was auto-closing on click, clearing `contextMenuState` before `handleForceValueConfirm` could use it
- Added `pendingForceContext` state to preserve the context when opening the force value modal
- Fixed condition in `handleForceVariable` that incorrectly triggered release force when `valueBuffer` was provided

## Test plan
- [ ] Start the debugger and connect to a PLC runtime
- [ ] In the Debugger tab, right-click on an INT variable and select "Force Value"
- [ ] Enter an integer value and confirm
- [ ] Verify the value is forced correctly
- [ ] Test with REAL/LREAL (float) types
- [ ] Test with STRING types
- [ ] Verify boolean Force True/False still works
- [ ] Verify Release Force works for all types

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Force Value modal state management for more reliable opening, closing, and cancellation.
  * Modal now correctly displays variable names when forcing values.
  * Improved variable forcing logic for proper buffer handling and release conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->