### PR TITLE
fix: enable renaming of servers and remote devices in project tree

### DIFF
--- a/src/renderer/components/_molecules/project-tree/index.tsx
+++ b/src/renderer/components/_molecules/project-tree/index.tsx
@@ -285,8 +285,8 @@ const ProjectTreeLeaf = ({ leafLang, leafType, label, onClick: handleLeafClick, 
     workspaceActions: { setSelectedProjectTreeLeaf },
     pouActions: { deleteRequest: deletePouRequest, rename: renamePou, duplicate: duplicatePou },
     datatypeActions: { deleteRequest: deleteDatatypeRequest, rename: renameDatatype, duplicate: duplicateDatatype },
-    serverActions: { deleteRequest: deleteServerRequest },
-    remoteDeviceActions: { deleteRequest: deleteRemoteDeviceRequest },
+    serverActions: { deleteRequest: deleteServerRequest, rename: renameServer },
+    remoteDeviceActions: { deleteRequest: deleteRemoteDeviceRequest, rename: renameRemoteDevice },
     fileActions: { getFile },
   } = useOpenPLCStore()
 
@@ -324,10 +324,10 @@ const ProjectTreeLeaf = ({ leafLang, leafType, label, onClick: handleLeafClick, 
   const handleRenameFile = async (newLabel: string) => {
     setIsEditing(false)
 
-    if (!isAPou && !isDatatype) {
+    if (!isAPou && !isDatatype && !isServer && !isRemoteDevice) {
       toast({
         title: 'Error',
-        description: 'Only POU or datatype files can be renamed.',
+        description: 'Only POU, datatype, server, or remote device files can be renamed.',
         variant: 'fail',
       })
       return
@@ -336,7 +336,7 @@ const ProjectTreeLeaf = ({ leafLang, leafType, label, onClick: handleLeafClick, 
     if (!newLabel || !label) {
       toast({
         title: 'Error',
-        description: 'Pou or datatype label is required to rename.',
+        description: 'Label is required to rename.',
         variant: 'fail',
       })
       return
@@ -352,6 +352,22 @@ const ProjectTreeLeaf = ({ leafLang, leafType, label, onClick: handleLeafClick, 
 
     if (isDatatype) {
       const res = await renameDatatype(label, newLabel)
+      if (!res.success) {
+        setNewLabel(label || '')
+      }
+      return
+    }
+
+    if (isServer) {
+      const res = await renameServer(label, newLabel)
+      if (!res.success) {
+        setNewLabel(label || '')
+      }
+      return
+    }
+
+    if (isRemoteDevice) {
+      const res = await renameRemoteDevice(label, newLabel)
       if (!res.success) {
         setNewLabel(label || '')
       }


### PR DESCRIPTION
## Summary

- Fixes the error "Only POU or datatype files can be renamed" when attempting to rename servers or remote devices from the project tree context menu
- Fixes the error "Error saving file. File with name [name] does not exist" that appeared after renaming or deleting servers/remote devices

## Changes

- Add `rename` methods to `serverActions` and `remoteDeviceActions` in the shared slice
- Update `handleRenameFile` in project-tree component to handle servers and remote devices
- Fix save error by marking workspace as unsaved instead of calling `saveFile()` (servers/remote devices are stored in `project.json`, not as separate files in the file slice)

## Test plan

- [ ] Create a server in a project
- [ ] Right-click on the server in the project tree and select "Rename"
- [ ] Verify the rename works without error toasts
- [ ] Create a remote device in a project
- [ ] Right-click on the remote device in the project tree and select "Rename"
- [ ] Verify the rename works without error toasts
- [ ] Delete a server and verify no error toast appears
- [ ] Delete a remote device and verify no error toast appears
- [ ] Save the project and verify changes are persisted

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now rename servers and remote devices in the project tree
  * Rename validation prevents duplicate names and requires valid naming
  * Changes reflect across tabs and editor views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->