### PR TITLE
fix: Python blocks with no input variables don't work

### DIFF
--- a/src/utils/python/generateSTCode.ts
+++ b/src/utils/python/generateSTCode.ts
@@ -41,6 +41,13 @@ const generateCStructs = (inputVars: PLCVariable[], outputVars: PLCVariable[]): 
     inputVars.forEach((variable) => {
       structs += `        ${mapTypeToC(variable.type)} ${variable.name};\n`
     })
+  } else {
+    // Padding field ensures sizeof() >= 1, preventing mmap() failure with size 0.
+    // This allows Python blocks with only output variables (no inputs) to work.
+    // TODO: A more robust fix would also add handling in the runtime's python_loader.c
+    // to gracefully handle size 0 by either skipping shared memory allocation entirely
+    // or using a minimum size of 1 byte when shm_in_size or shm_out_size is 0.
+    structs += '        uint8_t _padding;\n'
   }
   structs += '    } shm_data_in_t;\n'
   structs += '    #pragma pack(pop)\n\n'
@@ -52,6 +59,10 @@ const generateCStructs = (inputVars: PLCVariable[], outputVars: PLCVariable[]): 
     outputVars.forEach((variable) => {
       structs += `        ${mapTypeToC(variable.type)} ${variable.name};\n`
     })
+  } else {
+    // Padding field ensures sizeof() >= 1, preventing mmap() failure with size 0.
+    // This allows Python blocks with only input variables (no outputs) to work.
+    structs += '        uint8_t _padding;\n'
   }
   structs += '    } shm_data_out_t;\n'
 


### PR DESCRIPTION
## Summary

- Fixes issue where Python blocks with only output variables (no input variables) caused runtime shared memory errors
- Added padding field to empty C structs to ensure `sizeof() >= 1`, preventing `mmap()` failure with size 0

## Root Cause

When a Python block has no input variables, the generated C struct was empty:
```c
typedef struct {
    // Empty - no fields!
} shm_data_in_t;
```

This caused `sizeof(shm_data_in_t) = 0`, which then failed in the runtime's `python_loader.c` when calling `mmap(NULL, 0, ...)` since POSIX does not allow mapping 0 bytes.

## Solution

Added a `uint8_t _padding` field to empty structs:
```c
typedef struct {
    uint8_t _padding;  // Ensures sizeof() >= 1
} shm_data_in_t;
```

The padding byte exists in shared memory but is never read or written. The Python side still uses format string `'='` which expects 0 bytes, and this works correctly.

## Test plan

- [ ] Create a Python block with only output variables (no inputs)
- [ ] Compile and run the program
- [ ] Verify no shared memory errors occur
- [ ] Verify output variables are correctly written

Closes #511

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code generation failures that occurred when there were no input or output variables, preventing potential runtime errors in data structure initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->