### PR TITLE
Fix debugger polling to fetch only visible variables

### DIFF
--- a/src/renderer/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/monaco/index.tsx
@@ -115,6 +115,7 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
   const monacoRef = useRef<null | typeof monaco>(null)
   const focusDisposables = useRef<{ onFocus?: monaco.IDisposable; onBlur?: monaco.IDisposable }>({})
   const [editorMounted, setEditorMounted] = useState(false)
+  const [modelVersion, setModelVersion] = useState(0)
 
   const {
     editor,
@@ -283,11 +284,17 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
     }
   }, [pou?.type, name, language])
 
-  // Reset editorMounted when switching POUs so debug position scanning
-  // waits for the new model to be ready via onMount
+  // Track when @monaco-editor/react switches models (tab changes with keepCurrentModel).
+  // onMount only fires once on initial mount, so we use onDidChangeModel to know when the
+  // model has actually switched, then bump modelVersion to trigger debugVarPositions recomputation.
   useEffect(() => {
-    setEditorMounted(false)
-  }, [name])
+    const editor = editorRef.current
+    if (!editor) return
+    const disposable = editor.onDidChangeModel(() => {
+      setModelVersion((v) => v + 1)
+    })
+    return () => disposable.dispose()
+  }, [editorMounted])
 
   // Update readOnly when debugger visibility changes on an already-mounted editor
   useEffect(() => {
@@ -320,6 +327,11 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
 
     const model = editorRef.current.getModel()
     if (!model) return null
+
+    // Guard: ensure the model matches the current POU. During tab switches the memo may
+    // fire before @monaco-editor/react has swapped the model, so we'd scan the wrong file.
+    const expectedUri = monaco.Uri.file(uniqueMonacoPath).toString()
+    if (model.uri.toString() !== expectedUri) return null
 
     const prefix = fbInstanceContext
       ? `${fbInstanceContext.programName}:${fbInstanceContext.fbVariableName}.`
@@ -363,7 +375,7 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
     }
 
     return { prefix, positions }
-  }, [isDebuggerVisible, debugVarKeySet, language, name, fbInstanceContext, editorMounted])
+  }, [isDebuggerVisible, debugVarKeySet, language, name, fbInstanceContext, editorMounted, modelVersion])
 
   // Phase 2: stamp current values onto cached positions (runs on each poll, O(positions) map lookups only)
   useEffect(() => {

--- a/src/renderer/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/monaco/index.tsx
@@ -283,6 +283,12 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
     }
   }, [pou?.type, name, language])
 
+  // Reset editorMounted when switching POUs so debug position scanning
+  // waits for the new model to be ready via onMount
+  useEffect(() => {
+    setEditorMounted(false)
+  }, [name])
+
   // Update readOnly when debugger visibility changes on an already-mounted editor
   useEffect(() => {
     editorRef.current?.updateOptions({ readOnly: isDebuggerVisible })

--- a/src/renderer/screens/workspace-screen.tsx
+++ b/src/renderer/screens/workspace-screen.tsx
@@ -1172,7 +1172,7 @@ const WorkspaceScreen = () => {
           }
         })
 
-        const { editor, ladderFlows } = useOpenPLCStore.getState()
+        const { editor, ladderFlows, fbdFlows } = useOpenPLCStore.getState()
         const currentPou = currentProject.data.pous.find((pou) => pou.data.name === editor.meta.name)
 
         // Helper to create composite key for current POU, handling FB instance context
@@ -1212,127 +1212,66 @@ const WorkspaceScreen = () => {
                     }
                   }
                 }
-              })
-            })
-          }
 
