### PR TITLE
migrate(step-7): DevicePort adapter implementation

### DIFF
--- a/docs/migration-state.md
+++ b/docs/migration-state.md
@@ -8,7 +8,7 @@ adapters
 
 ## Current Step
 
-6
+7
 
 ## Step Log
 
@@ -21,7 +21,7 @@ adapters
 | 4 | adapters | SystemPort adapter implementation | done | 2026-03-10 |
 | 5 | adapters | WindowPort adapter implementation | done | 2026-03-10 |
 | 6 | adapters | AcceleratorPort adapter implementation | done | 2026-03-10 |
-| 7 | adapters | DevicePort adapter implementation | pending | |
+| 7 | adapters | DevicePort adapter implementation | done | 2026-03-10 |
 | 8 | adapters | ProjectPort adapter implementation | pending | |
 | 9 | adapters | CompilerPort adapter implementation | pending | |
 | 10 | adapters | RuntimePort adapter implementation | pending | |

--- a/src2/adapters/editor-platform.ts
+++ b/src2/adapters/editor-platform.ts
@@ -19,6 +19,7 @@
 import type { PlatformPorts } from '../providers/platform/types'
 import { EDITOR_CAPABILITIES } from '../providers/platform/ports/platform-capabilities'
 import { createEditorAcceleratorAdapter } from './editor/accelerator-adapter'
+import { createEditorDeviceAdapter } from './editor/device-adapter'
 import { createEditorSystemAdapter } from './editor/system-adapter'
 import { createEditorThemeAdapter } from './editor/theme-adapter'
 import { createEditorWindowAdapter } from './editor/window-adapter'
