### PR TITLE
fix: Handle Python LSP errors and disable buggy findDefinition feature

### DIFF
--- a/src/renderer/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/monaco/index.tsx
@@ -533,7 +533,9 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
 
     if (language === 'python' && pou) {
       injectPythonTemplateIfNeeded(editorInstance, pou, name)
-      void initPythonLSP(monacoInstance).then(() => setupPythonLSPForEditor(editorInstance))
+      initPythonLSP(monacoInstance)
+        .then(() => setupPythonLSPForEditor(editorInstance))
+        .catch((err) => console.warn('[Python LSP]', err.message))
     }
 
     if (language === 'cpp' && pou) {

--- a/src/renderer/components/_features/[workspace]/editor/monaco/python-lsp/index.ts
+++ b/src/renderer/components/_features/[workspace]/editor/monaco/python-lsp/index.ts
@@ -15,7 +15,7 @@ export async function initPythonLSP(monacoModule: typeof monaco): Promise<void> 
       signatureHelp: false,
       diagnostic: true,
       rename: false,
-      findDefinition: true,
+      findDefinition: false,
     },
     diagnosticsInterval: 1000,
   })


### PR DESCRIPTION
## Summary
- Add error handling (`.catch`) to Python LSP initialization to prevent uncaught exceptions from polluting the console
- Disable `findDefinition` feature which throws "Invalid result" errors due to a bug in `monaco-pyright-lsp` library (v0.1.7)

## Root Cause
The third-party library `monaco-pyright-lsp` has a bug in its `provideDefinition` method that throws `Error("Invalid result")` instead of returning `null` when the LSP server can't find a definition.

## Changes
| File | Change |
|------|--------|
| `src/renderer/.../monaco/index.tsx` | Added `.catch()` error handler to LSP initialization |
| `src/renderer/.../monaco/python-lsp/index.ts` | Disabled `findDefinition: false` |

## Impact
- Python autocomplete: ✅ Working
- Python hover: ✅ Working  
- Python diagnostics: ✅ Working
- Go to Definition (Ctrl+Click): ❌ Disabled (until library is fixed or migrated)

## Related
- Fixes [DOPE-154](https://autonomylogic.atlassian.net/browse/DOPE-154)
- Migration plan: [DOPE-155](https://autonomylogic.atlassian.net/browse/DOPE-155)

## Test plan
- [ ] Create a new Python function block
- [ ] Verify no "Invalid result" errors in console
- [ ] Verify autocomplete works
- [ ] Verify hover information displays
- [ ] Verify syntax diagnostics appear for invalid Python code

🤖 Generated with [Claude Code](https://claude.ai/code)

[DOPE-154]: https://autonomylogic.atlassian.net/browse/DOPE-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOPE-155]: https://autonomylogic.atlassian.net/browse/DOPE-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling when initializing Python language server features to improve stability
  * Disabled "Go to Definition" functionality in the Python editor

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->