### PR TITLE
fix: Preserve debug property when switching variable declaration views

### DIFF
--- a/src/renderer/components/_organisms/variables-editor/index.tsx
+++ b/src/renderer/components/_organisms/variables-editor/index.tsx
@@ -771,10 +771,16 @@ const VariablesEditor = () => {
         typeChangedPairsToApply.push(pair)
       }
 
+      // Build a map of debug flags from existing variables
+      const debugByName = new Map(tableData.map((v) => [v.name.toLowerCase(), v.debug ?? false]))
+
+      // Preserve debug flags for renamed variables
+      for (const pair of renamedPairs) {
+        debugByName.set(pair.newName.toLowerCase(), pair.oldVariable.debug ?? false)
+      }
+
       const finalVariables = newVariables.map((newVar) => {
-        // Preserve debug property from existing variable if it exists
-        const existingVariable = tableData.find((v) => v.name.toLowerCase() === newVar.name.toLowerCase())
-        const debug = existingVariable?.debug ?? false
+        const debug = debugByName.get(newVar.name.toLowerCase()) ?? false
 
         const typeChangePair = typeChangedPairs.find((pair) => pair.name.toLowerCase() === newVar.name.toLowerCase())
 


### PR DESCRIPTION
## Summary

- Fixes a bug where debug variable selections were lost when switching between Text View and Table View in the variable declaration editor
- The IEC parser was defaulting all variables to `debug: false`, overwriting user selections
- Now preserves the `debug` property from existing variables by matching them by name

## Root Cause

When switching from Code View back to Table View, the `commitCode` function parses the IEC text using `parseIecStringToVariables()`, which creates new variable objects with `debug: false` hardcoded. The fix preserves the `debug` property from the existing `tableData` variables.

## Test Plan

- [ ] Open a POU in the editor
- [ ] In Table View, enable debug on one or more variables (click the debug icon)
- [ ] Switch to Text View (Code View)
- [ ] Switch back to Table View
- [ ] Verify the debug selections are preserved

Closes #542

**Jira:** [DOPE-156](https://autonomylogic.atlassian.net/browse/DOPE-156)

🤖 Generated with [Claude Code](https://claude.ai/code)

[DOPE-156]: https://autonomylogic.atlassian.net/browse/DOPE-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Variable debug flags are now preserved when updating configurations — including when variables are renamed or when type changes aren't applied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->