### PR TITLE
feat: add live debug inline values for ST/IL editor

### DIFF
--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -184,6 +184,21 @@
   z-index: 10 !important;
 }
 
+/* Debug inline value badges for ST/IL editors during debug sessions */
+.oplc-monaco-wrapper .debug-inline-value {
+  color: #ffffff;
+  background-color: #2e7d32;
+  padding: 0px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+  font-weight: 600;
+  margin-left: 8px;
+}
+
+.dark .oplc-monaco-wrapper .debug-inline-value {
+  background-color: #388e3c;
+}
+
 /* Ensure Radix popper/select content sits well above Monaco */
 [data-radix-popper-content-wrapper],
 [data-radix-select-content],


### PR DESCRIPTION
## Summary

- Displays real-time debug variable values as green inline badges next to variable occurrences in Structured Text and Instruction List Monaco editors, matching the existing debug visualization in FBD/LD graphical editors
- Strips comment regions (`//`, `(* *)`, `/* */`) before scanning so variables inside comments are never decorated
- Matches complex variable expressions (FB members like `TON0.Q`, array elements like `my_array[3]`) by reading keys directly from the `debugVariableValues` store map, with longest-first matching and overlap detection to prevent partial matches
- Sets the ST/IL editor to read-only during active debug sessions (consistent with FBD/LD behavior)

## Test plan

- [ ] Open a project with an ST program containing variables of various types (BOOL, INT, REAL, TIME)
- [ ] Include FB instances (e.g., TON, CTU) and array variables in the program
- [ ] Mark variables for debug, compile, and start the debugger
- [ ] Verify green inline value badges appear next to variable occurrences and update in real-time
- [ ] Verify `TON0.Q`, `TON0.ET`, `my_array[3]` etc. show their own badges at the correct positions
- [ ] Verify variables inside comments (`//`, `(* *)`, `/* */`) do NOT get badges
- [ ] Verify editor becomes read-only during debug and re-enables on disconnect
- [ ] Verify switching tabs preserves/restores decorations correctly
- [ ] Run `npm run lint` and `npm run test` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline debug values now display next to matching expressions in ST/IL editors during debugging sessions.
  * Editor automatically switches to read-only mode when the debugger is active to prevent accidental edits.

* **Improvements**
  * More stable tracking and positioning of inline values, correctly handling commented code and long names to reduce visual overlap.

* **Style**
  * Enhanced visual styling for debug value badges to improve readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->