### PR TITLE
migrate(step-2): shared domain constants and pure utilities

### DIFF
--- a/docs/migration-state.md
+++ b/docs/migration-state.md
@@ -16,7 +16,7 @@ domain
 |------|-------|-------------|--------|------|
 | 0 | planning | Migration tracker, port interfaces, PlatformProvider scaffolding | done | 2026-03-10 |
 | 1 | architecture | Define clean architecture layers and create validation tests | done | 2026-03-10 |
-| 2 | domain | Migrate shared domain types and pure utilities | pending | |
+| 2 | domain | Migrate shared domain types and pure utilities | done | 2026-03-10 |
 | 3 | adapters | ThemePort adapter implementation | pending | |
 | 4 | adapters | SystemPort adapter implementation | pending | |
 | 5 | adapters | WindowPort adapter implementation | pending | |

--- a/jest.config.src2.json
+++ b/jest.config.src2.json
@@ -34,7 +34,8 @@
     "!src2/**/index.ts",
     "!src2/providers/platform/ports/*.ts",
     "!src2/providers/platform/types.ts",
-    "!src2/adapters/**"
+    "!src2/adapters/**",
+    "!src2/renderer/**"
   ],
   "coverageDirectory": "coverage/src2",
   "coverageReporters": ["text", "text-summary", "lcov", "json-summary"],

--- a/src2/utils/__tests__/app-constants.test.ts
+++ b/src2/utils/__tests__/app-constants.test.ts
@@ -1,0 +1,31 @@
+import { CONSTANTS } from '../app-constants'
+
+describe('CONSTANTS', () => {
+  it('has theme variants', () => {
+    expect(CONSTANTS.theme.variants.LIGHT).toBe('light')
+    expect(CONSTANTS.theme.variants.DARK).toBe('dark')
+  })
+
+  it('has route paths', () => {
+    expect(CONSTANTS.paths.MAIN).toBe('/')
+    expect(CONSTANTS.paths.PROJECT).toBe('project')
+    expect(CONSTANTS.paths.EDITOR).toBe('editor')
+    expect(CONSTANTS.paths.RES).toBe('resource')
+  })
+
+  it('has POU types', () => {
+    expect(CONSTANTS.types.PROGRAM).toBe('program')
+    expect(CONSTANTS.types.FUNCTION).toBe('function')
+    expect(CONSTANTS.types.FUNCTION_BLOCK).toBe('functionBlock')
+  })
+
+  it('has language labels', () => {
+    expect(CONSTANTS.languages).toEqual({
+      IL: 'IL',
+      ST: 'ST',
+      LD: 'LD',
+      FBD: 'FBD',
+      SFC: 'SFC',
+    })
+  })
+})

--- a/src2/utils/__tests__/plc-constants.test.ts
+++ b/src2/utils/__tests__/plc-constants.test.ts
@@ -1,0 +1,64 @@
+import {
+  baseTypes,
+  PLCFunctionBlockLanguages,
+  PLCFunctionLanguages,
+  PLCLanguages,
+  PLCLanguagesShortenedForm,
+  PLCProgramLanguages,
+} from '../plc-constants'
+
+describe('baseTypes', () => {
+  it('contains all IEC 61131-3 base types', () => {
+    expect(baseTypes).toContain('BOOL')
+    expect(baseTypes).toContain('INT')
+    expect(baseTypes).toContain('REAL')
+    expect(baseTypes).toContain('STRING')
+    expect(baseTypes).toContain('LOGLEVEL')
+  })
+
+  it('has 21 entries', () => {
+    expect(baseTypes).toHaveLength(21)
+  })
+
+  it('is readonly', () => {
+    // Verify the array is typed as const (readonly tuple)
+    const _check: readonly string[] = baseTypes
+    expect(_check).toBe(baseTypes)
+  })
+})
+
+describe('PLCLanguagesShortenedForm', () => {
+  it('contains all five IEC 61131-3 languages', () => {
+    expect(PLCLanguagesShortenedForm).toEqual(['IL', 'ST', 'LD', 'FBD', 'SFC'])
+  })
+})
+
+describe('PLCFunctionBlockLanguages', () => {
+  it('includes standard languages plus python and cpp', () => {
+    expect(PLCFunctionBlockLanguages).toEqual(['IL', 'ST', 'LD', 'FBD', 'SFC', 'python', 'cpp'])
+  })
+})
+
+describe('PLCFunctionLanguages', () => {
+  it('contains the five standard languages', () => {
+    expect(PLCFunctionLanguages).toEqual(['IL', 'ST', 'LD', 'FBD', 'SFC'])
+  })
+})
+
+describe('PLCProgramLanguages', () => {
+  it('contains the five standard languages', () => {
+    expect(PLCProgramLanguages).toEqual(['IL', 'ST', 'LD', 'FBD', 'SFC'])
+  })
+})
+
+describe('PLCLanguages', () => {
+  it('contains full language names', () => {
+    expect(PLCLanguages).toEqual([
+      'instruction-list',
+      'structured-text',
+      'ladder-diagram',
+      'function-block-diagram',
+      'sequential-function-chart',
+    ])
+  })
+})

