### PR TITLE
fix: global struct variable debugger shows no values

### DIFF
--- a/src/renderer/screens/workspace-screen.tsx
+++ b/src/renderer/screens/workspace-screen.tsx
@@ -11,6 +11,7 @@ import { cn, isOpenPLCRuntimeTarget, isSimulatorTarget } from '@root/utils'
 import {
   appendToDebugPath,
   buildDebugPath,
+  buildGlobalDebugPath,
   getFieldIndexFromMapWithFallback,
   getIndexFromMapWithFallback,
 } from '@root/utils/debug-variable-finder'
@@ -606,13 +607,22 @@ const WorkspaceScreen = () => {
               }
             }
 
+            const isExternal = fbInstance.class === 'external'
+
             allBaseTypeVars.forEach((fbVar) => {
               // Use fallback to try both FB-style and struct-style paths
-              const index = getIndexFromMapWithFallback(
-                debugVariableIndexes,
-                programInstance.name,
-                `${fbInstance.name}.${fbVar.name}`,
-              )
+              let index: number | undefined
+              if (isExternal) {
+                // External (global) FB members use CONFIG0__ prefix
+                const globalFieldPath = `${buildGlobalDebugPath(fbInstance.name)}.${fbVar.name.toUpperCase()}`
+                index = debugVariableIndexes.get(globalFieldPath)
+              } else {
+                index = getIndexFromMapWithFallback(
+                  debugVariableIndexes,
+                  programInstance.name,
+                  `${fbInstance.name}.${fbVar.name}`,
+                )
+              }
 
               if (index !== undefined) {
                 const blockVarName = `${fbInstance.name}.${fbVar.name}`
@@ -661,7 +671,9 @@ const WorkspaceScreen = () => {
                 v.type.definition === 'array',
             )
             if (nestedVariables.length > 0) {
-              const debugPathPrefix = buildDebugPath(programInstance.name, fbInstance.name)
+              const debugPathPrefix = isExternal
+                ? buildGlobalDebugPath(fbInstance.name)
+                : buildDebugPath(programInstance.name, fbInstance.name)
               const variableNamePrefix = fbInstance.name
               processNestedVariables(nestedVariables, pou.data.name, debugPathPrefix, variableNamePrefix)
             }
@@ -717,7 +729,10 @@ const WorkspaceScreen = () => {
           }
 
           if (variablesToProcess) {
-            const debugPathPrefix = buildDebugPath(programInstance.name, udtVar.name)
+            const debugPathPrefix =
+              udtVar.class === 'external'
+                ? buildGlobalDebugPath(udtVar.name)
+                : buildDebugPath(programInstance.name, udtVar.name)
             const variableNamePrefix = udtVar.name
             processNestedVariables(variablesToProcess, pou.data.name, debugPathPrefix, variableNamePrefix)
           }
@@ -1029,7 +1044,10 @@ const WorkspaceScreen = () => {
 
         if (customFB && customFB.type === 'function-block') {
           // For custom FBs, use visitFbInstance to process all internals
-          const debugPathPrefix = buildDebugPath(programInstance.name, fbInstance.name)
+          const debugPathPrefix =
+            fbInstance.class === 'external'
+              ? buildGlobalDebugPath(fbInstance.name)
+              : buildDebugPath(programInstance.name, fbInstance.name)
           const variablePathPrefix = fbInstance.name
           visitFbInstance(customFB, debugPathPrefix, variablePathPrefix, programPou.data.name, blockExecutionControlMap)
         }


### PR DESCRIPTION
## Summary

- Fixes the debug path prefix used when resolving indices for members of global (external) struct/FB variables
- Global variables use `CONFIG0__` prefix in `debug.c`, but the `variableInfoMap` building code always constructed local `RES0__INSTANCE` paths, causing all index lookups for global struct members to fail silently
- Checks `variable.class === 'external'` in three code paths that process nested FB/struct members and switches to `buildGlobalDebugPath` accordingly

Fixes #638

## Test plan

- [ ] Create a project with a struct type (e.g., `MY_STRUCT` with `FIELD1: INT`, `FIELD2: BOOL`)
- [ ] Declare a global variable of that struct type (`VAR_GLOBAL`)
- [ ] Reference it in a program via `VAR_EXTERNAL`
- [ ] Start the debugger and verify struct member values are displayed for the global variable
- [ ] Verify local struct variables still work correctly (no regression)
- [ ] Verify local FB instances still debug correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of external and global variables during debugging sessions. Variables defined outside the current scope are now properly resolved and indexed, ensuring accurate real-time monitoring and inspection.

* **Refactor**
  * Optimized internal path resolution logic for external variable references to enhance performance and consistency across nested variable processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->