### PR TITLE
feat: added dragging abilities to variables

### DIFF
--- a/src/renderer/components/_atoms/graphical-editor/fbd/variable.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/fbd/variable.tsx
@@ -13,7 +13,7 @@ import {
   parseStringValue,
   stringToBuffer,
 } from '@root/utils/PLC/variable-types'
-import { Node, NodeProps, Position } from '@xyflow/react'
+import { Node, NodeProps, NodeResizer, Position } from '@xyflow/react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { Modal, ModalContent, ModalTitle } from '../../../_molecules/modal'
@@ -51,7 +51,7 @@ export const DEFAULT_VARIABLE_CONNECTOR_Y = DEFAULT_VARIABLE_HEIGHT / 2
 export const Z_INDEX_DEBUGGER_VARIABLE = 10
 
 const VariableElement = (block: VariableProps) => {
-  const { id, data, selected } = block
+  const { id, data, selected, width, height } = block
   const {
     editor,
     editorActions: { updateModelFBD },
@@ -573,8 +573,8 @@ const VariableElement = (block: VariableProps) => {
           <TooltipTrigger asChild>
             <div
               style={{
-                width: ELEMENT_SIZE,
-                height: ELEMENT_HEIGHT,
+                width: width ?? ELEMENT_SIZE,
+                height: height ?? ELEMENT_HEIGHT,
                 ...(debuggerColor
                   ? {
                       borderColor: debuggerColor,
@@ -603,8 +603,8 @@ const VariableElement = (block: VariableProps) => {
               <div
                 className='relative flex items-center'
                 style={{
-                  width: DEFAULT_VARIABLE_WIDTH,
-                  height: DEFAULT_VARIABLE_HEIGHT,
+                  width: width ? width - 16 : DEFAULT_VARIABLE_WIDTH,
+                  height: height ?? DEFAULT_VARIABLE_HEIGHT,
                 }}
               >
                 <HighlightedTextArea
@@ -625,8 +625,8 @@ const VariableElement = (block: VariableProps) => {
                   setTextAreaValue={setVariableValue}
                   handleSubmit={handleSubmitVariableValueOnTextareaBlur}
                   inputHeight={{
-                    height: DEFAULT_VARIABLE_HEIGHT / 2,
-                    scrollLimiter: DEFAULT_VARIABLE_HEIGHT,
+                    height: (height ?? DEFAULT_VARIABLE_HEIGHT) / 2,
+                    scrollLimiter: height ?? DEFAULT_VARIABLE_HEIGHT,
                   }}
                   ref={inputVariableRef}
                   disabled={isDebuggerVisible}
@@ -780,6 +780,17 @@ const VariableElement = (block: VariableProps) => {
       {data.handles.map((handle, index) => (
         <CustomHandle key={index} {...handle} isDebuggerVisible={isDebuggerVisible} />
       ))}
+
+      <NodeResizer
+        isVisible={selected ?? false}
+        minWidth={ELEMENT_SIZE}
+        minHeight={ELEMENT_HEIGHT}
+        handleStyle={{
+          borderRadius: '0',
+          width: '8px',
+          height: '8px',
+        }}
+      />
     </>
   )
 }


### PR DESCRIPTION
# Pull request info

this PR adds the option to drag and resize variables in fbd
## References

this PR resolves #624 

## Description of the changes proposed
Enabled the dynamic resizing for FBD variable blocks using NodeResizer. This allows the blocks to be manually expanded to properly display long variable names and constants without text clipping.

## DOD checklist

- [ ] The code is complete and according to developers’ standards.
- [ ] I have performed a self-review of my code.
- [ ] Meet the acceptance criteria.
- [ ] Unit tests are written and green.
- [ ] Test coverage: __ %.
- [ ] Integration tests are written and green.
- [ ] Changes were communicated and updated in the ticket description.
- [ ] Reviewed and accepted by the Product Owner.
- [ ] End-to-end test are successful.

https://github.com/user-attachments/assets/b42b75ac-7873-4a31-b683-e0c1a379b480



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Variable elements in the graphical editor are now resizable with visual resize handles that appear when selected.
  * Element dimensions are now responsive and customizable instead of fixed, allowing better control over block sizing in the function block diagram.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->