### PR TITLE
feat: add channel mapping (located variables) for EtherCAT devices

### DIFF
--- a/configs/webpack/webpack.config.renderer.dev.ts
+++ b/configs/webpack/webpack.config.renderer.dev.ts
@@ -206,6 +206,7 @@ const configuration: ICustomConfiguration = {
       configType: 'flat',
       extensions: ['ts', 'tsx'],
       eslintPath: 'eslint/use-at-your-own-risk',
+      cache: false,
     }),
   ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "@tanstack/react-table": "^8.10.7",
         "@xyflow/react": "^12.0.1",
         "auto-zustand-selectors-hook": "^2.0.0",
-        "bcryptjs": "^3.0.3",
         "clsx": "^2.0.0",
         "cva": "npm:class-variance-authority@^0.7.0",
         "dompurify": "^3.2.4",
@@ -43,6 +42,7 @@
         "electron-store": "^8.1.0",
         "electron-updater": "^6.1.4",
         "embla-carousel-react": "^8.0.0-rc17",
+        "fast-xml-parser": "^5.3.4",
         "i18next": "^23.5.1",
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
@@ -11663,14 +11663,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bcryptjs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
-      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
-      "bin": {
-        "bcrypt": "bin/bcrypt"
-      }
-    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -15734,6 +15726,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
+      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -26729,6 +26738,17 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
     },
     "node_modules/style-loader": {
       "version": "3.3.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "postinstall": "ts-node scripts/check-native-dep.js && electron-builder install-app-deps && npm run build:dll",
     "package": "ts-node scripts/clean.js dist && npm run build && electron-builder build --publish never && npm run build:dll",
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir release/app",
-    "prestart": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./configs/webpack/webpack.config.main.dev.ts",
+    "prestart": "rimraf configs/dll/tsconfig.tsbuildinfo && cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./configs/webpack/webpack.config.main.dev.ts",
     "start:dev": "ts-node scripts/check-port-in-use.js && npm run prestart && npm run start:renderer",
     "start:main": "concurrently -k \"cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --watch --config ./configs/webpack/webpack.config.main.dev.ts\" \"electronmon .\"",
     "start:preload": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./configs/webpack/webpack.config.preload.dev.ts",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "electron-store": "^8.1.0",
     "electron-updater": "^6.1.4",
     "embla-carousel-react": "^8.0.0-rc17",
+    "fast-xml-parser": "^5.3.4",
     "i18next": "^23.5.1",
     "immer": "^10.1.1",
     "lodash": "^4.17.21",

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -870,7 +870,7 @@ class MainProcessBridge implements MainIpcModule {
     itemId: string,
   ): Promise<{ success: boolean; error?: string }> => {
     try {
-      return await this.esiService.deleteXmlFile(projectPath, itemId)
+      return await this.esiService.deleteRepositoryItemV2(projectPath, itemId)
     } catch (error) {
       return { success: false, error: String(error) }
     }
@@ -920,7 +920,11 @@ class MainProcessBridge implements MainIpcModule {
     filename: string,
     content: string,
   ): Promise<{ success: boolean; item?: ESIRepositoryItemLight; error?: string }> => {
-    return this.esiService.parseAndSaveFile(projectPath, filename, content)
+    try {
+      return await this.esiService.parseAndSaveFile(projectPath, filename, content)
+    } catch (error) {
+      return { success: false, error: String(error) }
+    }
   }
 
   /**
@@ -930,7 +934,11 @@ class MainProcessBridge implements MainIpcModule {
     _event: IpcMainInvokeEvent,
     projectPath: string,
   ): Promise<{ success: boolean; error?: string }> => {
-    return this.esiService.clearRepository(projectPath)
+    try {
+      return await this.esiService.clearRepository(projectPath)
+    } catch (error) {
+      return { success: false, error: String(error) }
+    }
   }
 
   /**

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -9,7 +9,7 @@ import type {
   EtherCATValidateResponse,
   NetworkInterface,
 } from '@root/types/ethercat'
-import type { ESIRepositoryItem } from '@root/types/ethercat/esi-types'
+import type { ESIDevice, ESIRepositoryItem, ESIRepositoryItemLight } from '@root/types/ethercat/esi-types'
 import { CreatePouFileProps, PouServiceResponse } from '@root/types/IPC/pou-service'
 import { CreateProjectFileProps, IProjectServiceResponse } from '@root/types/IPC/project-service'
 import { DeviceConfiguration, DevicePin } from '@root/types/PLC/devices'
@@ -498,5 +498,49 @@ const rendererProcessBridge = {
     existingItems: ESIRepositoryItem[],
   ): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('esi:delete-repository-item', projectPath, itemId, existingItems),
+
+  // ===================== ESI OPTIMIZED (v2) METHODS =====================
+
+  /**
+   * Parse and save a single ESI file in the main process
+   */
+  esiParseAndSaveFile: (
+    projectPath: string,
+    filename: string,
+    content: string,
+  ): Promise<{ success: boolean; item?: ESIRepositoryItemLight; error?: string }> =>
+    ipcRenderer.invoke('esi:parse-and-save-file', projectPath, filename, content),
+
+  /**
+   * Clear the entire ESI repository (bulk delete all files + reset index)
+   */
+  esiClearRepository: (projectPath: string): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('esi:clear-repository', projectPath),
+
+  /**
+   * Load a full ESI device on-demand (with PDOs, SM, FMMU)
+   */
+  esiLoadDeviceFull: (
+    projectPath: string,
+    itemId: string,
+    deviceIndex: number,
+  ): Promise<{ success: boolean; device?: ESIDevice; error?: string }> =>
+    ipcRenderer.invoke('esi:load-device-full', projectPath, itemId, deviceIndex),
+
+  /**
+   * Load repository as lightweight items (instant from v2 cache)
+   */
+  esiLoadRepositoryLight: (
+    projectPath: string,
+  ): Promise<{ success: boolean; items?: ESIRepositoryItemLight[]; needsMigration?: boolean; error?: string }> =>
+    ipcRenderer.invoke('esi:load-repository-light', projectPath),
+
+  /**
+   * Migrate v1 repository to v2 with device summaries
+   */
+  esiMigrateRepository: (
+    projectPath: string,
+  ): Promise<{ success: boolean; items?: ESIRepositoryItemLight[]; error?: string }> =>
+    ipcRenderer.invoke('esi:migrate-repository', projectPath),
 }
 export default rendererProcessBridge

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -9,6 +9,7 @@ import type {
   EtherCATValidateResponse,
   NetworkInterface,
 } from '@root/types/ethercat'
+import type { ESIRepositoryItem } from '@root/types/ethercat/esi-types'
 import { CreatePouFileProps, PouServiceResponse } from '@root/types/IPC/pou-service'
 import { CreateProjectFileProps, IProjectServiceResponse } from '@root/types/IPC/project-service'
 import { DeviceConfiguration, DevicePin } from '@root/types/PLC/devices'
@@ -418,5 +419,84 @@ const rendererProcessBridge = {
     validateRequest: EtherCATValidateRequest,
   ): Promise<{ success: boolean; data?: EtherCATValidateResponse; error?: string }> =>
     ipcRenderer.invoke('ethercat:validate', ipAddress, jwtToken, validateRequest),
+
+  // ===================== ESI REPOSITORY METHODS =====================
+
+  /**
+   * Load ESI repository index from project
+   */
+  esiLoadRepositoryIndex: (
+    projectPath: string,
+  ): Promise<{
+    success: boolean
+    data?: {
+      version: number
+      items: Array<{
+        id: string
+        filename: string
+        vendorId: string
+        vendorName: string
+        deviceCount: number
+        loadedAt: number
+        warnings?: string[]
+      }>
+    } | null
+    error?: string
+  }> => ipcRenderer.invoke('esi:load-repository-index', projectPath),
+
+  /**
+   * Save ESI repository index to project
+   */
+  esiSaveRepositoryIndex: (
+    projectPath: string,
+    items: ESIRepositoryItem[],
+  ): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('esi:save-repository-index', projectPath, items),
+
+  /**
+   * Save an ESI XML file to project
+   */
+  esiSaveXmlFile: (
+    projectPath: string,
+    itemId: string,
+    xmlContent: string,
+  ): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('esi:save-xml-file', projectPath, itemId, xmlContent),
+
+  /**
+   * Load an ESI XML file from project
+   */
+  esiLoadXmlFile: (
+    projectPath: string,
+    itemId: string,
+  ): Promise<{ success: boolean; content?: string; error?: string }> =>
+    ipcRenderer.invoke('esi:load-xml-file', projectPath, itemId),
+
+  /**
+   * Delete an ESI XML file from project
+   */
+  esiDeleteXmlFile: (projectPath: string, itemId: string): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('esi:delete-xml-file', projectPath, itemId),
+
+  /**
+   * Save a complete ESI repository item (XML + update index)
+   */
+  esiSaveRepositoryItem: (
+    projectPath: string,
+    item: ESIRepositoryItem,
+    xmlContent: string,
+    existingItems: ESIRepositoryItem[],
+  ): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('esi:save-repository-item', projectPath, item, xmlContent, existingItems),
+
+  /**
+   * Delete an ESI repository item (XML + update index)
+   */
+  esiDeleteRepositoryItem: (
+    projectPath: string,
+    itemId: string,
+    existingItems: ESIRepositoryItem[],
+  ): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('esi:delete-repository-item', projectPath, itemId, existingItems),
 }
 export default rendererProcessBridge

--- a/src/main/services/esi-service/esi-parser-main.ts
+++ b/src/main/services/esi-service/esi-parser-main.ts
@@ -1,0 +1,448 @@
+/**
+ * ESI XML Parser for Main Process
+ *
+ * Uses fast-xml-parser for high-performance parsing in the Node.js main process.
+ * Provides two parsing levels:
+ * - parseESILight: Extracts lightweight device summaries (fast, for repository listing)
+ * - parseESIDeviceFull: Extracts complete device data on-demand (for configuration)
+ */
+
+import type {
+  ESIDevice,
+  ESIDeviceSummary,
+  ESIDeviceType,
+  ESIFMMU,
+  ESIGroup,
+  ESIPdo,
+  ESIPdoEntry,
+  ESISyncManager,
+  ESIVendor,
+} from '@root/types/ethercat/esi-types'
+import { XMLParser } from 'fast-xml-parser'
+
+// ===================== SHARED HELPERS =====================
+
+/**
+ * Parse hex string to normalized 0x format
+ */
+function parseHexValue(value: string | number | undefined | null): string {
+  if (value === undefined || value === null) return '0x0'
+  const str = String(value)
+  const cleaned = str.replace('#x', '0x').replace('#X', '0x')
+  return cleaned.startsWith('0x') ? cleaned : `0x${cleaned}`
+}
+
+/**
+ * Ensure a value is always an array (fast-xml-parser returns single items as objects)
+ */
+function ensureArray<T>(value: T | T[] | undefined | null): T[] {
+  if (value === undefined || value === null) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+/**
+ * Get text value from a parsed element that may be string, number, object with #text,
+ * or array of localized objects (e.g. [{#text: "Name EN", @_LcId: "1033"}, {#text: "Name DE", @_LcId: "1031"}]).
+ * For arrays, prefers LcId 1033 (English) then falls back to the first element.
+ */
+function getTextValue(value: unknown): string {
+  if (value === undefined || value === null) return ''
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number') return String(value)
+  if (Array.isArray(value)) {
+    if (value.length === 0) return ''
+    // Prefer English (LcId 1033), fall back to first element
+    const english = (value as Record<string, unknown>[]).find(
+      (v) => typeof v === 'object' && v !== null && '@_LcId' in v && String(v['@_LcId'] as string) === '1033',
+    )
+    return getTextValue(english ?? value[0])
+  }
+  if (typeof value === 'object' && value !== null && '#text' in value) {
+    return getTextValue((value as { '#text': unknown })['#text'])
+  }
+  return typeof value === 'object' ? JSON.stringify(value) : String(value as string)
+}
+
+/**
+ * Create a configured XMLParser instance
+ */
+function createParser(): XMLParser {
+  return new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: '@_',
+    textNodeName: '#text',
+    parseAttributeValue: false,
+    trimValues: true,
+    isArray: (tagName: string) => {
+      // Tags that can appear multiple times and should always be arrays
+      const arrayTags = ['Device', 'Group', 'RxPdo', 'TxPdo', 'Entry', 'Fmmu', 'Sm', 'Object', 'SubItem']
+      return arrayTags.includes(tagName)
+    },
+  })
+}
+
+// ===================== LIGHT PARSING =====================
+
+interface ESILightResult {
+  success: boolean
+  vendor?: ESIVendor
+  devices?: ESIDeviceSummary[]
+  warnings?: string[]
+  error?: string
+}
+
+/**
+ * Parse ESI XML extracting only lightweight device summaries.
+ * Counts PDO entries and sums bit lengths without building full entry objects.
+ */
+export function parseESILight(xmlString: string, filename?: string): ESILightResult {
+  const warnings: string[] = []
+
+  try {
+    const parser = createParser()
+    const parsed = parser.parse(xmlString) as Record<string, unknown>
+
+    const root = parsed['EtherCATInfo'] as Record<string, unknown> | undefined
+    if (!root) {
+      return { success: false, error: 'Invalid ESI file: Missing EtherCATInfo root element' }
+    }
+
+    // Parse Vendor
+    const vendorObj = root['Vendor'] as Record<string, unknown> | undefined
+    if (!vendorObj) {
+      return { success: false, error: 'Invalid ESI file: Missing Vendor information' }
+    }
+
+    const vendor: ESIVendor = {
+      id: parseHexValue(vendorObj['Id'] as string | number | undefined),
+      name: getTextValue(vendorObj['Name']) || 'Unknown Vendor',
+    }
+
+    // Parse Groups
+    const descriptions = root['Descriptions'] as Record<string, unknown> | undefined
+    const groupsMap = new Map<string, string>()
+
+    if (descriptions) {
+      const groupsObj = descriptions['Groups'] as Record<string, unknown> | undefined
+      if (groupsObj) {
+        const groups = ensureArray(groupsObj['Group'] as Record<string, unknown> | Record<string, unknown>[])
+        for (const group of groups) {
+          const groupType = getTextValue(group['Type'])
+          const groupName = getTextValue(group['Name'])
+          if (groupType) {
+            groupsMap.set(groupType, groupName)
+          }
+        }
+      }
+    }
+
+    // Parse Devices (lightweight)
+    const devices: ESIDeviceSummary[] = []
+
+    if (descriptions) {
+      const devicesObj = descriptions['Devices'] as Record<string, unknown> | undefined
+      if (devicesObj) {
+        const deviceElements = ensureArray(devicesObj['Device'] as Record<string, unknown> | Record<string, unknown>[])
+
+        for (const deviceEl of deviceElements) {
+          const summary = parseDeviceSummary(deviceEl, groupsMap)
+          devices.push(summary)
+        }
+      }
+    }
+
+    if (devices.length === 0) {
+      warnings.push(`No devices found in ESI file${filename ? ` (${filename})` : ''}`)
+    }
+
+    return {
+      success: true,
+      vendor,
+      devices,
+      warnings: warnings.length > 0 ? warnings : undefined,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to parse ESI file: ${error instanceof Error ? error.message : String(error)}`,
+    }
+  }
+}
+
+/**
+ * Extract a lightweight device summary from a parsed device element
+ */
+function parseDeviceSummary(deviceEl: Record<string, unknown>, groupsMap: Map<string, string>): ESIDeviceSummary {
+  // Parse Type
+  const typeEl = deviceEl['Type'] as Record<string, unknown> | string | undefined
+  let type: ESIDeviceType
+  if (typeEl && typeof typeEl === 'object') {
+    type = {
+      productCode: parseHexValue(typeEl['@_ProductCode'] as string | undefined),
+      revisionNo: parseHexValue(typeEl['@_RevisionNo'] as string | undefined),
+      name: getTextValue(typeEl['#text'] ?? typeEl['@_Name']),
+    }
+  } else {
+    type = { productCode: '0x0', revisionNo: '0x0', name: getTextValue(typeEl) || 'Unknown' }
+  }
+
+  // Group
+  const groupType = getTextValue(deviceEl['GroupType'])
+  const groupName = groupsMap.get(groupType) || undefined
+
+  // Physics
+  const physics = (deviceEl['@_Physics'] as string | undefined) || undefined
+
+  // Count PDO entries and compute bytes
+  const txPdos = ensureArray(deviceEl['TxPdo'] as Record<string, unknown> | Record<string, unknown>[])
+  const rxPdos = ensureArray(deviceEl['RxPdo'] as Record<string, unknown> | Record<string, unknown>[])
+
+  const { channelCount: inputChannelCount, totalBits: inputBits } = countPdoEntries(txPdos)
+  const { channelCount: outputChannelCount, totalBits: outputBits } = countPdoEntries(rxPdos)
+
+  return {
+    type,
+    name: getTextValue(deviceEl['Name']) || 'Unknown Device',
+    groupName,
+    physics,
+    inputChannelCount,
+    outputChannelCount,
+    totalInputBytes: Math.ceil(inputBits / 8),
+    totalOutputBytes: Math.ceil(outputBits / 8),
+    description: getTextValue(deviceEl['Comment']) || undefined,
+  }
+}
+
+/**
+ * Count non-padding entries and total bits in PDO list (without building full entry objects)
+ */
+function countPdoEntries(pdos: Record<string, unknown>[]): {
+  channelCount: number
+  totalBits: number
+} {
+  let channelCount = 0
+  let totalBits = 0
+
+  for (const pdo of pdos) {
+    const entries = ensureArray(pdo['Entry'] as Record<string, unknown> | Record<string, unknown>[])
+    for (const entry of entries) {
+      const bitLen = parseInt(getTextValue(entry['BitLen']) || '0', 10) || 0
+      totalBits += bitLen
+
+      // Count non-padding entries
+      const index = entry['Index']
+      if (index !== undefined && index !== null) {
+        const indexStr = getTextValue(index)
+        if (indexStr && indexStr !== '0' && indexStr !== '#x0000' && indexStr !== '0x0000') {
+          channelCount++
+        }
+      }
+    }
+  }
+
+  return { channelCount, totalBits }
+}
+
+// ===================== FULL DEVICE PARSING =====================
+
+interface ESIDeviceFullResult {
+  success: boolean
+  device?: ESIDevice
+  error?: string
+}
+
+/**
+ * Parse a single device from ESI XML at the given index with full detail.
+ * Used on-demand when complete PDO/SM/FMMU data is needed.
+ */
+export function parseESIDeviceFull(xmlString: string, deviceIndex: number): ESIDeviceFullResult {
+  try {
+    const parser = createParser()
+    const parsed = parser.parse(xmlString) as Record<string, unknown>
+
+    const root = parsed['EtherCATInfo'] as Record<string, unknown> | undefined
+    if (!root) {
+      return { success: false, error: 'Invalid ESI file: Missing EtherCATInfo root element' }
+    }
+
+    const descriptions = root['Descriptions'] as Record<string, unknown> | undefined
+    if (!descriptions) {
+      return { success: false, error: 'No Descriptions element found' }
+    }
+
+    // Parse groups for name lookup
+    const groups: ESIGroup[] = []
+    const groupsObj = descriptions['Groups'] as Record<string, unknown> | undefined
+    if (groupsObj) {
+      const groupElements = ensureArray(groupsObj['Group'] as Record<string, unknown> | Record<string, unknown>[])
+      for (const g of groupElements) {
+        groups.push({
+          type: getTextValue(g['Type']),
+          name: getTextValue(g['Name']),
+          imageUrl: getTextValue(g['ImageData16x14']) || undefined,
+          description: getTextValue(g['Comment']) || undefined,
+        })
+      }
+    }
+
+    const devicesObj = descriptions['Devices'] as Record<string, unknown> | undefined
+    if (!devicesObj) {
+      return { success: false, error: 'No Devices element found' }
+    }
+
+    const deviceElements = ensureArray(devicesObj['Device'] as Record<string, unknown> | Record<string, unknown>[])
+
+    if (deviceIndex < 0 || deviceIndex >= deviceElements.length) {
+      return { success: false, error: `Device index ${deviceIndex} out of range (0-${deviceElements.length - 1})` }
+    }
+
+    const deviceEl = deviceElements[deviceIndex]
+    const device = parseFullDevice(deviceEl, groups)
+
+    return { success: true, device }
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to parse device: ${error instanceof Error ? error.message : String(error)}`,
+    }
+  }
+}
+
+/**
+ * Parse a complete ESIDevice from a parsed device element
+ */
+function parseFullDevice(deviceEl: Record<string, unknown>, groups: ESIGroup[]): ESIDevice {
+  // Parse Type
+  const typeEl = deviceEl['Type'] as Record<string, unknown> | string | undefined
+  let type: ESIDeviceType
+  if (typeEl && typeof typeEl === 'object') {
+    type = {
+      productCode: parseHexValue(typeEl['@_ProductCode'] as string | undefined),
+      revisionNo: parseHexValue(typeEl['@_RevisionNo'] as string | undefined),
+      name: getTextValue(typeEl['#text'] ?? typeEl['@_Name']),
+    }
+  } else {
+    type = { productCode: '0x0', revisionNo: '0x0', name: getTextValue(typeEl) || 'Unknown' }
+  }
+
+  // Group
+  const groupType = getTextValue(deviceEl['GroupType'])
+  const group = groups.find((g) => g.type === groupType)
+
+  // Physics
+  const physics = (deviceEl['@_Physics'] as string | undefined) || undefined
+
+  // Parse FMMUs
+  const fmmu: ESIFMMU[] = []
+  const fmmuElements = ensureArray(
+    deviceEl['Fmmu'] as (Record<string, unknown> | string) | (Record<string, unknown> | string)[],
+  )
+  for (const f of fmmuElements) {
+    const fmmuText = typeof f === 'string' ? f : getTextValue(f['#text'] ?? f)
+    fmmu.push({ type: (fmmuText || 'Outputs') as ESIFMMU['type'] })
+  }
+
+  // Parse Sync Managers
+  const syncManagers: ESISyncManager[] = []
+  const smElements = ensureArray(deviceEl['Sm'] as Record<string, unknown> | Record<string, unknown>[])
+  for (let i = 0; i < smElements.length; i++) {
+    const sm = smElements[i]
+    const smTypeMap: Record<string, ESISyncManager['type']> = {
+      MbxOut: 'MbxOut',
+      MbxIn: 'MbxIn',
+      Outputs: 'Outputs',
+      Inputs: 'Inputs',
+    }
+    const smText = getTextValue(sm['#text'] ?? sm)
+    syncManagers.push({
+      index: i,
+      startAddress: parseHexValue(sm['@_StartAddress'] as string | undefined),
+      controlByte: parseHexValue(sm['@_ControlByte'] as string | undefined),
+      defaultSize: parseInt(getTextValue(sm['@_DefaultSize']) || '0', 10) || 0,
+      enable: getTextValue(sm['@_Enable']) !== '0',
+      type: smTypeMap[smText] || 'Outputs',
+    })
+  }
+
+  // Parse RxPDOs
+  const rxPdo: ESIPdo[] = []
+  const rxPdoElements = ensureArray(deviceEl['RxPdo'] as Record<string, unknown> | Record<string, unknown>[])
+  for (const pdoEl of rxPdoElements) {
+    rxPdo.push(parseFullPdo(pdoEl))
+  }
+
+  // Parse TxPDOs
+  const txPdo: ESIPdo[] = []
+  const txPdoElements = ensureArray(deviceEl['TxPdo'] as Record<string, unknown> | Record<string, unknown>[])
+  for (const pdoEl of txPdoElements) {
+    txPdo.push(parseFullPdo(pdoEl))
+  }
+
+  return {
+    type,
+    name: getTextValue(deviceEl['Name']) || 'Unknown Device',
+    groupName: group?.name,
+    physics,
+    fmmu,
+    syncManagers,
+    rxPdo,
+    txPdo,
+    description: getTextValue(deviceEl['Comment']) || undefined,
+  }
+}
+
+/**
+ * Parse a full PDO with all entries
+ */
+function parseFullPdo(pdoEl: Record<string, unknown>): ESIPdo {
+  const entries: ESIPdoEntry[] = []
+  const entryElements = ensureArray(pdoEl['Entry'] as Record<string, unknown> | Record<string, unknown>[])
+
+  for (const entryEl of entryElements) {
+    const entry = parseFullPdoEntry(entryEl)
+    if (entry) {
+      entries.push(entry)
+    }
+  }
+
+  return {
+    index: parseHexValue(entryElements.length > 0 ? (pdoEl['Index'] as string | undefined) : undefined),
+    name: getTextValue(pdoEl['Name']) || 'Unnamed PDO',
+    fixed: getTextValue(pdoEl['@_Fixed']).toLowerCase() === 'true',
+    mandatory: getTextValue(pdoEl['@_Mandatory']).toLowerCase() === 'true',
+    smIndex: pdoEl['@_Sm'] !== undefined ? parseInt(getTextValue(pdoEl['@_Sm']) || '0', 10) : undefined,
+    entries,
+  }
+}
+
+/**
+ * Parse a single PDO entry
+ */
+function parseFullPdoEntry(entryEl: Record<string, unknown>): ESIPdoEntry | null {
+  const indexValue = entryEl['Index']
+  const bitLen = parseInt(getTextValue(entryEl['BitLen']) || '0', 10) || 0
+
+  const indexStr = getTextValue(indexValue)
+
+  // Padding entry (no index but has bit length)
+  if (!indexStr && bitLen > 0) {
+    return {
+      index: '0x0000',
+      subIndex: '0x00',
+      bitLen,
+      name: 'Padding',
+      dataType: 'BIT',
+    }
+  }
+
+  if (!indexStr) return null
+
+  return {
+    index: parseHexValue(indexStr),
+    subIndex: parseHexValue(getTextValue(entryEl['SubIndex'])),
+    bitLen,
+    name: getTextValue(entryEl['Name']) || 'Unnamed',
+    dataType: getTextValue(entryEl['DataType']) || 'BYTE',
+    comment: getTextValue(entryEl['Comment']) || undefined,
+  }
+}

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/channel-mapping-table.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/channel-mapping-table.tsx
@@ -61,6 +61,23 @@ const ChannelMappingTable = ({ channels, mappings, onAliasChange }: ChannelMappi
     return map
   }, [mappings])
 
