### PR TITLE
fix: make force display consistent between LD and FBD editors

### DIFF
--- a/src/renderer/components/_atoms/graphical-editor/fbd/variable.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/fbd/variable.tsx
@@ -383,16 +383,16 @@ const VariableElement = (block: VariableProps) => {
       return undefined
     }
 
-    const variableType = getVariableType()
-    if (!variableType || variableType.toUpperCase() !== 'BOOL') {
-      return undefined
-    }
-
     const compositeKey = getCompositeKey(data.variable.name)
 
     if (debugForcedVariables.has(compositeKey)) {
       const forcedValue = debugForcedVariables.get(compositeKey)
       return forcedValue ? '#80C000' : '#4080FF'
+    }
+
+    const variableType = getVariableType()
+    if (!variableType || variableType.toUpperCase() !== 'BOOL') {
+      return undefined
     }
 
     const value = debugVariableValues.get(compositeKey)


### PR DESCRIPTION
## Summary
- Fixes inconsistent forced variable display between Ladder (LD) and FBD editors
- Moves the forced variable check before the BOOL type guard in FBD's `getDebuggerColor()`, so forced variables of **any type** get the border/shadow visual indicator — matching Ladder editor behavior
- Natural runtime value coloring (green/blue for TRUE/FALSE) remains BOOL-only, as intended

## Root Cause
The FBD variable component had a BOOL type guard that returned early before checking forced state, preventing non-BOOL forced variables from receiving visual feedback (border + box shadow). The Ladder editor had no such guard, causing the inconsistency.

## Test plan
- [ ] Force a BOOL variable in LD — verify green/blue display
- [ ] Force a BOOL variable in FBD — verify same green/blue border + shadow
- [ ] Force a non-BOOL variable (e.g., INT) in LD — verify text color changes
- [ ] Force a non-BOOL variable (e.g., INT) in FBD — verify border/shadow now displays (was missing before)
- [ ] Release a forced variable — verify display returns to normal in both editors

Closes #525
DOPE-163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the graphical editor where forced variable colors were not being applied correctly during debugging. Variable colors now properly display forced values regardless of variable type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->