-          // Get FB instance context for function block POUs
-          let fbInstanceCtx: { programName: string; fbVariableName: string } | null = null
-          if (currentPou.type === 'function-block') {
-            const fbTypeKey = currentPou.data.name.toUpperCase()
-            const selectedKey = fbSelectedInstance.get(fbTypeKey)
-            if (selectedKey) {
-              const instances = fbDebugInstances.get(fbTypeKey) || []
-              const selectedInstance = instances.find((inst) => inst.key === selectedKey)
-              if (selectedInstance) {
-                fbInstanceCtx = {
-                  programName: selectedInstance.programName,
-                  fbVariableName: selectedInstance.fbVariableName,
-                }
-              }
-            }
-          }
-
-          // For FB POUs, poll nested FB variables using instance context
-          // For program POUs, poll FB instance variables using the standard approach
-          if (currentPou.type === 'function-block' && fbInstanceCtx) {
-            // Poll all nested BOOL variables within the FB instance
-            Array.from(variableInfoMapRef.current.entries()).forEach(([_, varInfos]) => {
-              for (const varInfo of varInfos) {
-                if (
-                  varInfo.pouName === fbInstanceCtx.programName &&
-                  varInfo.variable.name.startsWith(`${fbInstanceCtx.fbVariableName}.`) &&
-                  varInfo.variable.type.definition === 'base-type' &&
-                  varInfo.variable.type.value.toLowerCase() === 'bool'
-                ) {
-                  const compositeKey = `${varInfo.pouName}:${varInfo.variable.name}`
-                  debugVariableKeys.add(compositeKey)
-                }
-              }
-            })
-          } else {
-            const functionBlockInstances = currentPou.data.variables.filter(
-              (variable) => variable.type.definition === 'derived',
-            )
-
-            functionBlockInstances.forEach((fbInstance) => {
-              Array.from(variableInfoMapRef.current!.entries()).forEach(([_, varInfos]) => {
-                for (const varInfo of varInfos) {
-                  if (
-                    varInfo.pouName === currentPou.data.name &&
-                    varInfo.variable.name.startsWith(`${fbInstance.name}.`) &&
-                    varInfo.variable.type.definition === 'base-type' &&
-                    varInfo.variable.type.value.toLowerCase() === 'bool'
-                  ) {
-                    const compositeKey = `${varInfo.pouName}:${varInfo.variable.name}`
-                    debugVariableKeys.add(compositeKey)
+                // Variable nodes can display non-BOOL DebugValueBadges and also support force menus.
+                // Poll only the variable referenced by the node (not every variable in the POU).
+                if (node.type === 'variable') {
+                  const nodeData = node.data as {
+                    variable?: { name?: string }
+                  }
+                  const variableName = nodeData.variable?.name
+                  if (variableName) {
+                    const compositeKey = makeCompositeKeyForCurrentPou(variableName)
+                    if (compositeKey) {
+                      debugVariableKeys.add(compositeKey)
+                    }
                   }
                 }
-              })
-            })
-          }
 
-          // For FB POUs, poll function outputs using instance context
-          // For program POUs, poll function outputs using the standard approach
-          if (currentPou.type === 'function-block' && fbInstanceCtx && currentLadderFlow) {
-            currentLadderFlow.rungs.forEach((rung) => {
-              rung.nodes.forEach((node) => {
+                // Block nodes may show output DebugValueBadges (function blocks + functions).
+                // Poll only those output variables for blocks present on the diagram.
                 if (node.type === 'block') {
                   const blockData = node.data as {
-                    variant?: { type: string }
+                    variant?: {
+                      type?: string
+                      name?: string
+                      variables?: Array<{ name: string; class: string; type: { definition: string; value: string } }>
+                    }
+                    variable?: { name?: string }
                     numericId?: string
                   }
 
-                  if (blockData.variant?.type === 'function' && blockData.numericId) {
-                    Array.from(variableInfoMapRef.current!.entries()).forEach(([_, varInfos]) => {
-                      for (const varInfo of varInfos) {
-                        if (
-                          varInfo.pouName === fbInstanceCtx.programName &&
-                          varInfo.variable.name.startsWith(`${fbInstanceCtx.fbVariableName}.`) &&
-                          varInfo.variable.name.includes(blockData.numericId!)
-                        ) {
-                          const compositeKey = `${varInfo.pouName}:${varInfo.variable.name}`
+                  const variantType = blockData.variant?.type
+                  const variantName = blockData.variant?.name
+                  const variantVars = blockData.variant?.variables ?? []
+                  const outputVars = variantVars.filter((v) => v.class === 'output' || v.class === 'inOut')
+
+                  if (variantType === 'function-block') {
+                    const instanceName = blockData.variable?.name
+                    if (instanceName) {
+                      for (const outVar of outputVars) {
+                        const compositeKey = makeCompositeKeyForCurrentPou(`${instanceName}.${outVar.name}`)
+                        if (compositeKey) {
                           debugVariableKeys.add(compositeKey)
                         }
                       }
-                    })
+                    }
+                  } else if (variantType === 'function' && variantName && blockData.numericId) {
+                    const numericId = blockData.numericId
+                    for (const outVar of outputVars) {
+                      const tmpName = `_TMP_${variantName.toUpperCase()}${numericId}_${outVar.name}`
+                      const compositeKey = makeCompositeKeyForCurrentPou(tmpName)
+                      if (compositeKey) {
+                        debugVariableKeys.add(compositeKey)
+                      }
+                    }
                   }
                 }
               })
             })
-          } else {
-            const instances = currentProject.data.configuration.resource.instances
-            const programInstance = instances.find((inst) => inst.program === currentPou.data.name)
-            if (programInstance && currentLadderFlow) {
-              currentLadderFlow.rungs.forEach((rung) => {
-                rung.nodes.forEach((node) => {
-                  if (node.type === 'block') {
-                    const blockData = node.data as {
-                      variant?: { type: string }
-                      numericId?: string
-                    }
-
-                    if (blockData.variant?.type === 'function' && blockData.numericId) {
-                      Array.from(variableInfoMapRef.current!.entries()).forEach(([_, varInfos]) => {
-                        for (const varInfo of varInfos) {
-                          if (
-                            varInfo.pouName === currentPou.data.name &&
-                            varInfo.variable.name.includes(blockData.numericId!)
-                          ) {
-                            const compositeKey = `${varInfo.pouName}:${varInfo.variable.name}`
-                            debugVariableKeys.add(compositeKey)
-                          }
-                        }
-                      })
-                    }
-                  }
-                })
-              })
-            }
           }
         }
 
-        const { fbdFlows } = useOpenPLCStore.getState()
         if (currentPou && currentPou.data.body.language === 'fbd') {
           const currentFbdFlow = fbdFlows.find((flow) => flow.name === editor.meta.name)
           if (currentFbdFlow) {
@@ -1344,164 +1283,48 @@ const WorkspaceScreen = () => {
                 const variableName = nodeData.variable?.name
 
                 if (variableName) {
-                  const variable = currentPou.data.variables.find(
-                    (v) => v.name.toLowerCase() === variableName.toLowerCase(),
-                  )
-                  if (variable && variable.type.value.toUpperCase() === 'BOOL') {
-                    const compositeKey = makeCompositeKeyForCurrentPou(variableName)
+                  const compositeKey = makeCompositeKeyForCurrentPou(variableName)
+                  if (compositeKey) {
+                    debugVariableKeys.add(compositeKey)
+                  }
+                }
+              }
+
+              if (node.type === 'block') {
+                const blockData = node.data as {
+                  variant?: {
+                    type?: string
+                    name?: string
+                    variables?: Array<{ name: string; class: string; type: { definition: string; value: string } }>
+                  }
+                  variable?: { name?: string }
+                  numericId?: string
+                }
+
+                const variantType = blockData.variant?.type
+                const variantName = blockData.variant?.name
+                const variantVars = blockData.variant?.variables ?? []
+                const outputVars = variantVars.filter((v) => v.class === 'output' || v.class === 'inOut')
+
+                if (variantType === 'function-block') {
+                  const instanceName = blockData.variable?.name
+                  if (instanceName) {
+                    for (const outVar of outputVars) {
+                      const compositeKey = makeCompositeKeyForCurrentPou(`${instanceName}.${outVar.name}`)
+                      if (compositeKey) {
+                        debugVariableKeys.add(compositeKey)
+                      }
+                    }
+                  }
+                } else if (variantType === 'function' && variantName && blockData.numericId) {
+                  const numericId = blockData.numericId
+                  for (const outVar of outputVars) {
+                    const tmpName = `_TMP_${variantName.toUpperCase()}${numericId}_${outVar.name}`
+                    const compositeKey = makeCompositeKeyForCurrentPou(tmpName)
                     if (compositeKey) {
                       debugVariableKeys.add(compositeKey)
                     }
                   }
-                }
-              }
-            })
-          }
-
-          // Get FB instance context for function block POUs (FBD)
-          let fbdFbInstanceCtx: { programName: string; fbVariableName: string } | null = null
-          if (currentPou.type === 'function-block') {
-            const fbTypeKey = currentPou.data.name.toUpperCase()
-            const selectedKey = fbSelectedInstance.get(fbTypeKey)
-            if (selectedKey) {
-              const instances = fbDebugInstances.get(fbTypeKey) || []
-              const selectedInstance = instances.find((inst) => inst.key === selectedKey)
-              if (selectedInstance) {
-                fbdFbInstanceCtx = {
-                  programName: selectedInstance.programName,
-                  fbVariableName: selectedInstance.fbVariableName,
-                }
-              }
-            }
-          }
-
-          // For FB POUs, poll nested FB variables using instance context
-          // For program POUs, poll FB instance variables using the standard approach
-          if (currentPou.type === 'function-block' && fbdFbInstanceCtx) {
-            // Poll all nested BOOL variables within the FB instance
-            Array.from(variableInfoMapRef.current.entries()).forEach(([_, varInfos]) => {
-              for (const varInfo of varInfos) {
-                if (
-                  varInfo.pouName === fbdFbInstanceCtx.programName &&
-                  varInfo.variable.name.startsWith(`${fbdFbInstanceCtx.fbVariableName}.`) &&
-                  varInfo.variable.type.definition === 'base-type' &&
-                  varInfo.variable.type.value.toLowerCase() === 'bool'
-                ) {
-                  const compositeKey = `${varInfo.pouName}:${varInfo.variable.name}`
-                  debugVariableKeys.add(compositeKey)
-                }
-              }
-            })
-          } else {
-            const functionBlockInstances = currentPou.data.variables.filter(
-              (variable) => variable.type.definition === 'derived',
-            )
-
-            functionBlockInstances.forEach((fbInstance) => {
-              Array.from(variableInfoMapRef.current!.entries()).forEach(([_, varInfos]) => {
-                for (const varInfo of varInfos) {
-                  if (
-                    varInfo.pouName === currentPou.data.name &&
-                    varInfo.variable.name.startsWith(`${fbInstance.name}.`) &&
-                    varInfo.variable.type.definition === 'base-type' &&
-                    varInfo.variable.type.value.toLowerCase() === 'bool'
-                  ) {
-                    const compositeKey = `${varInfo.pouName}:${varInfo.variable.name}`
-                    debugVariableKeys.add(compositeKey)
-                  }
-                }
-              })
-            })
-          }
-
-          // For FB POUs, poll function outputs using instance context
-          // For program POUs, poll function outputs using the standard approach
-          if (currentPou.type === 'function-block' && fbdFbInstanceCtx && currentFbdFlow) {
-            currentFbdFlow.rung.nodes.forEach((node) => {
-              if (node.type === 'block') {
-                const blockData = node.data as {
-                  variant?: { type: string }
-                  numericId?: string
-                }
-
-                if (blockData.variant?.type === 'function' && blockData.numericId) {
-                  Array.from(variableInfoMapRef.current!.entries()).forEach(([_, varInfos]) => {
-                    for (const varInfo of varInfos) {
-                      if (
-                        varInfo.pouName === fbdFbInstanceCtx.programName &&
-                        varInfo.variable.name.startsWith(`${fbdFbInstanceCtx.fbVariableName}.`) &&
-                        varInfo.variable.name.includes(blockData.numericId!)
-                      ) {
-                        const compositeKey = `${varInfo.pouName}:${varInfo.variable.name}`
-                        debugVariableKeys.add(compositeKey)
-                      }
-                    }
-                  })
-                }
-              }
-            })
-          } else {
-            const instances = currentProject.data.configuration.resource.instances
-            const programInstance = instances.find((inst) => inst.program === currentPou.data.name)
-            if (programInstance && currentFbdFlow) {
-              currentFbdFlow.rung.nodes.forEach((node) => {
-                if (node.type === 'block') {
-                  const blockData = node.data as {
-                    variant?: { type: string }
-                    numericId?: string
-                  }
-
-                  if (blockData.variant?.type === 'function' && blockData.numericId) {
-                    Array.from(variableInfoMapRef.current!.entries()).forEach(([_, varInfos]) => {
-                      for (const varInfo of varInfos) {
-                        if (
-                          varInfo.pouName === currentPou.data.name &&
-                          varInfo.variable.name.includes(blockData.numericId!)
-                        ) {
-                          const compositeKey = `${varInfo.pouName}:${varInfo.variable.name}`
-                          debugVariableKeys.add(compositeKey)
-                        }
-                      }
-                    })
-                  }
-                }
-              })
-            }
-          }
-        }
-
-        // Poll all variables of the active POU so non-BOOL values can be displayed on the diagram.
-        // This adds every variable registered in variableInfoMapRef that belongs to the current POU,
-        // enabling the DebugValueBadge components to show real-time values for INT, REAL, etc.
-        if (currentPou) {
-          if (currentPou.type === 'function-block') {
-            // For FB POUs, resolve the selected instance context and match variables by
-            // program name + instance path prefix (same pattern used for BOOL polling above).
-            const fbTypeKey = currentPou.data.name.toUpperCase()
-            const selectedKey = fbSelectedInstance.get(fbTypeKey)
-            if (selectedKey) {
-              const instances = fbDebugInstances.get(fbTypeKey) || []
-              const selectedInstance = instances.find((inst) => inst.key === selectedKey)
-              if (selectedInstance) {
-                const instancePrefix = `${selectedInstance.fbVariableName}.`
-                Array.from(variableInfoMapRef.current.values()).forEach((varInfos) => {
-                  for (const varInfo of varInfos) {
-                    if (
-                      varInfo.pouName === selectedInstance.programName &&
-                      varInfo.variable.name.startsWith(instancePrefix)
-                    ) {
-                      debugVariableKeys.add(`${varInfo.pouName}:${varInfo.variable.name}`)
-                    }
-                  }
-                })
-              }
-            }
-          } else {
-            const activePouName = currentPou.data.name
-            Array.from(variableInfoMapRef.current.values()).forEach((varInfos) => {
-              for (const varInfo of varInfos) {
-                if (varInfo.pouName === activePouName) {
-                  debugVariableKeys.add(`${varInfo.pouName}:${varInfo.variable.name}`)
                 }
               }
             })

--- a/src/renderer/screens/workspace-screen.tsx
+++ b/src/renderer/screens/workspace-screen.tsx
@@ -176,6 +176,17 @@ const WorkspaceScreen = () => {
   const graphListRef = useRef<string[]>([])
   const batchOffsetRef = useRef<number>(0)
 
+  // Cache for diagram/source variable keys — recomputed only when the active POU or FB
+  // instance context changes. During debug the editor is read-only, so the same POU+context
+  // always yields the same set of keys. This avoids rebuilding regex objects (ST/IL) and
+  // re-scanning flow nodes (LD/FBD) on every 50ms poll tick.
+  const diagramVarKeysCache = useRef<{
+    pouName: string
+    language: string
+    fbContextKey: string
+    keys: Set<string>
+  } | null>(null)
+
   useEffect(() => {
     isMountedRef.current = true
     return () => {
@@ -210,6 +221,7 @@ const WorkspaceScreen = () => {
         pollingIntervalRef.current = null
       }
       variableInfoMapRef.current = null
+      diagramVarKeysCache.current = null
       return
     }
 
@@ -1200,217 +1212,252 @@ const WorkspaceScreen = () => {
         const { editor, ladderFlows, fbdFlows } = useOpenPLCStore.getState()
         const currentPou = currentProject.data.pous.find((pou) => pou.data.name === editor.meta.name)
 
-        // Helper to create composite key for current POU, handling FB instance context
-        const makeCompositeKeyForCurrentPou = (variableName: string): string | null => {
-          if (!currentPou) return null
-          if (currentPou.type === 'function-block') {
-            const fbTypeKey = currentPou.data.name.toUpperCase()
-            const selectedKey = fbSelectedInstance.get(fbTypeKey)
-            if (!selectedKey) return null
-            const instances = fbDebugInstances.get(fbTypeKey) || []
-            const selectedInstance = instances.find((inst) => inst.key === selectedKey)
-            if (!selectedInstance) return null
-            return `${selectedInstance.programName}:${selectedInstance.fbVariableName}.${variableName}`
-          }
-          return `${currentPou.data.name}:${variableName}`
-        }
+        // --- Diagram/source variable keys (cached) ---
+        // During debug the editor is read-only, so the set of variables visible on the diagram
+        // or referenced in source text is stable for a given POU + FB instance context.
+        // We cache this set and only recompute when the active POU or FB context changes,
+        // avoiding redundant regex compilation (ST/IL) and node scanning (LD/FBD) every 50ms tick.
+        if (currentPou) {
+          const pouName = currentPou.data.name
+          const pouLanguage = currentPou.data.body.language
+          const fbContextKey =
+            currentPou.type === 'function-block' ? fbSelectedInstance.get(currentPou.data.name.toUpperCase()) ?? '' : ''
 
-        if (currentPou && currentPou.data.body.language === 'ld') {
-          const currentLadderFlow = ladderFlows.find((flow) => flow.name === editor.meta.name)
-          if (currentLadderFlow) {
-            currentLadderFlow.rungs.forEach((rung) => {
-              rung.nodes.forEach((node) => {
-                if (node.type === 'contact' || node.type === 'coil') {
-                  const nodeData = node.data as {
-                    variable?: { name?: string; type?: { definition?: string; value?: string } }
-                  }
-                  const variableName = nodeData.variable?.name
+          const cached = diagramVarKeysCache.current
+          if (
+            cached &&
+            cached.pouName === pouName &&
+            cached.language === pouLanguage &&
+            cached.fbContextKey === fbContextKey
+          ) {
+            // Reuse cached keys
+            cached.keys.forEach((key) => debugVariableKeys.add(key))
+          } else {
+            // Recompute: build the set of keys from diagram nodes or source text
+            const newKeys = new Set<string>()
 
-                  if (
-                    variableName &&
-                    nodeData.variable?.type?.definition === 'base-type' &&
-                    nodeData.variable?.type?.value?.toUpperCase() === 'BOOL'
-                  ) {
-                    const compositeKey = makeCompositeKeyForCurrentPou(variableName)
-                    if (compositeKey) {
-                      debugVariableKeys.add(compositeKey)
-                    }
-                  }
-                }
+            // Resolve FB instance context once (used by makeCompositeKey and ST/IL FB children)
+            let resolvedFbInstance: { programName: string; fbVariableName: string } | null = null
+            if (currentPou.type === 'function-block') {
+              const fbTypeKey = currentPou.data.name.toUpperCase()
+              const selectedKey = fbSelectedInstance.get(fbTypeKey)
+              if (selectedKey) {
+                const instances = fbDebugInstances.get(fbTypeKey) || []
+                resolvedFbInstance = instances.find((inst) => inst.key === selectedKey) ?? null
+              }
+            }
 
-                // Variable nodes can display non-BOOL DebugValueBadges and also support force menus.
-                // Poll only the variable referenced by the node (not every variable in the POU).
-                if (node.type === 'variable') {
-                  const nodeData = node.data as {
-                    variable?: { name?: string }
-                  }
-                  const variableName = nodeData.variable?.name
-                  if (variableName) {
-                    const compositeKey = makeCompositeKeyForCurrentPou(variableName)
-                    if (compositeKey) {
-                      debugVariableKeys.add(compositeKey)
-                    }
-                  }
-                }
+            const makeCompositeKey = (variableName: string): string | null => {
+              if (currentPou.type === 'function-block') {
+                if (!resolvedFbInstance) return null
+                return `${resolvedFbInstance.programName}:${resolvedFbInstance.fbVariableName}.${variableName}`
+              }
+              return `${currentPou.data.name}:${variableName}`
+            }
 
-                // Block nodes may show output DebugValueBadges (function blocks + functions).
-                // Poll only those output variables for blocks present on the diagram.
-                if (node.type === 'block') {
-                  const blockData = node.data as {
-                    variant?: {
-                      type?: string
-                      name?: string
-                      variables?: Array<{ name: string; class: string; type: { definition: string; value: string } }>
-                    }
-                    variable?: { name?: string }
-                    numericId?: string
-                  }
+            if (pouLanguage === 'ld') {
+              const currentLadderFlow = ladderFlows.find((flow) => flow.name === editor.meta.name)
+              if (currentLadderFlow) {
+                currentLadderFlow.rungs.forEach((rung) => {
+                  rung.nodes.forEach((node) => {
+                    if (node.type === 'contact' || node.type === 'coil') {
+                      const nodeData = node.data as {
+                        variable?: { name?: string; type?: { definition?: string; value?: string } }
+                      }
+                      const variableName = nodeData.variable?.name
 
-                  const variantType = blockData.variant?.type
-                  const variantName = blockData.variant?.name
-                  const variantVars = blockData.variant?.variables ?? []
-                  const outputVars = variantVars.filter((v) => v.class === 'output' || v.class === 'inOut')
-
-                  if (variantType === 'function-block') {
-                    const instanceName = blockData.variable?.name
-                    if (instanceName) {
-                      for (const outVar of outputVars) {
-                        const compositeKey = makeCompositeKeyForCurrentPou(`${instanceName}.${outVar.name}`)
+                      if (
+                        variableName &&
+                        nodeData.variable?.type?.definition === 'base-type' &&
+                        nodeData.variable?.type?.value?.toUpperCase() === 'BOOL'
+                      ) {
+                        const compositeKey = makeCompositeKey(variableName)
                         if (compositeKey) {
-                          debugVariableKeys.add(compositeKey)
+                          newKeys.add(compositeKey)
                         }
                       }
                     }
-                  } else if (variantType === 'function' && variantName && blockData.numericId) {
-                    const numericId = blockData.numericId
-                    for (const outVar of outputVars) {
-                      const tmpName = `_TMP_${variantName.toUpperCase()}${numericId}_${outVar.name}`
-                      const compositeKey = makeCompositeKeyForCurrentPou(tmpName)
-                      if (compositeKey) {
-                        debugVariableKeys.add(compositeKey)
+
+                    if (node.type === 'variable') {
+                      const nodeData = node.data as {
+                        variable?: { name?: string }
+                      }
+                      const variableName = nodeData.variable?.name
+                      if (variableName) {
+                        const compositeKey = makeCompositeKey(variableName)
+                        if (compositeKey) {
+                          newKeys.add(compositeKey)
+                        }
                       }
                     }
-                  }
-                }
-              })
-            })
-          }
-        }
 
-        if (currentPou && currentPou.data.body.language === 'fbd') {
-          const currentFbdFlow = fbdFlows.find((flow) => flow.name === editor.meta.name)
-          if (currentFbdFlow) {
-            currentFbdFlow.rung.nodes.forEach((node) => {
-              if (node.type === 'input-variable' || node.type === 'output-variable' || node.type === 'inout-variable') {
-                const nodeData = node.data as {
-                  variable?: { name?: string }
-                }
-                const variableName = nodeData.variable?.name
+                    if (node.type === 'block') {
+                      const blockData = node.data as {
+                        variant?: {
+                          type?: string
+                          name?: string
+                          variables?: Array<{
+                            name: string
+                            class: string
+                            type: { definition: string; value: string }
+                          }>
+                        }
+                        variable?: { name?: string }
+                        numericId?: string
+                      }
 
-                if (variableName) {
-                  const compositeKey = makeCompositeKeyForCurrentPou(variableName)
-                  if (compositeKey) {
-                    debugVariableKeys.add(compositeKey)
-                  }
-                }
+                      const variantType = blockData.variant?.type
+                      const variantName = blockData.variant?.name
+                      const variantVars = blockData.variant?.variables ?? []
+                      const outputVars = variantVars.filter((v) => v.class === 'output' || v.class === 'inOut')
+
+                      if (variantType === 'function-block') {
+                        const instanceName = blockData.variable?.name
+                        if (instanceName) {
+                          for (const outVar of outputVars) {
+                            const compositeKey = makeCompositeKey(`${instanceName}.${outVar.name}`)
+                            if (compositeKey) {
+                              newKeys.add(compositeKey)
+                            }
+                          }
+                        }
+                      } else if (variantType === 'function' && variantName && blockData.numericId) {
+                        const numericId = blockData.numericId
+                        for (const outVar of outputVars) {
+                          const tmpName = `_TMP_${variantName.toUpperCase()}${numericId}_${outVar.name}`
+                          const compositeKey = makeCompositeKey(tmpName)
+                          if (compositeKey) {
+                            newKeys.add(compositeKey)
+                          }
+                        }
+                      }
+                    }
+                  })
+                })
               }
+            }
 
-              if (node.type === 'block') {
-                const blockData = node.data as {
-                  variant?: {
-                    type?: string
-                    name?: string
-                    variables?: Array<{ name: string; class: string; type: { definition: string; value: string } }>
-                  }
-                  variable?: { name?: string }
-                  numericId?: string
-                }
+            if (pouLanguage === 'fbd') {
+              const currentFbdFlow = fbdFlows.find((flow) => flow.name === editor.meta.name)
+              if (currentFbdFlow) {
+                currentFbdFlow.rung.nodes.forEach((node) => {
+                  if (
+                    node.type === 'input-variable' ||
+                    node.type === 'output-variable' ||
+                    node.type === 'inout-variable'
+                  ) {
+                    const nodeData = node.data as {
+                      variable?: { name?: string }
+                    }
+                    const variableName = nodeData.variable?.name
 
-                const variantType = blockData.variant?.type
-                const variantName = blockData.variant?.name
-                const variantVars = blockData.variant?.variables ?? []
-                const outputVars = variantVars.filter((v) => v.class === 'output' || v.class === 'inOut')
-
-                if (variantType === 'function-block') {
-                  const instanceName = blockData.variable?.name
-                  if (instanceName) {
-                    for (const outVar of outputVars) {
-                      const compositeKey = makeCompositeKeyForCurrentPou(`${instanceName}.${outVar.name}`)
+                    if (variableName) {
+                      const compositeKey = makeCompositeKey(variableName)
                       if (compositeKey) {
-                        debugVariableKeys.add(compositeKey)
+                        newKeys.add(compositeKey)
                       }
                     }
                   }
-                } else if (variantType === 'function' && variantName && blockData.numericId) {
-                  const numericId = blockData.numericId
-                  for (const outVar of outputVars) {
-                    const tmpName = `_TMP_${variantName.toUpperCase()}${numericId}_${outVar.name}`
-                    const compositeKey = makeCompositeKeyForCurrentPou(tmpName)
+
+                  if (node.type === 'block') {
+                    const blockData = node.data as {
+                      variant?: {
+                        type?: string
+                        name?: string
+                        variables?: Array<{
+                          name: string
+                          class: string
+                          type: { definition: string; value: string }
+                        }>
+                      }
+                      variable?: { name?: string }
+                      numericId?: string
+                    }
+
+                    const variantType = blockData.variant?.type
+                    const variantName = blockData.variant?.name
+                    const variantVars = blockData.variant?.variables ?? []
+                    const outputVars = variantVars.filter((v) => v.class === 'output' || v.class === 'inOut')
+
+                    if (variantType === 'function-block') {
+                      const instanceName = blockData.variable?.name
+                      if (instanceName) {
+                        for (const outVar of outputVars) {
+                          const compositeKey = makeCompositeKey(`${instanceName}.${outVar.name}`)
+                          if (compositeKey) {
+                            newKeys.add(compositeKey)
+                          }
+                        }
+                      }
+                    } else if (variantType === 'function' && variantName && blockData.numericId) {
+                      const numericId = blockData.numericId
+                      for (const outVar of outputVars) {
+                        const tmpName = `_TMP_${variantName.toUpperCase()}${numericId}_${outVar.name}`
+                        const compositeKey = makeCompositeKey(tmpName)
+                        if (compositeKey) {
+                          newKeys.add(compositeKey)
+                        }
+                      }
+                    }
+                  }
+                })
+              }
+            }
+
+            // ST/IL: poll variables that appear in the editor source text.
+            // The regex matches are intentionally broad (no comment stripping) — this is the
+            // polling side, not the display side. Over-matching just polls a few extra variables;
+            // the Monaco badge display already strips comments before rendering.
+            if (pouLanguage === 'st' || pouLanguage === 'il') {
+              const sourceText = typeof currentPou.data.body.value === 'string' ? currentPou.data.body.value : ''
+              if (sourceText) {
+                const candidates = currentPou.data.variables.map((v) => v.name).filter((n) => n && n.trim() !== '')
+
+                for (const varName of candidates) {
+                  const pattern = new RegExp(`\\b${varName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
+                  if (pattern.test(sourceText)) {
+                    const compositeKey = makeCompositeKey(varName)
                     if (compositeKey) {
-                      debugVariableKeys.add(compositeKey)
+                      newKeys.add(compositeKey)
                     }
                   }
                 }
-              }
-            })
-          }
-        }
 
-        // --- ST/IL: poll variables that appear in the editor source text ---
-        if (currentPou && (currentPou.data.body.language === 'st' || currentPou.data.body.language === 'il')) {
-          const sourceText = typeof currentPou.data.body.value === 'string' ? currentPou.data.body.value : ''
-          if (sourceText) {
-            // Build candidate list: all POU variables
-            const candidates = currentPou.data.variables.map((v) => v.name).filter((n) => n && n.trim() !== '')
+                // For derived-type (FB instance) variables that appear in source, poll their children
+                const fbInstances = currentPou.data.variables.filter(
+                  (v) => v.type.definition === 'derived' && v.name && v.name.trim() !== '',
+                )
+                for (const fbInstance of fbInstances) {
+                  const fbPattern = new RegExp(`\\b${fbInstance.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
+                  if (!fbPattern.test(sourceText)) continue
 
-            // Check which variables appear in the source text (word-boundary match)
-            for (const varName of candidates) {
-              const pattern = new RegExp(`\\b${varName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
-              if (pattern.test(sourceText)) {
-                const compositeKey = makeCompositeKeyForCurrentPou(varName)
-                if (compositeKey) {
-                  debugVariableKeys.add(compositeKey)
-                }
-              }
-            }
-
-            // For derived-type (FB instance) variables that appear in source, poll their children
-            const fbInstances = currentPou.data.variables.filter(
-              (v) => v.type.definition === 'derived' && v.name && v.name.trim() !== '',
-            )
-            for (const fbInstance of fbInstances) {
-              const fbPattern = new RegExp(`\\b${fbInstance.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
-              if (!fbPattern.test(sourceText)) continue
-
-              Array.from(variableInfoMapRef.current.entries()).forEach(([_, varInfos]) => {
-                for (const varInfo of varInfos) {
-                  if (currentPou.type === 'function-block') {
-                    // FB POU: resolve through instance context
-                    const fbTypeKey = currentPou.data.name.toUpperCase()
-                    const selectedKey = fbSelectedInstance.get(fbTypeKey)
-                    if (selectedKey) {
-                      const instances = fbDebugInstances.get(fbTypeKey) || []
-                      const selectedInstance = instances.find((inst) => inst.key === selectedKey)
-                      if (
-                        selectedInstance &&
-                        varInfo.pouName === selectedInstance.programName &&
-                        varInfo.variable.name.startsWith(`${selectedInstance.fbVariableName}.${fbInstance.name}.`)
-                      ) {
-                        debugVariableKeys.add(`${varInfo.pouName}:${varInfo.variable.name}`)
+                  Array.from(variableInfoMapRef.current.entries()).forEach(([_, varInfos]) => {
+                    for (const varInfo of varInfos) {
+                      if (resolvedFbInstance) {
+                        // FB POU: resolve through instance context (already hoisted above)
+                        if (
+                          varInfo.pouName === resolvedFbInstance.programName &&
+                          varInfo.variable.name.startsWith(`${resolvedFbInstance.fbVariableName}.${fbInstance.name}.`)
+                        ) {
+                          newKeys.add(`${varInfo.pouName}:${varInfo.variable.name}`)
+                        }
+                      } else {
+                        // Program POU: match directly
+                        if (
+                          varInfo.pouName === currentPou.data.name &&
+                          varInfo.variable.name.startsWith(`${fbInstance.name}.`)
+                        ) {
+                          newKeys.add(`${varInfo.pouName}:${varInfo.variable.name}`)
+                        }
                       }
                     }
-                  } else {
-                    // Program POU: match directly
-                    if (
-                      varInfo.pouName === currentPou.data.name &&
-                      varInfo.variable.name.startsWith(`${fbInstance.name}.`)
-                    ) {
-                      debugVariableKeys.add(`${varInfo.pouName}:${varInfo.variable.name}`)
-                    }
-                  }
+                  })
                 }
-              })
+              }
             }
+
+            diagramVarKeysCache.current = { pouName, language: pouLanguage, fbContextKey, keys: newKeys }
+            newKeys.forEach((key) => debugVariableKeys.add(key))
           }
         }
 
@@ -1570,6 +1617,7 @@ const WorkspaceScreen = () => {
         clearInterval(pollingIntervalRef.current)
         pollingIntervalRef.current = null
       }
+      diagramVarKeysCache.current = null
       void window.bridge.debuggerDisconnect().catch((error: unknown) => {
         const { consoleActions } = useOpenPLCStore.getState()
         consoleActions.addLog({

--- a/src/renderer/screens/workspace-screen.tsx
+++ b/src/renderer/screens/workspace-screen.tsx
@@ -1356,6 +1356,64 @@ const WorkspaceScreen = () => {
           }
         }
 
+        // --- ST/IL: poll variables that appear in the editor source text ---
+        if (currentPou && (currentPou.data.body.language === 'st' || currentPou.data.body.language === 'il')) {
+          const sourceText = typeof currentPou.data.body.value === 'string' ? currentPou.data.body.value : ''
+          if (sourceText) {
+            // Build candidate list: all POU variables
+            const candidates = currentPou.data.variables.map((v) => v.name).filter((n) => n && n.trim() !== '')
+
+            // Check which variables appear in the source text (word-boundary match)
+            for (const varName of candidates) {
+              const pattern = new RegExp(`\\b${varName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
+              if (pattern.test(sourceText)) {
+                const compositeKey = makeCompositeKeyForCurrentPou(varName)
+                if (compositeKey) {
+                  debugVariableKeys.add(compositeKey)
+                }
+              }
+            }
+
+            // For derived-type (FB instance) variables that appear in source, poll their children
+            const fbInstances = currentPou.data.variables.filter(
+              (v) => v.type.definition === 'derived' && v.name && v.name.trim() !== '',
+            )
+            for (const fbInstance of fbInstances) {
+              const fbPattern = new RegExp(`\\b${fbInstance.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
+              if (!fbPattern.test(sourceText)) continue
+
+              Array.from(variableInfoMapRef.current.entries()).forEach(([_, varInfos]) => {
+                for (const varInfo of varInfos) {
+                  if (currentPou.type === 'function-block') {
+                    // FB POU: resolve through instance context
+                    const fbTypeKey = currentPou.data.name.toUpperCase()
+                    const selectedKey = fbSelectedInstance.get(fbTypeKey)
+                    if (selectedKey) {
+                      const instances = fbDebugInstances.get(fbTypeKey) || []
+                      const selectedInstance = instances.find((inst) => inst.key === selectedKey)
+                      if (
+                        selectedInstance &&
+                        varInfo.pouName === selectedInstance.programName &&
+                        varInfo.variable.name.startsWith(`${selectedInstance.fbVariableName}.${fbInstance.name}.`)
+                      ) {
+                        debugVariableKeys.add(`${varInfo.pouName}:${varInfo.variable.name}`)
+                      }
+                    }
+                  } else {
+                    // Program POU: match directly
+                    if (
+                      varInfo.pouName === currentPou.data.name &&
+                      varInfo.variable.name.startsWith(`${fbInstance.name}.`)
+                    ) {
+                      debugVariableKeys.add(`${varInfo.pouName}:${varInfo.variable.name}`)
+                    }
+                  }
+                }
+              })
+            }
+          }
+        }
+
         // Forced variables must also be polled so their current value appears in the debugger panel
         const {
           workspace: { debugForcedVariables: currentForcedVars },

--- a/src/renderer/screens/workspace-screen.tsx
+++ b/src/renderer/screens/workspace-screen.tsx
@@ -1115,44 +1115,71 @@ const WorkspaceScreen = () => {
         // creates a watched key like main:IRRIGATION_MAIN_CONTROLLER0.TON0, and its children
         // (like ET, PT) should be polled when TON0 is expanded
         const shouldPollNestedVariable = (varName: string, pouName: string, currentGraphList: string[]): boolean => {
-          const parts = varName.split('.')
-          if (parts.length <= 1) return true // Not a nested variable
-
-          // Check if this variable is in the graph list
+          // Fast-path: graphed variables must always be polled.
           const compositeKey = `${pouName}:${varName}`
           if (currentGraphList.includes(compositeKey)) {
             return true
           }
 
-          // Find the deepest watched ancestor
-          // For example, if varName is 'IRRIGATION_MAIN_CONTROLLER0.TON0.ET':
-          // - Check if 'main:IRRIGATION_MAIN_CONTROLLER0.TON0' is watched (deepest)
-          // - If not, check if 'main:IRRIGATION_MAIN_CONTROLLER0' is watched
-          let watchedAncestorIndex = -1
-          for (let i = parts.length - 1; i >= 1; i--) {
-            const candidatePath = parts.slice(0, i).join('.')
-            const candidateKey = `${pouName}:${candidatePath}`
+          if (debugVariableKeys.has(compositeKey)) {
+            return true
+          }
+
+          const hierarchyPaths: string[] = []
+          const dotParts = varName.split('.')
+          let prefix = ''
+          for (const part of dotParts) {
+            const hasBracket = part.includes('[')
+            if (hasBracket) {
+              const base = part.split('[')[0]
+              if (base) {
+                const basePath = prefix ? `${prefix}.${base}` : base
+                if (hierarchyPaths[hierarchyPaths.length - 1] !== basePath) {
+                  hierarchyPaths.push(basePath)
+                }
+              }
+            }
+
+            const fullPath = prefix ? `${prefix}.${part}` : part
+            hierarchyPaths.push(fullPath)
+            prefix = fullPath
+          }
+
+          // If there's no hierarchy, treat as not pollable.
+          if (hierarchyPaths.length === 0) {
+            return false
+          }
+
+          // If this is not nested (single path, no bracket-derived parent), it must be explicitly watched/forced.
+          // (This matches previous behavior for simple variables.)
+          if (hierarchyPaths.length === 1) {
+            return debugVariableKeys.has(`${pouName}:${hierarchyPaths[0]}`)
+          }
+
+          // Find the deepest watched ancestor in the hierarchy.
+          let watchedAncestorPos = -1
+          for (let i = hierarchyPaths.length - 2; i >= 0; i--) {
+            const candidateKey = `${pouName}:${hierarchyPaths[i]}`
             if (debugVariableKeys.has(candidateKey)) {
-              watchedAncestorIndex = i
+              watchedAncestorPos = i
               break
             }
           }
 
-          // If no ancestor is watched, don't poll this variable
-          if (watchedAncestorIndex === -1) {
+          if (watchedAncestorPos === -1) {
             return false
           }
 
-          // Check if all nodes from the watched ancestor to this variable are expanded
-          // Start from the watched ancestor (which must be expanded to see its children)
-          for (let i = watchedAncestorIndex; i < parts.length; i++) {
-            const parentPath = parts.slice(0, i).join('.')
-            const parentKey = `${pouName}:${parentPath}`
+          // Ensure every ancestor from watched -> parent of target is expanded.
+          // The target node itself does not need to be expanded to show its value.
+          for (let i = watchedAncestorPos; i < hierarchyPaths.length - 1; i++) {
+            const parentKey = `${pouName}:${hierarchyPaths[i]}`
             const isParentExpanded = debugExpandedNodes.get(parentKey) ?? false
             if (!isParentExpanded) {
               return false
             }
           }
+
           return true
         }
 
@@ -1160,11 +1187,9 @@ const WorkspaceScreen = () => {
         // This now supports arbitrary nesting depth by finding the deepest watched ancestor
         Array.from(variableInfoMapRef.current.entries()).forEach(([_, varInfos]) => {
           for (const varInfo of varInfos) {
-            if (varInfo.variable.name.includes('.')) {
+            // Treat both dot-nesting (A.B) and array indexing (A[1]) as nested.
+            if (varInfo.variable.name.includes('.') || varInfo.variable.name.includes('[')) {
               const childKey = `${varInfo.pouName}:${varInfo.variable.name}`
-
-              // Check if this nested variable should be polled based on expansion state
-              // shouldPollNestedVariable now handles finding the watched ancestor internally
               if (shouldPollNestedVariable(varInfo.variable.name, varInfo.pouName, graphListRef.current)) {
                 debugVariableKeys.add(childKey)
               }


### PR DESCRIPTION
## Commit message

fix(debugger): poll only visible/used variables (avoid polling entire POU)


## PR: Reduce debugger polling to visible variables

### Problem
Online debugging over Modbus RTU (USB serial @ 115200) was updating very slowly (~5s) even for small projects. The debugger was polling a very large number of variables (e.g. 691) every cycle, which makes the update rate unusable for step-by-step logic debugging.

**Root cause:** the renderer polling loop in the workspace screen explicitly added **all variables from the active POU** into the poll set (mainly to support numeric debug badges), causing a project-wide flood regardless of what the user is actually viewing.

### What changed
Updated the renderer-side debugger polling logic to request **only the variables that are actually needed**, while keeping all existing debugger features.

**Changed file:**
- src/renderer/screens/workspace-screen.tsx

### New polling behavior (how it works)
Each polling tick builds a set of composite keys and requests only those debug indexes:

#### Always included (existing behavior preserved)
- **Watched variables**: variables flagged with `debug === true`
- **Forced variables**: always polled so the debugger panel remains accurate
- **Nested/expanded variables**: children are polled only when their watched ancestor is expanded  
  (and graphed variables continue to be included)

#### Newly included: only what’s on the active diagram (LD + FBD)
To keep diagram indicators/badges working without polling everything:
- **LD**
  - contacts/coils (BOOL variables used on the diagram)
  - variable nodes (so `DebugValueBadge` and force context menus work)
  - block output badges (functions + function blocks), by generating the same names the UI uses:
    - FB outputs: `instanceName.outputName`
    - Function outputs: `_TMP_<FUNCNAME><numericId>_<OUTNAME>`
- **FBD**
  - variable nodes
  - block output badges (functions + function blocks), same naming logic as above

### Removed (core fix)
- Removed the “poll all variables of the active POU” logic that caused hundreds of unrelated variables to be fetched every cycle.

### Why this improves update rate
RTU performance is dominated by the number of variables being read. Polling 691 variables guarantees slow refresh regardless of batch size.

With this change, the polled set scales with:
- what’s **visible in the active LD/FBD diagram**, plus
- what the user has explicitly **watched / graphed / expanded / forced**

This dramatically reduces reads for small projects and restores interactive update speed.

### Compatibility / No regression intent
No functionality was removed:
- watch list still works
- graph list still works
- expand-to-fetch-children still works
- forcing still works (and forced vars remain polled)
- diagram debug badges still work, without polling unrelated variables



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and cached polling/key derivation across program, FB, FBD and ST/IL contexts to reduce per-tick work and ensure cache invalidation on context changes and teardown.
  * Track editor model switches to recompute debug scans when the active file/model changes.
* **New Features**
  * Polling now includes variables referenced in editor source, FB outputs, temps, and deeply nested/bracketed paths.
* **Bug Fixes**
  * More reliable handling of non-BOOL values, array/bracketed paths, and diagram-exposed outputs for correct updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->