### PR TITLE
fix: Allow custom pin names in device configuration

### DIFF
--- a/src/renderer/store/slices/device/validation/pins.ts
+++ b/src/renderer/store/slices/device/validation/pins.ts
@@ -229,7 +229,8 @@ const checkIfPinExists = (pinMap: DevicePin[], name: string) => {
 }
 
 const pinValidation = (name: string) => {
-  const regex = /^(?:\d+|[A-Za-z]+(?:_\d+|_[A-Za-z]+)*|[A-Za-z]+\d*(?:_[A-Za-z]+\d*)*)$/
+  // Allow alphanumeric characters, underscores, and dots. Block spaces, hyphens, and special characters.
+  const regex = /^[A-Za-z0-9_.]+$/
   return regex.test(name)
 }
 
@@ -246,7 +247,7 @@ const checkIfPinIsValid = (pinMap: DevicePin[], name: string | undefined) => {
     return {
       ok: false,
       title: 'Invalid Pin',
-      message: 'Pin must be alphanumeric or use underscores.',
+      message: 'Pin must contain only letters, numbers, underscores, or dots.',
     }
   }
 

--- a/src/types/PLC/devices/pin.ts
+++ b/src/types/PLC/devices/pin.ts
@@ -16,7 +16,7 @@ type PinTypes = (typeof pinTypes)[number]
  *    - Following the prefix, the address must have a integer number starting with 0
  */
 const devicePinSchema = z.object({
-  pin: z.string().max(6),
+  pin: z.string().min(1),
   pinType: z.enum(pinTypes),
   address: z.string(),
   name: z.string().optional(),


### PR DESCRIPTION
## Summary

- Remove the overly restrictive `max(6)` character limit on pin names in the Zod schema
- Simplify the pin validation regex to allow alphanumeric characters, underscores, and dots
- Update the error message to reflect the new validation rules

This fixes an issue where custom pins (like `BTN_USER` for Arduino Opta) were accepted in the UI but rejected during project save with the error "The device pin mapping data is not valid."

## Root Cause

The Zod schema in `pin.ts` had a `.max(6)` constraint, but the runtime validation in `pins.ts` used a regex with no length limit. This caused a mismatch where the UI accepted longer pin names but the save validation rejected them.

## Test plan

- [x] Existing unit tests pass (50/50)
- [x] Linting passes
- [ ] Manual test: Add a custom pin like `BTN_USER` to Arduino Opta device configuration
- [ ] Manual test: Save the project and verify it succeeds without validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed the 6-character limit on pin names, allowing longer identifiers.
  * Pin names can now include dots in addition to letters, numbers, and underscores.
  * Improved validation error messages to clearly specify allowed characters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->