### PR TITLE
migrate(step-4): SystemPort adapter implementation

### DIFF
--- a/docs/migration-state.md
+++ b/docs/migration-state.md
@@ -8,7 +8,7 @@ adapters
 
 ## Current Step
 
-3
+4
 
 ## Step Log
 
@@ -18,7 +18,7 @@ adapters
 | 1 | architecture | Define clean architecture layers and create validation tests | done | 2026-03-10 |
 | 2 | domain | Migrate shared domain types and pure utilities | done | 2026-03-10 |
 | 3 | adapters | ThemePort adapter implementation | done | 2026-03-10 |
-| 4 | adapters | SystemPort adapter implementation | pending | |
+| 4 | adapters | SystemPort adapter implementation | done | 2026-03-10 |
 | 5 | adapters | WindowPort adapter implementation | pending | |
 | 6 | adapters | AcceleratorPort adapter implementation | pending | |
 | 7 | adapters | DevicePort adapter implementation | pending | |

--- a/src2/adapters/editor-platform.ts
+++ b/src2/adapters/editor-platform.ts
@@ -18,6 +18,7 @@
 
 import type { PlatformPorts } from '../providers/platform/types'
 import { EDITOR_CAPABILITIES } from '../providers/platform/ports/platform-capabilities'
+import { createEditorSystemAdapter } from './editor/system-adapter'
 import { createEditorThemeAdapter } from './editor/theme-adapter'
 
 function notMigrated(portName: string): never {
@@ -55,7 +56,7 @@ export const editorPorts: PlatformPorts = {
   simulator: createStubPort('SimulatorPort'),
   project: createStubPort('ProjectPort'),
   device: createStubPort('DevicePort'),
-  system: createStubPort('SystemPort'),
+  system: createEditorSystemAdapter(),
   window: createStubPort('WindowPort'),
   accelerator: createStubPort('AcceleratorPort'),
   theme: createEditorThemeAdapter(),

--- a/src2/adapters/editor/system-adapter.ts
+++ b/src2/adapters/editor/system-adapter.ts
@@ -1,0 +1,41 @@
+/**
+ * Editor SystemPort adapter — delegates to Electron IPC bridge.
+ *
+ * Uses window.bridge methods to communicate with the main process
+ * for system info, persistent storage (electron-store), external
+ * links (shell.openExternal), and logging.
+ *
+ * IPC channels used:
+ *   - system:get-system-info  (invoke)
+ *   - app:store-get           (invoke)
+ *   - app:store-set           (send)
+ *   - open-external-link      (invoke)
+ *   - util:log                (send)
+ */
+
+import type { SystemPort } from '../../providers/platform/ports/system-port'
+import type { SystemInfo } from '../../providers/platform/ports/types'
+
+export function createEditorSystemAdapter(): SystemPort {
+  return {
+    getSystemInfo(): Promise<SystemInfo> {
+      return window.bridge.getSystemInfo()
+    },
+
+    getStoreValue(key: string): Promise<unknown> {
+      return window.bridge.getStoreValue(key)
+    },
+
+    setStoreValue(key: string, value: string): void {
+      window.bridge.setStoreValue(key, value)
+    },
+
+    openExternalLink(url: string): Promise<{ success: boolean }> {
+      return window.bridge.openExternalLinkAccelerator(url)
+    },
+
+    log(level: 'info' | 'error', message: string): void {
+      window.bridge.log(level, message)
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Implement editor SystemPort adapter delegating to `window.bridge.*` IPC methods (getSystemInfo, getStoreValue, setStoreValue, openExternalLinkAccelerator, log)
- Wire adapter into `editor-platform.ts`, replacing the stub proxy

## Validation Gates
- [x] Architecture validation passes (`npx tsx src2/__architecture__/validate.ts`)
- [x] Unit tests pass with 100% coverage
- [x] Shared files identical between repos

## Step Progress
Step 4 of 27 — Phase: adapters

Generated with [Claude Code](https://claude.com/claude-code)