### PR TITLE
feat: Replace SHA-256 with bcrypt for OPC-UA user password hashing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@tanstack/react-table": "^8.10.7",
         "@xyflow/react": "^12.0.1",
         "auto-zustand-selectors-hook": "^2.0.0",
+        "bcryptjs": "^3.0.3",
         "clsx": "^2.0.0",
         "cva": "npm:class-variance-authority@^0.7.0",
         "dompurify": "^3.2.4",
@@ -11660,6 +11661,14 @@
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/big.js": {
       "version": "5.2.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@tanstack/react-table": "^8.10.7",
     "@xyflow/react": "^12.0.1",
     "auto-zustand-selectors-hook": "^2.0.0",
+    "bcryptjs": "^3.0.3",
     "clsx": "^2.0.0",
     "cva": "npm:class-variance-authority@^0.7.0",
     "dompurify": "^3.2.4",

--- a/src/renderer/components/_features/[workspace]/editor/server/opcua-server/components/user-modal.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/server/opcua-server/components/user-modal.tsx
@@ -4,6 +4,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger } from '@root/renderer
 import { Modal, ModalContent, ModalFooter, ModalHeader, ModalTitle } from '@root/renderer/components/_molecules/modal'
 import type { OpcUaTrustedCertificate, OpcUaUser } from '@root/types/PLC/open-plc'
 import { cn } from '@root/utils'
+import * as bcrypt from 'bcryptjs'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -29,14 +30,11 @@ const ROLE_OPTIONS: { value: UserRole; label: string; description: string }[] = 
   { value: 'engineer', label: 'Engineer', description: 'Full administrative access' },
 ]
 
-// Simple password hashing using SHA-256 (Web Crypto API)
-// Note: For production, consider using bcrypt or similar
+// Password hashing using bcrypt with cost factor 10
+const BCRYPT_SALT_ROUNDS = 10
+
 const hashPassword = async (password: string): Promise<string> => {
-  const encoder = new TextEncoder()
-  const data = encoder.encode(password)
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
-  const hashArray = Array.from(new Uint8Array(hashBuffer))
-  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+  return bcrypt.hash(password, BCRYPT_SALT_ROUNDS)
 }
 
 export const UserModal = ({


### PR DESCRIPTION
## Summary
- Replace SHA-256 password hashing with bcrypt for OPC-UA user authentication
- Add bcryptjs library as dependency with cost factor 10 for secure hashing
- Improves security against brute-force attacks through bcrypt's adaptive cost factor

## Test plan
- [x] Verify user creation in OPC-UA server configuration works correctly
- [x] Confirm password hashing produces valid bcrypt hashes
- [x] Test authentication with newly created users

🤖 Generated with [Claude Code](https://claude.com/claude-code)