@@ -57,7 +58,7 @@ export const editorPorts: PlatformPorts = {
   debugger: createStubPort('DebuggerPort'),
   simulator: createStubPort('SimulatorPort'),
   project: createStubPort('ProjectPort'),
-  device: createStubPort('DevicePort'),
+  device: createEditorDeviceAdapter(),
   system: createEditorSystemAdapter(),
   window: createEditorWindowAdapter(),
   accelerator: createEditorAcceleratorAdapter(),

--- a/src2/adapters/editor/__tests__/device-adapter.test.ts
+++ b/src2/adapters/editor/__tests__/device-adapter.test.ts
@@ -1,0 +1,71 @@
+import { createEditorDeviceAdapter } from '../device-adapter'
+import type { DevicePort } from '../../../providers/platform/ports/device-port'
+import type { BoardInfo, CommunicationPort } from '../../../providers/platform/ports/types'
+
+const mockBoards = new Map<string, BoardInfo>([
+  [
+    'Arduino Uno',
+    {
+      compiler: 'arduino-cli',
+      core: 'arduino:avr',
+      preview: 'uno.png',
+      specs: { CPU: 'ATmega328P', RAM: '2 KB' },
+      pins: { defaultDin: ['2', '3'], defaultDout: ['4', '5'] },
+    },
+  ],
+])
+
+const mockPorts: CommunicationPort[] = [
+  { name: '/dev/ttyUSB0', address: '/dev/ttyUSB0' },
+  { name: '/dev/ttyACM0', address: '/dev/ttyACM0' },
+]
+
+const mockRefreshResult = [{ board: 'Arduino Uno', version: '1.8.6' }]
+
+beforeEach(() => {
+  window.bridge = {
+    getAvailableBoards: jest.fn().mockResolvedValue(mockBoards),
+    getAvailableCommunicationPorts: jest.fn().mockResolvedValue(mockPorts),
+    refreshAvailableBoards: jest.fn().mockResolvedValue(mockRefreshResult),
+    refreshCommunicationPorts: jest.fn().mockResolvedValue(mockPorts),
+    getPreviewImage: jest.fn().mockResolvedValue('data:image/png;base64,abc123'),
+  } as unknown as typeof window.bridge
+})
+
+describe('createEditorDeviceAdapter', () => {
+  let adapter: DevicePort
+
+  beforeEach(() => {
+    adapter = createEditorDeviceAdapter()
+  })
+
+  it('delegates getAvailableBoards to window.bridge', async () => {
+    const result = await adapter.getAvailableBoards()
+    expect(window.bridge.getAvailableBoards).toHaveBeenCalledTimes(1)
+    expect(result).toBe(mockBoards)
+  })
+
+  it('delegates getCommunicationPorts to window.bridge', async () => {
+    const result = await adapter.getCommunicationPorts()
+    expect(window.bridge.getAvailableCommunicationPorts).toHaveBeenCalledTimes(1)
+    expect(result).toBe(mockPorts)
+  })
+
+  it('delegates refreshBoards to window.bridge', async () => {
+    const result = await adapter.refreshBoards()
+    expect(window.bridge.refreshAvailableBoards).toHaveBeenCalledTimes(1)
+    expect(result).toBe(mockRefreshResult)
+  })
+
+  it('delegates refreshCommunicationPorts to window.bridge', async () => {
+    const result = await adapter.refreshCommunicationPorts()
+    expect(window.bridge.refreshCommunicationPorts).toHaveBeenCalledTimes(1)
+    expect(result).toBe(mockPorts)
+  })
+
+  it('delegates getPreviewImage to window.bridge with image name', async () => {
+    const result = await adapter.getPreviewImage('uno.png')
+    expect(window.bridge.getPreviewImage).toHaveBeenCalledWith('uno.png')
+    expect(result).toBe('data:image/png;base64,abc123')
+  })
+})

--- a/src2/adapters/editor/device-adapter.ts
+++ b/src2/adapters/editor/device-adapter.ts
@@ -1,0 +1,42 @@
+/**
+ * Editor DevicePort adapter — delegates to Electron IPC bridge.
+ *
+ * Communicates with the main process HardwareModule which reads HAL
+ * JSON files from resources/sources/boards/ and queries arduino-cli
+ * for installed cores. Board preview images are returned as base64
+ * data URIs from the local filesystem.
+ *
+ * IPC channels:
+ *   hardware:get-available-boards              (invoke)
+ *   hardware:get-available-communication-ports  (invoke)
+ *   hardware:refresh-available-boards           (invoke)
+ *   hardware:refresh-communication-ports        (invoke)
+ *   util:get-preview-image                      (invoke)
+ */
+
+import type { DevicePort } from '../../providers/platform/ports/device-port'
+import type { BoardInfo, CommunicationPort } from '../../providers/platform/ports/types'
+
+export function createEditorDeviceAdapter(): DevicePort {
+  return {
+    getAvailableBoards(): Promise<Map<string, BoardInfo>> {
+      return window.bridge.getAvailableBoards()
+    },
+
+    getCommunicationPorts(): Promise<CommunicationPort[]> {
+      return window.bridge.getAvailableCommunicationPorts()
+    },
+
+    refreshBoards(): Promise<Array<{ board: string; version: string }>> {
+      return window.bridge.refreshAvailableBoards()
+    },
+
+    refreshCommunicationPorts(): Promise<CommunicationPort[]> {
+      return window.bridge.refreshCommunicationPorts()
+    },
+
+    getPreviewImage(imageName: string): Promise<string> {
+      return window.bridge.getPreviewImage(imageName)
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Editor adapter delegates `getAvailableBoards`, `getCommunicationPorts`, `refreshBoards`, `refreshCommunicationPorts`, and `getPreviewImage` to `window.bridge` IPC
- Wired `createEditorDeviceAdapter()` into `editor-platform.ts`, replacing the stub proxy
- Added adapter tests verifying correct IPC delegation

## Validation Gates
- [x] Architecture validation passes (`npx tsx src2/__architecture__/validate.ts`)
- [x] Unit tests pass with 100% coverage
- [x] Shared files identical between repos

## Step Progress
Step 7 of 30 — Phase: adapters

Generated with [Claude Code](https://claude.com/claude-code)