### PR TITLE
Fix FB instance autocomplete failing after project reload

### DIFF
--- a/src/renderer/components/_features/[workspace]/editor/monaco/completion/fb.completion.ts
+++ b/src/renderer/components/_features/[workspace]/editor/monaco/completion/fb.completion.ts
@@ -54,7 +54,10 @@ function findFinalType(
 
   // Start with the first variable (e.g., "LocalVar")
   const rootVariable = pouVariables.find((v) => v.name === instancePath[0])
-  if (!rootVariable || rootVariable.type?.definition !== 'derived') {
+  if (
+    !rootVariable ||
+    (rootVariable.type?.definition !== 'derived' && rootVariable.type?.definition !== 'user-data-type')
+  ) {
     return null
   }
 
@@ -85,7 +88,7 @@ function findFinalType(
         const field = customFB.data.variables.find(
           (v) => v.name === fieldName && (v.class === 'input' || v.class === 'output' || v.class === 'inOut'),
         )
-        if (field && field.type?.definition === 'derived') {
+        if (field && (field.type?.definition === 'derived' || field.type?.definition === 'user-data-type')) {
           currentTypeName = field.type.value
         } else {
           return null
@@ -115,7 +118,9 @@ function findFBType(
 ): { type: string; isStandard: boolean } | null {
   // First, check in POU variables (from the store)
   const pouVariable = pouVariables.find((variable) => {
-    const matches = variable.name === instanceName && variable.type?.definition === 'derived'
+    const matches =
+      variable.name === instanceName &&
+      (variable.type?.definition === 'derived' || variable.type?.definition === 'user-data-type')
     return matches
   })
 


### PR DESCRIPTION
## Summary
- FB dot-access autocomplete (e.g. `timer_check.IN`, `simple_sum.LocalVar`) stopped working after saving and reopening a project
- Root cause: `findFBType` and `findFinalType` in `fb.completion.ts` only matched variables with `definition === 'derived'`, but the IEC parser (`parseIecStringToVariables`) assigns `'user-data-type'` to all non-base types when loading from file
- Fix: accept both `'derived'` and `'user-data-type'` definitions in the three affected checks — the functions already verify the type matches a known FB before returning suggestions

## Test plan
- [ ] Create a project with ST, C++, and Python function blocks
- [ ] Add instances of each FB type in a ST program and verify dot-access autocomplete works
- [ ] Save and reopen the project — verify autocomplete still works after reload
- [ ] Verify multi-level dot access (e.g. `myVar.nestedFB.`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced code completion accuracy by improving type resolution capabilities in the editor. The editor now properly recognizes and handles additional type definitions, delivering more accurate and comprehensive auto-completion suggestions when working with various data types and structures. This improvement provides developers with more intelligent code suggestions and a more seamless, efficient development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->