### PR TITLE
Fix C/C++ blocks: allow duplicate I/O names by scoping generated macros

### DIFF
--- a/src/utils/cpp/generateCBlocksCode.ts
+++ b/src/utils/cpp/generateCBlocksCode.ts
@@ -17,6 +17,10 @@ const generateDefine = (variable: PLCVariable): string => {
   return `#define ${name} (*(vars->${upperName}))\n`
 }
 
+const generateUndef = (variable: PLCVariable): string => {
+  return `#undef ${variable.name}\n`
+}
+
 const processUserCode = (pou: CppPouData): string => {
   const structName = `${pou.name.toUpperCase()}_VARS`
   const setupFunctionName = `${pou.name.toLowerCase()}_setup`
@@ -61,6 +65,14 @@ const processUserCode = (pou: CppPouData): string => {
   modifiedUserCode = modifiedUserCode.replace(/void\s+loop\s*\(\s*\)/g, `void ${loopFunctionName}(${structName} *vars)`)
 
   processedCode += modifiedUserCode
+  processedCode += '\n'
+
+  inputVariables.forEach((variable) => {
+    processedCode += generateUndef(variable)
+  })
+  outputVariables.forEach((variable) => {
+    processedCode += generateUndef(variable)
+  })
   processedCode += '\n'
 
   return processedCode


### PR DESCRIPTION
The C/C++ block generator emits #define aliases for each block’s inputs/outputs (e.g. REQ, DONE, ERROR). When multiple blocks share the same port names, concatenating all blocks into one flat c_blocks_code.cpp caused macro redefinition conflicts.

This change undefines the per-block alias macros after each block’s code is emitted, allowing different blocks to reuse the same port names safely while keeping instance wiring/assignments unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated C code now automatically includes cleanup directives that undefine all input and output variables after code generation, preventing potential naming conflicts and improving code isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->