### PR TITLE
fix: correct extensible block input names and types

### DIFF
--- a/src/utils/PLC/extensible-block-variables.ts
+++ b/src/utils/PLC/extensible-block-variables.ts
@@ -1,0 +1,142 @@
+/**
+ * Utility functions for managing extensible block inputs (MUX, ADD, AND, OR, etc.).
+ *
+ * Extensible inputs always match the pattern /^IN\d+$/ (e.g. IN0, IN1, IN2).
+ * Everything else (K, G, MN, MX, EN, ENO, OUT) is either fixed or an output.
+ *
+ * MUX starts extensible inputs at IN0; all other blocks start at IN1.
+ */
+
+/** Minimal variable interface compatible with both FBD and Ladder BlockVariant variables */
+interface BlockVariable {
+  name: string
+  class: string
+  type: { definition: string; value: string }
+  id?: string
+}
+
+interface ClassifiedVariables {
+  enVariable: BlockVariable | undefined
+  fixedInputs: BlockVariable[]
+  extensibleInputs: BlockVariable[]
+  outputs: BlockVariable[]
+}
+
+const EXTENSIBLE_INPUT_PATTERN = /^IN\d+$/
+
+function isExtensibleInput(variable: BlockVariable): boolean {
+  return variable.class === 'input' && EXTENSIBLE_INPUT_PATTERN.test(variable.name)
+}
+
+function getExtensibleIndex(variable: BlockVariable): number {
+  return Number(variable.name.slice(2))
+}
+
+/** Separate block variables into EN / fixed inputs / extensible inputs / outputs */
+function classifyBlockVariables(variables: BlockVariable[]): ClassifiedVariables {
+  const enVariable = variables.find((v) => v.class === 'input' && v.name === 'EN')
+  const fixedInputs = variables.filter(
+    (v) => (v.class === 'input' || v.class === 'inOut') && v.name !== 'EN' && !isExtensibleInput(v),
+  )
+  const extensibleInputs = variables
+    .filter((v) => isExtensibleInput(v))
+    .sort((a, b) => getExtensibleIndex(a) - getExtensibleIndex(b))
+  const outputs = variables.filter((v) => v.class === 'output')
+
+  return { enVariable, fixedInputs, extensibleInputs, outputs }
+}
+
+/** Get the type that new extensible inputs should have (derived from existing IN<n> variables) */
+function getExtensibleInputType(variables: BlockVariable[]): BlockVariable['type'] {
+  const { extensibleInputs } = classifyBlockVariables(variables)
+  if (extensibleInputs.length > 0) {
+    return extensibleInputs[0].type
+  }
+  // Fallback: first non-EN input
+  const firstInput = variables.find((v) => v.class === 'input' && v.name !== 'EN')
+  return firstInput?.type ?? { definition: 'base-type', value: 'INT' }
+}
+
+/** Determine the starting index for extensible inputs (0 for MUX, 1 for others) */
+function getExtensibleStartIndex(variables: BlockVariable[]): number {
+  const { extensibleInputs } = classifyBlockVariables(variables)
+  if (extensibleInputs.length > 0) {
+    return getExtensibleIndex(extensibleInputs[0])
+  }
+  return 1
+}
+
+/** Build the next extensible input variable with the correct name and type */
+function buildNextExtensibleInput(variables: BlockVariable[]): BlockVariable {
+  const { extensibleInputs } = classifyBlockVariables(variables)
+  const type = getExtensibleInputType(variables)
+
+  let nextIndex: number
+  if (extensibleInputs.length > 0) {
+    nextIndex = Math.max(...extensibleInputs.map(getExtensibleIndex)) + 1
+  } else {
+    nextIndex = 1
+  }
+
+  return { name: `IN${nextIndex}`, class: 'input', type }
+}
+
+/**
+ * Remove the last extensible input and return the new variable list.
+ * Returns null if already at the minimum extensible count.
+ */
+function removeLastExtensibleInput(variables: BlockVariable[], minExtensible = 2): BlockVariable[] | null {
+  const classified = classifyBlockVariables(variables)
+  if (classified.extensibleInputs.length <= minExtensible) {
+    return null
+  }
+  return assembleVariables({
+    ...classified,
+    extensibleInputs: classified.extensibleInputs.slice(0, -1),
+  })
+}
+
+/**
+ * Rebuild the variable list for a target total non-EN input count (fixed + extensible).
+ * Preserves fixed inputs and generates extensible inputs with correct names and types.
+ */
+function rebuildVariablesForInputCount(variables: BlockVariable[], targetTotalNonEN: number): BlockVariable[] {
+  const classified = classifyBlockVariables(variables)
+  const targetExtensible = Math.max(targetTotalNonEN - classified.fixedInputs.length, 2)
+  const type = getExtensibleInputType(variables)
+  const startIndex = getExtensibleStartIndex(variables)
+
+  const newExtensible: BlockVariable[] = []
+  for (let i = 0; i < targetExtensible; i++) {
+    newExtensible.push({ name: `IN${startIndex + i}`, class: 'input', type })
+  }
+
+  return assembleVariables({ ...classified, extensibleInputs: newExtensible })
+}
+
+/** Reassemble variables in the correct order: EN? + fixedInputs + extensibleInputs + outputs */
+function assembleVariables(classified: ClassifiedVariables): BlockVariable[] {
+  const result: BlockVariable[] = []
+  if (classified.enVariable) result.push(classified.enVariable)
+  result.push(...classified.fixedInputs)
+  result.push(...classified.extensibleInputs)
+  result.push(...classified.outputs)
+  return result
+}
+
+/** Calculate minimum total non-EN input count (fixed inputs + minimum extensible) */
+function getMinInputCount(variables: BlockVariable[], minExtensible = 2): number {
+  const { fixedInputs } = classifyBlockVariables(variables)
+  return fixedInputs.length + minExtensible
+}
+
+export {
+  assembleVariables,
+  buildNextExtensibleInput,
+  classifyBlockVariables,
+  getExtensibleInputType,
+  getMinInputCount,
+  rebuildVariablesForInputCount,
+  removeLastExtensibleInput,
+}
+export type { BlockVariable, ClassifiedVariables }


