### PR TITLE
fix: use name-based lookup for FBD continuation autocomplete selection

### DIFF
--- a/src/renderer/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
@@ -247,9 +247,11 @@ const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProp
         return
       }
 
-      const selectedVariable =
-        filteredVariables.find((variableItem) => variableItem.id === variable.id) ??
-        filteredVariables.find((variableItem) => variableItem.name === variable.name)
+      // Look up by name to ensure correct selection for continuation/connector blocks
+      // (all connection nodes share the same ID, so ID lookup would always match the first item)
+      const selectedVariable = filteredVariables.find(
+        (variableItem) => variableItem.name.toLowerCase() === variable.name.toLowerCase(),
+      )
       if (!selectedVariable) {
         submitAddVariable({ variableName: valueToSearch })
         return


### PR DESCRIPTION
## Summary
- Fixes the bug where clicking on any continuation/connector autocomplete option always selected the first entry
- Changed from ID-based to name-based lookup, matching the ladder autocomplete pattern
- Root cause: all continuation/connector nodes share the same ID (`'connection'`), so `find()` by ID always returned the first match

## Root Cause Analysis
In `FBDBlockAutoComplete`, the `submit` function used ID-first lookup:
```tsx
filteredVariables.find((v) => v.id === variable.id) ?? filteredVariables.find((v) => v.name === variable.name)
```

Since connection nodes are built with `{ id: 'connection', name: label }`, ALL items had the same ID, causing the first `find()` to always match the first item in the array.

## Test plan
- [ ] Create multiple connectors with different names in FBD
- [ ] Create a continuation and open the autocomplete dropdown
- [ ] Click on any connector option (not the first one)
- [ ] Verify the clicked connector name is selected, not the first one

Fixes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable selection logic in the FBD graphical editor's autocomplete functionality. The editor now uses case-insensitive name-based matching to consistently identify and select the correct variables when working with continuation and connector blocks, providing more predictable and reliable behavior. Automatic variable creation remains available as a fallback option when no matching variable is identified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->