### PR TITLE
fix: Show toast notification when variable creation fails in graphical editors

### DIFF
--- a/src/renderer/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
@@ -194,7 +194,14 @@ const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProp
         scope: 'local',
         associatedPou: editor.meta.name,
       })
-      if (!res.ok) return
+      if (!res.ok) {
+        toast({
+          title: res.title ?? 'Error',
+          description: res.message ?? 'Failed to create variable',
+          variant: 'fail',
+        })
+        return
+      }
 
       const variable = res.data as PLCVariable | undefined
 

--- a/src/renderer/components/_atoms/graphical-editor/ladder/autocomplete/index.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/ladder/autocomplete/index.tsx
@@ -1,3 +1,4 @@
+import { toast } from '@root/renderer/components/_features/[app]/toast/use-toast'
 import { useOpenPLCStore } from '@root/renderer/store'
 import { extractNumberAtEnd } from '@root/renderer/store/slices/project/validation/variables'
 import { PLCVariable } from '@root/types/PLC'
@@ -181,7 +182,14 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
         scope: 'local',
         associatedPou: editor.meta.name,
       })
-      if (!res.ok) return
+      if (!res.ok) {
+        toast({
+          title: res.title ?? 'Error',
+          description: res.message ?? 'Failed to create variable',
+          variant: 'fail',
+        })
+        return
+      }
 
       const variable = res.data as PLCVariable | undefined
 


### PR DESCRIPTION
## Summary
- Added toast notification feedback when variable creation fails in graphical editor autocomplete components
- Users now see an error message when attempting to create a variable with an invalid or empty name
- Applied to both FBD and Ladder autocomplete components

## Test plan
- [ ] Open a FBD or Ladder editor
- [ ] Add a variable block (e.g., input variable, contact, coil)
- [ ] Try to create a new variable without providing a name (leave empty and press Enter or click "Add variable")
- [ ] Verify that a toast notification appears with the error message
- [ ] Verify that creating a variable with a valid name still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced error handling in autocomplete components to display user-visible feedback when variable creation fails.
* Toast notifications now inform users of errors with descriptive messages when attempting to create variables.
* Applied to both FBD and Ladder editors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->