+  // Build a 1-based per-direction index for each channel (stable regardless of filtering)
+  const channelIndexMap = useMemo(() => {
+    const map = new Map<string, number>()
+    let inputIdx = 0
+    let outputIdx = 0
+    for (const ch of channels) {
+      if (ch.direction === 'input') {
+        inputIdx++
+        map.set(ch.id, inputIdx)
+      } else {
+        outputIdx++
+        map.set(ch.id, outputIdx)
+      }
+    }
+    return map
+  }, [channels])
+
   // Filter channels based on direction and search
   const filteredChannels = useMemo(() => {
     return channels.filter((channel) => {
@@ -72,9 +89,6 @@ const ChannelMappingTable = ({ channels, mappings, onAliasChange }: ChannelMappi
         const search = searchTerm.toLowerCase()
         const mapping = mappingMap.get(channel.id)
         return (
-          channel.name.toLowerCase().includes(search) ||
-          channel.dataType.toLowerCase().includes(search) ||
-          channel.entryIndex.toLowerCase().includes(search) ||
           channel.iecType.toLowerCase().includes(search) ||
           (mapping?.iecLocation.toLowerCase().includes(search) ?? false) ||
           (mapping?.alias?.toLowerCase().includes(search) ?? false)
@@ -144,26 +158,17 @@ const ChannelMappingTable = ({ channels, mappings, onAliasChange }: ChannelMappi
         <table className='w-full table-fixed'>
           <thead className='sticky top-0 bg-neutral-100 dark:bg-neutral-900'>
             <tr>
-              <th className='w-[7%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
-                Dir
-              </th>
-              <th className='w-[18%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
-                Name
+              <th className='w-[8%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                #
               </th>
               <th className='w-[10%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
-                Index
-              </th>
-              <th className='w-[9%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
-                Type
-              </th>
-              <th className='w-[6%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
-                Bits
-              </th>
-              <th className='w-[9%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
-                IEC Type
+                Dir
               </th>
               <th className='w-[14%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
-                IEC Location
+                IEC Type
+              </th>
+              <th className='w-[22%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                Address
               </th>
               <th className='px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>Alias</th>
             </tr>
@@ -171,7 +176,7 @@ const ChannelMappingTable = ({ channels, mappings, onAliasChange }: ChannelMappi
           <tbody>
             {filteredChannels.length === 0 ? (
               <tr>
-                <td colSpan={8} className='px-4 py-8 text-center text-sm text-neutral-500 dark:text-neutral-400'>
+                <td colSpan={5} className='px-4 py-8 text-center text-sm text-neutral-500 dark:text-neutral-400'>
                   {channels.length === 0 ? 'No channels available' : 'No channels match the current filter'}
                 </td>
               </tr>
@@ -183,6 +188,9 @@ const ChannelMappingTable = ({ channels, mappings, onAliasChange }: ChannelMappi
                     key={channel.id}
                     className='border-b border-neutral-200 transition-colors hover:bg-neutral-50 dark:border-neutral-800 dark:hover:bg-neutral-800/50'
                   >
+                    <td className='px-2 py-1.5 text-sm font-medium text-neutral-950 dark:text-neutral-100'>
+                      {channelIndexMap.get(channel.id) ?? ''}
+                    </td>
                     <td className='px-2 py-1.5'>
                       <span
                         className={cn(
@@ -195,17 +203,6 @@ const ChannelMappingTable = ({ channels, mappings, onAliasChange }: ChannelMappi
                         {channel.direction === 'input' ? 'IN' : 'OUT'}
                       </span>
                     </td>
-                    <td
-                      className='truncate px-2 py-1.5 text-sm font-medium text-neutral-950 dark:text-neutral-100'
-                      title={channel.name}
-                    >
-                      {channel.name}
-                    </td>
-                    <td className='px-2 py-1.5 font-mono text-xs text-neutral-600 dark:text-neutral-400'>
-                      {channel.entryIndex}:{channel.entrySubIndex}
-                    </td>
-                    <td className='px-2 py-1.5 text-xs text-neutral-600 dark:text-neutral-400'>{channel.dataType}</td>
-                    <td className='px-2 py-1.5 text-xs text-neutral-600 dark:text-neutral-400'>{channel.bitLen}</td>
                     <td className='px-2 py-1.5 text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                       {channel.iecType}
                     </td>

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/channel-mapping-table.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/channel-mapping-table.tsx
@@ -1,0 +1,202 @@
+import type { ESIChannel, EtherCATChannelMapping } from '@root/types/ethercat/esi-types'
+import { cn } from '@root/utils'
+import { useMemo, useState } from 'react'
+
+type ChannelMappingTableProps = {
+  channels: ESIChannel[]
+  mappings: EtherCATChannelMapping[]
+  onLocationChange: (channelId: string, newLocation: string) => void
+}
+
+type FilterDirection = 'all' | 'input' | 'output'
+
+/**
+ * Channel Mapping Table Component
+ *
+ * Displays channels with editable IEC 61131-3 located variable addresses.
+ */
+const ChannelMappingTable = ({ channels, mappings, onLocationChange }: ChannelMappingTableProps) => {
+  const [filterDirection, setFilterDirection] = useState<FilterDirection>('all')
+  const [searchTerm, setSearchTerm] = useState('')
+
+  // Build a lookup map from channelId to mapping
+  const mappingMap = useMemo(() => {
+    const map = new Map<string, EtherCATChannelMapping>()
+    for (const m of mappings) {
+      map.set(m.channelId, m)
+    }
+    return map
+  }, [mappings])
+
+  // Filter channels based on direction and search
+  const filteredChannels = useMemo(() => {
+    return channels.filter((channel) => {
+      if (filterDirection !== 'all' && channel.direction !== filterDirection) {
+        return false
+      }
+
+      if (searchTerm) {
+        const search = searchTerm.toLowerCase()
+        const mapping = mappingMap.get(channel.id)
+        return (
+          channel.name.toLowerCase().includes(search) ||
+          channel.dataType.toLowerCase().includes(search) ||
+          channel.entryIndex.toLowerCase().includes(search) ||
+          channel.iecType.toLowerCase().includes(search) ||
+          (mapping?.iecLocation.toLowerCase().includes(search) ?? false)
+        )
+      }
+
+      return true
+    })
+  }, [channels, filterDirection, searchTerm, mappingMap])
+
+  const inputCount = channels.filter((c) => c.direction === 'input').length
+  const outputCount = channels.filter((c) => c.direction === 'output').length
+
+  return (
+    <div className='flex flex-col gap-3'>
+      {/* Filters */}
+      <div className='flex flex-wrap items-center gap-3'>
+        {/* Direction Filter */}
+        <div className='flex rounded-md border border-neutral-300 dark:border-neutral-700'>
+          <button
+            onClick={() => setFilterDirection('all')}
+            className={cn(
+              'px-3 py-1 text-xs font-medium transition-colors',
+              filterDirection === 'all'
+                ? 'bg-brand text-white'
+                : 'bg-white text-neutral-700 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800',
+            )}
+          >
+            All ({channels.length})
+          </button>
+          <button
+            onClick={() => setFilterDirection('input')}
+            className={cn(
+              'border-l border-neutral-300 px-3 py-1 text-xs font-medium transition-colors dark:border-neutral-700',
+              filterDirection === 'input'
+                ? 'bg-green-500 text-white'
+                : 'bg-white text-neutral-700 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800',
+            )}
+          >
+            Inputs ({inputCount})
+          </button>
+          <button
+            onClick={() => setFilterDirection('output')}
+            className={cn(
+              'border-l border-neutral-300 px-3 py-1 text-xs font-medium transition-colors dark:border-neutral-700',
+              filterDirection === 'output'
+                ? 'bg-blue-500 text-white'
+                : 'bg-white text-neutral-700 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800',
+            )}
+          >
+            Outputs ({outputCount})
+          </button>
+        </div>
+
+        {/* Search */}
+        <input
+          type='text'
+          placeholder='Search channels...'
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className='h-[30px] rounded-md border border-neutral-300 bg-white px-2 text-xs text-neutral-700 outline-none focus:border-brand dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300'
+        />
+      </div>
+
+      {/* Table */}
+      <div className='max-h-[400px] overflow-auto rounded-lg border border-neutral-200 dark:border-neutral-800'>
+        <table className='w-full table-fixed'>
+          <thead className='sticky top-0 bg-neutral-100 dark:bg-neutral-900'>
+            <tr>
+              <th className='w-[7%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                Dir
+              </th>
+              <th className='w-[22%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                Name
+              </th>
+              <th className='w-[12%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                Index
+              </th>
+              <th className='w-[10%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                Type
+              </th>
+              <th className='w-[7%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                Bits
+              </th>
+              <th className='w-[10%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                IEC Type
+              </th>
+              <th className='px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                IEC Location
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredChannels.length === 0 ? (
+              <tr>
+                <td colSpan={7} className='px-4 py-8 text-center text-sm text-neutral-500 dark:text-neutral-400'>
+                  {channels.length === 0 ? 'No channels available' : 'No channels match the current filter'}
+                </td>
+              </tr>
+            ) : (
+              filteredChannels.map((channel) => {
+                const mapping = mappingMap.get(channel.id)
+                return (
+                  <tr
+                    key={channel.id}
+                    className='border-b border-neutral-200 transition-colors hover:bg-neutral-50 dark:border-neutral-800 dark:hover:bg-neutral-800/50'
+                  >
+                    <td className='px-2 py-1.5'>
+                      <span
+                        className={cn(
+                          'inline-block rounded px-1.5 py-0.5 text-xs font-medium',
+                          channel.direction === 'input'
+                            ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                            : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+                        )}
+                      >
+                        {channel.direction === 'input' ? 'IN' : 'OUT'}
+                      </span>
+                    </td>
+                    <td
+                      className='truncate px-2 py-1.5 text-sm font-medium text-neutral-950 dark:text-neutral-100'
+                      title={channel.name}
+                    >
+                      {channel.name}
+                    </td>
+                    <td className='px-2 py-1.5 font-mono text-xs text-neutral-600 dark:text-neutral-400'>
+                      {channel.entryIndex}:{channel.entrySubIndex}
+                    </td>
+                    <td className='px-2 py-1.5 text-xs text-neutral-600 dark:text-neutral-400'>{channel.dataType}</td>
+                    <td className='px-2 py-1.5 text-xs text-neutral-600 dark:text-neutral-400'>{channel.bitLen}</td>
+                    <td className='px-2 py-1.5 text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                      {channel.iecType}
+                    </td>
+                    <td className='px-2 py-1.5'>
+                      <input
+                        type='text'
+                        value={mapping?.iecLocation ?? ''}
+                        onChange={(e) => onLocationChange(channel.id, e.target.value)}
+                        className={cn(
+                          'h-[24px] w-full rounded border px-1.5 font-mono text-xs outline-none',
+                          'border-neutral-300 bg-white text-neutral-700 focus:border-brand dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-300',
+                          mapping?.userEdited &&
+                            'border-amber-400 bg-amber-50 dark:border-amber-600 dark:bg-amber-900/20',
+                        )}
+                        title={mapping?.userEdited ? 'Manually edited' : 'Auto-generated'}
+                      />
+                    </td>
+                  </tr>
+                )
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+export { ChannelMappingTable }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-device-row.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-device-row.tsx
@@ -1,0 +1,167 @@
+import { ArrowIcon } from '@root/renderer/assets/icons'
+import type { ConfiguredEtherCATDevice, ESIDevice, ESIRepositoryItem } from '@root/types/ethercat/esi-types'
+import { cn } from '@root/utils'
+import { getDeviceSummary } from '@root/utils/ethercat/esi-parser'
+import { useMemo } from 'react'
+
+type ConfiguredDeviceRowProps = {
+  device: ConfiguredEtherCATDevice
+  repository: ESIRepositoryItem[]
+  isExpanded: boolean
+  onToggleExpand: () => void
+  isSelected: boolean
+  onSelect: () => void
+}
+
+/**
+ * Configured Device Row Component
+ *
+ * Displays a configured EtherCAT device with expandable details.
+ * Follows the IOGroupRow pattern from remote-device editor.
+ */
+const ConfiguredDeviceRow = ({
+  device,
+  repository,
+  isExpanded,
+  onToggleExpand,
+  isSelected,
+  onSelect,
+}: ConfiguredDeviceRowProps) => {
+  // Resolve the ESI device from repository
+  const esiDevice = useMemo<ESIDevice | null>(() => {
+    const repoItem = repository.find((r) => r.id === device.esiDeviceRef.repositoryItemId)
+    if (!repoItem) return null
+    return repoItem.devices[device.esiDeviceRef.deviceIndex] || null
+  }, [repository, device.esiDeviceRef])
+
+  const repoItem = useMemo(() => {
+    return repository.find((r) => r.id === device.esiDeviceRef.repositoryItemId)
+  }, [repository, device.esiDeviceRef.repositoryItemId])
+
+  const summary = useMemo(() => {
+    if (!esiDevice) return null
+    return getDeviceSummary(esiDevice)
+  }, [esiDevice])
+
+  const ioSummary = summary ? `${summary.totalInputBytes}B/${summary.totalOutputBytes}B` : '-'
+
+  return (
+    <>
+      {/* Main row */}
+      <tr
+        onClick={onSelect}
+        className={cn(
+          'cursor-pointer border-b border-neutral-200 dark:border-neutral-800',
+          isSelected && 'bg-brand/10 dark:bg-brand/20',
+        )}
+      >
+        <td className='px-2 py-2'>
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onToggleExpand()
+            }}
+            className='flex items-center justify-center'
+          >
+            <ArrowIcon
+              direction='right'
+              className={cn('h-4 w-4 stroke-brand-light transition-all', isExpanded && 'rotate-270 stroke-brand')}
+            />
+          </button>
+        </td>
+        <td className='px-2 py-2 text-sm font-medium text-neutral-950 dark:text-neutral-100'>{device.name}</td>
+        <td className='px-2 py-2 text-sm text-neutral-700 dark:text-neutral-300'>{esiDevice?.name || 'Unknown'}</td>
+        <td className='px-2 py-2 text-sm text-neutral-700 dark:text-neutral-300'>
+          {device.position !== undefined ? device.position : '-'}
+        </td>
+        <td className='px-2 py-2 text-sm text-neutral-700 dark:text-neutral-300'>{ioSummary}</td>
+        <td className='px-2 py-2'>
+          <span
+            className={cn(
+              'inline-block rounded px-1.5 py-0.5 text-xs font-medium',
+              device.addedFrom === 'scan'
+                ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+            )}
+          >
+            {device.addedFrom === 'scan' ? 'Scan' : 'Manual'}
+          </span>
+        </td>
+      </tr>
+
+      {/* Expanded details */}
+      {isExpanded && (
+        <>
+          {/* Device Info Section */}
+          <tr className='border-b border-neutral-100 bg-neutral-50 dark:border-neutral-900 dark:bg-neutral-900/50'>
+            <td className='px-2 py-2'></td>
+            <td colSpan={5} className='px-2 py-2'>
+              <div className='rounded-md border border-neutral-200 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-900'>
+                <h5 className='mb-2 text-xs font-medium uppercase text-neutral-500 dark:text-neutral-400'>
+                  Device Info
+                </h5>
+                <div className='grid grid-cols-2 gap-x-6 gap-y-1 text-xs md:grid-cols-4'>
+                  <div>
+                    <span className='text-neutral-500 dark:text-neutral-400'>Vendor:</span>{' '}
+                    <span className='text-neutral-700 dark:text-neutral-300'>{repoItem?.vendor.name || 'Unknown'}</span>
+                  </div>
+                  <div>
+                    <span className='text-neutral-500 dark:text-neutral-400'>Vendor ID:</span>{' '}
+                    <span className='font-mono text-neutral-700 dark:text-neutral-300'>{device.vendorId}</span>
+                  </div>
+                  <div>
+                    <span className='text-neutral-500 dark:text-neutral-400'>Product Code:</span>{' '}
+                    <span className='font-mono text-neutral-700 dark:text-neutral-300'>{device.productCode}</span>
+                  </div>
+                  <div>
+                    <span className='text-neutral-500 dark:text-neutral-400'>Revision:</span>{' '}
+                    <span className='font-mono text-neutral-700 dark:text-neutral-300'>{device.revisionNo}</span>
+                  </div>
+                  <div>
+                    <span className='text-neutral-500 dark:text-neutral-400'>ESI File:</span>{' '}
+                    <span className='text-neutral-700 dark:text-neutral-300'>{repoItem?.filename || 'Not found'}</span>
+                  </div>
+                  {esiDevice?.groupName && (
+                    <div>
+                      <span className='text-neutral-500 dark:text-neutral-400'>Group:</span>{' '}
+                      <span className='text-neutral-700 dark:text-neutral-300'>{esiDevice.groupName}</span>
+                    </div>
+                  )}
+                  {summary && (
+                    <>
+                      <div>
+                        <span className='text-neutral-500 dark:text-neutral-400'>Input Channels:</span>{' '}
+                        <span className='text-neutral-700 dark:text-neutral-300'>{summary.inputChannelCount}</span>
+                      </div>
+                      <div>
+                        <span className='text-neutral-500 dark:text-neutral-400'>Output Channels:</span>{' '}
+                        <span className='text-neutral-700 dark:text-neutral-300'>{summary.outputChannelCount}</span>
+                      </div>
+                    </>
+                  )}
+                </div>
+              </div>
+            </td>
+          </tr>
+
+          {/* Configuration Section (placeholder for future IO mapping) */}
+          <tr className='border-b border-neutral-100 bg-neutral-50 dark:border-neutral-900 dark:bg-neutral-900/50'>
+            <td className='px-2 py-2'></td>
+            <td colSpan={5} className='px-2 py-2'>
+              <div className='rounded-md border border-dashed border-neutral-300 bg-neutral-100 p-4 dark:border-neutral-700 dark:bg-neutral-800/50'>
+                <h5 className='mb-1 text-xs font-medium uppercase text-neutral-500 dark:text-neutral-400'>
+                  Configuration
+                </h5>
+                <p className='text-xs text-neutral-500 dark:text-neutral-400'>
+                  IO mapping and device configuration will be available here.
+                </p>
+              </div>
+            </td>
+          </tr>
+        </>
+      )}
+    </>
+  )
+}
+
+export { ConfiguredDeviceRow }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-device-row.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-device-row.tsx
@@ -43,7 +43,7 @@ const ConfiguredDeviceRow = ({
     return getDeviceSummary(esiDevice)
   }, [esiDevice])
 
-  const ioSummary = summary ? `${summary.totalInputBytes}B/${summary.totalOutputBytes}B` : '-'
+  const ioSummary = summary ? `${summary.inputChannelCount} / ${summary.outputChannelCount}` : '-'
 
   return (
     <>

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-device-row.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-device-row.tsx
@@ -1,12 +1,11 @@
 import { ArrowIcon } from '@root/renderer/assets/icons'
-import type { ConfiguredEtherCATDevice, ESIDevice, ESIRepositoryItem } from '@root/types/ethercat/esi-types'
+import type { ConfiguredEtherCATDevice, ESIDeviceSummary, ESIRepositoryItemLight } from '@root/types/ethercat/esi-types'
 import { cn } from '@root/utils'
-import { getDeviceSummary } from '@root/utils/ethercat/esi-parser'
 import { useMemo } from 'react'
 
 type ConfiguredDeviceRowProps = {
   device: ConfiguredEtherCATDevice
-  repository: ESIRepositoryItem[]
+  repository: ESIRepositoryItemLight[]
   isExpanded: boolean
   onToggleExpand: () => void
   isSelected: boolean
@@ -27,8 +26,8 @@ const ConfiguredDeviceRow = ({
   isSelected,
   onSelect,
 }: ConfiguredDeviceRowProps) => {
-  // Resolve the ESI device from repository
-  const esiDevice = useMemo<ESIDevice | null>(() => {
+  // Resolve the ESI device summary from repository
+  const esiDevice = useMemo<ESIDeviceSummary | null>(() => {
     const repoItem = repository.find((r) => r.id === device.esiDeviceRef.repositoryItemId)
     if (!repoItem) return null
     return repoItem.devices[device.esiDeviceRef.deviceIndex] || null
@@ -38,12 +37,7 @@ const ConfiguredDeviceRow = ({
     return repository.find((r) => r.id === device.esiDeviceRef.repositoryItemId)
   }, [repository, device.esiDeviceRef.repositoryItemId])
 
-  const summary = useMemo(() => {
-    if (!esiDevice) return null
-    return getDeviceSummary(esiDevice)
-  }, [esiDevice])
-
-  const ioSummary = summary ? `${summary.inputChannelCount} / ${summary.outputChannelCount}` : '-'
+  const ioSummary = esiDevice ? `${esiDevice.inputChannelCount} / ${esiDevice.outputChannelCount}` : '-'
 
   return (
     <>
@@ -127,15 +121,15 @@ const ConfiguredDeviceRow = ({
                       <span className='text-neutral-700 dark:text-neutral-300'>{esiDevice.groupName}</span>
                     </div>
                   )}
-                  {summary && (
+                  {esiDevice && (
                     <>
                       <div>
                         <span className='text-neutral-500 dark:text-neutral-400'>Input Channels:</span>{' '}
-                        <span className='text-neutral-700 dark:text-neutral-300'>{summary.inputChannelCount}</span>
+                        <span className='text-neutral-700 dark:text-neutral-300'>{esiDevice.inputChannelCount}</span>
                       </div>
                       <div>
                         <span className='text-neutral-500 dark:text-neutral-400'>Output Channels:</span>{' '}
-                        <span className='text-neutral-700 dark:text-neutral-300'>{summary.outputChannelCount}</span>
+                        <span className='text-neutral-700 dark:text-neutral-300'>{esiDevice.outputChannelCount}</span>
                       </div>
                     </>
                   )}

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-devices.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-devices.tsx
@@ -28,6 +28,7 @@ type ConfiguredDevicesProps = {
   projectPath: string
   onUpdateChannelMappings: (deviceId: string, mappings: EtherCATChannelMapping[]) => void
   onEnrichDevice: (deviceId: string, data: EnrichDeviceData) => void
+  usedAddresses: Set<string>
 }
 
 /**
@@ -44,6 +45,7 @@ const ConfiguredDevices = ({
   projectPath,
   onUpdateChannelMappings,
   onEnrichDevice,
+  usedAddresses,
 }: ConfiguredDevicesProps) => {
   const [expandedDevices, setExpandedDevices] = useState<Set<string>>(new Set())
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null)
@@ -140,6 +142,7 @@ const ConfiguredDevices = ({
                   projectPath={projectPath}
                   onUpdateChannelMappings={(mappings) => onUpdateChannelMappings(device.id, mappings)}
                   onEnrichDevice={(data) => onEnrichDevice(device.id, data)}
+                  usedAddresses={usedAddresses}
                 />
               ))
             )}

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-devices.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-devices.tsx
@@ -1,6 +1,11 @@
 import { MinusIcon, PlusIcon } from '@root/renderer/assets/icons'
 import TableActions from '@root/renderer/components/_atoms/table-actions'
-import type { ConfiguredEtherCATDevice, ESIRepositoryItemLight } from '@root/types/ethercat/esi-types'
+import type {
+  ConfiguredEtherCATDevice,
+  ESIRepositoryItemLight,
+  EtherCATChannelMapping,
+  EtherCATSlaveConfig,
+} from '@root/types/ethercat/esi-types'
 import { useCallback, useState } from 'react'
 
 import { ConfiguredDeviceRow } from './configured-device-row'
@@ -10,6 +15,9 @@ type ConfiguredDevicesProps = {
   repository: ESIRepositoryItemLight[]
   onAddDevice: () => void
   onRemoveDevice: (deviceId: string) => void
+  onUpdateDevice: (deviceId: string, config: EtherCATSlaveConfig) => void
+  projectPath: string
+  onUpdateChannelMappings: (deviceId: string, mappings: EtherCATChannelMapping[]) => void
 }
 
 /**
@@ -17,7 +25,15 @@ type ConfiguredDevicesProps = {
  *
  * Displays the list of configured EtherCAT devices with add/remove functionality.
  */
-const ConfiguredDevices = ({ devices, repository, onAddDevice, onRemoveDevice }: ConfiguredDevicesProps) => {
+const ConfiguredDevices = ({
+  devices,
+  repository,
+  onAddDevice,
+  onRemoveDevice,
+  onUpdateDevice,
+  projectPath,
+  onUpdateChannelMappings,
+}: ConfiguredDevicesProps) => {
   const [expandedDevices, setExpandedDevices] = useState<Set<string>>(new Set())
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null)
 
@@ -109,6 +125,9 @@ const ConfiguredDevices = ({ devices, repository, onAddDevice, onRemoveDevice }:
                   onToggleExpand={() => handleToggleExpand(device.id)}
                   isSelected={selectedDeviceId === device.id}
                   onSelect={() => setSelectedDeviceId(device.id)}
+                  onUpdateDevice={(config) => onUpdateDevice(device.id, config)}
+                  projectPath={projectPath}
+                  onUpdateChannelMappings={(mappings) => onUpdateChannelMappings(device.id, mappings)}
                 />
               ))
             )}

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-devices.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-devices.tsx
@@ -1,13 +1,13 @@
 import { MinusIcon, PlusIcon } from '@root/renderer/assets/icons'
 import TableActions from '@root/renderer/components/_atoms/table-actions'
-import type { ConfiguredEtherCATDevice, ESIRepositoryItem } from '@root/types/ethercat/esi-types'
+import type { ConfiguredEtherCATDevice, ESIRepositoryItemLight } from '@root/types/ethercat/esi-types'
 import { useCallback, useState } from 'react'
 
 import { ConfiguredDeviceRow } from './configured-device-row'
 
 type ConfiguredDevicesProps = {
   devices: ConfiguredEtherCATDevice[]
-  repository: ESIRepositoryItem[]
+  repository: ESIRepositoryItemLight[]
   onAddDevice: () => void
   onRemoveDevice: (deviceId: string) => void
 }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-devices.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-devices.tsx
@@ -86,7 +86,7 @@ const ConfiguredDevices = ({ devices, repository, onAddDevice, onRemoveDevice }:
                 Position
               </th>
               <th className='w-[15%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
-                I/O
+                Channels (In/Out)
               </th>
               <th className='px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>Source</th>
             </tr>

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-devices.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-devices.tsx
@@ -5,10 +5,19 @@ import type {
   ESIRepositoryItemLight,
   EtherCATChannelMapping,
   EtherCATSlaveConfig,
+  PersistedChannelInfo,
+  PersistedPdo,
 } from '@root/types/ethercat/esi-types'
 import { useCallback, useState } from 'react'
 
 import { ConfiguredDeviceRow } from './configured-device-row'
+
+type EnrichDeviceData = {
+  channelInfo?: PersistedChannelInfo[]
+  rxPdos?: PersistedPdo[]
+  txPdos?: PersistedPdo[]
+  slaveType?: string
+}
 
 type ConfiguredDevicesProps = {
   devices: ConfiguredEtherCATDevice[]
@@ -18,6 +27,7 @@ type ConfiguredDevicesProps = {
   onUpdateDevice: (deviceId: string, config: EtherCATSlaveConfig) => void
   projectPath: string
   onUpdateChannelMappings: (deviceId: string, mappings: EtherCATChannelMapping[]) => void
+  onEnrichDevice: (deviceId: string, data: EnrichDeviceData) => void
 }
 
 /**
@@ -33,6 +43,7 @@ const ConfiguredDevices = ({
   onUpdateDevice,
   projectPath,
   onUpdateChannelMappings,
+  onEnrichDevice,
 }: ConfiguredDevicesProps) => {
   const [expandedDevices, setExpandedDevices] = useState<Set<string>>(new Set())
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null)
@@ -128,6 +139,7 @@ const ConfiguredDevices = ({
                   onUpdateDevice={(config) => onUpdateDevice(device.id, config)}
                   projectPath={projectPath}
                   onUpdateChannelMappings={(mappings) => onUpdateChannelMappings(device.id, mappings)}
+                  onEnrichDevice={(data) => onEnrichDevice(device.id, data)}
                 />
               ))
             )}

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-devices.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/configured-devices.tsx
@@ -1,0 +1,122 @@
+import { MinusIcon, PlusIcon } from '@root/renderer/assets/icons'
+import TableActions from '@root/renderer/components/_atoms/table-actions'
+import type { ConfiguredEtherCATDevice, ESIRepositoryItem } from '@root/types/ethercat/esi-types'
+import { useCallback, useState } from 'react'
+
+import { ConfiguredDeviceRow } from './configured-device-row'
+
+type ConfiguredDevicesProps = {
+  devices: ConfiguredEtherCATDevice[]
+  repository: ESIRepositoryItem[]
+  onAddDevice: () => void
+  onRemoveDevice: (deviceId: string) => void
+}
+
+/**
+ * Configured Devices Component
+ *
+ * Displays the list of configured EtherCAT devices with add/remove functionality.
+ */
+const ConfiguredDevices = ({ devices, repository, onAddDevice, onRemoveDevice }: ConfiguredDevicesProps) => {
+  const [expandedDevices, setExpandedDevices] = useState<Set<string>>(new Set())
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null)
+
+  const handleToggleExpand = useCallback((deviceId: string) => {
+    setExpandedDevices((prev) => {
+      const next = new Set(prev)
+      if (next.has(deviceId)) {
+        next.delete(deviceId)
+      } else {
+        next.add(deviceId)
+      }
+      return next
+    })
+  }, [])
+
+  const handleRemoveSelected = useCallback(() => {
+    if (selectedDeviceId) {
+      onRemoveDevice(selectedDeviceId)
+      setSelectedDeviceId(null)
+    }
+  }, [selectedDeviceId, onRemoveDevice])
+
+  return (
+    <div className='flex flex-1 flex-col overflow-hidden'>
+      {/* Header with actions */}
+      <div className='mb-2 flex items-center justify-between'>
+        <h3 className='text-sm font-medium text-neutral-950 dark:text-neutral-100'>
+          Configured Devices {devices.length > 0 && `(${devices.length})`}
+        </h3>
+        <TableActions
+          actions={[
+            {
+              ariaLabel: 'Add Device',
+              onClick: onAddDevice,
+              icon: <PlusIcon className='h-4 w-4 stroke-brand' />,
+              id: 'add-device-button',
+            },
+            {
+              ariaLabel: 'Remove Device',
+              onClick: handleRemoveSelected,
+              disabled: !selectedDeviceId,
+              icon: <MinusIcon className='h-4 w-4 stroke-brand' />,
+              id: 'remove-device-button',
+            },
+          ]}
+          buttonProps={{
+            className:
+              'rounded-md p-1 hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-50 disabled:cursor-not-allowed',
+          }}
+        />
+      </div>
+
+      {/* Devices table */}
+      <div className='flex-1 overflow-auto rounded-lg border border-neutral-200 dark:border-neutral-800'>
+        <table className='w-full table-fixed'>
+          <thead className='sticky top-0 bg-neutral-100 dark:bg-neutral-900'>
+            <tr>
+              <th className='w-8 px-2 py-2'></th>
+              <th className='w-[20%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                Name
+              </th>
+              <th className='w-[20%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                Type
+              </th>
+              <th className='w-[10%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                Position
+              </th>
+              <th className='w-[15%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                I/O
+              </th>
+              <th className='px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>Source</th>
+            </tr>
+          </thead>
+          <tbody>
+            {devices.length === 0 ? (
+              <tr>
+                <td colSpan={6} className='px-4 py-8 text-center text-sm text-neutral-500 dark:text-neutral-400'>
+                  No devices configured. Click the + button to add a device from the repository, or use the Discovery
+                  tab to scan and add devices.
+                </td>
+              </tr>
+            ) : (
+              devices.map((device) => (
+                <ConfiguredDeviceRow
+                  key={device.id}
+                  device={device}
+                  repository={repository}
+                  isExpanded={expandedDevices.has(device.id)}
+                  onToggleExpand={() => handleToggleExpand(device.id)}
+                  isSelected={selectedDeviceId === device.id}
+                  onSelect={() => setSelectedDeviceId(device.id)}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+export { ConfiguredDevices }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/device-browser-modal.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/device-browser-modal.tsx
@@ -1,0 +1,272 @@
+import { Modal, ModalContent, ModalFooter, ModalHeader, ModalTitle } from '@root/renderer/components/_molecules/modal'
+import type { ESIDevice, ESIDeviceRef, ESIRepositoryItem } from '@root/types/ethercat/esi-types'
+import { cn } from '@root/utils'
+import { useCallback, useMemo, useState } from 'react'
+
+type DeviceBrowserModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  onSelectDevice: (ref: ESIDeviceRef, device: ESIDevice, repoItem: ESIRepositoryItem) => void
+  repository: ESIRepositoryItem[]
+}
+
+/**
+ * Device Browser Modal Component
+ *
+ * Modal for browsing and selecting devices from the ESI repository.
+ * Groups devices by vendor for easier navigation.
+ */
+const DeviceBrowserModal = ({ isOpen, onClose, onSelectDevice, repository }: DeviceBrowserModalProps) => {
+  const [searchTerm, setSearchTerm] = useState('')
+  const [selectedRef, setSelectedRef] = useState<ESIDeviceRef | null>(null)
+  const [expandedVendors, setExpandedVendors] = useState<Set<string>>(new Set())
+
+  // Group devices by vendor
+  const groupedDevices = useMemo(() => {
+    const groups: Map<
+      string,
+      {
+        vendorId: string
+        vendorName: string
+        devices: Array<{
+          repoItem: ESIRepositoryItem
+          device: ESIDevice
+          deviceIndex: number
+        }>
+      }
+    > = new Map()
+
+    for (const repoItem of repository) {
+      const vendorKey = repoItem.vendor.id
+      if (!groups.has(vendorKey)) {
+        groups.set(vendorKey, {
+          vendorId: repoItem.vendor.id,
+          vendorName: repoItem.vendor.name,
+          devices: [],
+        })
+      }
+
+      for (let i = 0; i < repoItem.devices.length; i++) {
+        const device = repoItem.devices[i]
+        // Apply search filter
+        if (searchTerm) {
+          const search = searchTerm.toLowerCase()
+          const matches =
+            device.name.toLowerCase().includes(search) ||
+            device.type.productCode.toLowerCase().includes(search) ||
+            repoItem.vendor.name.toLowerCase().includes(search)
+          if (!matches) continue
+        }
+
+        groups.get(vendorKey)!.devices.push({
+          repoItem,
+          device,
+          deviceIndex: i,
+        })
+      }
+    }
+
+    // Remove empty groups
+    for (const [key, group] of groups) {
+      if (group.devices.length === 0) {
+        groups.delete(key)
+      }
+    }
+
+    return Array.from(groups.values())
+  }, [repository, searchTerm])
+
+  const handleToggleVendor = useCallback((vendorId: string) => {
+    setExpandedVendors((prev) => {
+      const next = new Set(prev)
+      if (next.has(vendorId)) {
+        next.delete(vendorId)
+      } else {
+        next.add(vendorId)
+      }
+      return next
+    })
+  }, [])
+
+  const handleSelectDevice = useCallback((repoItemId: string, deviceIndex: number) => {
+    setSelectedRef({ repositoryItemId: repoItemId, deviceIndex })
+  }, [])
+
+  const handleConfirm = useCallback(() => {
+    if (!selectedRef) return
+
+    const repoItem = repository.find((r) => r.id === selectedRef.repositoryItemId)
+    if (!repoItem) return
+
+    const device = repoItem.devices[selectedRef.deviceIndex]
+    if (!device) return
+
+    onSelectDevice(selectedRef, device, repoItem)
+    setSelectedRef(null)
+    setSearchTerm('')
+    onClose()
+  }, [selectedRef, repository, onSelectDevice, onClose])
+
+  const handleClose = useCallback(() => {
+    setSelectedRef(null)
+    setSearchTerm('')
+    onClose()
+  }, [onClose])
+
+  // Auto-expand all vendors when searching
+  const effectiveExpandedVendors = useMemo(() => {
+    if (searchTerm) {
+      return new Set(groupedDevices.map((g) => g.vendorId))
+    }
+    return expandedVendors
+  }, [searchTerm, groupedDevices, expandedVendors])
+
+  const totalDevices = groupedDevices.reduce((sum, g) => sum + g.devices.length, 0)
+
+  return (
+    <Modal open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <ModalContent className='h-[600px] w-[600px]' onClose={handleClose}>
+        <ModalHeader>
+          <ModalTitle>Add Device from Repository</ModalTitle>
+        </ModalHeader>
+
+        {/* Search */}
+        <div className='mb-2'>
+          <input
+            type='text'
+            placeholder='Search devices by name, product code, or vendor...'
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className='h-[34px] w-full rounded-md border border-neutral-300 bg-white px-3 text-sm text-neutral-700 outline-none focus:border-brand dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300'
+          />
+        </div>
+
+        {/* Device count */}
+        <div className='mb-2 text-xs text-neutral-500 dark:text-neutral-400'>
+          {totalDevices} device(s) in {groupedDevices.length} vendor(s)
+        </div>
+
+        {/* Device list */}
+        <div className='flex-1 overflow-auto rounded-lg border border-neutral-200 dark:border-neutral-800'>
+          {groupedDevices.length === 0 ? (
+            <div className='flex h-full items-center justify-center p-4'>
+              <p className='text-sm text-neutral-500 dark:text-neutral-400'>
+                {repository.length === 0
+                  ? 'No ESI files loaded. Upload files in the Repository tab first.'
+                  : 'No devices match your search.'}
+              </p>
+            </div>
+          ) : (
+            <div className='divide-y divide-neutral-200 dark:divide-neutral-800'>
+              {groupedDevices.map((group) => (
+                <div key={group.vendorId}>
+                  {/* Vendor header */}
+                  <button
+                    onClick={() => handleToggleVendor(group.vendorId)}
+                    className='flex w-full items-center gap-2 bg-neutral-100 px-3 py-2 text-left hover:bg-neutral-200 dark:bg-neutral-900 dark:hover:bg-neutral-800'
+                  >
+                    <svg
+                      className={cn(
+                        'h-3 w-3 text-neutral-500 transition-transform',
+                        effectiveExpandedVendors.has(group.vendorId) && 'rotate-90',
+                      )}
+                      fill='none'
+                      viewBox='0 0 24 24'
+                      stroke='currentColor'
+                    >
+                      <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M9 5l7 7-7 7' />
+                    </svg>
+                    <span className='text-sm font-medium text-neutral-700 dark:text-neutral-300'>
+                      {group.vendorName}
+                    </span>
+                    <span className='font-mono text-xs text-neutral-500'>({group.vendorId})</span>
+                    <span className='ml-auto text-xs text-neutral-500'>{group.devices.length} device(s)</span>
+                  </button>
+
+                  {/* Devices */}
+                  {effectiveExpandedVendors.has(group.vendorId) && (
+                    <div className='divide-y divide-neutral-100 dark:divide-neutral-900'>
+                      {group.devices.map(({ repoItem, device, deviceIndex }) => {
+                        const isSelected =
+                          selectedRef?.repositoryItemId === repoItem.id && selectedRef?.deviceIndex === deviceIndex
+                        return (
+                          <div
+                            key={`${repoItem.id}-${deviceIndex}`}
+                            onClick={() => handleSelectDevice(repoItem.id, deviceIndex)}
+                            className={cn(
+                              'flex cursor-pointer items-center gap-3 px-3 py-2 pl-8 hover:bg-neutral-50 dark:hover:bg-neutral-800/50',
+                              isSelected && 'bg-brand/10 dark:bg-brand/20',
+                            )}
+                          >
+                            <svg
+                              className='h-4 w-4 flex-shrink-0 text-brand'
+                              fill='none'
+                              viewBox='0 0 24 24'
+                              stroke='currentColor'
+                            >
+                              <path
+                                strokeLinecap='round'
+                                strokeLinejoin='round'
+                                strokeWidth={2}
+                                d='M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z'
+                              />
+                            </svg>
+                            <div className='min-w-0 flex-1'>
+                              <div className='flex items-center gap-2'>
+                                <span className='truncate text-sm font-medium text-neutral-900 dark:text-neutral-100'>
+                                  {device.name}
+                                </span>
+                                {device.groupName && (
+                                  <span className='flex-shrink-0 rounded bg-neutral-200 px-1.5 py-0.5 text-xs text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300'>
+                                    {device.groupName}
+                                  </span>
+                                )}
+                              </div>
+                              <div className='flex gap-3 text-xs text-neutral-500 dark:text-neutral-400'>
+                                <span className='font-mono'>{device.type.productCode}</span>
+                                <span>Rev: {device.type.revisionNo}</span>
+                                <span className='truncate'>from {repoItem.filename}</span>
+                              </div>
+                            </div>
+                            {isSelected && (
+                              <svg
+                                className='h-4 w-4 flex-shrink-0 text-brand'
+                                fill='none'
+                                viewBox='0 0 24 24'
+                                stroke='currentColor'
+                              >
+                                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M5 13l4 4L19 7' />
+                              </svg>
+                            )}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <ModalFooter className='flex justify-end gap-2 pt-3'>
+          <button
+            onClick={handleClose}
+            className='rounded-md border border-neutral-300 bg-white px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800'
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={!selectedRef}
+            className='rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-medium-dark disabled:cursor-not-allowed disabled:opacity-50'
+          >
+            Add Device
+          </button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export { DeviceBrowserModal }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/device-browser-modal.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/device-browser-modal.tsx
@@ -1,13 +1,13 @@
 import { Modal, ModalContent, ModalFooter, ModalHeader, ModalTitle } from '@root/renderer/components/_molecules/modal'
-import type { ESIDevice, ESIDeviceRef, ESIRepositoryItem } from '@root/types/ethercat/esi-types'
+import type { ESIDeviceRef, ESIDeviceSummary, ESIRepositoryItemLight } from '@root/types/ethercat/esi-types'
 import { cn } from '@root/utils'
 import { useCallback, useMemo, useState } from 'react'
 
 type DeviceBrowserModalProps = {
   isOpen: boolean
   onClose: () => void
-  onSelectDevice: (ref: ESIDeviceRef, device: ESIDevice, repoItem: ESIRepositoryItem) => void
-  repository: ESIRepositoryItem[]
+  onSelectDevice: (ref: ESIDeviceRef, device: ESIDeviceSummary, repoItem: ESIRepositoryItemLight) => void
+  repository: ESIRepositoryItemLight[]
 }
 
 /**
@@ -29,8 +29,8 @@ const DeviceBrowserModal = ({ isOpen, onClose, onSelectDevice, repository }: Dev
         vendorId: string
         vendorName: string
         devices: Array<{
-          repoItem: ESIRepositoryItem
-          device: ESIDevice
+          repoItem: ESIRepositoryItemLight
+          device: ESIDeviceSummary
           deviceIndex: number
         }>
       }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/discovered-device-table.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/discovered-device-table.tsx
@@ -1,0 +1,184 @@
+import { Checkbox } from '@root/renderer/components/_atoms/checkbox'
+import type { DeviceMatchQuality, ScannedDeviceMatch } from '@root/types/ethercat/esi-types'
+import { cn } from '@root/utils'
+import { getBestMatchQuality } from '@root/utils/ethercat/device-matcher'
+
+type DiscoveredDeviceTableProps = {
+  deviceMatches: ScannedDeviceMatch[]
+  selectedDevices: Set<number>
+  onSelectDevice: (position: number, selected: boolean) => void
+  onSelectAll: (selected: boolean) => void
+  isScanning: boolean
+}
+
+/**
+ * Get badge styling for match quality
+ */
+function getMatchBadge(quality: DeviceMatchQuality): { label: string; className: string } {
+  switch (quality) {
+    case 'exact':
+      return {
+        label: 'Exact',
+        className: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+      }
+    case 'partial':
+      return {
+        label: 'Partial',
+        className: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+      }
+    case 'none':
+      return {
+        label: 'None',
+        className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+      }
+  }
+}
+
+/**
+ * Discovered Device Table Component
+ *
+ * Displays scanned EtherCAT devices with match indicators and selection checkboxes.
+ */
+const DiscoveredDeviceTable = ({
+  deviceMatches,
+  selectedDevices,
+  onSelectDevice,
+  onSelectAll,
+  isScanning,
+}: DiscoveredDeviceTableProps) => {
+  // Calculate selection state
+  const selectableDevices = deviceMatches.filter((dm) => getBestMatchQuality(dm.matches) !== 'none')
+  const allSelected =
+    selectableDevices.length > 0 && selectableDevices.every((dm) => selectedDevices.has(dm.device.position))
+  const someSelected = selectableDevices.some((dm) => selectedDevices.has(dm.device.position))
+
+  const handleSelectAll = () => {
+    onSelectAll(!allSelected)
+  }
+
+  return (
+    <div className='flex-1 overflow-auto rounded-lg border border-neutral-200 dark:border-neutral-800'>
+      <table className='w-full table-fixed'>
+        <thead className='sticky top-0 bg-neutral-100 dark:bg-neutral-900'>
+          <tr>
+            <th className='w-[40px] px-2 py-2'>
+              <Checkbox
+                checked={someSelected && !allSelected ? 'indeterminate' : allSelected}
+                onCheckedChange={handleSelectAll}
+                disabled={selectableDevices.length === 0}
+              />
+            </th>
+            <th className='w-[8%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+              Pos
+            </th>
+            <th className='w-[20%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+              Name
+            </th>
+            <th className='w-[12%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+              Vendor
+            </th>
+            <th className='w-[14%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+              Product
+            </th>
+            <th className='w-[10%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+              State
+            </th>
+            <th className='w-[12%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+              I/O
+            </th>
+            <th className='px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>Match</th>
+          </tr>
+        </thead>
+        <tbody>
+          {deviceMatches.length === 0 ? (
+            <tr>
+              <td colSpan={8} className='px-4 py-8 text-center text-sm text-neutral-500 dark:text-neutral-400'>
+                {isScanning
+                  ? 'Scanning for devices...'
+                  : 'No devices found. Click "Scan" to discover EtherCAT devices on the network.'}
+              </td>
+            </tr>
+          ) : (
+            deviceMatches.map((dm) => {
+              const bestQuality = getBestMatchQuality(dm.matches)
+              const badge = getMatchBadge(bestQuality)
+              const isSelectable = bestQuality !== 'none'
+              const isSelected = selectedDevices.has(dm.device.position)
+
+              return (
+                <tr
+                  key={dm.device.position}
+                  onClick={() => isSelectable && onSelectDevice(dm.device.position, !isSelected)}
+                  className={cn(
+                    'border-b border-neutral-200 transition-colors dark:border-neutral-800',
+                    isSelectable && 'cursor-pointer hover:bg-neutral-50 dark:hover:bg-neutral-800/50',
+                    isSelected && 'bg-brand/10 dark:bg-brand/20',
+                    !isSelectable && 'opacity-60',
+                  )}
+                >
+                  <td className='px-2 py-2'>
+                    <Checkbox
+                      checked={isSelected}
+                      onCheckedChange={(checked) => onSelectDevice(dm.device.position, !!checked)}
+                      onClick={(e) => e.stopPropagation()}
+                      disabled={!isSelectable}
+                    />
+                  </td>
+                  <td className='px-2 py-2 text-sm font-medium text-neutral-700 dark:text-neutral-300'>
+                    {dm.device.position}
+                  </td>
+                  <td
+                    className='truncate px-2 py-2 text-sm font-medium text-neutral-950 dark:text-neutral-100'
+                    title={dm.device.name}
+                  >
+                    {dm.device.name}
+                  </td>
+                  <td className='px-2 py-2 font-mono text-xs text-neutral-600 dark:text-neutral-400'>
+                    0x{dm.device.vendor_id.toString(16).padStart(4, '0').toUpperCase()}
+                  </td>
+                  <td className='px-2 py-2 font-mono text-xs text-neutral-600 dark:text-neutral-400'>
+                    0x{dm.device.product_code.toString(16).padStart(8, '0').toUpperCase()}
+                  </td>
+                  <td className='px-2 py-2'>
+                    <span
+                      className={cn(
+                        'inline-block rounded px-1.5 py-0.5 text-xs font-medium',
+                        dm.device.state === 'OP'
+                          ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                          : dm.device.state === 'SAFE-OP'
+                            ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+                            : 'bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400',
+                      )}
+                    >
+                      {dm.device.state}
+                    </span>
+                  </td>
+                  <td className='px-2 py-2 text-xs text-neutral-600 dark:text-neutral-400'>
+                    {dm.device.input_bytes}B / {dm.device.output_bytes}B
+                  </td>
+                  <td className='px-2 py-2'>
+                    <div className='flex items-center gap-2'>
+                      <span className={cn('inline-block rounded px-1.5 py-0.5 text-xs font-medium', badge.className)}>
+                        {bestQuality === 'exact' && '✓ '}
+                        {bestQuality === 'partial' && '~ '}
+                        {bestQuality === 'none' && '✗ '}
+                        {badge.label}
+                      </span>
+                      {dm.matches.length > 1 && (
+                        <span className='text-xs text-neutral-500 dark:text-neutral-400'>
+                          ({dm.matches.length} matches)
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              )
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export { DiscoveredDeviceTable }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-device-info.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-device-info.tsx
@@ -1,0 +1,165 @@
+import type { ESIDevice, ESIFile } from '@root/types/ethercat/esi-types'
+import { cn } from '@root/utils'
+import { getDeviceSummary } from '@root/utils/ethercat/esi-parser'
+
+type ESIDeviceInfoProps = {
+  esiFile: ESIFile
+  selectedDeviceIndex: number
+  onSelectDevice: (index: number) => void
+}
+
+/**
+ * ESI Device Info Component
+ *
+ * Displays vendor information and device details from an ESI file.
+ */
+const ESIDeviceInfo = ({ esiFile, selectedDeviceIndex, onSelectDevice }: ESIDeviceInfoProps) => {
+  const selectedDevice: ESIDevice | undefined = esiFile.devices[selectedDeviceIndex]
+  const summary = selectedDevice ? getDeviceSummary(selectedDevice) : null
+
+  return (
+    <div className='flex flex-col gap-4'>
+      {/* Vendor Information */}
+      <div className='rounded-lg border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-700 dark:bg-neutral-900'>
+        <h4 className='mb-2 text-xs font-medium uppercase text-neutral-500 dark:text-neutral-400'>Vendor</h4>
+        <div className='grid grid-cols-2 gap-2 text-sm'>
+          <div>
+            <span className='text-neutral-500 dark:text-neutral-400'>Name: </span>
+            <span className='font-medium text-neutral-700 dark:text-neutral-300'>{esiFile.vendor.name}</span>
+          </div>
+          <div>
+            <span className='text-neutral-500 dark:text-neutral-400'>ID: </span>
+            <span className='font-mono text-neutral-700 dark:text-neutral-300'>{esiFile.vendor.id}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Device Selector (if multiple devices) */}
+      {esiFile.devices.length > 1 && (
+        <div className='flex flex-col gap-2'>
+          <label className='text-xs font-medium text-neutral-950 dark:text-white'>Select Device</label>
+          <div className='flex flex-wrap gap-2'>
+            {esiFile.devices.map((device, index) => (
+              <button
+                key={index}
+                onClick={() => onSelectDevice(index)}
+                className={cn(
+                  'rounded-md border px-3 py-1.5 text-xs font-medium transition-colors',
+                  selectedDeviceIndex === index
+                    ? 'border-brand bg-brand text-white'
+                    : 'border-neutral-300 bg-white text-neutral-700 hover:border-brand hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800',
+                )}
+              >
+                {device.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Selected Device Information */}
+      {selectedDevice && (
+        <div className='rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-900'>
+          <div className='mb-3 flex items-start justify-between'>
+            <div>
+              <h3 className='text-base font-semibold text-neutral-900 dark:text-neutral-100'>{selectedDevice.name}</h3>
+              <p className='text-xs text-neutral-500 dark:text-neutral-400'>{selectedDevice.type.name}</p>
+            </div>
+            {selectedDevice.groupName && (
+              <span className='rounded bg-neutral-100 px-2 py-0.5 text-xs text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400'>
+                {selectedDevice.groupName}
+              </span>
+            )}
+          </div>
+
+          {/* Device Details Grid */}
+          <div className='grid grid-cols-2 gap-x-4 gap-y-2 text-xs md:grid-cols-4'>
+            <div>
+              <span className='text-neutral-500 dark:text-neutral-400'>Product Code</span>
+              <p className='font-mono font-medium text-neutral-700 dark:text-neutral-300'>
+                {selectedDevice.type.productCode}
+              </p>
+            </div>
+            <div>
+              <span className='text-neutral-500 dark:text-neutral-400'>Revision</span>
+              <p className='font-mono font-medium text-neutral-700 dark:text-neutral-300'>
+                {selectedDevice.type.revisionNo}
+              </p>
+            </div>
+            <div>
+              <span className='text-neutral-500 dark:text-neutral-400'>Physics</span>
+              <p className='font-medium text-neutral-700 dark:text-neutral-300'>{selectedDevice.physics || 'N/A'}</p>
+            </div>
+            <div>
+              <span className='text-neutral-500 dark:text-neutral-400'>CoE Support</span>
+              <p className='font-medium text-neutral-700 dark:text-neutral-300'>{summary?.hasCoe ? 'Yes' : 'No'}</p>
+            </div>
+          </div>
+
+          {/* I/O Summary */}
+          {summary && (
+            <div className='mt-4 border-t border-neutral-200 pt-3 dark:border-neutral-700'>
+              <h4 className='mb-2 text-xs font-medium uppercase text-neutral-500 dark:text-neutral-400'>I/O Summary</h4>
+              <div className='grid grid-cols-2 gap-4 md:grid-cols-4'>
+                <div className='rounded-md bg-green-50 p-2 dark:bg-green-900/20'>
+                  <p className='text-lg font-bold text-green-700 dark:text-green-400'>{summary.inputChannelCount}</p>
+                  <p className='text-xs text-green-600 dark:text-green-500'>Input Channels</p>
+                </div>
+                <div className='rounded-md bg-blue-50 p-2 dark:bg-blue-900/20'>
+                  <p className='text-lg font-bold text-blue-700 dark:text-blue-400'>{summary.outputChannelCount}</p>
+                  <p className='text-xs text-blue-600 dark:text-blue-500'>Output Channels</p>
+                </div>
+                <div className='rounded-md bg-neutral-100 p-2 dark:bg-neutral-800'>
+                  <p className='text-lg font-bold text-neutral-700 dark:text-neutral-300'>
+                    {summary.totalInputBytes} B
+                  </p>
+                  <p className='text-xs text-neutral-500 dark:text-neutral-400'>Input Size</p>
+                </div>
+                <div className='rounded-md bg-neutral-100 p-2 dark:bg-neutral-800'>
+                  <p className='text-lg font-bold text-neutral-700 dark:text-neutral-300'>
+                    {summary.totalOutputBytes} B
+                  </p>
+                  <p className='text-xs text-neutral-500 dark:text-neutral-400'>Output Size</p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Sync Managers */}
+          {selectedDevice.syncManagers.length > 0 && (
+            <div className='mt-4 border-t border-neutral-200 pt-3 dark:border-neutral-700'>
+              <h4 className='mb-2 text-xs font-medium uppercase text-neutral-500 dark:text-neutral-400'>
+                Sync Managers
+              </h4>
+              <div className='flex flex-wrap gap-2'>
+                {selectedDevice.syncManagers.map((sm) => (
+                  <div
+                    key={sm.index}
+                    className={cn(
+                      'rounded-md border px-2 py-1 text-xs',
+                      sm.type === 'Inputs' || sm.type === 'MbxIn'
+                        ? 'border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-900/20 dark:text-green-400'
+                        : 'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-400',
+                    )}
+                  >
+                    SM{sm.index}: {sm.type}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Description */}
+          {selectedDevice.description && (
+            <div className='mt-4 border-t border-neutral-200 pt-3 dark:border-neutral-700'>
+              <h4 className='mb-1 text-xs font-medium uppercase text-neutral-500 dark:text-neutral-400'>Description</h4>
+              <p className='text-xs text-neutral-600 dark:text-neutral-400'>{selectedDevice.description}</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export { ESIDeviceInfo }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-parse-progress.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-parse-progress.tsx
@@ -1,0 +1,41 @@
+type ESIParseProgressProps = {
+  currentFile?: string
+  currentFileIndex: number
+  totalFiles: number
+  percentage: number
+}
+
+/**
+ * ESI Parse Progress Component
+ *
+ * Shows a progress bar with file-by-file status during ESI XML parsing.
+ */
+const ESIParseProgress = ({ currentFile, currentFileIndex, totalFiles, percentage }: ESIParseProgressProps) => {
+  return (
+    <div className='flex flex-col gap-2'>
+      <div className='flex items-center justify-between text-xs text-neutral-600 dark:text-neutral-400'>
+        <span>
+          Processing file {currentFileIndex + 1} / {totalFiles}
+        </span>
+        <span>{percentage}%</span>
+      </div>
+
+      {/* Progress bar */}
+      <div className='h-2 w-full overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-700'>
+        <div
+          className='h-full rounded-full bg-brand transition-all duration-200'
+          style={{ width: `${Math.max(percentage, 2)}%` }}
+        />
+      </div>
+
+      {/* Current file name */}
+      {currentFile && (
+        <span className='truncate text-xs text-neutral-500 dark:text-neutral-400' title={currentFile}>
+          {currentFile}
+        </span>
+      )}
+    </div>
+  )
+}
+
+export { ESIParseProgress }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository-table.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository-table.tsx
@@ -1,0 +1,215 @@
+import { ArrowIcon } from '@root/renderer/assets/icons'
+import type { ESIRepositoryItem } from '@root/types/ethercat/esi-types'
+import { cn } from '@root/utils'
+import { useCallback, useState } from 'react'
+
+type ESIRepositoryTableProps = {
+  repository: ESIRepositoryItem[]
+  onRemoveItem: (itemId: string) => void
+  onClearAll: () => void
+}
+
+/**
+ * ESI Repository Table Component
+ *
+ * Displays loaded ESI files with expandable rows showing contained devices.
+ */
+const ESIRepositoryTable = ({ repository, onRemoveItem, onClearAll }: ESIRepositoryTableProps) => {
+  const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set())
+
+  const handleToggleExpand = useCallback((itemId: string) => {
+    setExpandedItems((prev) => {
+      const next = new Set(prev)
+      if (next.has(itemId)) {
+        next.delete(itemId)
+      } else {
+        next.add(itemId)
+      }
+      return next
+    })
+  }, [])
+
+  if (repository.length === 0) {
+    return (
+      <div className='flex flex-1 items-center justify-center rounded-lg border border-dashed border-neutral-300 p-8 dark:border-neutral-700'>
+        <p className='text-sm text-neutral-500 dark:text-neutral-400'>
+          No ESI files loaded. Upload files above to populate the repository.
+        </p>
+      </div>
+    )
+  }
+
+  const totalDevices = repository.reduce((sum, item) => sum + item.devices.length, 0)
+
+  return (
+    <div className='flex flex-col gap-2'>
+      {/* Header with count and clear button */}
+      <div className='flex items-center justify-between'>
+        <span className='text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+          Loaded Files ({repository.length}) - {totalDevices} device(s)
+        </span>
+        <button
+          onClick={onClearAll}
+          className='text-xs text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
+        >
+          Clear All
+        </button>
+      </div>
+
+      {/* Repository list */}
+      <div className='flex-1 overflow-auto rounded-lg border border-neutral-200 dark:border-neutral-800'>
+        <table className='w-full table-fixed'>
+          <thead className='sticky top-0 bg-neutral-100 dark:bg-neutral-900'>
+            <tr>
+              <th className='w-8 px-2 py-2'></th>
+              <th className='w-[35%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                Filename
+              </th>
+              <th className='w-[30%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                Vendor
+              </th>
+              <th className='w-[15%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                Devices
+              </th>
+              <th className='px-2 py-2 text-right text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {repository.map((item) => (
+              <RepositoryItemRow
+                key={item.id}
+                item={item}
+                isExpanded={expandedItems.has(item.id)}
+                onToggleExpand={() => handleToggleExpand(item.id)}
+                onRemove={() => onRemoveItem(item.id)}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+type RepositoryItemRowProps = {
+  item: ESIRepositoryItem
+  isExpanded: boolean
+  onToggleExpand: () => void
+  onRemove: () => void
+}
+
+const RepositoryItemRow = ({ item, isExpanded, onToggleExpand, onRemove }: RepositoryItemRowProps) => {
+  return (
+    <>
+      {/* Main row */}
+      <tr className='cursor-pointer border-b border-neutral-200 hover:bg-neutral-50 dark:border-neutral-800 dark:hover:bg-neutral-800/50'>
+        <td className='px-2 py-2'>
+          <button onClick={onToggleExpand} className='flex items-center justify-center'>
+            <ArrowIcon
+              direction='right'
+              className={cn('h-4 w-4 stroke-brand-light transition-all', isExpanded && 'rotate-270 stroke-brand')}
+            />
+          </button>
+        </td>
+        <td className='px-2 py-2'>
+          <div className='flex items-center gap-2'>
+            <svg
+              className='h-4 w-4 text-neutral-500 dark:text-neutral-400'
+              fill='none'
+              viewBox='0 0 24 24'
+              stroke='currentColor'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                strokeWidth={1.5}
+                d='M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z'
+              />
+            </svg>
+            <span className='truncate text-sm font-medium text-neutral-950 dark:text-neutral-100' title={item.filename}>
+              {item.filename}
+            </span>
+            {item.warnings && item.warnings.length > 0 && (
+              <span className='rounded bg-yellow-100 px-1.5 py-0.5 text-xs text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'>
+                {item.warnings.length} warning(s)
+              </span>
+            )}
+          </div>
+        </td>
+        <td className='px-2 py-2'>
+          <span className='text-sm text-neutral-700 dark:text-neutral-300'>{item.vendor.name}</span>
+          <span className='ml-1 font-mono text-xs text-neutral-500 dark:text-neutral-500'>({item.vendor.id})</span>
+        </td>
+        <td className='px-2 py-2 text-sm text-neutral-700 dark:text-neutral-300'>{item.devices.length}</td>
+        <td className='px-2 py-2 text-right'>
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onRemove()
+            }}
+            className='text-xs text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
+          >
+            Remove
+          </button>
+        </td>
+      </tr>
+
+      {/* Expanded device rows */}
+      {isExpanded &&
+        item.devices.map((device, index) => (
+          <tr
+            key={`${item.id}-${index}`}
+            className='border-b border-neutral-100 bg-neutral-50 dark:border-neutral-900 dark:bg-neutral-900/50'
+          >
+            <td className='px-2 py-1'></td>
+            <td className='px-2 py-1 pl-8' colSpan={4}>
+              <div className='flex items-center gap-4'>
+                <div className='flex items-center gap-2'>
+                  <svg className='h-3.5 w-3.5 text-brand' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+                    <path
+                      strokeLinecap='round'
+                      strokeLinejoin='round'
+                      strokeWidth={2}
+                      d='M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z'
+                    />
+                  </svg>
+                  <span className='text-sm font-medium text-neutral-800 dark:text-neutral-200'>{device.name}</span>
+                </div>
+                <span className='font-mono text-xs text-neutral-500 dark:text-neutral-400'>
+                  {device.type.productCode}
+                </span>
+                <span className='font-mono text-xs text-neutral-500 dark:text-neutral-400'>
+                  Rev: {device.type.revisionNo}
+                </span>
+                {device.groupName && (
+                  <span className='rounded bg-neutral-200 px-1.5 py-0.5 text-xs text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300'>
+                    {device.groupName}
+                  </span>
+                )}
+              </div>
+            </td>
+          </tr>
+        ))}
+
+      {/* Warnings row */}
+      {isExpanded && item.warnings && item.warnings.length > 0 && (
+        <tr className='border-b border-neutral-100 bg-yellow-50 dark:border-neutral-900 dark:bg-yellow-900/10'>
+          <td className='px-2 py-1'></td>
+          <td className='px-2 py-1 pl-8' colSpan={4}>
+            <div className='flex flex-col gap-0.5'>
+              {item.warnings.map((warning, index) => (
+                <span key={index} className='text-xs text-yellow-700 dark:text-yellow-400'>
+                  {warning}
+                </span>
+              ))}
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+export { ESIRepositoryTable }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository-table.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository-table.tsx
@@ -1,10 +1,10 @@
 import { ArrowIcon } from '@root/renderer/assets/icons'
-import type { ESIRepositoryItem } from '@root/types/ethercat/esi-types'
+import type { ESIRepositoryItemLight } from '@root/types/ethercat/esi-types'
 import { cn } from '@root/utils'
 import { useCallback, useState } from 'react'
 
 type ESIRepositoryTableProps = {
-  repository: ESIRepositoryItem[]
+  repository: ESIRepositoryItemLight[]
   onRemoveItem: (itemId: string) => void | Promise<void>
   onClearAll: () => void | Promise<void>
 }
@@ -94,7 +94,7 @@ const ESIRepositoryTable = ({ repository, onRemoveItem, onClearAll }: ESIReposit
 }
 
 type RepositoryItemRowProps = {
-  item: ESIRepositoryItem
+  item: ESIRepositoryItemLight
   isExpanded: boolean
   onToggleExpand: () => void
   onRemove: () => void

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository-table.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository-table.tsx
@@ -7,6 +7,7 @@ type ESIRepositoryTableProps = {
   repository: ESIRepositoryItemLight[]
   onRemoveItem: (itemId: string) => void | Promise<void>
   onClearAll: () => void | Promise<void>
+  isLoading?: boolean
 }
 
 /**
@@ -14,7 +15,7 @@ type ESIRepositoryTableProps = {
  *
  * Displays loaded ESI files with expandable rows showing contained devices.
  */
-const ESIRepositoryTable = ({ repository, onRemoveItem, onClearAll }: ESIRepositoryTableProps) => {
+const ESIRepositoryTable = ({ repository, onRemoveItem, onClearAll, isLoading = false }: ESIRepositoryTableProps) => {
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set())
 
   const handleToggleExpand = useCallback((itemId: string) => {
@@ -50,9 +51,10 @@ const ESIRepositoryTable = ({ repository, onRemoveItem, onClearAll }: ESIReposit
         </span>
         <button
           onClick={() => void onClearAll()}
-          className='text-xs text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
+          disabled={isLoading}
+          className='text-xs text-red-600 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400 dark:hover:text-red-300'
         >
-          Clear All
+          {isLoading ? 'Clearing...' : 'Clear All'}
         </button>
       </div>
 

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository-table.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository-table.tsx
@@ -42,7 +42,7 @@ const ESIRepositoryTable = ({ repository, onRemoveItem, onClearAll }: ESIReposit
   const totalDevices = repository.reduce((sum, item) => sum + item.devices.length, 0)
 
   return (
-    <div className='flex flex-col gap-2'>
+    <div className='flex flex-1 flex-col gap-2 overflow-hidden'>
       {/* Header with count and clear button */}
       <div className='flex items-center justify-between'>
         <span className='text-xs font-medium text-neutral-700 dark:text-neutral-300'>

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository-table.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository-table.tsx
@@ -5,8 +5,8 @@ import { useCallback, useState } from 'react'
 
 type ESIRepositoryTableProps = {
   repository: ESIRepositoryItem[]
-  onRemoveItem: (itemId: string) => void
-  onClearAll: () => void
+  onRemoveItem: (itemId: string) => void | Promise<void>
+  onClearAll: () => void | Promise<void>
 }
 
 /**
@@ -49,7 +49,7 @@ const ESIRepositoryTable = ({ repository, onRemoveItem, onClearAll }: ESIReposit
           Loaded Files ({repository.length}) - {totalDevices} device(s)
         </span>
         <button
-          onClick={onClearAll}
+          onClick={() => void onClearAll()}
           className='text-xs text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
         >
           Clear All
@@ -83,7 +83,7 @@ const ESIRepositoryTable = ({ repository, onRemoveItem, onClearAll }: ESIReposit
                 item={item}
                 isExpanded={expandedItems.has(item.id)}
                 onToggleExpand={() => handleToggleExpand(item.id)}
-                onRemove={() => onRemoveItem(item.id)}
+                onRemove={() => void onRemoveItem(item.id)}
               />
             ))}
           </tbody>

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository.tsx
@@ -1,0 +1,108 @@
+import type { ESIParseResult, ESIRepositoryItem } from '@root/types/ethercat/esi-types'
+import { useCallback, useState } from 'react'
+
+import { ESIRepositoryTable } from './esi-repository-table'
+import { ESIUpload, parseResultsToRepositoryItems } from './esi-upload'
+
+type ESIRepositoryProps = {
+  repository: ESIRepositoryItem[]
+  onRepositoryChange: (repository: ESIRepositoryItem[]) => void
+}
+
+/**
+ * ESI Repository Component
+ *
+ * Manages the ESI file repository with upload and display functionality.
+ * Combines upload zone with repository table.
+ */
+const ESIRepository = ({ repository, onRepositoryChange }: ESIRepositoryProps) => {
+  const [uploadErrors, setUploadErrors] = useState<Array<{ filename: string; error: string }>>([])
+  const [isLoading] = useState(false)
+
+  const handleFilesLoaded = useCallback(
+    (results: Array<{ result: ESIParseResult; filename: string }>) => {
+      const { items, errors } = parseResultsToRepositoryItems(results)
+
+      // Add new items to existing repository (avoiding duplicates by filename)
+      const existingFilenames = new Set(repository.map((r) => r.filename))
+      const newItems = items.filter((item) => !existingFilenames.has(item.filename))
+
+      if (newItems.length > 0) {
+        onRepositoryChange([...repository, ...newItems])
+      }
+
+      // Show errors for failed files
+      setUploadErrors(errors)
+    },
+    [repository, onRepositoryChange],
+  )
+
+  const handleRemoveItem = useCallback(
+    (itemId: string) => {
+      onRepositoryChange(repository.filter((item) => item.id !== itemId))
+    },
+    [repository, onRepositoryChange],
+  )
+
+  const handleClearAll = useCallback(() => {
+    onRepositoryChange([])
+    setUploadErrors([])
+  }, [onRepositoryChange])
+
+  const handleDismissError = useCallback((filename: string) => {
+    setUploadErrors((prev) => prev.filter((e) => e.filename !== filename))
+  }, [])
+
+  return (
+    <div className='flex flex-1 flex-col gap-4 overflow-hidden'>
+      {/* Upload Area */}
+      <ESIUpload onFilesLoaded={handleFilesLoaded} repositoryCount={repository.length} isLoading={isLoading} />
+
+      {/* Error Messages */}
+      {uploadErrors.length > 0 && (
+        <div className='flex flex-col gap-2'>
+          {uploadErrors.map((error) => (
+            <div
+              key={error.filename}
+              className='flex items-center justify-between rounded-md border border-red-200 bg-red-50 px-3 py-2 dark:border-red-800 dark:bg-red-900/20'
+            >
+              <div className='flex items-center gap-2'>
+                <svg
+                  className='h-4 w-4 text-red-500 dark:text-red-400'
+                  fill='none'
+                  viewBox='0 0 24 24'
+                  stroke='currentColor'
+                >
+                  <path
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    strokeWidth={2}
+                    d='M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+                  />
+                </svg>
+                <span className='text-sm text-red-700 dark:text-red-300'>
+                  <strong>{error.filename || 'File'}</strong>: {error.error}
+                </span>
+              </div>
+              <button
+                onClick={() => handleDismissError(error.filename)}
+                className='text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
+              >
+                <svg className='h-4 w-4' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+                  <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Repository Table */}
+      <div className='flex flex-1 flex-col overflow-hidden'>
+        <ESIRepositoryTable repository={repository} onRemoveItem={handleRemoveItem} onClearAll={handleClearAll} />
+      </div>
+    </div>
+  )
+}
+
+export { ESIRepository }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository.tsx
@@ -38,16 +38,10 @@ const ESIRepository = ({ repository, onRepositoryChange, projectPath, isLoading 
       setIsSaving(true)
 
       try {
-        // We still use the old delete IPC since it works for both v1/v2
         const result: ESIServiceResponse = await window.bridge.esiDeleteXmlFile(projectPath, itemId)
 
         if (result.success) {
-          const updatedRepo = repository.filter((item) => item.id !== itemId)
-          // Re-save the v2 index
-          await window.bridge.esiMigrateRepository(projectPath).catch(() => {
-            // Fallback: just update state
-          })
-          onRepositoryChange(updatedRepo)
+          onRepositoryChange(repository.filter((item) => item.id !== itemId))
         } else {
           console.error('Failed to delete ESI item:', result.error)
         }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository.tsx
@@ -78,9 +78,7 @@ const ESIRepository = ({ repository, onRepositoryChange, projectPath, isLoading 
     }
   }, [onRepositoryChange, projectPath])
 
-  const handleDismissError = useCallback((filename: string) => {
-    setUploadErrors((prev) => prev.filter((e) => e.filename !== filename))
-  }, [])
+  const [errorsExpanded, setErrorsExpanded] = useState(false)
 
   const isProcessing = isLoading || isSaving
 
@@ -94,42 +92,52 @@ const ESIRepository = ({ repository, onRepositoryChange, projectPath, isLoading 
         projectPath={projectPath}
       />
 
-      {/* Error Messages */}
+      {/* Error Summary (collapsible) */}
       {uploadErrors.length > 0 && (
-        <div className='flex flex-col gap-2'>
-          {uploadErrors.map((error) => (
-            <div
-              key={error.filename}
-              className='flex items-center justify-between rounded-md border border-red-200 bg-red-50 px-3 py-2 dark:border-red-800 dark:bg-red-900/20'
-            >
-              <div className='flex items-center gap-2'>
-                <svg
-                  className='h-4 w-4 text-red-500 dark:text-red-400'
-                  fill='none'
-                  viewBox='0 0 24 24'
-                  stroke='currentColor'
-                >
-                  <path
-                    strokeLinecap='round'
-                    strokeLinejoin='round'
-                    strokeWidth={2}
-                    d='M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
-                  />
-                </svg>
-                <span className='text-sm text-red-700 dark:text-red-300'>
-                  <strong>{error.filename || 'File'}</strong>: {error.error}
-                </span>
-              </div>
-              <button
-                onClick={() => handleDismissError(error.filename)}
-                className='text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
+        <div className='shrink-0 rounded-md border border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20'>
+          <div className='flex items-center justify-between px-3 py-2'>
+            <button onClick={() => setErrorsExpanded((prev) => !prev)} className='flex items-center gap-2'>
+              <svg
+                className='h-4 w-4 text-red-500 dark:text-red-400'
+                fill='none'
+                viewBox='0 0 24 24'
+                stroke='currentColor'
               >
-                <svg className='h-4 w-4' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
-                  <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
-                </svg>
-              </button>
+                <path
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                  strokeWidth={2}
+                  d='M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+                />
+              </svg>
+              <span className='text-sm text-red-700 dark:text-red-300'>
+                {uploadErrors.length} file(s) failed to parse
+              </span>
+              <svg
+                className={`h-3 w-3 text-red-500 transition-transform dark:text-red-400 ${errorsExpanded ? 'rotate-180' : ''}`}
+                fill='none'
+                viewBox='0 0 24 24'
+                stroke='currentColor'
+              >
+                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M19 9l-7 7-7-7' />
+              </svg>
+            </button>
+            <button
+              onClick={() => setUploadErrors([])}
+              className='text-xs text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300'
+            >
+              Dismiss
+            </button>
+          </div>
+          {errorsExpanded && (
+            <div className='max-h-32 overflow-auto border-t border-red-200 px-3 py-2 dark:border-red-800'>
+              {uploadErrors.map((error) => (
+                <div key={error.filename} className='py-0.5 text-xs text-red-600 dark:text-red-400'>
+                  <strong>{error.filename || 'File'}</strong>: {error.error}
+                </div>
+              ))}
             </div>
-          ))}
+          )}
         </div>
       )}
 

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-repository.tsx
@@ -143,7 +143,12 @@ const ESIRepository = ({ repository, onRepositoryChange, projectPath, isLoading 
 
       {/* Repository Table */}
       <div className='flex flex-1 flex-col overflow-hidden'>
-        <ESIRepositoryTable repository={repository} onRemoveItem={handleRemoveItem} onClearAll={handleClearAll} />
+        <ESIRepositoryTable
+          repository={repository}
+          onRemoveItem={handleRemoveItem}
+          onClearAll={handleClearAll}
+          isLoading={isSaving}
+        />
       </div>
     </div>
   )

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
@@ -1,0 +1,198 @@
+import { ArrowIcon } from '@root/renderer/assets/icons'
+import type { ESIParseResult, ESIRepositoryItem } from '@root/types/ethercat/esi-types'
+import { cn } from '@root/utils'
+import { parseESI } from '@root/utils/ethercat/esi-parser'
+import { useCallback, useRef, useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
+
+type ESIUploadProps = {
+  onFilesLoaded: (results: Array<{ result: ESIParseResult; filename: string }>) => void
+  repositoryCount?: number
+  isLoading?: boolean
+}
+
+/**
+ * ESI File Upload Component
+ *
+ * Allows users to upload multiple EtherCAT ESI XML files via drag-and-drop or file picker.
+ * Supports batch processing with non-blocking error handling.
+ */
+const ESIUpload = ({ onFilesLoaded, repositoryCount = 0, isLoading = false }: ESIUploadProps) => {
+  const [isDragging, setIsDragging] = useState(false)
+  const [processingCount, setProcessingCount] = useState(0)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const processFiles = useCallback(
+    async (files: FileList) => {
+      const xmlFiles = Array.from(files).filter((file) => file.name.endsWith('.xml'))
+
+      if (xmlFiles.length === 0) {
+        onFilesLoaded([
+          {
+            result: { success: false, error: 'No XML files found. Please upload .xml ESI files.' },
+            filename: '',
+          },
+        ])
+        return
+      }
+
+      setProcessingCount(xmlFiles.length)
+
+      const results: Array<{ result: ESIParseResult; filename: string }> = []
+
+      for (const file of xmlFiles) {
+        try {
+          const text = await file.text()
+          const result = parseESI(text, file.name)
+          results.push({ result, filename: file.name })
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : 'Failed to read file'
+          results.push({
+            result: { success: false, error: errorMessage },
+            filename: file.name,
+          })
+        }
+      }
+
+      setProcessingCount(0)
+      onFilesLoaded(results)
+    },
+    [onFilesLoaded],
+  )
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragging(true)
+  }, [])
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragging(false)
+  }, [])
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setIsDragging(false)
+
+      const files = e.dataTransfer.files
+      if (files.length > 0) {
+        void processFiles(files)
+      }
+    },
+    [processFiles],
+  )
+
+  const handleFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files
+      if (files && files.length > 0) {
+        void processFiles(files)
+      }
+      // Reset input so same files can be selected again
+      e.target.value = ''
+    },
+    [processFiles],
+  )
+
+  const handleClick = useCallback(() => {
+    fileInputRef.current?.click()
+  }, [])
+
+  const isProcessing = isLoading || processingCount > 0
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <label className='text-xs font-medium text-neutral-950 dark:text-white'>ESI Device Files</label>
+
+      {/* Drop zone */}
+      <div
+        onClick={handleClick}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        className={cn(
+          'flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-6 transition-colors',
+          isDragging
+            ? 'bg-brand/10 dark:bg-brand/20 border-brand'
+            : 'border-neutral-300 hover:border-brand hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800/50',
+          isProcessing && 'pointer-events-none opacity-50',
+        )}
+      >
+        <input ref={fileInputRef} type='file' accept='.xml' multiple onChange={handleFileSelect} className='hidden' />
+
+        {isProcessing ? (
+          <div className='flex items-center gap-2'>
+            <ArrowIcon size='sm' className='animate-spin stroke-brand' />
+            <span className='text-sm text-neutral-600 dark:text-neutral-400'>
+              Processing {processingCount > 0 ? `${processingCount} file(s)` : ''}...
+            </span>
+          </div>
+        ) : (
+          <div className='flex flex-col items-center gap-1'>
+            <svg
+              className='h-8 w-8 text-neutral-400 dark:text-neutral-500'
+              fill='none'
+              viewBox='0 0 24 24'
+              stroke='currentColor'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                strokeWidth={1.5}
+                d='M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12'
+              />
+            </svg>
+            <span className='text-sm text-neutral-600 dark:text-neutral-400'>
+              Drop ESI files here or <span className='text-brand'>browse</span>
+            </span>
+            <span className='text-xs text-neutral-500 dark:text-neutral-400'>
+              Supports multiple .xml ESI files (ETG.2000)
+            </span>
+            {repositoryCount > 0 && (
+              <span className='mt-1 text-xs text-neutral-500 dark:text-neutral-400'>
+                {repositoryCount} file(s) currently loaded
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Convert parse results to repository items
+ */
+export function parseResultsToRepositoryItems(results: Array<{ result: ESIParseResult; filename: string }>): {
+  items: ESIRepositoryItem[]
+  errors: Array<{ filename: string; error: string }>
+} {
+  const items: ESIRepositoryItem[] = []
+  const errors: Array<{ filename: string; error: string }> = []
+
+  for (const { result, filename } of results) {
+    if (result.success && result.data) {
+      items.push({
+        id: uuidv4(),
+        filename: result.data.filename || filename,
+        vendor: result.data.vendor,
+        devices: result.data.devices,
+        loadedAt: Date.now(),
+        warnings: result.warnings,
+      })
+    } else {
+      errors.push({
+        filename,
+        error: result.error || 'Unknown parsing error',
+      })
+    }
+  }
+
+  return { items, errors }
+}
+
+export { ESIUpload }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
@@ -6,7 +6,7 @@ import { useCallback, useRef, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
 type ESIUploadProps = {
-  onFilesLoaded: (results: Array<{ result: ESIParseResult; filename: string }>) => void
+  onFilesLoaded: (results: Array<{ result: ESIParseResult; filename: string; xmlContent: string }>) => void
   repositoryCount?: number
   isLoading?: boolean
 }
@@ -31,6 +31,7 @@ const ESIUpload = ({ onFilesLoaded, repositoryCount = 0, isLoading = false }: ES
           {
             result: { success: false, error: 'No XML files found. Please upload .xml ESI files.' },
             filename: '',
+            xmlContent: '',
           },
         ])
         return
@@ -38,18 +39,19 @@ const ESIUpload = ({ onFilesLoaded, repositoryCount = 0, isLoading = false }: ES
 
       setProcessingCount(xmlFiles.length)
 
-      const results: Array<{ result: ESIParseResult; filename: string }> = []
+      const results: Array<{ result: ESIParseResult; filename: string; xmlContent: string }> = []
 
       for (const file of xmlFiles) {
         try {
           const text = await file.text()
           const result = parseESI(text, file.name)
-          results.push({ result, filename: file.name })
+          results.push({ result, filename: file.name, xmlContent: text })
         } catch (err) {
           const errorMessage = err instanceof Error ? err.message : 'Failed to read file'
           results.push({
             result: { success: false, error: errorMessage },
             filename: file.name,
+            xmlContent: '',
           })
         }
       }
@@ -167,7 +169,9 @@ const ESIUpload = ({ onFilesLoaded, repositoryCount = 0, isLoading = false }: ES
 /**
  * Convert parse results to repository items
  */
-export function parseResultsToRepositoryItems(results: Array<{ result: ESIParseResult; filename: string }>): {
+export function parseResultsToRepositoryItems(
+  results: Array<{ result: ESIParseResult; filename: string; xmlContent: string }>,
+): {
   items: ESIRepositoryItem[]
   errors: Array<{ filename: string; error: string }>
 } {

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
@@ -55,6 +55,8 @@ const ESIUpload = ({ onFilesLoaded, repository, isLoading = false, projectPath }
       const newItems: ESIRepositoryItemLight[] = []
       const errors: Array<{ filename: string; error: string }> = []
 
+      const MAX_FILE_SIZE = 100 * 1024 * 1024 // 100MB
+
       // Process files one at a time to avoid memory issues
       for (let i = 0; i < xmlFiles.length; i++) {
         const file = xmlFiles[i]
@@ -66,6 +68,14 @@ const ESIUpload = ({ onFilesLoaded, repository, isLoading = false, projectPath }
           totalFiles: xmlFiles.length,
           percentage: Math.round((i / xmlFiles.length) * 100),
         })
+
+        if (file.size > MAX_FILE_SIZE) {
+          errors.push({
+            filename: file.name,
+            error: `File too large (${Math.round(file.size / 1024 / 1024)}MB). Maximum is 100MB.`,
+          })
+          continue
+        }
 
         try {
           const text = await file.text()

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/index.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/index.tsx
@@ -1,19 +1,33 @@
 import { ArrowIcon } from '@root/renderer/assets/icons'
 import { useOpenPLCStore } from '@root/renderer/store'
 import type { EtherCATDevice, NetworkInterface } from '@root/types/ethercat'
+import type {
+  ConfiguredEtherCATDevice,
+  ESIDevice,
+  ESIDeviceRef,
+  ESIRepositoryItem,
+  ScannedDeviceMatch,
+} from '@root/types/ethercat/esi-types'
 import { cn } from '@root/utils'
+import { countMatchedDevices, getBestMatchQuality, matchDevicesToRepository } from '@root/utils/ethercat/device-matcher'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
 
-import { DeviceScanTable } from './components/device-scan-table'
+import { ConfiguredDevices } from './components/configured-devices'
+import { DeviceBrowserModal } from './components/device-browser-modal'
+import { DiscoveredDeviceTable } from './components/discovered-device-table'
+import { ESIRepository } from './components/esi-repository'
 import { InterfaceSelector } from './components/interface-selector'
+
+type EditorTab = 'repository' | 'discovery' | 'configured'
 
 /**
  * EtherCAT Device Editor
  *
  * Provides interface for:
- * - Selecting network interface for EtherCAT communication
- * - Scanning for EtherCAT devices on the selected interface
- * - Displaying discovered devices with their properties
+ * - Managing ESI file repository (Repository tab)
+ * - Scanning for EtherCAT devices and matching with repository (Discovery tab)
+ * - Viewing and configuring added devices (Configured Devices tab)
  */
 const EtherCATEditor = () => {
   const { editor, runtimeConnection } = useOpenPLCStore()
@@ -23,6 +37,16 @@ const EtherCATEditor = () => {
   // Runtime connection state
   const { connectionStatus, jwtToken, ipAddress } = runtimeConnection
   const isConnectedToRuntime = connectionStatus === 'connected' && ipAddress !== null && jwtToken !== null
+
+  // Tab state
+  const [activeTab, setActiveTab] = useState<EditorTab>('repository')
+
+  // Repository state
+  const [repository, setRepository] = useState<ESIRepositoryItem[]>([])
+
+  // Configured devices state
+  const [configuredDevices, setConfiguredDevices] = useState<ConfiguredEtherCATDevice[]>([])
+  const [isDeviceBrowserOpen, setIsDeviceBrowserOpen] = useState(false)
 
   // Network interfaces state
   const [interfaces, setInterfaces] = useState<NetworkInterface[]>([])
@@ -35,14 +59,21 @@ const EtherCATEditor = () => {
   const [serviceMessage, setServiceMessage] = useState<string>('')
 
   // Scan state
-  const [devices, setDevices] = useState<EtherCATDevice[]>([])
+  const [scannedDevices, setScannedDevices] = useState<EtherCATDevice[]>([])
   const [isScanning, setIsScanning] = useState(false)
   const [scanError, setScanError] = useState<string | null>(null)
-  const [scanMessage, setScanMessage] = useState<string>('')
+  const [_scanMessage, setScanMessage] = useState<string>('')
   const [scanTimeMs, setScanTimeMs] = useState<number | null>(null)
 
-  // Selected device for details
-  const [selectedDevicePosition, setSelectedDevicePosition] = useState<number | null>(null)
+  // Discovery selection state
+  const [selectedScannedDevices, setSelectedScannedDevices] = useState<Set<number>>(new Set())
+
+  // Matched devices (scanned devices with repository matches)
+  const deviceMatches = useMemo<ScannedDeviceMatch[]>(() => {
+    return matchDevicesToRepository(scannedDevices, repository)
+  }, [scannedDevices, repository])
+
+  const matchCounts = useMemo(() => countMatchedDevices(deviceMatches), [deviceMatches])
 
   // Check EtherCAT service status when connected to runtime
   const checkServiceStatus = useCallback(async () => {
@@ -82,7 +113,6 @@ const EtherCATEditor = () => {
       const result = await window.bridge.etherCATGetInterfaces(ipAddress, jwtToken)
       if (result.success && result.data) {
         setInterfaces(result.data)
-        // Auto-select first interface if available
         if (result.data.length > 0 && !selectedInterface) {
           setSelectedInterface(result.data[0].name)
         }
@@ -108,8 +138,9 @@ const EtherCATEditor = () => {
     setIsScanning(true)
     setScanError(null)
     setScanMessage('')
-    setDevices([])
-    setSelectedDevicePosition(null)
+    setScannedDevices([])
+    setSelectedScannedDevices(new Set())
+    setScanTimeMs(null)
 
     try {
       const result = await window.bridge.etherCATScan(ipAddress, jwtToken, {
@@ -118,7 +149,7 @@ const EtherCATEditor = () => {
       })
 
       if (result.success && result.data) {
-        setDevices(result.data.devices)
+        setScannedDevices(result.data.devices)
         setScanMessage(result.data.message)
         setScanTimeMs(result.data.scan_time_ms)
 
@@ -143,60 +174,96 @@ const EtherCATEditor = () => {
     } else {
       setServiceAvailable(null)
       setInterfaces([])
-      setDevices([])
+      setScannedDevices([])
       setSelectedInterface('')
     }
   }, [isConnectedToRuntime, checkServiceStatus, fetchInterfaces])
 
-  // Get selected device details
-  const selectedDevice = useMemo(() => {
-    if (selectedDevicePosition === null) return null
-    return devices.find((d) => d.position === selectedDevicePosition) || null
-  }, [devices, selectedDevicePosition])
+  // Handle device selection from scan
+  const handleSelectScannedDevice = useCallback((position: number, selected: boolean) => {
+    setSelectedScannedDevices((prev) => {
+      const next = new Set(prev)
+      if (selected) {
+        next.add(position)
+      } else {
+        next.delete(position)
+      }
+      return next
+    })
+  }, [])
 
-  // Render not connected state
-  if (!isConnectedToRuntime) {
-    return (
-      <div aria-label='EtherCAT editor container' className='flex h-full w-full flex-col overflow-hidden p-4'>
-        <div className='mb-4'>
-          <h2 className='text-lg font-semibold text-neutral-1000 dark:text-neutral-100'>
-            EtherCAT Device: {deviceName}
-          </h2>
-          <p className='text-sm text-neutral-600 dark:text-neutral-400'>Protocol: EtherCAT</p>
-        </div>
-        <div className='flex flex-1 items-center justify-center rounded-lg border border-dashed border-neutral-300 dark:border-neutral-700'>
-          <div className='text-center'>
-            <p className='text-sm font-medium text-neutral-700 dark:text-neutral-300'>Not connected to runtime</p>
-            <p className='mt-1 text-xs text-neutral-500 dark:text-neutral-400'>
-              Connect to the OpenPLC Runtime to scan for EtherCAT devices.
-            </p>
-          </div>
-        </div>
-      </div>
-    )
-  }
+  // Handle select all scanned devices
+  const handleSelectAllScanned = useCallback(
+    (selected: boolean) => {
+      if (selected) {
+        // Select only devices with matches
+        const selectable = deviceMatches
+          .filter((dm) => getBestMatchQuality(dm.matches) !== 'none')
+          .map((dm) => dm.device.position)
+        setSelectedScannedDevices(new Set(selectable))
+      } else {
+        setSelectedScannedDevices(new Set())
+      }
+    },
+    [deviceMatches],
+  )
 
-  // Render service not available state
-  if (serviceAvailable === false) {
-    return (
-      <div aria-label='EtherCAT editor container' className='flex h-full w-full flex-col overflow-hidden p-4'>
-        <div className='mb-4'>
-          <h2 className='text-lg font-semibold text-neutral-1000 dark:text-neutral-100'>
-            EtherCAT Device: {deviceName}
-          </h2>
-          <p className='text-sm text-neutral-600 dark:text-neutral-400'>Protocol: EtherCAT</p>
-        </div>
-        <div className='flex flex-1 items-center justify-center rounded-lg border border-dashed border-yellow-300 bg-yellow-50 dark:border-yellow-700 dark:bg-yellow-900/20'>
-          <div className='text-center'>
-            <p className='text-sm font-medium text-yellow-700 dark:text-yellow-300'>
-              EtherCAT Discovery Service Not Available
-            </p>
-            <p className='mt-1 max-w-md text-xs text-yellow-600 dark:text-yellow-400'>{serviceMessage}</p>
-          </div>
-        </div>
-      </div>
-    )
-  }
+  // Add selected scanned devices to configured devices
+  const handleAddSelectedFromScan = useCallback(() => {
+    const newDevices: ConfiguredEtherCATDevice[] = []
+
+    for (const position of selectedScannedDevices) {
+      const match = deviceMatches.find((dm) => dm.device.position === position)
+      if (!match || match.matches.length === 0) continue
+
+      // Use the best match (first one, which is sorted by quality)
+      const bestMatch = match.matches[0]
+      const repoItem = repository.find((r) => r.id === bestMatch.repositoryItemId)
+      if (!repoItem) continue
+
+      newDevices.push({
+        id: uuidv4(),
+        position: match.device.position,
+        name: match.device.name,
+        esiDeviceRef: {
+          repositoryItemId: bestMatch.repositoryItemId,
+          deviceIndex: bestMatch.deviceIndex,
+        },
+        vendorId: repoItem.vendor.id,
+        productCode: bestMatch.esiDevice.type.productCode,
+        revisionNo: bestMatch.esiDevice.type.revisionNo,
+        addedFrom: 'scan',
+      })
+    }
+
+    if (newDevices.length > 0) {
+      setConfiguredDevices((prev) => [...prev, ...newDevices])
+      setSelectedScannedDevices(new Set())
+      setActiveTab('configured')
+    }
+  }, [selectedScannedDevices, deviceMatches, repository])
+
+  // Handle adding device from browser modal
+  const handleAddDeviceFromBrowser = useCallback(
+    (ref: ESIDeviceRef, device: ESIDevice, repoItem: ESIRepositoryItem) => {
+      const newDevice: ConfiguredEtherCATDevice = {
+        id: uuidv4(),
+        name: device.name,
+        esiDeviceRef: ref,
+        vendorId: repoItem.vendor.id,
+        productCode: device.type.productCode,
+        revisionNo: device.type.revisionNo,
+        addedFrom: 'repository',
+      }
+      setConfiguredDevices((prev) => [...prev, newDevice])
+    },
+    [],
+  )
+
+  // Handle removing a configured device
+  const handleRemoveDevice = useCallback((deviceId: string) => {
+    setConfiguredDevices((prev) => prev.filter((d) => d.id !== deviceId))
+  }, [])
 
   return (
     <div aria-label='EtherCAT editor container' className='flex h-full w-full flex-col overflow-hidden p-4'>
@@ -206,116 +273,185 @@ const EtherCATEditor = () => {
         <p className='text-sm text-neutral-600 dark:text-neutral-400'>Protocol: EtherCAT</p>
       </div>
 
-      {/* Interface Selection and Scan Controls */}
-      <div className='mb-4 flex flex-wrap items-end gap-4'>
-        <InterfaceSelector
-          interfaces={interfaces}
-          selectedInterface={selectedInterface}
-          onSelectInterface={setSelectedInterface}
-          isLoading={isLoadingInterfaces}
-          error={interfaceError}
-          onRefresh={() => void fetchInterfaces()}
-        />
-
+      {/* Tabs */}
+      <div className='mb-4 flex border-b border-neutral-200 dark:border-neutral-700'>
         <button
-          onClick={() => void scanDevices()}
-          disabled={isScanning || !selectedInterface}
+          onClick={() => setActiveTab('repository')}
           className={cn(
-            'flex h-[30px] items-center gap-2 rounded-md px-4 text-sm font-medium transition-colors',
-            'bg-brand text-white hover:bg-brand-medium-dark',
-            'disabled:cursor-not-allowed disabled:opacity-50',
+            'px-4 py-2 text-sm font-medium transition-colors',
+            activeTab === 'repository'
+              ? 'border-b-2 border-brand text-brand'
+              : 'text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200',
           )}
         >
-          {isScanning ? (
-            <>
-              <ArrowIcon size='sm' className='animate-spin stroke-white' />
-              Scanning...
-            </>
-          ) : (
-            'Scan Devices'
+          Repository
+          {repository.length > 0 && (
+            <span className='ml-1 rounded-full bg-neutral-200 px-1.5 py-0.5 text-xs dark:bg-neutral-700'>
+              {repository.length}
+            </span>
           )}
         </button>
-
-        {scanTimeMs !== null && (
-          <span className='text-xs text-neutral-500 dark:text-neutral-400'>Scan completed in {scanTimeMs}ms</span>
-        )}
+        <button
+          onClick={() => setActiveTab('discovery')}
+          className={cn(
+            'px-4 py-2 text-sm font-medium transition-colors',
+            activeTab === 'discovery'
+              ? 'border-b-2 border-brand text-brand'
+              : 'text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200',
+          )}
+        >
+          Discovery
+          {scannedDevices.length > 0 && (
+            <span className='ml-1 rounded-full bg-neutral-200 px-1.5 py-0.5 text-xs dark:bg-neutral-700'>
+              {scannedDevices.length}
+            </span>
+          )}
+        </button>
+        <button
+          onClick={() => setActiveTab('configured')}
+          className={cn(
+            'px-4 py-2 text-sm font-medium transition-colors',
+            activeTab === 'configured'
+              ? 'border-b-2 border-brand text-brand'
+              : 'text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200',
+          )}
+        >
+          Configured Devices
+          {configuredDevices.length > 0 && (
+            <span className='bg-brand/20 ml-1 rounded-full px-1.5 py-0.5 text-xs text-brand'>
+              {configuredDevices.length}
+            </span>
+          )}
+        </button>
       </div>
 
-      {/* Error/Status Messages */}
-      {scanError && (
-        <div className='mb-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 dark:border-red-800 dark:bg-red-900/20'>
-          <p className='text-sm text-red-700 dark:text-red-300'>{scanError}</p>
+      {/* Repository Tab */}
+      {activeTab === 'repository' && <ESIRepository repository={repository} onRepositoryChange={setRepository} />}
+
+      {/* Discovery Tab */}
+      {activeTab === 'discovery' && (
+        <div className='flex flex-1 flex-col overflow-hidden'>
+          {/* Not connected state */}
+          {!isConnectedToRuntime && (
+            <div className='flex flex-1 items-center justify-center rounded-lg border border-dashed border-neutral-300 dark:border-neutral-700'>
+              <div className='text-center'>
+                <p className='text-sm font-medium text-neutral-700 dark:text-neutral-300'>Not connected to runtime</p>
+                <p className='mt-1 text-xs text-neutral-500 dark:text-neutral-400'>
+                  Connect to the OpenPLC Runtime to scan for EtherCAT devices.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Service not available state */}
+          {isConnectedToRuntime && serviceAvailable === false && (
+            <div className='flex flex-1 items-center justify-center rounded-lg border border-dashed border-yellow-300 bg-yellow-50 dark:border-yellow-700 dark:bg-yellow-900/20'>
+              <div className='text-center'>
+                <p className='text-sm font-medium text-yellow-700 dark:text-yellow-300'>
+                  EtherCAT Discovery Service Not Available
+                </p>
+                <p className='mt-1 max-w-md text-xs text-yellow-600 dark:text-yellow-400'>{serviceMessage}</p>
+              </div>
+            </div>
+          )}
+
+          {/* Connected state */}
+          {isConnectedToRuntime && serviceAvailable !== false && (
+            <>
+              {/* Interface Selection and Scan Controls */}
+              <div className='mb-4 flex flex-wrap items-end gap-4'>
+                <InterfaceSelector
+                  interfaces={interfaces}
+                  selectedInterface={selectedInterface}
+                  onSelectInterface={setSelectedInterface}
+                  isLoading={isLoadingInterfaces}
+                  error={interfaceError}
+                  onRefresh={() => void fetchInterfaces()}
+                />
+
+                <button
+                  onClick={() => void scanDevices()}
+                  disabled={isScanning || !selectedInterface}
+                  className={cn(
+                    'flex h-[30px] items-center gap-2 rounded-md px-4 text-sm font-medium transition-colors',
+                    'bg-brand text-white hover:bg-brand-medium-dark',
+                    'disabled:cursor-not-allowed disabled:opacity-50',
+                  )}
+                >
+                  {isScanning ? (
+                    <>
+                      <ArrowIcon size='sm' className='animate-spin stroke-white' />
+                      Scanning...
+                    </>
+                  ) : (
+                    'Scan'
+                  )}
+                </button>
+
+                {scanTimeMs !== null && (
+                  <span className='text-xs text-neutral-500 dark:text-neutral-400'>Completed in {scanTimeMs}ms</span>
+                )}
+              </div>
+
+              {/* Error/Status Messages */}
+              {scanError && (
+                <div className='mb-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 dark:border-red-800 dark:bg-red-900/20'>
+                  <p className='text-sm text-red-700 dark:text-red-300'>{scanError}</p>
+                </div>
+              )}
+
+              {/* Match summary */}
+              {deviceMatches.length > 0 && (
+                <div className='mb-4 flex items-center justify-between'>
+                  <div className='flex items-center gap-4'>
+                    <span className='text-sm text-neutral-700 dark:text-neutral-300'>
+                      Found {matchCounts.total} device(s):
+                    </span>
+                    <span className='text-xs text-green-600 dark:text-green-400'>{matchCounts.exact} exact</span>
+                    <span className='text-xs text-yellow-600 dark:text-yellow-400'>{matchCounts.partial} partial</span>
+                    <span className='text-xs text-red-600 dark:text-red-400'>{matchCounts.none} no match</span>
+                  </div>
+                  {selectedScannedDevices.size > 0 && (
+                    <button
+                      onClick={handleAddSelectedFromScan}
+                      className='rounded-md bg-brand px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-medium-dark'
+                    >
+                      Add Selected ({selectedScannedDevices.size})
+                    </button>
+                  )}
+                </div>
+              )}
+
+              {/* Discovered Devices Table */}
+              <DiscoveredDeviceTable
+                deviceMatches={deviceMatches}
+                selectedDevices={selectedScannedDevices}
+                onSelectDevice={handleSelectScannedDevice}
+                onSelectAll={handleSelectAllScanned}
+                isScanning={isScanning}
+              />
+            </>
+          )}
         </div>
       )}
 
-      {scanMessage && !scanError && (
-        <div className='mb-4 rounded-md border border-green-200 bg-green-50 px-3 py-2 dark:border-green-800 dark:bg-green-900/20'>
-          <p className='text-sm text-green-700 dark:text-green-300'>{scanMessage}</p>
-        </div>
-      )}
-
-      {/* Devices Table */}
-      <div className='flex flex-1 flex-col overflow-hidden'>
-        <div className='mb-2'>
-          <h3 className='text-sm font-medium text-neutral-950 dark:text-neutral-100'>
-            Discovered Devices {devices.length > 0 && `(${devices.length})`}
-          </h3>
-        </div>
-
-        <DeviceScanTable
-          devices={devices}
-          selectedPosition={selectedDevicePosition}
-          onSelectDevice={setSelectedDevicePosition}
-          isScanning={isScanning}
+      {/* Configured Devices Tab */}
+      {activeTab === 'configured' && (
+        <ConfiguredDevices
+          devices={configuredDevices}
+          repository={repository}
+          onAddDevice={() => setIsDeviceBrowserOpen(true)}
+          onRemoveDevice={handleRemoveDevice}
         />
-      </div>
-
-      {/* Selected Device Details */}
-      {selectedDevice && (
-        <div className='mt-4 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-700 dark:bg-neutral-900'>
-          <h4 className='mb-2 text-sm font-medium text-neutral-950 dark:text-neutral-100'>
-            Device Details: {selectedDevice.name}
-          </h4>
-          <div className='grid grid-cols-2 gap-x-8 gap-y-1 text-xs md:grid-cols-4'>
-            <div>
-              <span className='text-neutral-500 dark:text-neutral-400'>Position:</span>{' '}
-              <span className='text-neutral-700 dark:text-neutral-300'>{selectedDevice.position}</span>
-            </div>
-            <div>
-              <span className='text-neutral-500 dark:text-neutral-400'>Vendor ID:</span>{' '}
-              <span className='text-neutral-700 dark:text-neutral-300'>0x{selectedDevice.vendor_id.toString(16)}</span>
-            </div>
-            <div>
-              <span className='text-neutral-500 dark:text-neutral-400'>Product Code:</span>{' '}
-              <span className='text-neutral-700 dark:text-neutral-300'>
-                0x{selectedDevice.product_code.toString(16)}
-              </span>
-            </div>
-            <div>
-              <span className='text-neutral-500 dark:text-neutral-400'>Revision:</span>{' '}
-              <span className='text-neutral-700 dark:text-neutral-300'>0x{selectedDevice.revision.toString(16)}</span>
-            </div>
-            <div>
-              <span className='text-neutral-500 dark:text-neutral-400'>Serial:</span>{' '}
-              <span className='text-neutral-700 dark:text-neutral-300'>{selectedDevice.serial_number || 'N/A'}</span>
-            </div>
-            <div>
-              <span className='text-neutral-500 dark:text-neutral-400'>State:</span>{' '}
-              <span className='text-neutral-700 dark:text-neutral-300'>{selectedDevice.state}</span>
-            </div>
-            <div>
-              <span className='text-neutral-500 dark:text-neutral-400'>CoE Support:</span>{' '}
-              <span className='text-neutral-700 dark:text-neutral-300'>{selectedDevice.has_coe ? 'Yes' : 'No'}</span>
-            </div>
-            <div>
-              <span className='text-neutral-500 dark:text-neutral-400'>I/O:</span>{' '}
-              <span className='text-neutral-700 dark:text-neutral-300'>
-                {selectedDevice.input_bytes}B in / {selectedDevice.output_bytes}B out
-              </span>
-            </div>
-          </div>
-        </div>
       )}
+
+      {/* Device Browser Modal */}
+      <DeviceBrowserModal
+        isOpen={isDeviceBrowserOpen}
+        onClose={() => setIsDeviceBrowserOpen(false)}
+        onSelectDevice={handleAddDeviceFromBrowser}
+        repository={repository}
+      />
     </div>
   )
 }

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/index.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/index.tsx
@@ -494,9 +494,11 @@ const EtherCATEditor = () => {
           <InputWithRef
             type='number'
             value={masterConfig.cycleTimeUs}
-            onChange={(e) => {
-              const val = parseInt(e.target.value, 10)
-              if (!isNaN(val)) handleUpdateMasterConfig({ cycleTimeUs: val })
+            onChange={(e) => handleUpdateMasterConfig({ cycleTimeUs: Number(e.target.value) })}
+            onBlur={(e) => {
+              const val = Number(e.target.value)
+              if (!val || val < 100) handleUpdateMasterConfig({ cycleTimeUs: 100 })
+              else if (val > 100000) handleUpdateMasterConfig({ cycleTimeUs: 100000 })
             }}
             min={100}
             max={100000}
@@ -511,9 +513,11 @@ const EtherCATEditor = () => {
           <InputWithRef
             type='number'
             value={masterConfig.watchdogTimeoutCycles ?? 3}
-            onChange={(e) => {
-              const val = parseInt(e.target.value, 10)
-              if (!isNaN(val)) handleUpdateMasterConfig({ watchdogTimeoutCycles: val })
+            onChange={(e) => handleUpdateMasterConfig({ watchdogTimeoutCycles: Number(e.target.value) })}
+            onBlur={(e) => {
+              const val = Number(e.target.value)
+              if (!val || val < 1) handleUpdateMasterConfig({ watchdogTimeoutCycles: 1 })
+              else if (val > 100) handleUpdateMasterConfig({ watchdogTimeoutCycles: 100 })
             }}
             min={1}
             max={100}

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/index.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/index.tsx
@@ -65,6 +65,32 @@ const EtherCATEditor = () => {
     return (remoteDevice?.ethercatConfig?.devices ?? []) as ConfiguredEtherCATDevice[]
   }, [remoteDevice])
 
+  // Collect all IEC addresses used across all remote devices (Modbus + EtherCAT)
+  const usedAddresses = useMemo(() => {
+    const addresses = new Set<string>()
+    const allRemoteDevices = project.data.remoteDevices || []
+
+    for (const rd of allRemoteDevices) {
+      // Modbus devices
+      if (rd.modbusTcpConfig?.ioGroups) {
+        for (const group of rd.modbusTcpConfig.ioGroups) {
+          for (const point of group.ioPoints) {
+            addresses.add(point.iecLocation)
+          }
+        }
+      }
+      // EtherCAT devices
+      if (rd.ethercatConfig?.devices) {
+        for (const dev of rd.ethercatConfig.devices) {
+          for (const mapping of dev.channelMappings) {
+            addresses.add(mapping.iecLocation)
+          }
+        }
+      }
+    }
+    return addresses
+  }, [project.data.remoteDevices])
+
   const masterConfig = useMemo(() => {
     return (
       remoteDevice?.ethercatConfig?.masterConfig ?? {
@@ -728,6 +754,7 @@ const EtherCATEditor = () => {
           projectPath={projectPath}
           onUpdateChannelMappings={handleUpdateChannelMappings}
           onEnrichDevice={handleEnrichDevice}
+          usedAddresses={usedAddresses}
         />
       )}
 

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/index.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/index.tsx
@@ -66,7 +66,13 @@ const EtherCATEditor = () => {
   }, [remoteDevice])
 
   const masterConfig = useMemo(() => {
-    return remoteDevice?.ethercatConfig?.masterConfig ?? { networkInterface: 'eth0', cycleTimeUs: 1000 }
+    return (
+      remoteDevice?.ethercatConfig?.masterConfig ?? {
+        networkInterface: 'eth0',
+        cycleTimeUs: 1000,
+        watchdogTimeoutCycles: 3,
+      }
+    )
   }, [remoteDevice])
 
   const syncDevicesToStore = useCallback(
@@ -263,7 +269,7 @@ const EtherCATEditor = () => {
   useEffect(() => {
     if (remoteDevice && !remoteDevice.ethercatConfig) {
       projectActions.updateEthercatConfig(deviceName, {
-        masterConfig: { networkInterface: 'eth0', cycleTimeUs: 1000 },
+        masterConfig: { networkInterface: 'eth0', cycleTimeUs: 1000, watchdogTimeoutCycles: 3 },
         devices: [],
       })
     }
@@ -498,6 +504,23 @@ const EtherCATEditor = () => {
           />
           <span className='text-[10px] text-neutral-500 dark:text-neutral-500'>
             EtherCAT bus cycle time in microseconds
+          </span>
+        </div>
+        <div className='flex flex-col gap-1'>
+          <span className='text-xs text-neutral-600 dark:text-neutral-400'>Watchdog Timeout (cycles)</span>
+          <InputWithRef
+            type='number'
+            value={masterConfig.watchdogTimeoutCycles ?? 3}
+            onChange={(e) => {
+              const val = parseInt(e.target.value, 10)
+              if (!isNaN(val)) handleUpdateMasterConfig({ watchdogTimeoutCycles: val })
+            }}
+            min={1}
+            max={100}
+            className='h-[26px] w-24 rounded-md border border-neutral-300 bg-white px-2 py-1 text-xs text-neutral-700 outline-none focus:border-brand-medium-dark dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-300'
+          />
+          <span className='text-[10px] text-neutral-500 dark:text-neutral-500'>
+            Missed cycles before watchdog triggers
           </span>
         </div>
       </div>

--- a/src/renderer/components/_features/[workspace]/editor/device/ethercat/index.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/device/ethercat/index.tsx
@@ -6,9 +6,12 @@ import type {
   ESIDeviceRef,
   ESIDeviceSummary,
   ESIRepositoryItemLight,
+  EtherCATChannelMapping,
+  EtherCATSlaveConfig,
   ScannedDeviceMatch,
 } from '@root/types/ethercat/esi-types'
 import { cn } from '@root/utils'
+import { createDefaultSlaveConfig } from '@root/utils/ethercat/device-config-defaults'
 import { countMatchedDevices, getBestMatchQuality, matchDevicesToRepository } from '@root/utils/ethercat/device-matcher'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
@@ -277,6 +280,8 @@ const EtherCATEditor = () => {
         productCode: bestMatch.esiDevice.type.productCode,
         revisionNo: bestMatch.esiDevice.type.revisionNo,
         addedFrom: 'scan',
+        config: createDefaultSlaveConfig(),
+        channelMappings: [],
       })
     }
 
@@ -298,6 +303,8 @@ const EtherCATEditor = () => {
         productCode: device.type.productCode,
         revisionNo: device.type.revisionNo,
         addedFrom: 'repository',
+        config: createDefaultSlaveConfig(),
+        channelMappings: [],
       }
       setConfiguredDevices((prev) => [...prev, newDevice])
     },
@@ -307,6 +314,16 @@ const EtherCATEditor = () => {
   // Handle removing a configured device
   const handleRemoveDevice = useCallback((deviceId: string) => {
     setConfiguredDevices((prev) => prev.filter((d) => d.id !== deviceId))
+  }, [])
+
+  // Handle updating a configured device's configuration
+  const handleUpdateDevice = useCallback((deviceId: string, config: EtherCATSlaveConfig) => {
+    setConfiguredDevices((prev) => prev.map((d) => (d.id === deviceId ? { ...d, config } : d)))
+  }, [])
+
+  // Handle updating a configured device's channel mappings
+  const handleUpdateChannelMappings = useCallback((deviceId: string, channelMappings: EtherCATChannelMapping[]) => {
+    setConfiguredDevices((prev) => prev.map((d) => (d.id === deviceId ? { ...d, channelMappings } : d)))
   }, [])
 
   return (
@@ -512,6 +529,9 @@ const EtherCATEditor = () => {
           repository={repository}
           onAddDevice={() => setIsDeviceBrowserOpen(true)}
           onRemoveDevice={handleRemoveDevice}
+          onUpdateDevice={handleUpdateDevice}
+          projectPath={projectPath}
+          onUpdateChannelMappings={handleUpdateChannelMappings}
         />
       )}
 

--- a/src/renderer/hooks/use-store-selectors.ts
+++ b/src/renderer/hooks/use-store-selectors.ts
@@ -92,18 +92,37 @@ const remoteDeviceSelectors = {
       const ioPoints: RemoteDeviceIOPoint[] = []
 
       for (const device of remoteDevices) {
-        if (!device.modbusTcpConfig?.ioGroups) continue
-        for (const ioGroup of device.modbusTcpConfig.ioGroups) {
-          for (const point of ioGroup.ioPoints) {
-            ioPoints.push({
-              deviceName: device.name,
-              ioGroupName: ioGroup.name,
-              ioPointId: point.id,
-              ioPointName: point.name,
-              ioPointType: point.type,
-              iecLocation: point.iecLocation,
-              alias: point.alias,
-            })
+        // Modbus IO points
+        if (device.modbusTcpConfig?.ioGroups) {
+          for (const ioGroup of device.modbusTcpConfig.ioGroups) {
+            for (const point of ioGroup.ioPoints) {
+              ioPoints.push({
+                deviceName: device.name,
+                ioGroupName: ioGroup.name,
+                ioPointId: point.id,
+                ioPointName: point.name,
+                ioPointType: point.type,
+                iecLocation: point.iecLocation,
+                alias: point.alias,
+              })
+            }
+          }
+        }
+        // EtherCAT channel mappings
+        if (device.ethercatConfig?.devices) {
+          for (const dev of device.ethercatConfig.devices) {
+            for (const mapping of dev.channelMappings) {
+              if (!mapping.alias) continue
+              ioPoints.push({
+                deviceName: device.name,
+                ioGroupName: dev.name,
+                ioPointId: mapping.channelId,
+                ioPointName: mapping.channelId,
+                ioPointType: 'ethercat',
+                iecLocation: mapping.iecLocation,
+                alias: mapping.alias,
+              })
+            }
           }
         }
       }

--- a/src/renderer/store/slices/project/slice.ts
+++ b/src/renderer/store/slices/project/slice.ts
@@ -1,5 +1,6 @@
 import { toast } from '@root/renderer/components/_features/[app]/toast/use-toast'
 import type {
+  EthercatConfig,
   OpcUaNodeConfig,
   OpcUaSecurityProfile,
   OpcUaServerConfig,
@@ -2256,6 +2257,29 @@ const createProjectSlice: StateCreator<ProjectSlice, [], [], ProjectSlice> = (se
           // Common fields
           if (config.timeout !== undefined) modbusCfg.timeout = config.timeout
           if (config.slaveId !== undefined) modbusCfg.slaveId = config.slaveId
+        }),
+      )
+      return response
+    },
+
+    updateEthercatConfig: (deviceName: string, ethercatConfig: EthercatConfig): ProjectResponse => {
+      let response: ProjectResponse = { ok: true }
+      setState(
+        produce(({ project }: ProjectSlice) => {
+          if (!project.data.remoteDevices) {
+            response = { ok: false, message: 'No remote devices found' }
+            return
+          }
+          const device = project.data.remoteDevices.find((d) => d.name === deviceName)
+          if (!device) {
+            response = { ok: false, message: 'Remote device not found' }
+            return
+          }
+          if (device.protocol !== 'ethercat') {
+            response = { ok: false, message: 'Device is not an EtherCAT device' }
+            return
+          }
+          device.ethercatConfig = ethercatConfig
         }),
       )
       return response

--- a/src/renderer/store/slices/project/slice.ts
+++ b/src/renderer/store/slices/project/slice.ts
@@ -2332,6 +2332,13 @@ const createProjectSlice: StateCreator<ProjectSlice, [], [], ProjectSlice> = (se
                 }
               }
             }
+            if (remoteDevice.ethercatConfig?.devices) {
+              for (const dev of remoteDevice.ethercatConfig.devices) {
+                for (const mapping of dev.channelMappings) {
+                  usedAddresses.add(mapping.iecLocation)
+                }
+              }
+            }
           }
           const ioPoints = generateIOPoints(ioGroup.functionCode, ioGroup.length, ioGroup.name, usedAddresses)
           modbusCfg.ioGroups.push({
@@ -2386,6 +2393,13 @@ const createProjectSlice: StateCreator<ProjectSlice, [], [], ProjectSlice> = (se
                   if (group.id === ioGroupId) continue
                   for (const point of group.ioPoints) {
                     usedAddresses.add(point.iecLocation)
+                  }
+                }
+              }
+              if (remoteDevice.ethercatConfig?.devices) {
+                for (const dev of remoteDevice.ethercatConfig.devices) {
+                  for (const mapping of dev.channelMappings) {
+                    usedAddresses.add(mapping.iecLocation)
                   }
                 }
               }

--- a/src/renderer/store/slices/project/types.ts
+++ b/src/renderer/store/slices/project/types.ts
@@ -1,5 +1,6 @@
 import {
   bodySchema,
+  EthercatConfigSchema,
   OpcUaNodeConfigSchema,
   PLCDataTypeSchema,
   PLCFunctionBlockSchema,
@@ -556,6 +557,7 @@ const _projectActionsSchema = z.object({
     .returns(projectResponseSchema),
   deleteIOGroup: z.function().args(z.string(), z.string()).returns(projectResponseSchema),
   updateIOPointAlias: z.function().args(z.string(), z.string(), z.string(), z.string()).returns(projectResponseSchema),
+  updateEthercatConfig: z.function().args(z.string(), EthercatConfigSchema).returns(projectResponseSchema),
 })
 type ProjectActions = z.infer<typeof _projectActionsSchema>
 

--- a/src/types/PLC/open-plc.ts
+++ b/src/types/PLC/open-plc.ts
@@ -667,6 +667,32 @@ const EtherCATSlaveConfigSchema = z.object({
   distributedClocks: EtherCATDistributedClocksSchema,
 })
 
+const PersistedPdoEntrySchema = z.object({
+  index: z.string(),
+  subIndex: z.string(),
+  bitLen: z.number(),
+  name: z.string(),
+  dataType: z.string(),
+})
+
+const PersistedPdoSchema = z.object({
+  index: z.string(),
+  name: z.string(),
+  entries: z.array(PersistedPdoEntrySchema),
+})
+
+const PersistedChannelInfoSchema = z.object({
+  channelId: z.string(),
+  name: z.string(),
+  direction: z.enum(['input', 'output']),
+  pdoIndex: z.string(),
+  entryIndex: z.string(),
+  entrySubIndex: z.string(),
+  dataType: z.string(),
+  bitLen: z.number(),
+  iecType: z.string(),
+})
+
 const ConfiguredEtherCATDeviceSchema = z.object({
   id: z.string(),
   position: z.number().optional(),
@@ -678,6 +704,10 @@ const ConfiguredEtherCATDeviceSchema = z.object({
   addedFrom: z.enum(['repository', 'scan']),
   config: EtherCATSlaveConfigSchema,
   channelMappings: z.array(EtherCATChannelMappingSchema),
+  channelInfo: z.array(PersistedChannelInfoSchema).optional(),
+  rxPdos: z.array(PersistedPdoSchema).optional(),
+  txPdos: z.array(PersistedPdoSchema).optional(),
+  slaveType: z.string().optional(),
 })
 
 const EthercatConfigSchema = z.object({

--- a/src/types/PLC/open-plc.ts
+++ b/src/types/PLC/open-plc.ts
@@ -616,6 +616,7 @@ const EtherCATChannelMappingSchema = z.object({
   channelId: z.string(),
   iecLocation: z.string(),
   userEdited: z.boolean(),
+  alias: z.string().optional(),
 })
 
 const ESIDeviceRefSchema = z.object({

--- a/src/types/PLC/open-plc.ts
+++ b/src/types/PLC/open-plc.ts
@@ -610,10 +610,86 @@ type ModbusTcpConfig = z.infer<typeof ModbusTcpConfigSchema>
 const PLCRemoteDeviceProtocolSchema = z.enum(['modbus-tcp', 'ethernet-ip', 'ethercat', 'profinet'])
 type PLCRemoteDeviceProtocol = z.infer<typeof PLCRemoteDeviceProtocolSchema>
 
+// ---- EtherCAT Configuration Schemas ----
+
+const EtherCATChannelMappingSchema = z.object({
+  channelId: z.string(),
+  iecLocation: z.string(),
+  userEdited: z.boolean(),
+})
+
+const ESIDeviceRefSchema = z.object({
+  repositoryItemId: z.string(),
+  deviceIndex: z.number(),
+})
+
+const EtherCATStartupChecksSchema = z.object({
+  checkVendorId: z.boolean(),
+  checkProductCode: z.boolean(),
+  checkRevisionNumber: z.boolean(),
+  downloadPdoConfig: z.boolean(),
+})
+
+const EtherCATAddressingSchema = z.object({
+  ethercatAddress: z.number(),
+  optionalSlave: z.boolean(),
+})
+
+const EtherCATTimeoutsSchema = z.object({
+  sdoTimeoutMs: z.number(),
+  initToPreOpTimeoutMs: z.number(),
+  safeOpToOpTimeoutMs: z.number(),
+})
+
+const EtherCATWatchdogSchema = z.object({
+  smWatchdogEnabled: z.boolean(),
+  smWatchdogMs: z.number(),
+  pdiWatchdogEnabled: z.boolean(),
+  pdiWatchdogMs: z.number(),
+})
+
+const EtherCATDistributedClocksSchema = z.object({
+  dcEnabled: z.boolean(),
+  dcSyncUnitCycleUs: z.number(),
+  dcSync0Enabled: z.boolean(),
+  dcSync0CycleUs: z.number(),
+  dcSync0ShiftUs: z.number(),
+  dcSync1Enabled: z.boolean(),
+  dcSync1CycleUs: z.number(),
+  dcSync1ShiftUs: z.number(),
+})
+
+const EtherCATSlaveConfigSchema = z.object({
+  startupChecks: EtherCATStartupChecksSchema,
+  addressing: EtherCATAddressingSchema,
+  timeouts: EtherCATTimeoutsSchema,
+  watchdog: EtherCATWatchdogSchema,
+  distributedClocks: EtherCATDistributedClocksSchema,
+})
+
+const ConfiguredEtherCATDeviceSchema = z.object({
+  id: z.string(),
+  position: z.number().optional(),
+  name: z.string(),
+  esiDeviceRef: ESIDeviceRefSchema,
+  vendorId: z.string(),
+  productCode: z.string(),
+  revisionNo: z.string(),
+  addedFrom: z.enum(['repository', 'scan']),
+  config: EtherCATSlaveConfigSchema,
+  channelMappings: z.array(EtherCATChannelMappingSchema),
+})
+
+const EthercatConfigSchema = z.object({
+  devices: z.array(ConfiguredEtherCATDeviceSchema),
+})
+type EthercatConfig = z.infer<typeof EthercatConfigSchema>
+
 const PLCRemoteDeviceSchema = z.object({
   name: z.string(),
   protocol: PLCRemoteDeviceProtocolSchema,
   modbusTcpConfig: ModbusTcpConfigSchema.optional(),
+  ethercatConfig: EthercatConfigSchema.optional(),
 })
 type PLCRemoteDevice = z.infer<typeof PLCRemoteDeviceSchema>
 
@@ -683,6 +759,8 @@ type PLCProject = z.infer<typeof PLCProjectSchema>
 export {
   baseTypeSchema,
   bodySchema,
+  ConfiguredEtherCATDeviceSchema,
+  EthercatConfigSchema,
   ModbusErrorHandlingSchema,
   ModbusFunctionCodeSchema,
   ModbusIOGroupSchema,
@@ -742,6 +820,7 @@ export {
 export type {
   BaseType,
   BodySchema,
+  EthercatConfig,
   ModbusErrorHandling,
   ModbusFunctionCode,
   ModbusIOGroup,

--- a/src/types/PLC/open-plc.ts
+++ b/src/types/PLC/open-plc.ts
@@ -713,6 +713,7 @@ const ConfiguredEtherCATDeviceSchema = z.object({
 const EtherCATMasterConfigSchema = z.object({
   networkInterface: z.string(),
   cycleTimeUs: z.number().int().min(100).max(100000),
+  watchdogTimeoutCycles: z.number().int().min(1).max(100).optional(),
 })
 type EtherCATMasterConfig = z.infer<typeof EtherCATMasterConfigSchema>
 

--- a/src/types/PLC/open-plc.ts
+++ b/src/types/PLC/open-plc.ts
@@ -710,7 +710,14 @@ const ConfiguredEtherCATDeviceSchema = z.object({
   slaveType: z.string().optional(),
 })
 
+const EtherCATMasterConfigSchema = z.object({
+  networkInterface: z.string(),
+  cycleTimeUs: z.number().int().min(100).max(100000),
+})
+type EtherCATMasterConfig = z.infer<typeof EtherCATMasterConfigSchema>
+
 const EthercatConfigSchema = z.object({
+  masterConfig: EtherCATMasterConfigSchema.optional(),
   devices: z.array(ConfiguredEtherCATDeviceSchema),
 })
 type EthercatConfig = z.infer<typeof EthercatConfigSchema>
@@ -791,6 +798,7 @@ export {
   bodySchema,
   ConfiguredEtherCATDeviceSchema,
   EthercatConfigSchema,
+  EtherCATMasterConfigSchema,
   ModbusErrorHandlingSchema,
   ModbusFunctionCodeSchema,
   ModbusIOGroupSchema,
@@ -851,6 +859,7 @@ export type {
   BaseType,
   BodySchema,
   EthercatConfig,
+  EtherCATMasterConfig,
   ModbusErrorHandling,
   ModbusFunctionCode,
   ModbusIOGroup,

--- a/src/types/ethercat/esi-types.ts
+++ b/src/types/ethercat/esi-types.ts
@@ -1,0 +1,363 @@
+/**
+ * EtherCAT Slave Information (ESI) Types
+ *
+ * Types for parsing and representing ESI XML files following ETG.2000 specification.
+ * ESI files describe EtherCAT slave device properties, PDO mappings, and communication settings.
+ */
+
+// ===================== VENDOR =====================
+
+/**
+ * Vendor information from ESI file
+ */
+export interface ESIVendor {
+  /** Vendor ID (hex format, e.g., "0x0002" for Beckhoff) */
+  id: string
+  /** Vendor name */
+  name: string
+}
+
+// ===================== DEVICE INFO =====================
+
+/**
+ * Device type information
+ */
+export interface ESIDeviceType {
+  /** Product code (hex format) */
+  productCode: string
+  /** Revision number (hex format) */
+  revisionNo: string
+  /** Type name/description */
+  name: string
+}
+
+/**
+ * Sync Manager configuration
+ */
+export interface ESISyncManager {
+  /** SM index (0-3 typically) */
+  index: number
+  /** Start address */
+  startAddress: string
+  /** Control byte */
+  controlByte: string
+  /** Default size */
+  defaultSize: number
+  /** Enable flag */
+  enable: boolean
+  /** SM type: Mailbox Out, Mailbox In, Process Data Out, Process Data In */
+  type: 'MbxOut' | 'MbxIn' | 'Outputs' | 'Inputs'
+}
+
+/**
+ * FMMU (Fieldbus Memory Management Unit) configuration
+ */
+export interface ESIFMMU {
+  /** FMMU type: Outputs, Inputs, MbxState */
+  type: 'Outputs' | 'Inputs' | 'MbxState'
+}
+
+// ===================== PDO ENTRIES =====================
+
+/**
+ * EtherCAT data types used in PDO entries
+ * Common types: BOOL, SINT, INT, DINT, LINT, USINT, UINT, UDINT, ULINT,
+ * REAL, LREAL, STRING, BYTE, WORD, DWORD, BIT, BIT2-BIT7
+ * Using string to allow vendor-specific custom types
+ */
+export type ESIDataType = string
+
+/**
+ * PDO Entry - represents a single variable in a PDO
+ */
+export interface ESIPdoEntry {
+  /** Entry index (hex, e.g., "#x6000") */
+  index: string
+  /** Entry subindex (hex, e.g., "#x01") */
+  subIndex: string
+  /** Bit length of the data */
+  bitLen: number
+  /** Entry name/identifier */
+  name: string
+  /** Data type */
+  dataType: ESIDataType
+  /** Optional: Comment/description */
+  comment?: string
+}
+
+/**
+ * Process Data Object - TxPdo (slave to master) or RxPdo (master to slave)
+ */
+export interface ESIPdo {
+  /** PDO index (hex, e.g., "#x1600" for RxPdo, "#x1A00" for TxPdo) */
+  index: string
+  /** PDO name */
+  name: string
+  /** Whether this PDO is fixed (cannot be modified) */
+  fixed: boolean
+  /** Whether this PDO is mandatory */
+  mandatory: boolean
+  /** SM index this PDO is assigned to */
+  smIndex?: number
+  /** List of entries in this PDO */
+  entries: ESIPdoEntry[]
+}
+
+// ===================== COE (CANopen over EtherCAT) =====================
+
+/**
+ * CoE Object Dictionary entry
+ */
+export interface ESICoEObject {
+  /** Object index (hex) */
+  index: string
+  /** Object name */
+  name: string
+  /** Object type */
+  type: string
+  /** Bit size */
+  bitSize: number
+  /** Access rights */
+  access: 'RO' | 'RW' | 'WO'
+  /** PDO mapping allowed */
+  pdoMapping: boolean
+  /** Default value */
+  defaultValue?: string
+  /** Subindexes for complex objects */
+  subItems?: ESICoESubItem[]
+}
+
+/**
+ * CoE Object subitem (for array/record types)
+ */
+export interface ESICoESubItem {
+  /** Subindex */
+  subIndex: string
+  /** Name */
+  name: string
+  /** Data type */
+  type: string
+  /** Bit size */
+  bitSize: number
+  /** Access rights */
+  access: 'RO' | 'RW' | 'WO'
+  /** Default value */
+  defaultValue?: string
+}
+
+// ===================== DEVICE =====================
+
+/**
+ * Complete ESI Device representation
+ */
+export interface ESIDevice {
+  /** Device type information */
+  type: ESIDeviceType
+  /** Device name */
+  name: string
+  /** Group name (category) */
+  groupName?: string
+  /** Physics type (e.g., "YY") */
+  physics?: string
+  /** FMMU configurations */
+  fmmu: ESIFMMU[]
+  /** Sync Manager configurations */
+  syncManagers: ESISyncManager[]
+  /** RxPDOs (master to slave) */
+  rxPdo: ESIPdo[]
+  /** TxPDOs (slave to master) */
+  txPdo: ESIPdo[]
+  /** CoE objects (optional) */
+  coeObjects?: ESICoEObject[]
+  /** Device image URL (optional) */
+  imageUrl?: string
+  /** Additional description */
+  description?: string
+}
+
+// ===================== GROUP =====================
+
+/**
+ * Device group/category
+ */
+export interface ESIGroup {
+  /** Group type identifier */
+  type: string
+  /** Group name */
+  name: string
+  /** Group image URL (optional) */
+  imageUrl?: string
+  /** Group description */
+  description?: string
+}
+
+// ===================== COMPLETE ESI FILE =====================
+
+/**
+ * Complete ESI file representation
+ */
+export interface ESIFile {
+  /** Vendor information */
+  vendor: ESIVendor
+  /** Device groups */
+  groups: ESIGroup[]
+  /** Devices in the file */
+  devices: ESIDevice[]
+  /** Original filename */
+  filename?: string
+  /** File version info */
+  version?: string
+  /** Creation/modification info */
+  infoData?: {
+    version?: string
+    creationDate?: string
+    modificationDate?: string
+    vendorUrl?: string
+  }
+}
+
+// ===================== PARSED CHANNEL (for UI) =====================
+
+/**
+ * Represents a channel that can be mapped to a located variable
+ * This is a flattened view of PDO entries for easier UI handling
+ */
+export interface ESIChannel {
+  /** Unique identifier for this channel */
+  id: string
+  /** PDO type: input (TxPdo) or output (RxPdo) */
+  direction: 'input' | 'output'
+  /** Parent PDO index */
+  pdoIndex: string
+  /** Parent PDO name */
+  pdoName: string
+  /** Entry index */
+  entryIndex: string
+  /** Entry subindex */
+  entrySubIndex: string
+  /** Channel name */
+  name: string
+  /** Data type */
+  dataType: ESIDataType
+  /** Bit length */
+  bitLen: number
+  /** Bit offset within the PDO */
+  bitOffset: number
+  /** Byte offset (calculated) */
+  byteOffset: number
+  /** IEC 61131-3 compatible type */
+  iecType: string
+  /** Whether this channel is selected for mapping */
+  selected?: boolean
+  /** Mapped variable name (if assigned) */
+  mappedVariable?: string
+}
+
+// ===================== PARSE RESULT =====================
+
+/**
+ * Result of parsing an ESI file
+ */
+export interface ESIParseResult {
+  success: boolean
+  data?: ESIFile
+  error?: string
+  warnings?: string[]
+}
+
+// ===================== REPOSITORY =====================
+
+/**
+ * Item in the ESI repository (a loaded ESI file)
+ */
+export interface ESIRepositoryItem {
+  /** Unique identifier for this repository item */
+  id: string
+  /** Original filename */
+  filename: string
+  /** Vendor information */
+  vendor: ESIVendor
+  /** Devices contained in this file */
+  devices: ESIDevice[]
+  /** Timestamp when this file was loaded */
+  loadedAt: number
+  /** Parsing warnings (non-fatal issues) */
+  warnings?: string[]
+}
+
+// ===================== CONFIGURED DEVICES =====================
+
+/**
+ * Reference to an ESI device in the repository
+ */
+export interface ESIDeviceRef {
+  /** ID of the repository item containing the device */
+  repositoryItemId: string
+  /** Index of the device within the repository item */
+  deviceIndex: number
+}
+
+/**
+ * A configured EtherCAT device in the project
+ */
+export interface ConfiguredEtherCATDevice {
+  /** Unique identifier */
+  id: string
+  /** Position in the EtherCAT network (from scan or manual assignment) */
+  position?: number
+  /** User-editable name for this device */
+  name: string
+  /** Reference to the ESI device definition */
+  esiDeviceRef: ESIDeviceRef
+  /** Vendor ID (hex format) */
+  vendorId: string
+  /** Product code (hex format) */
+  productCode: string
+  /** Revision number (hex format) */
+  revisionNo: string
+  /** How this device was added */
+  addedFrom: 'repository' | 'scan'
+}
+
+// ===================== DEVICE MATCHING =====================
+
+/**
+ * Quality of match between a scanned device and ESI device
+ */
+export type DeviceMatchQuality = 'exact' | 'partial' | 'none'
+
+/**
+ * A potential match for a scanned device
+ */
+export interface DeviceMatch {
+  /** ID of the repository item containing the matched device */
+  repositoryItemId: string
+  /** Index of the device within the repository item */
+  deviceIndex: number
+  /** Quality of the match */
+  matchQuality: DeviceMatchQuality
+  /** The matched ESI device */
+  esiDevice: ESIDevice
+}
+
+/**
+ * A scanned device with its potential matches from the repository
+ */
+export interface ScannedDeviceMatch {
+  /** The scanned device from network discovery */
+  device: {
+    position: number
+    name: string
+    vendor_id: number
+    product_code: number
+    revision: number
+    serial_number: number
+    state: string
+    input_bytes: number
+    output_bytes: number
+  }
+  /** List of potential matches from the repository */
+  matches: DeviceMatch[]
+  /** The match selected by the user for addition */
+  selectedMatch?: ESIDeviceRef
+}

--- a/src/types/ethercat/esi-types.ts
+++ b/src/types/ethercat/esi-types.ts
@@ -265,6 +265,33 @@ export interface ESIParseResult {
   warnings?: string[]
 }
 
+// ===================== DEVICE SUMMARY (lightweight) =====================
+
+/**
+ * Lightweight device metadata without PDOs/SM/FMMU.
+ * Used for repository listing and device matching without full parsing.
+ */
+export interface ESIDeviceSummary {
+  /** Device type information */
+  type: ESIDeviceType
+  /** Device name */
+  name: string
+  /** Group name (category) */
+  groupName?: string
+  /** Physics type (e.g., "YY") */
+  physics?: string
+  /** Pre-computed count of non-padding TxPDO entries */
+  inputChannelCount: number
+  /** Pre-computed count of non-padding RxPDO entries */
+  outputChannelCount: number
+  /** Pre-computed total input bytes */
+  totalInputBytes: number
+  /** Pre-computed total output bytes */
+  totalOutputBytes: number
+  /** Additional description */
+  description?: string
+}
+
 // ===================== REPOSITORY =====================
 
 /**
@@ -279,6 +306,25 @@ export interface ESIRepositoryItem {
   vendor: ESIVendor
   /** Devices contained in this file */
   devices: ESIDevice[]
+  /** Timestamp when this file was loaded */
+  loadedAt: number
+  /** Parsing warnings (non-fatal issues) */
+  warnings?: string[]
+}
+
+/**
+ * Lightweight repository item with device summaries instead of full ESIDevice objects.
+ * Used for UI display and matching without loading full PDO data.
+ */
+export interface ESIRepositoryItemLight {
+  /** Unique identifier for this repository item */
+  id: string
+  /** Original filename */
+  filename: string
+  /** Vendor information */
+  vendor: ESIVendor
+  /** Lightweight device summaries */
+  devices: ESIDeviceSummary[]
   /** Timestamp when this file was loaded */
   loadedAt: number
   /** Parsing warnings (non-fatal issues) */
@@ -336,8 +382,8 @@ export interface DeviceMatch {
   deviceIndex: number
   /** Quality of the match */
   matchQuality: DeviceMatchQuality
-  /** The matched ESI device */
-  esiDevice: ESIDevice
+  /** The matched ESI device (lightweight summary) */
+  esiDevice: ESIDeviceSummary
 }
 
 /**

--- a/src/types/ethercat/esi-types.ts
+++ b/src/types/ethercat/esi-types.ts
@@ -253,6 +253,20 @@ export interface ESIChannel {
   mappedVariable?: string
 }
 
+// ===================== CHANNEL MAPPING =====================
+
+/**
+ * Mapping of an ESI channel to an IEC 61131-3 located variable address
+ */
+export interface EtherCATChannelMapping {
+  /** Matches ESIChannel.id */
+  channelId: string
+  /** IEC 61131-3 located variable address (e.g., "%IX0.0", "%QW2") */
+  iecLocation: string
+  /** True if the user manually edited this address */
+  userEdited: boolean
+}
+
 // ===================== PARSE RESULT =====================
 
 /**
@@ -363,6 +377,102 @@ export interface ConfiguredEtherCATDevice {
   revisionNo: string
   /** How this device was added */
   addedFrom: 'repository' | 'scan'
+  /** Per-slave configuration settings */
+  config: EtherCATSlaveConfig
+  /** Channel-to-located-variable mappings */
+  channelMappings: EtherCATChannelMapping[]
+}
+
+// ===================== PER-SLAVE CONFIGURATION =====================
+
+/**
+ * Startup identity checks for an EtherCAT slave.
+ * When enabled, the master verifies the slave's identity during startup.
+ */
+export interface EtherCATStartupChecks {
+  /** Verify slave vendor ID matches ESI definition */
+  checkVendorId: boolean
+  /** Verify slave product code matches ESI definition */
+  checkProductCode: boolean
+  /** Verify slave revision number matches ESI definition */
+  checkRevisionNumber: boolean
+  /** Download expected PDO/slot configuration to slave at startup */
+  downloadPdoConfig: boolean
+}
+
+/**
+ * Addressing configuration for an EtherCAT slave.
+ */
+export interface EtherCATAddressing {
+  /** Fixed EtherCAT station address (configured address). 0 = auto-assign from position (1001+) */
+  ethercatAddress: number
+  /** Mark slave as optional - network continues if this slave is absent */
+  optionalSlave: boolean
+}
+
+/**
+ * Timeout settings for an EtherCAT slave.
+ */
+export interface EtherCATTimeouts {
+  /** SDO (Service Data Object) operation timeout in milliseconds */
+  sdoTimeoutMs: number
+  /** Init to Pre-Operational state transition timeout in milliseconds */
+  initToPreOpTimeoutMs: number
+  /** Pre-Op to Safe-Op and Safe-Op to Operational transition timeout in milliseconds */
+  safeOpToOpTimeoutMs: number
+}
+
+/**
+ * Watchdog settings for an EtherCAT slave.
+ */
+export interface EtherCATWatchdog {
+  /** Enable Sync Manager watchdog */
+  smWatchdogEnabled: boolean
+  /** Sync Manager watchdog time in milliseconds */
+  smWatchdogMs: number
+  /** Enable Process Data Interface (PDI) watchdog */
+  pdiWatchdogEnabled: boolean
+  /** PDI watchdog time in milliseconds */
+  pdiWatchdogMs: number
+}
+
+/**
+ * Distributed Clocks (DC) settings for an EtherCAT slave.
+ * DC provides synchronized timing across all slaves in the network.
+ */
+export interface EtherCATDistributedClocks {
+  /** Enable Distributed Clocks for this slave */
+  dcEnabled: boolean
+  /** Base sync unit cycle time in microseconds. 0 = use master cycle time */
+  dcSyncUnitCycleUs: number
+  /** Enable SYNC0 pulse generation */
+  dcSync0Enabled: boolean
+  /** SYNC0 cycle time in microseconds. 0 = use master cycle time */
+  dcSync0CycleUs: number
+  /** SYNC0 shift/offset time in microseconds */
+  dcSync0ShiftUs: number
+  /** Enable SYNC1 pulse generation */
+  dcSync1Enabled: boolean
+  /** SYNC1 cycle time in microseconds. 0 = use master cycle time */
+  dcSync1CycleUs: number
+  /** SYNC1 shift/offset time in microseconds */
+  dcSync1ShiftUs: number
+}
+
+/**
+ * Complete per-slave configuration for a configured EtherCAT device.
+ */
+export interface EtherCATSlaveConfig {
+  /** Identity verification during startup */
+  startupChecks: EtherCATStartupChecks
+  /** Network addressing */
+  addressing: EtherCATAddressing
+  /** Communication timeouts */
+  timeouts: EtherCATTimeouts
+  /** Watchdog settings */
+  watchdog: EtherCATWatchdog
+  /** Distributed Clocks (DC) settings */
+  distributedClocks: EtherCATDistributedClocks
 }
 
 // ===================== DEVICE MATCHING =====================

--- a/src/types/ethercat/esi-types.ts
+++ b/src/types/ethercat/esi-types.ts
@@ -321,6 +321,8 @@ export interface EtherCATChannelMapping {
   iecLocation: string
   /** True if the user manually edited this address */
   userEdited: boolean
+  /** User-editable alias for this channel mapping */
+  alias?: string
 }
 
 // ===================== PARSE RESULT =====================

--- a/src/types/ethercat/esi-types.ts
+++ b/src/types/ethercat/esi-types.ts
@@ -253,6 +253,62 @@ export interface ESIChannel {
   mappedVariable?: string
 }
 
+// ===================== PERSISTED PDO/CHANNEL DATA =====================
+
+/**
+ * Persisted PDO entry - stored in project.json for runtime config generation.
+ * Includes padding entries (index "0x0000") for complete PDO layout.
+ */
+export interface PersistedPdoEntry {
+  /** Entry index (hex, e.g., "0x6000") */
+  index: string
+  /** Entry subindex (hex, e.g., "0x01") */
+  subIndex: string
+  /** Bit length of the data */
+  bitLen: number
+  /** Entry name */
+  name: string
+  /** Data type (e.g., "BOOL", "INT16", "BIT" for padding) */
+  dataType: string
+}
+
+/**
+ * Persisted PDO - stored in project.json for runtime config generation.
+ */
+export interface PersistedPdo {
+  /** PDO index (hex, e.g., "0x1A00") */
+  index: string
+  /** PDO name */
+  name: string
+  /** PDO entries including padding */
+  entries: PersistedPdoEntry[]
+}
+
+/**
+ * Persisted channel info with full metadata from ESI.
+ * Enriches the minimal channelId stored in EtherCATChannelMapping.
+ */
+export interface PersistedChannelInfo {
+  /** Unique channel ID matching ESIChannel.id format */
+  channelId: string
+  /** Channel display name from ESI */
+  name: string
+  /** Channel direction */
+  direction: 'input' | 'output'
+  /** Parent PDO index (hex) */
+  pdoIndex: string
+  /** Entry index (hex) */
+  entryIndex: string
+  /** Entry subindex (hex) */
+  entrySubIndex: string
+  /** ESI data type */
+  dataType: string
+  /** Bit length */
+  bitLen: number
+  /** IEC 61131-3 compatible type */
+  iecType: string
+}
+
 // ===================== CHANNEL MAPPING =====================
 
 /**
@@ -381,6 +437,14 @@ export interface ConfiguredEtherCATDevice {
   config: EtherCATSlaveConfig
   /** Channel-to-located-variable mappings */
   channelMappings: EtherCATChannelMapping[]
+  /** Enriched channel metadata from ESI (persisted for runtime config generation) */
+  channelInfo?: PersistedChannelInfo[]
+  /** RxPDOs with full layout including padding (persisted for runtime config generation) */
+  rxPdos?: PersistedPdo[]
+  /** TxPDOs with full layout including padding (persisted for runtime config generation) */
+  txPdos?: PersistedPdo[]
+  /** Slave device type classification (e.g., "digital_input", "coupler") */
+  slaveType?: string
 }
 
 // ===================== PER-SLAVE CONFIGURATION =====================

--- a/src/types/ethercat/index.ts
+++ b/src/types/ethercat/index.ts
@@ -5,6 +5,9 @@
  * Based on the runtime's /api/discovery/* REST API.
  */
 
+// Re-export ESI types
+export * from './esi-types'
+
 // ===================== ENUMS =====================
 
 /**

--- a/src/utils/ethercat/device-config-defaults.ts
+++ b/src/utils/ethercat/device-config-defaults.ts
@@ -1,0 +1,53 @@
+import type { EtherCATSlaveConfig } from '@root/types/ethercat/esi-types'
+
+/**
+ * Default per-slave configuration for a newly added EtherCAT device.
+ * Values based on SOEM defaults and industrial best practices.
+ */
+export const DEFAULT_SLAVE_CONFIG: Readonly<EtherCATSlaveConfig> = {
+  startupChecks: {
+    checkVendorId: true,
+    checkProductCode: true,
+    checkRevisionNumber: false,
+    downloadPdoConfig: false,
+  },
+  addressing: {
+    ethercatAddress: 0,
+    optionalSlave: false,
+  },
+  timeouts: {
+    sdoTimeoutMs: 1000,
+    initToPreOpTimeoutMs: 3000,
+    safeOpToOpTimeoutMs: 10000,
+  },
+  watchdog: {
+    smWatchdogEnabled: true,
+    smWatchdogMs: 100,
+    pdiWatchdogEnabled: false,
+    pdiWatchdogMs: 100,
+  },
+  distributedClocks: {
+    dcEnabled: false,
+    dcSyncUnitCycleUs: 0,
+    dcSync0Enabled: false,
+    dcSync0CycleUs: 0,
+    dcSync0ShiftUs: 0,
+    dcSync1Enabled: false,
+    dcSync1CycleUs: 0,
+    dcSync1ShiftUs: 0,
+  },
+}
+
+/**
+ * Creates a fresh mutable copy of the default slave config.
+ * Each device gets its own config object to avoid shared-reference mutations.
+ */
+export function createDefaultSlaveConfig(): EtherCATSlaveConfig {
+  return {
+    startupChecks: { ...DEFAULT_SLAVE_CONFIG.startupChecks },
+    addressing: { ...DEFAULT_SLAVE_CONFIG.addressing },
+    timeouts: { ...DEFAULT_SLAVE_CONFIG.timeouts },
+    watchdog: { ...DEFAULT_SLAVE_CONFIG.watchdog },
+    distributedClocks: { ...DEFAULT_SLAVE_CONFIG.distributedClocks },
+  }
+}

--- a/src/utils/ethercat/device-matcher.ts
+++ b/src/utils/ethercat/device-matcher.ts
@@ -1,0 +1,169 @@
+/**
+ * EtherCAT Device Matcher Utility
+ *
+ * Provides functions to match scanned EtherCAT devices against ESI repository items.
+ */
+
+import type { EtherCATDevice } from '@root/types/ethercat'
+import type {
+  DeviceMatch,
+  DeviceMatchQuality,
+  ESIRepositoryItem,
+  ScannedDeviceMatch,
+} from '@root/types/ethercat/esi-types'
+
+/**
+ * Parse a hex string to a number for comparison
+ * Handles formats: "0x1234", "#x1234", "1234"
+ */
+function parseHexToNumber(hexString: string): number {
+  const cleaned = hexString.replace('#x', '0x').replace('#X', '0x')
+  return parseInt(cleaned, 16) || 0
+}
+
+/**
+ * Determine the match quality between a scanned device and an ESI device
+ */
+function getMatchQuality(
+  scannedVendorId: number,
+  scannedProductCode: number,
+  scannedRevision: number,
+  esiVendorId: string,
+  esiProductCode: string,
+  esiRevisionNo: string,
+): DeviceMatchQuality {
+  const esiVendorNum = parseHexToNumber(esiVendorId)
+  const esiProductNum = parseHexToNumber(esiProductCode)
+  const esiRevisionNum = parseHexToNumber(esiRevisionNo)
+
+  // Check vendor ID first - must match for any level of match
+  if (scannedVendorId !== esiVendorNum) {
+    return 'none'
+  }
+
+  // Check product code - must match for partial or exact
+  if (scannedProductCode !== esiProductNum) {
+    return 'none'
+  }
+
+  // Check revision - exact match requires revision match
+  if (scannedRevision === esiRevisionNum) {
+    return 'exact'
+  }
+
+  // Vendor and product match, but different revision
+  return 'partial'
+}
+
+/**
+ * Find all matches for a single scanned device in the repository
+ */
+function findMatchesForDevice(scannedDevice: EtherCATDevice, repository: ESIRepositoryItem[]): DeviceMatch[] {
+  const matches: DeviceMatch[] = []
+
+  for (const repoItem of repository) {
+    const esiVendorId = repoItem.vendor.id
+
+    for (let deviceIndex = 0; deviceIndex < repoItem.devices.length; deviceIndex++) {
+      const esiDevice = repoItem.devices[deviceIndex]
+      const matchQuality = getMatchQuality(
+        scannedDevice.vendor_id,
+        scannedDevice.product_code,
+        scannedDevice.revision,
+        esiVendorId,
+        esiDevice.type.productCode,
+        esiDevice.type.revisionNo,
+      )
+
+      if (matchQuality !== 'none') {
+        matches.push({
+          repositoryItemId: repoItem.id,
+          deviceIndex,
+          matchQuality,
+          esiDevice,
+        })
+      }
+    }
+  }
+
+  // Sort matches: exact first, then partial
+  matches.sort((a, b) => {
+    if (a.matchQuality === 'exact' && b.matchQuality !== 'exact') return -1
+    if (a.matchQuality !== 'exact' && b.matchQuality === 'exact') return 1
+    return 0
+  })
+
+  return matches
+}
+
+/**
+ * Match an array of scanned devices against the ESI repository
+ *
+ * @param scannedDevices - Array of devices discovered via network scan
+ * @param repository - Array of loaded ESI repository items
+ * @returns Array of ScannedDeviceMatch objects with match information
+ */
+export function matchDevicesToRepository(
+  scannedDevices: EtherCATDevice[],
+  repository: ESIRepositoryItem[],
+): ScannedDeviceMatch[] {
+  return scannedDevices.map((device) => {
+    const matches = findMatchesForDevice(device, repository)
+
+    return {
+      device: {
+        position: device.position,
+        name: device.name,
+        vendor_id: device.vendor_id,
+        product_code: device.product_code,
+        revision: device.revision,
+        serial_number: device.serial_number,
+        state: device.state,
+        input_bytes: device.input_bytes,
+        output_bytes: device.output_bytes,
+      },
+      matches,
+      // Auto-select the best match if there's an exact match
+      selectedMatch:
+        matches.length > 0 && matches[0].matchQuality === 'exact'
+          ? {
+              repositoryItemId: matches[0].repositoryItemId,
+              deviceIndex: matches[0].deviceIndex,
+            }
+          : undefined,
+    }
+  })
+}
+
+/**
+ * Get the best match quality from a list of matches
+ */
+export function getBestMatchQuality(matches: DeviceMatch[]): DeviceMatchQuality {
+  if (matches.length === 0) return 'none'
+  if (matches.some((m) => m.matchQuality === 'exact')) return 'exact'
+  if (matches.some((m) => m.matchQuality === 'partial')) return 'partial'
+  return 'none'
+}
+
+/**
+ * Count devices by match quality
+ */
+export function countMatchedDevices(deviceMatches: ScannedDeviceMatch[]): {
+  exact: number
+  partial: number
+  none: number
+  total: number
+} {
+  let exact = 0
+  let partial = 0
+  let none = 0
+
+  for (const dm of deviceMatches) {
+    const bestQuality = getBestMatchQuality(dm.matches)
+    if (bestQuality === 'exact') exact++
+    else if (bestQuality === 'partial') partial++
+    else none++
+  }
+
+  return { exact, partial, none, total: deviceMatches.length }
+}

--- a/src/utils/ethercat/device-matcher.ts
+++ b/src/utils/ethercat/device-matcher.ts
@@ -8,7 +8,7 @@ import type { EtherCATDevice } from '@root/types/ethercat'
 import type {
   DeviceMatch,
   DeviceMatchQuality,
-  ESIRepositoryItem,
+  ESIRepositoryItemLight,
   ScannedDeviceMatch,
 } from '@root/types/ethercat/esi-types'
 
@@ -58,7 +58,7 @@ function getMatchQuality(
 /**
  * Find all matches for a single scanned device in the repository
  */
-function findMatchesForDevice(scannedDevice: EtherCATDevice, repository: ESIRepositoryItem[]): DeviceMatch[] {
+function findMatchesForDevice(scannedDevice: EtherCATDevice, repository: ESIRepositoryItemLight[]): DeviceMatch[] {
   const matches: DeviceMatch[] = []
 
   for (const repoItem of repository) {
@@ -105,7 +105,7 @@ function findMatchesForDevice(scannedDevice: EtherCATDevice, repository: ESIRepo
  */
 export function matchDevicesToRepository(
   scannedDevices: EtherCATDevice[],
-  repository: ESIRepositoryItem[],
+  repository: ESIRepositoryItemLight[],
 ): ScannedDeviceMatch[] {
   return scannedDevices.map((device) => {
     const matches = findMatchesForDevice(device, repository)

--- a/src/utils/ethercat/device-matcher.ts
+++ b/src/utils/ethercat/device-matcher.ts
@@ -17,8 +17,8 @@ import type {
  * Handles formats: "0x1234", "#x1234", "1234"
  */
 function parseHexToNumber(hexString: string): number {
-  const cleaned = hexString.replace('#x', '0x').replace('#X', '0x')
-  return parseInt(cleaned, 16) || 0
+  const cleaned = hexString.replace(/#x/gi, '0x')
+  return Number(cleaned) || 0
 }
 
 /**

--- a/src/utils/ethercat/enrich-device-data.ts
+++ b/src/utils/ethercat/enrich-device-data.ts
@@ -1,0 +1,109 @@
+/**
+ * EtherCAT Device Data Enrichment
+ *
+ * Pure functions that extract persistable data from a full ESIDevice.
+ * Used when adding devices to persist channel/PDO metadata for runtime config generation.
+ */
+
+import type {
+  ESIDevice,
+  ESIPdo,
+  PersistedChannelInfo,
+  PersistedPdo,
+  PersistedPdoEntry,
+} from '@root/types/ethercat/esi-types'
+
+import { esiTypeToIecType, pdoToChannels } from './esi-parser'
+
+/**
+ * Convert ESIPdo[] to PersistedPdo[] format.
+ * Preserves all entries including padding for complete PDO layout.
+ */
+export function persistPdos(pdos: ESIPdo[]): PersistedPdo[] {
+  return pdos.map((pdo) => ({
+    index: pdo.index,
+    name: pdo.name,
+    entries: pdo.entries.map(
+      (entry): PersistedPdoEntry => ({
+        index: entry.index,
+        subIndex: entry.subIndex,
+        bitLen: entry.bitLen,
+        name: entry.name,
+        dataType: entry.dataType,
+      }),
+    ),
+  }))
+}
+
+/**
+ * Build persisted channel info from ESIDevice using pdoToChannels.
+ * Extracts full metadata needed for runtime config generation.
+ */
+export function buildChannelInfo(device: ESIDevice): PersistedChannelInfo[] {
+  const channels = pdoToChannels(device)
+  return channels.map(
+    (ch): PersistedChannelInfo => ({
+      channelId: ch.id,
+      name: ch.name,
+      direction: ch.direction,
+      pdoIndex: ch.pdoIndex,
+      entryIndex: ch.entryIndex,
+      entrySubIndex: ch.entrySubIndex,
+      dataType: ch.dataType,
+      bitLen: ch.bitLen,
+      iecType: esiTypeToIecType(ch.dataType, ch.bitLen),
+    }),
+  )
+}
+
+/**
+ * Derive slave device type from PDO structure.
+ * Uses heuristics based on PDO direction and data sizes.
+ */
+export function deriveSlaveType(device: ESIDevice): string {
+  const hasNonPaddingEntry = (pdos: ESIPdo[]): boolean =>
+    pdos.some((pdo) => pdo.entries.some((e) => e.name !== 'Padding' && e.index !== '0x0000'))
+
+  const allBitSized = (pdos: ESIPdo[]): boolean =>
+    pdos.every((pdo) =>
+      pdo.entries.filter((e) => e.name !== 'Padding' && e.index !== '0x0000').every((e) => e.bitLen === 1),
+    )
+
+  const hasTxData = hasNonPaddingEntry(device.txPdo)
+  const hasRxData = hasNonPaddingEntry(device.rxPdo)
+
+  if (!hasTxData && !hasRxData) return 'coupler'
+
+  const txAllBit = hasTxData && allBitSized(device.txPdo)
+  const rxAllBit = hasRxData && allBitSized(device.rxPdo)
+
+  if (hasTxData && !hasRxData) {
+    return txAllBit ? 'digital_input' : 'analog_input'
+  }
+
+  if (hasRxData && !hasTxData) {
+    return rxAllBit ? 'digital_output' : 'analog_output'
+  }
+
+  // Both directions
+  if (txAllBit && rxAllBit) return 'digital_io'
+  return 'analog_io'
+}
+
+/**
+ * Enrich device data by extracting all persistable info from a full ESIDevice.
+ * Returns fields to spread into ConfiguredEtherCATDevice.
+ */
+export function enrichDeviceData(device: ESIDevice): {
+  channelInfo: PersistedChannelInfo[]
+  rxPdos: PersistedPdo[]
+  txPdos: PersistedPdo[]
+  slaveType: string
+} {
+  return {
+    channelInfo: buildChannelInfo(device),
+    rxPdos: persistPdos(device.rxPdo),
+    txPdos: persistPdos(device.txPdo),
+    slaveType: deriveSlaveType(device),
+  }
+}

--- a/src/utils/ethercat/esi-parser.ts
+++ b/src/utils/ethercat/esi-parser.ts
@@ -1,0 +1,489 @@
+/**
+ * EtherCAT ESI (EtherCAT Slave Information) XML Parser
+ *
+ * Parses ESI XML files following ETG.2000 specification and extracts
+ * device information, PDO mappings, and channel configurations.
+ */
+
+import type {
+  ESIChannel,
+  ESIDataType,
+  ESIDevice,
+  ESIDeviceType,
+  ESIFile,
+  ESIFMMU,
+  ESIGroup,
+  ESIParseResult,
+  ESIPdo,
+  ESIPdoEntry,
+  ESISyncManager,
+  ESIVendor,
+} from '@root/types/ethercat/esi-types'
+
+/**
+ * Parse hex string to number
+ * Handles formats: "#x1234", "0x1234", "1234"
+ */
+function parseHexValue(value: string | undefined | null): string {
+  if (!value) return '0x0'
+  const cleaned = value.replace('#x', '0x').replace('#X', '0x')
+  return cleaned.startsWith('0x') ? cleaned : `0x${cleaned}`
+}
+
+/**
+ * Parse hex string to decimal number
+ */
+function _hexToNumber(value: string | undefined | null): number {
+  if (!value) return 0
+  const hex = parseHexValue(value)
+  return parseInt(hex, 16) || 0
+}
+
+/**
+ * Get text content from an element by tag name
+ */
+function getElementText(parent: Element, tagName: string): string | undefined {
+  const element = parent.getElementsByTagName(tagName)[0]
+  return element?.textContent?.trim() || undefined
+}
+
+/**
+ * Get attribute value from an element
+ */
+function getAttribute(element: Element, attrName: string): string | undefined {
+  return element.getAttribute(attrName) || undefined
+}
+
+/**
+ * Parse Vendor information
+ */
+function parseVendor(vendorElement: Element): ESIVendor {
+  return {
+    id: parseHexValue(getElementText(vendorElement, 'Id')),
+    name: getElementText(vendorElement, 'Name') || 'Unknown Vendor',
+  }
+}
+
+/**
+ * Parse Group information
+ */
+function parseGroup(groupElement: Element): ESIGroup {
+  return {
+    type: getElementText(groupElement, 'Type') || '',
+    name: getElementText(groupElement, 'Name') || '',
+    imageUrl: getElementText(groupElement, 'ImageData16x14'),
+    description: getElementText(groupElement, 'Comment'),
+  }
+}
+
+/**
+ * Parse FMMU configuration
+ */
+function parseFMMU(fmmuElement: Element): ESIFMMU {
+  const text = fmmuElement.textContent?.trim() || 'Outputs'
+  return {
+    type: text as ESIFMMU['type'],
+  }
+}
+
+/**
+ * Parse Sync Manager configuration
+ */
+function parseSyncManager(smElement: Element, index: number): ESISyncManager {
+  const typeMap: Record<string, ESISyncManager['type']> = {
+    MbxOut: 'MbxOut',
+    MbxIn: 'MbxIn',
+    Outputs: 'Outputs',
+    Inputs: 'Inputs',
+  }
+
+  return {
+    index,
+    startAddress: parseHexValue(getAttribute(smElement, 'StartAddress')),
+    controlByte: parseHexValue(getAttribute(smElement, 'ControlByte')),
+    defaultSize: parseInt(getAttribute(smElement, 'DefaultSize') || '0', 10),
+    enable: getAttribute(smElement, 'Enable') !== '0',
+    type: typeMap[smElement.textContent?.trim() || 'Outputs'] || 'Outputs',
+  }
+}
+
+/**
+ * Parse PDO Entry
+ */
+function parsePdoEntry(entryElement: Element): ESIPdoEntry | null {
+  const index = getElementText(entryElement, 'Index')
+  const bitLen = parseInt(getElementText(entryElement, 'BitLen') || '0', 10)
+
+  // Skip padding entries (entries without index or with 0 bitlen used for alignment)
+  if (!index && bitLen > 0) {
+    // This is likely a padding entry, we'll include it but mark it
+    return {
+      index: '0x0000',
+      subIndex: '0x00',
+      bitLen,
+      name: 'Padding',
+      dataType: 'BIT',
+    }
+  }
+
+  if (!index) return null
+
+  return {
+    index: parseHexValue(index),
+    subIndex: parseHexValue(getElementText(entryElement, 'SubIndex')),
+    bitLen,
+    name: getElementText(entryElement, 'Name') || 'Unnamed',
+    dataType: getElementText(entryElement, 'DataType') || 'BYTE',
+    comment: getElementText(entryElement, 'Comment'),
+  }
+}
+
+/**
+ * Parse PDO (RxPdo or TxPdo)
+ */
+function parsePdo(pdoElement: Element): ESIPdo {
+  const entries: ESIPdoEntry[] = []
+  const entryElements = pdoElement.getElementsByTagName('Entry')
+
+  for (let i = 0; i < entryElements.length; i++) {
+    const entry = parsePdoEntry(entryElements[i])
+    if (entry) {
+      entries.push(entry)
+    }
+  }
+
+  return {
+    index: parseHexValue(getElementText(pdoElement, 'Index')),
+    name: getElementText(pdoElement, 'Name') || 'Unnamed PDO',
+    fixed: getAttribute(pdoElement, 'Fixed')?.toLowerCase() === 'true',
+    mandatory: getAttribute(pdoElement, 'Mandatory')?.toLowerCase() === 'true',
+    smIndex: getAttribute(pdoElement, 'Sm') ? parseInt(getAttribute(pdoElement, 'Sm')!, 10) : undefined,
+    entries,
+  }
+}
+
+/**
+ * Parse Device Type information
+ */
+function parseDeviceType(typeElement: Element): ESIDeviceType {
+  return {
+    productCode: parseHexValue(getAttribute(typeElement, 'ProductCode')),
+    revisionNo: parseHexValue(getAttribute(typeElement, 'RevisionNo')),
+    name: typeElement.textContent?.trim() || 'Unknown Type',
+  }
+}
+
+/**
+ * Parse Device
+ */
+function parseDevice(deviceElement: Element, groups: ESIGroup[]): ESIDevice {
+  // Parse Type
+  const typeElement = deviceElement.getElementsByTagName('Type')[0]
+  const type = typeElement ? parseDeviceType(typeElement) : { productCode: '0x0', revisionNo: '0x0', name: 'Unknown' }
+
+  // Get group reference
+  const groupType = getElementText(deviceElement, 'GroupType')
+  const group = groups.find((g) => g.type === groupType)
+
+  // Parse FMMUs
+  const fmmu: ESIFMMU[] = []
+  const fmmuElements = deviceElement.getElementsByTagName('Fmmu')
+  for (let i = 0; i < fmmuElements.length; i++) {
+    fmmu.push(parseFMMU(fmmuElements[i]))
+  }
+
+  // Parse Sync Managers
+  const syncManagers: ESISyncManager[] = []
+  const smElements = deviceElement.getElementsByTagName('Sm')
+  for (let i = 0; i < smElements.length; i++) {
+    syncManagers.push(parseSyncManager(smElements[i], i))
+  }
+
+  // Parse RxPDOs
+  const rxPdo: ESIPdo[] = []
+  const rxPdoElements = deviceElement.getElementsByTagName('RxPdo')
+  for (let i = 0; i < rxPdoElements.length; i++) {
+    rxPdo.push(parsePdo(rxPdoElements[i]))
+  }
+
+  // Parse TxPDOs
+  const txPdo: ESIPdo[] = []
+  const txPdoElements = deviceElement.getElementsByTagName('TxPdo')
+  for (let i = 0; i < txPdoElements.length; i++) {
+    txPdo.push(parsePdo(txPdoElements[i]))
+  }
+
+  return {
+    type,
+    name: getElementText(deviceElement, 'Name') || 'Unknown Device',
+    groupName: group?.name,
+    physics: getAttribute(deviceElement, 'Physics'),
+    fmmu,
+    syncManagers,
+    rxPdo,
+    txPdo,
+    description: getElementText(deviceElement, 'Comment'),
+  }
+}
+
+/**
+ * Map ESI data type to IEC 61131-3 type
+ */
+export function esiTypeToIecType(esiType: ESIDataType, bitLen: number): string {
+  const typeMap: Record<string, string> = {
+    BOOL: 'BOOL',
+    SINT: 'SINT',
+    INT: 'INT',
+    DINT: 'DINT',
+    LINT: 'LINT',
+    USINT: 'USINT',
+    UINT: 'UINT',
+    UDINT: 'UDINT',
+    ULINT: 'ULINT',
+    REAL: 'REAL',
+    LREAL: 'LREAL',
+    STRING: 'STRING',
+    BYTE: 'BYTE',
+    WORD: 'WORD',
+    DWORD: 'DWORD',
+  }
+
+  if (typeMap[esiType]) {
+    return typeMap[esiType]
+  }
+
+  // Handle BIT types
+  if (esiType.startsWith('BIT') || bitLen === 1) {
+    return 'BOOL'
+  }
+
+  // Infer from bit length
+  switch (bitLen) {
+    case 1:
+      return 'BOOL'
+    case 8:
+      return 'BYTE'
+    case 16:
+      return 'WORD'
+    case 32:
+      return 'DWORD'
+    case 64:
+      return 'LWORD'
+    default:
+      return 'BYTE'
+  }
+}
+
+/**
+ * Convert PDO entries to channels for UI
+ */
+export function pdoToChannels(device: ESIDevice): ESIChannel[] {
+  const channels: ESIChannel[] = []
+  let inputBitOffset = 0
+  let outputBitOffset = 0
+
+  // Process TxPDOs (inputs - slave to master)
+  for (const pdo of device.txPdo) {
+    for (const entry of pdo.entries) {
+      // Skip padding entries for channel list
+      if (entry.name === 'Padding' && entry.index === '0x0000') {
+        inputBitOffset += entry.bitLen
+        continue
+      }
+
+      channels.push({
+        id: `${pdo.index}-${entry.index}-${entry.subIndex}`,
+        direction: 'input',
+        pdoIndex: pdo.index,
+        pdoName: pdo.name,
+        entryIndex: entry.index,
+        entrySubIndex: entry.subIndex,
+        name: entry.name,
+        dataType: entry.dataType,
+        bitLen: entry.bitLen,
+        bitOffset: inputBitOffset,
+        byteOffset: Math.floor(inputBitOffset / 8),
+        iecType: esiTypeToIecType(entry.dataType, entry.bitLen),
+        selected: false,
+      })
+
+      inputBitOffset += entry.bitLen
+    }
+  }
+
+  // Process RxPDOs (outputs - master to slave)
+  for (const pdo of device.rxPdo) {
+    for (const entry of pdo.entries) {
+      // Skip padding entries for channel list
+      if (entry.name === 'Padding' && entry.index === '0x0000') {
+        outputBitOffset += entry.bitLen
+        continue
+      }
+
+      channels.push({
+        id: `${pdo.index}-${entry.index}-${entry.subIndex}`,
+        direction: 'output',
+        pdoIndex: pdo.index,
+        pdoName: pdo.name,
+        entryIndex: entry.index,
+        entrySubIndex: entry.subIndex,
+        name: entry.name,
+        dataType: entry.dataType,
+        bitLen: entry.bitLen,
+        bitOffset: outputBitOffset,
+        byteOffset: Math.floor(outputBitOffset / 8),
+        iecType: esiTypeToIecType(entry.dataType, entry.bitLen),
+        selected: false,
+      })
+
+      outputBitOffset += entry.bitLen
+    }
+  }
+
+  return channels
+}
+
+/**
+ * Parse ESI XML string
+ */
+export function parseESI(xmlString: string, filename?: string): ESIParseResult {
+  const warnings: string[] = []
+
+  try {
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(xmlString, 'text/xml')
+
+    // Check for parse errors
+    const parseError = doc.getElementsByTagName('parsererror')[0]
+    if (parseError) {
+      return {
+        success: false,
+        error: `XML parse error: ${parseError.textContent}`,
+      }
+    }
+
+    // Get root element
+    const root = doc.getElementsByTagName('EtherCATInfo')[0]
+    if (!root) {
+      return {
+        success: false,
+        error: 'Invalid ESI file: Missing EtherCATInfo root element',
+      }
+    }
+
+    // Parse Vendor
+    const vendorElement = root.getElementsByTagName('Vendor')[0]
+    if (!vendorElement) {
+      return {
+        success: false,
+        error: 'Invalid ESI file: Missing Vendor information',
+      }
+    }
+    const vendor = parseVendor(vendorElement)
+
+    // Parse Groups
+    const groups: ESIGroup[] = []
+    const descriptionsElement = root.getElementsByTagName('Descriptions')[0]
+    if (descriptionsElement) {
+      const groupsElement = descriptionsElement.getElementsByTagName('Groups')[0]
+      if (groupsElement) {
+        const groupElements = groupsElement.getElementsByTagName('Group')
+        for (let i = 0; i < groupElements.length; i++) {
+          groups.push(parseGroup(groupElements[i]))
+        }
+      }
+    }
+
+    // Parse Devices
+    const devices: ESIDevice[] = []
+    if (descriptionsElement) {
+      const devicesElement = descriptionsElement.getElementsByTagName('Devices')[0]
+      if (devicesElement) {
+        const deviceElements = devicesElement.getElementsByTagName('Device')
+        for (let i = 0; i < deviceElements.length; i++) {
+          devices.push(parseDevice(deviceElements[i], groups))
+        }
+      }
+    }
+
+    if (devices.length === 0) {
+      warnings.push('No devices found in ESI file')
+    }
+
+    // Parse InfoData (optional metadata)
+    const infoDataElement = root.getElementsByTagName('InfoData')[0]
+    const infoData = infoDataElement
+      ? {
+          version: getElementText(infoDataElement, 'Version'),
+          creationDate: getElementText(infoDataElement, 'CreationDate'),
+          modificationDate: getElementText(infoDataElement, 'ModificationDate'),
+          vendorUrl: getElementText(infoDataElement, 'VendorUrl'),
+        }
+      : undefined
+
+    const result: ESIFile = {
+      vendor,
+      groups,
+      devices,
+      filename,
+      infoData,
+    }
+
+    return {
+      success: true,
+      data: result,
+      warnings: warnings.length > 0 ? warnings : undefined,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to parse ESI file: ${error instanceof Error ? error.message : String(error)}`,
+    }
+  }
+}
+
+/**
+ * Calculate total PDO size in bytes
+ */
+export function calculatePdoSize(pdos: ESIPdo[]): number {
+  let totalBits = 0
+  for (const pdo of pdos) {
+    for (const entry of pdo.entries) {
+      totalBits += entry.bitLen
+    }
+  }
+  return Math.ceil(totalBits / 8)
+}
+
+/**
+ * Get device summary information
+ */
+export function getDeviceSummary(device: ESIDevice): {
+  totalInputBytes: number
+  totalOutputBytes: number
+  inputChannelCount: number
+  outputChannelCount: number
+  hasCoe: boolean
+} {
+  const inputBytes = calculatePdoSize(device.txPdo)
+  const outputBytes = calculatePdoSize(device.rxPdo)
+
+  let inputChannels = 0
+  let outputChannels = 0
+
+  for (const pdo of device.txPdo) {
+    inputChannels += pdo.entries.filter((e) => e.name !== 'Padding').length
+  }
+
+  for (const pdo of device.rxPdo) {
+    outputChannels += pdo.entries.filter((e) => e.name !== 'Padding').length
+  }
+
+  return {
+    totalInputBytes: inputBytes,
+    totalOutputBytes: outputBytes,
+    inputChannelCount: inputChannels,
+    outputChannelCount: outputChannels,
+    hasCoe: device.coeObjects !== undefined && device.coeObjects.length > 0,
+  }
+}

--- a/src/utils/ethercat/esi-parser.ts
+++ b/src/utils/ethercat/esi-parser.ts
@@ -26,17 +26,8 @@ import type {
  */
 function parseHexValue(value: string | undefined | null): string {
   if (!value) return '0x0'
-  const cleaned = value.replace('#x', '0x').replace('#X', '0x')
+  const cleaned = value.replace(/#x/gi, '0x')
   return cleaned.startsWith('0x') ? cleaned : `0x${cleaned}`
-}
-
-/**
- * Parse hex string to decimal number
- */
-function _hexToNumber(value: string | undefined | null): number {
-  if (!value) return 0
-  const hex = parseHexValue(value)
-  return parseInt(hex, 16) || 0
 }
 
 /**
@@ -81,8 +72,9 @@ function parseGroup(groupElement: Element): ESIGroup {
  */
 function parseFMMU(fmmuElement: Element): ESIFMMU {
   const text = fmmuElement.textContent?.trim() || 'Outputs'
+  const validTypes: ESIFMMU['type'][] = ['Outputs', 'Inputs', 'MbxState']
   return {
-    type: text as ESIFMMU['type'],
+    type: validTypes.includes(text as ESIFMMU['type']) ? (text as ESIFMMU['type']) : 'Outputs',
   }
 }
 

--- a/src/utils/ethercat/generate-ethercat-config.ts
+++ b/src/utils/ethercat/generate-ethercat-config.ts
@@ -44,6 +44,7 @@ interface RuntimeSlave {
 interface RuntimeMaster {
   interface: string
   cycle_time_us: number
+  watchdog_timeout_cycles: number
 }
 
 interface RuntimeDiagnostics {
@@ -185,6 +186,7 @@ export const generateEthercatConfig = (remoteDevices: PLCRemoteDevice[] | undefi
         master: {
           interface: remoteDevice.ethercatConfig?.masterConfig?.networkInterface || 'eth0',
           cycle_time_us: remoteDevice.ethercatConfig?.masterConfig?.cycleTimeUs ?? 1000,
+          watchdog_timeout_cycles: remoteDevice.ethercatConfig?.masterConfig?.watchdogTimeoutCycles ?? 3,
         },
         slaves,
         diagnostics: {

--- a/src/utils/ethercat/generate-ethercat-config.ts
+++ b/src/utils/ethercat/generate-ethercat-config.ts
@@ -1,0 +1,165 @@
+import type { PLCRemoteDevice } from '@root/types/PLC/open-plc'
+
+// Runtime JSON interfaces (snake_case for plugin consumption)
+
+interface EthercatDcConfig {
+  enabled: boolean
+  sync0_cycle_us?: number
+  sync0_shift_us?: number
+}
+
+interface EthercatPdoEntry {
+  index: string
+  address: string
+}
+
+interface EthercatPdoMapping {
+  inputs?: EthercatPdoEntry[]
+  outputs?: EthercatPdoEntry[]
+}
+
+interface EthercatSlaveJson {
+  position: number
+  name: string
+  vendor_id: string
+  product_code: string
+  revision: string
+  check_vendor: boolean
+  check_product: boolean
+  dc: EthercatDcConfig
+  pdo_mapping?: EthercatPdoMapping
+}
+
+interface EthercatMasterJson {
+  interface: string
+  cycle_time_us: number
+  dc_enabled: boolean
+  dc_sync_offset_percent: number
+}
+
+interface EthercatConfigJson {
+  master: EthercatMasterJson
+  slaves: EthercatSlaveJson[]
+}
+
+/**
+ * Generates the EtherCAT plugin configuration JSON from the project's remote devices.
+ * Returns null if there are no EtherCAT devices configured.
+ *
+ * @param remoteDevices - Array of PLCRemoteDevice from the project data
+ * @returns The EtherCAT configuration as a JSON string, or null if no devices are configured
+ */
+export const generateEthercatConfig = (remoteDevices: PLCRemoteDevice[] | undefined): string | null => {
+  if (!remoteDevices || remoteDevices.length === 0) {
+    return null
+  }
+
+  const ethercatRemoteDevices = remoteDevices.filter(
+    (device) => device.protocol === 'ethercat' && device.ethercatConfig,
+  )
+
+  if (ethercatRemoteDevices.length === 0) {
+    return null
+  }
+
+  // Collect all configured slaves across all EtherCAT remote devices
+  const allSlaves: EthercatSlaveJson[] = []
+  let anyDcEnabled = false
+
+  for (const remoteDevice of ethercatRemoteDevices) {
+    const devices = remoteDevice.ethercatConfig?.devices ?? []
+
+    for (let i = 0; i < devices.length; i++) {
+      const device = devices[i]
+      const position = device.position ?? i
+      const dc = device.config.distributedClocks
+
+      if (dc.dcEnabled) {
+        anyDcEnabled = true
+      }
+
+      // Build PDO mapping from channel mappings
+      const pdoMapping = buildPdoMapping(device.channelMappings)
+
+      const slave: EthercatSlaveJson = {
+        position,
+        name: device.name,
+        vendor_id: device.vendorId,
+        product_code: device.productCode,
+        revision: device.revisionNo,
+        check_vendor: device.config.startupChecks.checkVendorId,
+        check_product: device.config.startupChecks.checkProductCode,
+        dc: {
+          enabled: dc.dcEnabled,
+          ...(dc.dcEnabled && {
+            sync0_cycle_us: dc.dcSync0CycleUs,
+            sync0_shift_us: dc.dcSync0ShiftUs,
+          }),
+        },
+        ...(pdoMapping && { pdo_mapping: pdoMapping }),
+      }
+
+      allSlaves.push(slave)
+    }
+  }
+
+  if (allSlaves.length === 0) {
+    return null
+  }
+
+  const config: EthercatConfigJson = {
+    master: {
+      interface: 'eth0',
+      cycle_time_us: 4000,
+      dc_enabled: anyDcEnabled,
+      dc_sync_offset_percent: 20,
+    },
+    slaves: allSlaves,
+  }
+
+  return JSON.stringify(config, null, 2)
+}
+
+/**
+ * Builds PDO mapping from channel mappings.
+ * Groups channel mappings by direction (input/output) based on IEC location prefix.
+ */
+const buildPdoMapping = (
+  channelMappings: { channelId: string; iecLocation: string; userEdited: boolean }[],
+): EthercatPdoMapping | null => {
+  if (!channelMappings || channelMappings.length === 0) {
+    return null
+  }
+
+  const inputs: EthercatPdoEntry[] = []
+  const outputs: EthercatPdoEntry[] = []
+
+  for (const mapping of channelMappings) {
+    const loc = mapping.iecLocation
+    // Extract PDO index from channelId (format: "pdo_0x1A00_entry_0x6000_01" or similar)
+    const pdoIndexMatch = mapping.channelId.match(/pdo_(0x[0-9A-Fa-f]+)/)
+    const pdoIndex = pdoIndexMatch ? pdoIndexMatch[1] : '0x0000'
+
+    const entry: EthercatPdoEntry = {
+      index: pdoIndex,
+      address: loc,
+    }
+
+    // IEC location prefix determines direction: %I = input, %Q = output
+    if (loc.startsWith('%I')) {
+      inputs.push(entry)
+    } else if (loc.startsWith('%Q')) {
+      outputs.push(entry)
+    }
+  }
+
+  if (inputs.length === 0 && outputs.length === 0) {
+    return null
+  }
+
+  const result: EthercatPdoMapping = {}
+  if (inputs.length > 0) result.inputs = inputs
+  if (outputs.length > 0) result.outputs = outputs
+
+  return result
+}


### PR DESCRIPTION
## Summary

- Add channel-to-located-variable mapping table in each configured EtherCAT device's expanded view
- Channels from ESI PDOs are auto-assigned IEC 61131-3 addresses (`%IX0.0`, `%QW2`, `%QD4`, etc.) based on direction and data type
- Users can manually override any address (visually indicated with amber border)
- Direction filter (All/Input/Output) and search across the mapping table
- Fix stale eslint/tsc cache issue: disable `eslint-webpack-plugin` cache and clear `.tsbuildinfo` on prestart

## Test plan

- [ ] Add device from repository → expand → "Channel Mappings" section visible with loading spinner
- [ ] Channels loaded with correct auto-generated IEC addresses (BOOL→`%IX`/`%QX`, WORD→`%IW`/`%QW`, etc.)
- [ ] Edit an IEC location → input gets amber border, state updates immediately
- [ ] Direction filter (All/Input/Output) filters correctly with counts
- [ ] Search by name, type, or address works
- [ ] Collapse and re-expand → channels still loaded (no re-fetch)
- [ ] Run `npm run start:dev` from clean state → no eslint "type error typed" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)