### PR TITLE
fix: include FBD variable node types in rename propagation

### DIFF
--- a/src/renderer/utils/variable-references.ts
+++ b/src/renderer/utils/variable-references.ts
@@ -196,7 +196,12 @@ function searchWithinPou(
         })
       }
 
-      if (node.type === 'variable') {
+      if (
+        node.type === 'variable' ||
+        node.type === 'input-variable' ||
+        node.type === 'output-variable' ||
+        node.type === 'inout-variable'
+      ) {
         const data = node.data as { variable?: PLCVariable | { name?: string } }
         if (data.variable?.name?.toLowerCase() === normalizedName) {
           references.push({


### PR DESCRIPTION
## Summary

- Fixes variable rename propagation not working in FBD editor
- The `findAllReferencesToVariable` function was only checking for `node.type === 'variable'`, which works for Ladder but not FBD
- FBD uses `'input-variable'`, `'output-variable'`, and `'inout-variable'` as node types
- Added these FBD-specific node types to the check

## Test plan

- [ ] Create a variable in a FBD POU
- [ ] Use the variable in a variable node (input, output, or inout)
- [ ] Rename the variable in the variables table
- [ ] Verify the confirmation dialog appears
- [ ] Click "Yes" and verify the variable name is updated in the FBD editor

Fixes #566

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced variable reference detection across ladder and FBD editors to identify additional types of variable references, improving the accuracy of reference tracking throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->