### PR TITLE
fix: transfer documentation when selecting external variable from globals

### DIFF
--- a/src/renderer/components/_molecules/variables-table/editable-cell.tsx
+++ b/src/renderer/components/_molecules/variables-table/editable-cell.tsx
@@ -133,6 +133,10 @@ const EditableNameCell = ({
       })
     }
 
+    if (matchingGlobalVar.documentation) {
+      table.options.meta?.updateData(index, 'documentation', matchingGlobalVar.documentation)
+    }
+
     setCellValue(selectedName)
   }
 


### PR DESCRIPTION
## Summary
- When selecting a global variable for an External variable, the documentation field is now auto-filled alongside name and type
- Adds a single `updateData` call for `documentation` in `handleExternalVariableSelection`, mirroring the existing pattern for `type`

Closes #607

## Test plan
- [ ] Create a global variable with a Documentation value
- [ ] In a POU, add an External variable and select the global variable from the dropdown
- [ ] Confirm the Documentation field is automatically populated
- [ ] Verify name and type still transfer correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation field now automatically populates when selecting a global variable for external variables, streamlining the configuration experience alongside automatic name and type updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->