### PR TITLE
fix: resolve double scrollbar issue in OPC-UA Address Space tab

### DIFF
--- a/src/renderer/components/_features/[workspace]/editor/server/opcua-server/index.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/server/opcua-server/index.tsx
@@ -153,8 +153,11 @@ export const OpcUaServerEditor = () => {
         </Tabs.List>
 
         {/* General Settings Tab */}
-        <Tabs.Content value='general' className='flex-1 overflow-auto pt-4'>
-          <div className='pb-4'>
+        <Tabs.Content
+          value='general'
+          className='flex min-h-0 flex-1 flex-col overflow-hidden pt-4 data-[state=inactive]:hidden'
+        >
+          <div className='min-h-0 flex-1 overflow-auto pb-4'>
             <GeneralSettingsTab
               config={localConfig}
               onServerUpdate={handleServerSettingsUpdate}
@@ -164,8 +167,11 @@ export const OpcUaServerEditor = () => {
         </Tabs.Content>
 
         {/* Security Profiles Tab */}
-        <Tabs.Content value='security' className='flex-1 overflow-auto pt-4'>
-          <div className='pb-4'>
+        <Tabs.Content
+          value='security'
+          className='flex min-h-0 flex-1 flex-col overflow-hidden pt-4 data-[state=inactive]:hidden'
+        >
+          <div className='min-h-0 flex-1 overflow-auto pb-4'>
             <SecurityProfilesTab
               config={localConfig}
               serverName={serverName}
@@ -175,15 +181,21 @@ export const OpcUaServerEditor = () => {
         </Tabs.Content>
 
         {/* Users Tab */}
-        <Tabs.Content value='users' className='flex-1 overflow-auto pt-4'>
-          <div className='pb-4'>
+        <Tabs.Content
+          value='users'
+          className='flex min-h-0 flex-1 flex-col overflow-hidden pt-4 data-[state=inactive]:hidden'
+        >
+          <div className='min-h-0 flex-1 overflow-auto pb-4'>
             <UsersTab config={localConfig} serverName={serverName} onConfigChange={() => setEditingState('unsaved')} />
           </div>
         </Tabs.Content>
 
         {/* Certificates Tab */}
-        <Tabs.Content value='certificates' className='flex-1 overflow-auto pt-4'>
-          <div className='pb-4'>
+        <Tabs.Content
+          value='certificates'
+          className='flex min-h-0 flex-1 flex-col overflow-hidden pt-4 data-[state=inactive]:hidden'
+        >
+          <div className='min-h-0 flex-1 overflow-auto pb-4'>
             <CertificatesTab
               config={localConfig}
               serverName={serverName}
@@ -193,8 +205,11 @@ export const OpcUaServerEditor = () => {
         </Tabs.Content>
 
         {/* Address Space Tab */}
-        <Tabs.Content value='address-space' className='flex-1 overflow-auto pt-4'>
-          <div className='flex h-[calc(100vh-280px)] min-h-[400px] flex-col pb-4'>
+        <Tabs.Content
+          value='address-space'
+          className='flex min-h-0 flex-1 flex-col overflow-hidden pt-4 data-[state=inactive]:hidden'
+        >
+          <div className='flex min-h-0 flex-1 flex-col pb-4'>
             <AddressSpaceTab
               config={localConfig}
               serverName={serverName}


### PR DESCRIPTION
## Summary
- Replace fixed viewport-based height `calc(100vh-280px)` with flex-based layout that adapts to available space
- Add `data-[state=inactive]:hidden` to prevent inactive tabs from participating in flex layout
- Apply consistent flex layout pattern to all OPC-UA server configuration tabs (General, Security, Users, Certificates, Address Space)

## Test plan
- [ ] Open an OPC-UA server configuration
- [ ] Navigate to the Address Space tab and verify only inner scrollbars appear (inside "Available PLC Variables" and "Selected for OPC-UA" boxes)
- [ ] Resize the bottom panel (console/debugger) and verify the Address Space content adapts dynamically
- [ ] Switch between all tabs (General Settings, Security Profiles, Users, Certificates, Address Space) and verify each displays correctly with full available space
- [ ] Verify scrolling works properly on tabs with content that exceeds available space

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved tab panel layout and rendering in OPC UA server settings with enhanced visibility management for inactive tabs and optimized container structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->