### PR TITLE
feat: support array variable elements in Ladder/FBD graphical editors

### DIFF
--- a/src/renderer/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
@@ -5,6 +5,7 @@ import { extractNumberAtEnd } from '@root/renderer/store/slices/project/validati
 import { PLCVariable } from '@root/types/PLC'
 import { cn } from '@root/utils'
 import { newGraphicalEditorNodeID } from '@root/utils/new-graphical-editor-node-id'
+import { expandArrayVariables } from '@root/utils/PLC/array-variable-utils'
 import { Node } from '@xyflow/react'
 import { isArray } from 'lodash'
 import { ComponentPropsWithRef, forwardRef, useMemo } from 'react'
@@ -95,8 +96,10 @@ const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProp
       }
     }, [pou])
 
+    const expandedVariables = expandArrayVariables(variables.all)
+
     const filteredVariables = block.type?.includes('variable')
-      ? variables.all
+      ? expandedVariables
           .filter(
             (variable) =>
               variable.name.toLowerCase().includes(valueToSearch.toLowerCase()) &&

--- a/src/renderer/components/_atoms/graphical-editor/fbd/utils/utils.ts
+++ b/src/renderer/components/_atoms/graphical-editor/fbd/utils/utils.ts
@@ -1,6 +1,7 @@
 import type { EditorModel, FBDFlowType, LadderFlowType } from '@root/renderer/store/slices'
 import type { PLCPou } from '@root/types/PLC/open-plc'
 import type { PLCVariable } from '@root/types/PLC/units/variable'
+import { resolveArrayVariableByName } from '@root/utils/PLC/array-variable-utils'
 
 import { customNodeTypes } from '..'
 import type { BasicNodeData } from './types'
@@ -25,7 +26,7 @@ export const getFBDPouVariablesRungNodeAndEdges = (
   const node = rung?.nodes.find((node) => node.id === data.nodeId)
 
   const variables: PLCVariable[] = pou?.data.variables as PLCVariable[]
-  const variable = variables.find((variable) => {
+  let variable = variables.find((variable) => {
     if (!node) return undefined
     switch (node.type as keyof typeof customNodeTypes) {
       case 'block':
@@ -54,6 +55,27 @@ export const getFBDPouVariablesRungNodeAndEdges = (
         )
     }
   })
+
+  // Fallback: try to resolve as array element access (e.g. "Sensor[0]")
+  if (!variable && node) {
+    const nodeType = node.type as keyof typeof customNodeTypes
+    if (nodeType !== 'connector' && nodeType !== 'continuation' && nodeType !== 'comment') {
+      const varName = (node.data as BasicNodeData).variable.name || data.variableName
+      if (varName) {
+        const resolved = resolveArrayVariableByName(variables, varName)
+        if (
+          resolved &&
+          (nodeType === 'block' ||
+            nodeType === 'input-variable' ||
+            nodeType === 'output-variable' ||
+            nodeType === 'inout-variable' ||
+            resolved.type.definition !== 'derived')
+        ) {
+          variable = resolved
+        }
+      }
+    }
+  }
 
   const edgesThatNodeIsSource = rung?.edges.filter((edge) => edge.source === data.nodeId)
   const edgesThatNodeIsTarget = rung?.edges.filter((edge) => edge.target === data.nodeId)

--- a/src/renderer/components/_atoms/graphical-editor/fbd/variable.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/fbd/variable.tsx
@@ -3,6 +3,7 @@ import * as Popover from '@radix-ui/react-popover'
 import { useOpenPLCStore } from '@root/renderer/store'
 import { PLCVariable } from '@root/types/PLC'
 import { cn, generateNumericUUID } from '@root/utils'
+import { resolveArrayVariableByName } from '@root/utils/PLC/array-variable-utils'
 import {
   floatToBuffer,
   getVariableTypeInfo,
@@ -303,9 +304,9 @@ const VariableElement = (block: VariableProps) => {
 
     // For variable nodes, allow all types including derived (user-defined types)
     // Don't use getVariableByName here as it filters out derived types
-    let variable: PLCVariable | { name: string } | undefined = (pou.data.variables as PLCVariable[]).find(
-      (v) => v.name.toLowerCase() === variableNameToSubmit.toLowerCase(),
-    )
+    let variable: PLCVariable | { name: string } | undefined =
+      (pou.data.variables as PLCVariable[]).find((v) => v.name.toLowerCase() === variableNameToSubmit.toLowerCase()) ||
+      resolveArrayVariableByName(pou.data.variables as PLCVariable[], variableNameToSubmit)
     if (!variable) {
       setIsAVariable(false)
       variable = { name: variableNameToSubmit }

--- a/src/renderer/components/_atoms/graphical-editor/ladder/autocomplete/index.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/ladder/autocomplete/index.tsx
@@ -3,6 +3,7 @@ import { useOpenPLCStore } from '@root/renderer/store'
 import { extractNumberAtEnd } from '@root/renderer/store/slices/project/validation/variables'
 import { PLCVariable } from '@root/types/PLC'
 import { cn } from '@root/utils'
+import { expandArrayVariables } from '@root/utils/PLC/array-variable-utils'
 import { Node } from '@xyflow/react'
 import { ComponentPropsWithRef, forwardRef } from 'react'
 
@@ -72,9 +73,11 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
     const variables = pou?.data.variables || []
     const variableRestrictions = blockTypeRestrictions(block, blockType)
 
+    const expandedVariables = expandArrayVariables(variables as PLCVariable[])
+
     const filteredVariables =
       blockType !== 'block'
-        ? variables
+        ? expandedVariables
             .filter(
               (variable) =>
                 variable.name.toLowerCase().includes(valueToSearch.toLowerCase()) &&
@@ -213,9 +216,9 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
         return
       }
 
-      // Look up in the full variables list, not just filtered ones
+      // Look up in the expanded variables list (includes array elements)
       // This ensures we find the variable even if the filter state changed
-      const selectedVariable = variables.find(
+      const selectedVariable = expandedVariables.find(
         (variableItem) => variableItem.name.toLowerCase() === variable.name.toLowerCase(),
       )
       if (!selectedVariable) {
@@ -224,7 +227,7 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
         return
       }
 
-      submitVariableToBlock(selectedVariable as PLCVariable)
+      submitVariableToBlock(selectedVariable)
     }
 
     return (
@@ -235,7 +238,7 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
         setIsOpen={setIsOpen}
         keyPressed={keyPressed}
         searchValue={valueToSearch}
-        variables={filteredVariables as PLCVariable[]}
+        variables={filteredVariables}
         submit={submit}
       />
     )

--- a/src/renderer/components/_atoms/graphical-editor/utils/index.ts
+++ b/src/renderer/components/_atoms/graphical-editor/utils/index.ts
@@ -1,12 +1,17 @@
 import { baseTypeSchema, genericTypeSchema } from '@root/types/PLC'
 import type { PLCVariable } from '@root/types/PLC/units/variable'
+import { resolveArrayVariableByName } from '@root/utils/PLC/array-variable-utils'
 import { ZodLiteral } from 'zod'
 
 import { BlockVariant } from '../ladder/block'
 import { BlockVariant as newBlockVariant } from '../types/block'
 
-export const getVariableByName = (variables: PLCVariable[], name: string): PLCVariable | undefined =>
-  variables.find((variable) => variable.name === name && variable.type.definition !== 'derived')
+export const getVariableByName = (variables: PLCVariable[], name: string): PLCVariable | undefined => {
+  const exact = variables.find((variable) => variable.name === name && variable.type.definition !== 'derived')
+  if (exact) return exact
+
+  return resolveArrayVariableByName(variables, name)
+}
 
 export const getBlockDocumentation = (blockVariant: newBlockVariant): string => {
   const inputVariables = blockVariant.variables.filter(

--- a/src/utils/PLC/array-variable-utils.ts
+++ b/src/utils/PLC/array-variable-utils.ts
@@ -1,0 +1,158 @@
+import type { PLCVariable } from '@root/types/PLC/units/variable'
+
+const MAX_EXPANSION = 100
+
+interface ParsedArrayAccess {
+  baseName: string
+  indices: number[]
+}
+
+interface DimensionRange {
+  lower: number
+  upper: number
+}
+
+/**
+ * Parse an array access expression like "Sensor[0]" or "Matrix[0,1]".
+ * Returns null if the name is not a valid array access pattern.
+ */
+export const parseArrayAccess = (name: string): ParsedArrayAccess | null => {
+  const match = name.match(/^([A-Za-z_][A-Za-z0-9_]*)\[(.+)\]$/)
+  if (!match) return null
+
+  const baseName = match[1]
+  const indicesStr = match[2]
+
+  const parts = indicesStr.split(',')
+  const indices: number[] = []
+
+  for (const part of parts) {
+    const trimmed = part.trim()
+    if (!/^-?\d+$/.test(trimmed)) return null
+    indices.push(parseInt(trimmed, 10))
+  }
+
+  if (indices.length === 0) return null
+
+  return { baseName, indices }
+}
+
+/**
+ * Parse a dimension range string like "0..5" into lower and upper bounds.
+ */
+export const parseDimensionRange = (dimension: string): DimensionRange | null => {
+  const match = dimension.match(/^(-?\d+)\.\.(-?\d+)$/)
+  if (!match) return null
+
+  const lower = parseInt(match[1], 10)
+  const upper = parseInt(match[2], 10)
+
+  if (lower > upper) return null
+
+  return { lower, upper }
+}
+
+/**
+ * Validate that indices are within the declared array dimensions.
+ */
+export const validateArrayIndices = (indices: number[], dimensions: { dimension: string }[]): boolean => {
+  if (indices.length !== dimensions.length) return false
+
+  return indices.every((index, i) => {
+    const range = parseDimensionRange(dimensions[i].dimension)
+    if (!range) return false
+    return index >= range.lower && index <= range.upper
+  })
+}
+
+/**
+ * Resolve an array element access to a synthetic PLCVariable with the element's base type.
+ * Returns null if the indices are out of range or the variable is not an array.
+ */
+export const resolveArrayElement = (baseVariable: PLCVariable, access: ParsedArrayAccess): PLCVariable | null => {
+  if (baseVariable.type.definition !== 'array') return null
+
+  const { data } = baseVariable.type
+  if (!validateArrayIndices(access.indices, data.dimensions)) return null
+
+  const indexStr = access.indices.join(',')
+
+  return {
+    ...baseVariable,
+    name: `${access.baseName}[${indexStr}]`,
+    type: {
+      definition: data.baseType.definition,
+      value: data.baseType.value,
+    },
+  } as PLCVariable
+}
+
+/**
+ * Expand an array variable into all its indexed elements for autocomplete.
+ * Multidimensional arrays use comma notation: Matrix[0,0], Matrix[0,1], ...
+ * Capped at MAX_EXPANSION (100) elements to avoid flooding the UI.
+ */
+export const expandArrayVariable = (variable: PLCVariable): PLCVariable[] => {
+  if (variable.type.definition !== 'array') return [variable]
+
+  const { data } = variable.type
+  const ranges = data.dimensions.map((d) => parseDimensionRange(d.dimension)).filter((r): r is DimensionRange => !!r)
+
+  if (ranges.length !== data.dimensions.length) return [variable]
+
+  // Calculate total element count
+  const totalElements = ranges.reduce((acc, range) => acc * (range.upper - range.lower + 1), 1)
+  if (totalElements > MAX_EXPANSION) return [variable]
+
+  // Generate all index combinations
+  const combinations: number[][] = []
+  const generateCombinations = (dimIndex: number, current: number[]) => {
+    if (dimIndex === ranges.length) {
+      combinations.push([...current])
+      return
+    }
+    const range = ranges[dimIndex]
+    for (let i = range.lower; i <= range.upper; i++) {
+      current.push(i)
+      generateCombinations(dimIndex + 1, current)
+      current.pop()
+    }
+  }
+  generateCombinations(0, [])
+
+  return combinations.map((indices) => {
+    const indexStr = indices.join(',')
+    return {
+      ...variable,
+      name: `${variable.name}[${indexStr}]`,
+      type: {
+        definition: data.baseType.definition,
+        value: data.baseType.value,
+      },
+    } as PLCVariable
+  })
+}
+
+/**
+ * Expand all array variables in a list, replacing each array with its elements.
+ * Non-array variables pass through unchanged.
+ */
+export const expandArrayVariables = (variables: PLCVariable[]): PLCVariable[] => {
+  return variables.flatMap(expandArrayVariable)
+}
+
+/**
+ * Try to resolve a name as an array access against a variable list.
+ * Returns the resolved synthetic PLCVariable, or undefined if not resolvable.
+ */
+export const resolveArrayVariableByName = (variables: PLCVariable[], name: string): PLCVariable | undefined => {
+  const access = parseArrayAccess(name)
+  if (!access) return undefined
+
+  const baseVariable = variables.find(
+    (v) => v.name.toLowerCase() === access.baseName.toLowerCase() && v.type.definition === 'array',
+  )
+  if (!baseVariable) return undefined
+
+  return resolveArrayElement(baseVariable, access) ?? undefined
+}


### PR DESCRIPTION
## Summary
- Adds array element expansion in autocomplete so `Sensor[0]`..`Sensor[5]` appear when `Sensor : ARRAY[0..5] OF BOOL` is declared
- Adds array access resolution in variable lookup/validation so manually typed array elements (e.g. `Sensor[0]`) are recognized
- Supports multidimensional arrays with comma notation (`Matrix[0,1]`) and caps autocomplete expansion at 100 elements

Closes #585

## Test plan
- [ ] Create `Sensor : ARRAY[0..5] OF BOOL` → add ladder contact → autocomplete shows `Sensor[0]`..`Sensor[5]` → select one → no red indicator
- [ ] Same with ladder coil
- [ ] Create `Values : ARRAY[0..3] OF INT` → contact autocomplete should NOT show `Values[0]` (INT, not BOOL)
- [ ] Add block (e.g. ADD) → variable node → autocomplete shows `Values[0]`..`Values[3]`
- [ ] Type `Sensor[0]` directly in contact → recognized, no error
- [ ] Type `Sensor[99]` → red error indicator (out of range)
- [ ] Same tests in FBD editor
- [ ] Existing non-array variables still work exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for array variable access in graphical editors (e.g., `Sensor[0]`, `Matrix[0,1]`).
  * Enhanced variable lookup with improved resolution for array-derived variables.
  * Improved autocomplete and variable filtering for array variable handling in FBD and Ladder editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->