### PR DESCRIPTION
## Summary
- Fixes wrong input names (skipped indices) and wrong types when adding/removing inputs on extensible blocks (MUX, ADD, AND, OR, etc.)
- Extracted shared utility (`extensible-block-variables.ts`) that classifies variables by the `IN<n>` naming pattern, correctly distinguishing fixed inputs (like MUX's `K` selector) from extensible ones
- Refactored `handleInputsIncrement`, `handleInputsDecrement`, and `handleInputsSubmit` in both FBD and Ladder block components to use the new utility

Fixes #589

## Test plan
- [ ] **MUX increment**: Add MUX block → click + three times → inputs should be K, IN0, IN1, IN2, IN3 with all IN* having type ANY
- [ ] **MUX decrement**: From above → click - → should remove IN3, not K or IN0
- [ ] **MUX minimum**: Keep clicking - → should stop at K, IN0, IN1 (can't go below 2 extensible inputs)
- [ ] **MUX submit**: Type "6" in inputs field → should show K, IN0, IN1, IN2, IN3, IN4
- [ ] **ADD increment**: Add ADD → click + → should get IN1, IN2, IN3 with type ANY_NUM
- [ ] **ADD with EN**: Enable execution control → click + → should get EN, IN1, IN2, IN3 (EN not counted, types correct)
- [ ] **ADD submit**: Type "4" → should get IN1, IN2, IN3, IN4 with type ANY_NUM
- [ ] Run `npm run test` → all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured block variable management in graphical and ladder diagram editors to improve code maintainability and consistency. Enhanced internal utilities for handling extensible block inputs, making the codebase more organized and reducing complexity in input/output handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->