### PR TITLE
migrate(step-6): AcceleratorPort adapter implementation

### DIFF
--- a/docs/migration-state.md
+++ b/docs/migration-state.md
@@ -8,7 +8,7 @@ adapters
 
 ## Current Step
 
-5
+6
 
 ## Step Log
 
@@ -20,7 +20,7 @@ adapters
 | 3 | adapters | ThemePort adapter implementation | done | 2026-03-10 |
 | 4 | adapters | SystemPort adapter implementation | done | 2026-03-10 |
 | 5 | adapters | WindowPort adapter implementation | done | 2026-03-10 |
-| 6 | adapters | AcceleratorPort adapter implementation | pending | |
+| 6 | adapters | AcceleratorPort adapter implementation | done | 2026-03-10 |
 | 7 | adapters | DevicePort adapter implementation | pending | |
 | 8 | adapters | ProjectPort adapter implementation | pending | |
 | 9 | adapters | CompilerPort adapter implementation | pending | |

--- a/src2/adapters/editor-platform.ts
+++ b/src2/adapters/editor-platform.ts
@@ -18,6 +18,7 @@
 
 import type { PlatformPorts } from '../providers/platform/types'
 import { EDITOR_CAPABILITIES } from '../providers/platform/ports/platform-capabilities'
+import { createEditorAcceleratorAdapter } from './editor/accelerator-adapter'
 import { createEditorSystemAdapter } from './editor/system-adapter'
 import { createEditorThemeAdapter } from './editor/theme-adapter'
 import { createEditorWindowAdapter } from './editor/window-adapter'
@@ -59,7 +60,7 @@ export const editorPorts: PlatformPorts = {
   device: createStubPort('DevicePort'),
   system: createEditorSystemAdapter(),
   window: createEditorWindowAdapter(),
-  accelerator: createStubPort('AcceleratorPort'),
+  accelerator: createEditorAcceleratorAdapter(),
   theme: createEditorThemeAdapter(),
   capabilities: EDITOR_CAPABILITIES,
 }

--- a/src2/adapters/editor/accelerator-adapter.ts
+++ b/src2/adapters/editor/accelerator-adapter.ts
@@ -1,0 +1,174 @@
+/**
+ * Editor AcceleratorPort adapter — delegates to Electron menu accelerator IPC events.
+ *
+ * Each accelerator fires an IPC event from the main process menu when the user
+ * presses a keyboard shortcut. This adapter wraps `window.bridge.*` listener
+ * registrations and returns an Unsubscribe function that deactivates the callback.
+ *
+ * Note: Electron's `ipcRenderer.on` only supports `removeAllListeners(channel)`,
+ * not per-listener removal. We use an active flag so that unsubscribing prevents
+ * the callback from firing without removing all listeners on the channel.
+ *
+ * IPC channels:
+ *   project:create-accelerator
+ *   project:open-project-request
+ *   project:open-recent-accelerator
+ *   project:save-accelerator
+ *   project:save-file-accelerator
+ *   workspace:close-project-accelerator
+ *   compiler:export-project-request
+ *   workspace:close-tab-accelerator
+ *   workspace:delete-file-accelerator
+ *   project:find-in-project-accelerator
+ *   edit:undo-request
+ *   edit:redo-request
+ *   workspace:switch-perspective-accelerator
+ *   about:open-accelerator
+ */
+
+import type { AcceleratorPort } from '../../providers/platform/ports/accelerator-port'
+import type { Unsubscribe } from '../../providers/platform/ports/types'
+
+export function createEditorAcceleratorAdapter(): AcceleratorPort {
+  return {
+    onCreateProject(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.createProjectAccelerator(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+
+    onOpenProject(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.handleOpenProjectRequest(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+
+    onOpenRecent(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.openRecentAccelerator(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+
+    onSaveProject(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.saveProjectAccelerator(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+
+    onSaveFile(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.saveFileAccelerator(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+
+    onCloseProject(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.closeProjectAccelerator(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+
+    onExportProject(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.exportProjectRequest(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+
+    onCloseTab(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.closeTabAccelerator(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+
+    onDeleteFile(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.deleteFileAccelerator(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+
+    onFindInProject(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.findInProjectAccelerator(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+
+    onUndo(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.handleUndoRequest(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+
+    onRedo(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.handleRedoRequest(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+
+    onSwitchPerspective(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.switchPerspective(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+
+    onAbout(callback: () => void): Unsubscribe {
+      let active = true
+      window.bridge.aboutModalAccelerator(() => {
+        if (active) callback()
+      })
+      return () => {
+        active = false
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Editor adapter delegates to `window.bridge.*` IPC accelerator listeners (14 methods)
- Uses active-flag pattern for Unsubscribe since Electron IPC lacks per-listener removal
- Wired into `editor-platform.ts` replacing the stub proxy

## Validation Gates
- [x] Architecture validation passes (`npx tsx src2/__architecture__/validate.ts`)
- [x] Unit tests pass with 100% coverage
- [x] Shared files identical between repos

## Step Progress
Step 6 of 30 — Phase: adapters

Generated with [Claude Code](https://claude.com/claude-code)