### PR TITLE
fix: constants silently dropped when pressing Enter in LD/FBD autocomplete

### DIFF
--- a/src/renderer/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
@@ -4,6 +4,7 @@ import { useOpenPLCStore } from '@root/renderer/store'
 import { extractNumberAtEnd } from '@root/renderer/store/slices/project/validation/variables'
 import { PLCVariable } from '@root/types/PLC'
 import { cn } from '@root/utils'
+import { getLiteralType } from '@root/utils/keywords'
 import { newGraphicalEditorNodeID } from '@root/utils/new-graphical-editor-node-id'
 import { expandArrayVariables } from '@root/utils/PLC/array-variable-utils'
 import { Node } from '@xyflow/react'
@@ -241,6 +242,7 @@ const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProp
 
     const submit = ({ variable }: { variable: { id: string; name: string } }) => {
       if (variable.id === 'add') {
+        if (getLiteralType(valueToSearch)) return
         submitAddVariable({ variableName: valueToSearch })
         return
       }

--- a/src/renderer/components/_atoms/graphical-editor/ladder/autocomplete/index.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/ladder/autocomplete/index.tsx
@@ -3,6 +3,7 @@ import { useOpenPLCStore } from '@root/renderer/store'
 import { extractNumberAtEnd } from '@root/renderer/store/slices/project/validation/variables'
 import { PLCVariable } from '@root/types/PLC'
 import { cn } from '@root/utils'
+import { getLiteralType } from '@root/utils/keywords'
 import { expandArrayVariables } from '@root/utils/PLC/array-variable-utils'
 import { Node } from '@xyflow/react'
 import { ComponentPropsWithRef, forwardRef } from 'react'
@@ -212,6 +213,7 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
 
     const submit = ({ variable }: { variable: { id: string; name: string } }) => {
       if (variable.id === 'add') {
+        if (getLiteralType(valueToSearch)) return
         submitAddVariable({ variableName: valueToSearch })
         return
       }

--- a/src/renderer/components/_atoms/graphical-editor/ladder/coil.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/ladder/coil.tsx
@@ -10,6 +10,7 @@ import {
 } from '@root/renderer/assets/icons/flow/Coil'
 import { useOpenPLCStore } from '@root/renderer/store'
 import { cn, generateNumericUUID } from '@root/utils'
+import { getLiteralType } from '@root/utils/keywords'
 import type { Node, NodeProps } from '@xyflow/react'
 import { Position } from '@xyflow/react'
 import type { ReactNode } from 'react'
@@ -476,7 +477,8 @@ export const Coil = (block: CoilProps) => {
                 // Call triggerSubmit synchronously before blur to avoid race condition
                 // where autocomplete unmounts before processing the Enter key
                 autocompleteRef.current?.triggerSubmit?.()
-                inputVariableRef.current?.blur({ submit: false })
+                // For literals/constants, let the blur handler process them
+                inputVariableRef.current?.blur({ submit: !!getLiteralType(coilVariableValue) })
                 return
               }
               setKeyPressedAtTextarea(e.key)

--- a/src/renderer/components/_atoms/graphical-editor/ladder/contact.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/ladder/contact.tsx
@@ -8,6 +8,7 @@ import {
 } from '@root/renderer/assets/icons/flow/Contact'
 import { useOpenPLCStore } from '@root/renderer/store'
 import { cn, generateNumericUUID } from '@root/utils'
+import { getLiteralType } from '@root/utils/keywords'
 import type { Node, NodeProps } from '@xyflow/react'
 import { Position } from '@xyflow/react'
 import type { ReactNode } from 'react'
@@ -446,7 +447,8 @@ export const Contact = (block: ContactProps) => {
                 // Call triggerSubmit synchronously before blur to avoid race condition
                 // where autocomplete unmounts before processing the Enter key
                 autocompleteRef.current?.triggerSubmit?.()
-                inputVariableRef.current?.blur({ submit: false })
+                // For literals/constants, let the blur handler process them
+                inputVariableRef.current?.blur({ submit: !!getLiteralType(contactVariableValue) })
                 return
               }
               setKeyPressedAtTextarea(e.key)

--- a/src/renderer/components/_atoms/graphical-editor/ladder/variable.tsx
+++ b/src/renderer/components/_atoms/graphical-editor/ladder/variable.tsx
@@ -498,7 +498,9 @@ const VariableElement = (block: VariableProps) => {
               // Call triggerSubmit synchronously before blur to avoid race condition
               // where autocomplete unmounts before processing the Enter key
               autocompleteRef.current?.triggerSubmit?.()
-              inputVariableRef.current?.blur({ submit: false })
+              // For literals/constants, let the blur handler process them
+              // instead of suppressing it (triggerSubmit skips variable creation for literals)
+              inputVariableRef.current?.blur({ submit: !!getLiteralType(variableValue) })
               return
             }
             setKeyPressedAtTextarea(e.key)


### PR DESCRIPTION
## Summary

- **LD bug (data loss):** Typing a constant (e.g. `T#500ms`, `5`, `'hello'`) on a block input/output and pressing Enter showed an "Illegal variable name" toast and silently dropped the value — the input appeared accepted (yellow text) but compiled as 0
- **FBD bug (cosmetic):** Same scenario showed the error toast, but the constant was actually saved correctly since the blur handler wasn't suppressed
- **Root cause:** The autocomplete's Enter path unconditionally routed unmatched text to "Add variable" → `createVariable()`, which rejects literals via `isLegalIdentifier()`. In LD, `blur({ submit: false })` then suppressed the blur handler that would have correctly processed the constant

## Fix

Detect literals via `getLiteralType()` in two layers:

1. **Autocomplete `submit` functions** (LD + FBD): skip `createVariable()` for literals — prevents the error toast
2. **LD Enter handlers** (variable, contact, coil): pass `submit: true` for literals so the blur handler processes them with proper type validation

All IEC 61131-3 literal types are covered: numeric, time, date, TOD, datetime, string, and boolean constants.

## Test plan

- [ ] Add a TON block in LD, type `T#500ms` on PT input, press Enter → no error toast, value accepted (yellow text), compiles correctly
- [ ] Same test but click outside instead of Enter → still works (regression check)
- [ ] Test other constant types: `5` on an INT input, `3.14` on a REAL input, `TRUE` on a BOOL contact
- [ ] Test typing a new variable name and pressing Enter → variable is created as before
- [ ] Repeat the `T#500ms` test in FBD editor → no error toast, value accepted
- [ ] Test selecting an existing variable from the autocomplete dropdown with Enter → still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of literal type variables in autocomplete and input fields.
  * Fixed keyboard submit behavior for literal type values to prevent unintended variable creation.
  * Enhanced variable input validation for literal constants across graphical editor components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->