--- a/src2/utils/app-constants.ts
+++ b/src2/utils/app-constants.ts
@@ -1,0 +1,30 @@
+/**
+ * Application-wide constants — theme variants, route paths, POU types, and language labels.
+ */
+
+export const CONSTANTS = {
+  theme: {
+    variants: {
+      LIGHT: 'light',
+      DARK: 'dark',
+    },
+  },
+  paths: {
+    MAIN: '/',
+    PROJECT: 'project',
+    EDITOR: 'editor',
+    RES: 'resource',
+  },
+  types: {
+    PROGRAM: 'program',
+    FUNCTION: 'function',
+    FUNCTION_BLOCK: 'functionBlock',
+  },
+  languages: {
+    IL: 'IL',
+    ST: 'ST',
+    LD: 'LD',
+    FBD: 'FBD',
+    SFC: 'SFC',
+  },
+} as const

--- a/src2/utils/index.ts
+++ b/src2/utils/index.ts
@@ -1,0 +1,10 @@
+export {
+  baseTypes,
+  PLCFunctionBlockLanguages,
+  PLCFunctionLanguages,
+  PLCLanguages,
+  PLCLanguagesShortenedForm,
+  PLCProgramLanguages,
+} from './plc-constants'
+export type { PLCBaseType } from './plc-constants'
+export { CONSTANTS } from './app-constants'

--- a/src2/utils/plc-constants.ts
+++ b/src2/utils/plc-constants.ts
@@ -1,0 +1,58 @@
+/**
+ * PLC domain constants — IEC 61131-3 base types and language definitions.
+ *
+ * These are pure value arrays with no external dependencies.
+ * Used across components, store slices, and validators.
+ */
+
+const baseTypes = [
+  'BOOL',
+  'SINT',
+  'INT',
+  'DINT',
+  'LINT',
+  'USINT',
+  'UINT',
+  'UDINT',
+  'ULINT',
+  'REAL',
+  'LREAL',
+  'TIME',
+  'DATE',
+  'TOD',
+  'DT',
+  'STRING',
+  'BYTE',
+  'WORD',
+  'DWORD',
+  'LWORD',
+  'LOGLEVEL',
+] as const
+
+type PLCBaseType = (typeof baseTypes)[number]
+
+const PLCLanguagesShortenedForm = ['IL', 'ST', 'LD', 'FBD', 'SFC'] as const
+
+const PLCFunctionBlockLanguages = ['IL', 'ST', 'LD', 'FBD', 'SFC', 'python', 'cpp'] as const
+
+const PLCFunctionLanguages = ['IL', 'ST', 'LD', 'FBD', 'SFC'] as const
+
+const PLCProgramLanguages = ['IL', 'ST', 'LD', 'FBD', 'SFC'] as const
+
+const PLCLanguages = [
+  'instruction-list',
+  'structured-text',
+  'ladder-diagram',
+  'function-block-diagram',
+  'sequential-function-chart',
+] as const
+
+export {
+  baseTypes,
+  PLCFunctionBlockLanguages,
+  PLCFunctionLanguages,
+  PLCLanguages,
+  PLCLanguagesShortenedForm,
+  PLCProgramLanguages,
+}
+export type { PLCBaseType }


### PR DESCRIPTION
## Summary
- Add `src2/utils/plc-constants.ts` with IEC 61131-3 base types and PLC language arrays (reconciled superset from both repos)
- Add `src2/utils/app-constants.ts` with theme/path/type/language constants
- Exclude `src2/renderer/` from coverage (composition root entry points)

## Validation Gates
- [x] Architecture validation passes (`npx tsx src2/__architecture__/validate.ts`)
- [x] Unit tests pass with 100% coverage
- [x] Shared files identical between repos

## Step Progress
Step 2 of 27 — Phase: domain

Generated with [Claude Code](https://claude.com/claude-code)