### PR TITLE
fix: Use PBKDF2 instead of bcrypt for OPC-UA password hashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@tanstack/react-table": "^8.10.7",
     "@xyflow/react": "^12.0.1",
     "auto-zustand-selectors-hook": "^2.0.0",
-    "bcryptjs": "^3.0.3",
     "clsx": "^2.0.0",
     "cva": "npm:class-variance-authority@^0.7.0",
     "dompurify": "^3.2.4",


### PR DESCRIPTION
## Summary

- Replace bcrypt with PBKDF2-HMAC-SHA256 for password hashing in OPC-UA user configuration
- Fix authentication failures on Windows/MSYS2 where Python's bcrypt module cannot be built
- Remove unused bcryptjs dependency

## Problem

On Windows/MSYS2, the OpenPLC Runtime cannot verify bcrypt password hashes because the Python `bcrypt` module fails to build. This causes OPC-UA username/password authentication to always fail with the error:

```
bcrypt hash detected but bcrypt not available. Re-hash password with PBKDF2 or install bcrypt.
```

## Solution

Use PBKDF2-HMAC-SHA256 (via Web Crypto API) instead of bcrypt for password hashing. The hash format matches what the runtime expects:

```
pbkdf2:sha256:600000$<base64_salt>$<base64_hash>
```

The runtime already supports both bcrypt and PBKDF2 verification, so:
- **Linux/macOS**: Can verify both old bcrypt hashes and new PBKDF2 hashes
- **Windows/MSYS2**: Can now verify PBKDF2 hashes (bcrypt was never working)

## Security

PBKDF2 with 600,000 iterations is:
- OWASP recommended for SHA-256
- NIST SP 800-132 approved
- Combined with runtime rate limiting (5 attempts, 5-minute lockout), provides adequate security for this use case

## Test plan

- [ ] Create a new OPC-UA user with password authentication in the editor
- [ ] Verify the `passwordHash` in project.json starts with `pbkdf2:sha256:600000$`
- [ ] Connect to the OPC-UA server using the credentials on Windows/MSYS2
- [ ] Verify authentication succeeds
- [ ] Test on Linux/macOS to ensure cross-platform compatibility

---
Generated with [Claude Code](https://claude.ai/code)