### PR TITLE
migrate(step-10): RuntimePort adapter implementation

### DIFF
--- a/docs/migration-state.md
+++ b/docs/migration-state.md
@@ -8,7 +8,7 @@ adapters
 
 ## Current Step
 
-9
+10
 
 ## Step Log
 
@@ -24,7 +24,7 @@ adapters
 | 7 | adapters | DevicePort adapter implementation | done | 2026-03-10 |
 | 8 | adapters | ProjectPort adapter implementation | done | 2026-03-10 |
 | 9 | adapters | CompilerPort adapter implementation | done | 2026-03-10 |
-| 10 | adapters | RuntimePort adapter implementation | pending | |
+| 10 | adapters | RuntimePort adapter implementation | done | 2026-03-10 |
 | 11 | adapters | DebuggerPort adapter implementation | pending | |
 | 12 | adapters | SimulatorPort adapter implementation | pending | |
 | 13 | store | UI state slices (Workspace, Editor, Tabs, Modal, Search) | pending | |

--- a/src2/adapters/editor-platform.ts
+++ b/src2/adapters/editor-platform.ts
@@ -22,9 +22,20 @@ import { createEditorAcceleratorAdapter } from './editor/accelerator-adapter'
 import { createEditorCompilerAdapter } from './editor/compiler-adapter'
 import { createEditorDeviceAdapter } from './editor/device-adapter'
 import { createEditorProjectAdapter } from './editor/project-adapter'
+import { createEditorRuntimeAdapter } from './editor/runtime-adapter'
 import { createEditorSystemAdapter } from './editor/system-adapter'
 import { createEditorThemeAdapter } from './editor/theme-adapter'
 import { createEditorWindowAdapter } from './editor/window-adapter'
+
+/**
+ * Runtime connection target — IP address of the OpenPLC runtime device.
+ * Set by the store/UI when the user configures or connects to a device.
+ */
+let _runtimeIpAddress = ''
+
+export function setRuntimeIpAddress(ip: string): void {
+  _runtimeIpAddress = ip
+}
 
 function notMigrated(portName: string): never {
   throw new Error(`[EditorAdapter] ${portName} is not yet migrated. Implement the adapter to use this port.`)
@@ -56,7 +67,7 @@ function createStubPort<T extends object>(portName: string): T {
  */
 export const editorPorts: PlatformPorts = {
   compiler: createEditorCompilerAdapter(),
-  runtime: createStubPort('RuntimePort'),
+  runtime: createEditorRuntimeAdapter(() => _runtimeIpAddress),
   debugger: createStubPort('DebuggerPort'),
   simulator: createStubPort('SimulatorPort'),
   project: createEditorProjectAdapter(),

--- a/src2/adapters/editor/__tests__/runtime-adapter.test.ts
+++ b/src2/adapters/editor/__tests__/runtime-adapter.test.ts
@@ -1,0 +1,382 @@
+import { createEditorRuntimeAdapter } from '../runtime-adapter'
+import type { RuntimePort } from '../../../providers/platform/ports/runtime-port'
+
+let adapter: RuntimePort
+let mockIpAddress: string
+
+beforeEach(() => {
+  mockIpAddress = '192.168.1.100'
+
+  window.bridge = {
+    runtimeLogin: jest.fn().mockResolvedValue({ success: true, accessToken: 'jwt-token-123' }),
+    runtimeCreateUser: jest.fn().mockResolvedValue({ success: true }),
+    runtimeGetUsersInfo: jest.fn().mockResolvedValue({ hasUsers: true, runtimeVersion: '4.0.0' }),
+    runtimeGetStatus: jest.fn().mockResolvedValue({ success: true, status: 'RUNNING' }),
+    runtimeStartPlc: jest.fn().mockResolvedValue({ success: true }),
+    runtimeStopPlc: jest.fn().mockResolvedValue({ success: true }),
+    runtimeGetLogs: jest.fn().mockResolvedValue({ success: true, logs: [] }),
+    runtimeGetSerialPorts: jest.fn().mockResolvedValue({ success: true, ports: [] }),
+    runtimeGetCompilationStatus: jest.fn().mockResolvedValue({
+      success: true,
+      data: { status: 'SUCCESS', logs: [], exit_code: 0 },
+    }),
+    runtimeClearCredentials: jest.fn().mockResolvedValue({ success: true }),
+    onRuntimeTokenRefreshed: jest.fn().mockImplementation(() => jest.fn()),
+  } as unknown as typeof window.bridge
+
+  adapter = createEditorRuntimeAdapter(() => mockIpAddress)
+})
+
+// ---------------------------------------------------------------------------
+// login
+// ---------------------------------------------------------------------------
+
+describe('login', () => {
+  it('delegates to bridge with IP and credentials', async () => {
+    const result = await adapter.login({ username: 'admin', password: 'secret' })
+
+    expect(window.bridge.runtimeLogin).toHaveBeenCalledWith('192.168.1.100', 'admin', 'secret')
+    expect(result).toEqual({ success: true, accessToken: 'jwt-token-123' })
+  })
+
+  it('stores JWT token internally on success', async () => {
+    await adapter.login({ username: 'admin', password: 'secret' })
+
+    // Subsequent calls should use the stored token
+    await adapter.getStatus()
+    expect(window.bridge.runtimeGetStatus).toHaveBeenCalledWith('192.168.1.100', 'jwt-token-123', undefined)
+  })
+
+  it('does not store token on failure', async () => {
+    ;(window.bridge.runtimeLogin as jest.Mock).mockResolvedValue({ success: false, error: 'Bad password' })
+    await adapter.login({ username: 'admin', password: 'wrong' })
+
+    await adapter.getStatus()
+    expect(window.bridge.runtimeGetStatus).toHaveBeenCalledWith('192.168.1.100', '', undefined)
+  })
+
+  it('returns error when no IP configured', async () => {
+    mockIpAddress = ''
+    const result = await adapter.login({ username: 'admin', password: 'secret' })
+
+    expect(result).toEqual({ success: false, error: 'No runtime IP address configured' })
+    expect(window.bridge.runtimeLogin).not.toHaveBeenCalled()
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeLogin as jest.Mock).mockRejectedValue(new Error('IPC failed'))
+    const result = await adapter.login({ username: 'admin', password: 'secret' })
+
+    expect(result).toEqual({ success: false, error: 'IPC failed' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createUser
+// ---------------------------------------------------------------------------
+
+describe('createUser', () => {
+  it('delegates to bridge with IP and credentials', async () => {
+    const result = await adapter.createUser({ username: 'newuser', password: 'pass123' })
+
+    expect(window.bridge.runtimeCreateUser).toHaveBeenCalledWith('192.168.1.100', 'newuser', 'pass123')
+    expect(result).toEqual({ success: true })
+  })
+
+  it('returns error when no IP configured', async () => {
+    mockIpAddress = ''
+    const result = await adapter.createUser({ username: 'newuser', password: 'pass123' })
+
+    expect(result).toEqual({ success: false, error: 'No runtime IP address configured' })
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeCreateUser as jest.Mock).mockRejectedValue(new Error('Connection refused'))
+    const result = await adapter.createUser({ username: 'newuser', password: 'pass123' })
+
+    expect(result).toEqual({ success: false, error: 'Connection refused' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getUsersInfo
+// ---------------------------------------------------------------------------
+
+describe('getUsersInfo', () => {
+  it('delegates to bridge with IP', async () => {
+    const result = await adapter.getUsersInfo()
+
+    expect(window.bridge.runtimeGetUsersInfo).toHaveBeenCalledWith('192.168.1.100')
+    expect(result).toEqual({ hasUsers: true, runtimeVersion: '4.0.0' })
+  })
+
+  it('returns error when no IP configured', async () => {
+    mockIpAddress = ''
+    const result = await adapter.getUsersInfo()
+
+    expect(result).toEqual({ hasUsers: false, error: 'No runtime IP address configured' })
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeGetUsersInfo as jest.Mock).mockRejectedValue(new Error('Timeout'))
+    const result = await adapter.getUsersInfo()
+
+    expect(result).toEqual({ hasUsers: false, error: 'Timeout' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getStatus
+// ---------------------------------------------------------------------------
+
+describe('getStatus', () => {
+  it('delegates to bridge with IP, token, and includeStats', async () => {
+    await adapter.login({ username: 'admin', password: 'secret' })
+    const result = await adapter.getStatus(true)
+
+    expect(window.bridge.runtimeGetStatus).toHaveBeenCalledWith('192.168.1.100', 'jwt-token-123', true)
+    expect(result).toEqual({ success: true, status: 'RUNNING' })
+  })
+
+  it('passes undefined for includeStats when omitted', async () => {
+    await adapter.getStatus()
+
+    expect(window.bridge.runtimeGetStatus).toHaveBeenCalledWith('192.168.1.100', '', undefined)
+  })
+
+  it('returns error when no IP configured', async () => {
+    mockIpAddress = ''
+    const result = await adapter.getStatus()
+
+    expect(result).toEqual({ success: false, error: 'No runtime IP address configured' })
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeGetStatus as jest.Mock).mockRejectedValue(new Error('Network error'))
+    const result = await adapter.getStatus()
+
+    expect(result).toEqual({ success: false, error: 'Network error' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// startPlc
+// ---------------------------------------------------------------------------
+
+describe('startPlc', () => {
+  it('delegates to bridge with IP and token', async () => {
+    await adapter.login({ username: 'admin', password: 'secret' })
+    const result = await adapter.startPlc()
+
+    expect(window.bridge.runtimeStartPlc).toHaveBeenCalledWith('192.168.1.100', 'jwt-token-123')
+    expect(result).toEqual({ success: true })
+  })
+
+  it('returns error when no IP configured', async () => {
+    mockIpAddress = ''
+    const result = await adapter.startPlc()
+
+    expect(result).toEqual({ success: false, error: 'No runtime IP address configured' })
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeStartPlc as jest.Mock).mockRejectedValue(new Error('PLC busy'))
+    const result = await adapter.startPlc()
+
+    expect(result).toEqual({ success: false, error: 'PLC busy' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// stopPlc
+// ---------------------------------------------------------------------------
+
+describe('stopPlc', () => {
+  it('delegates to bridge with IP and token', async () => {
+    await adapter.login({ username: 'admin', password: 'secret' })
+    const result = await adapter.stopPlc()
+
+    expect(window.bridge.runtimeStopPlc).toHaveBeenCalledWith('192.168.1.100', 'jwt-token-123')
+    expect(result).toEqual({ success: true })
+  })
+
+  it('returns error when no IP configured', async () => {
+    mockIpAddress = ''
+    const result = await adapter.stopPlc()
+
+    expect(result).toEqual({ success: false, error: 'No runtime IP address configured' })
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeStopPlc as jest.Mock).mockRejectedValue(new Error('PLC error'))
+    const result = await adapter.stopPlc()
+
+    expect(result).toEqual({ success: false, error: 'PLC error' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getLogs
+// ---------------------------------------------------------------------------
+
+describe('getLogs', () => {
+  it('delegates to bridge with IP, token, and minId', async () => {
+    await adapter.login({ username: 'admin', password: 'secret' })
+    const result = await adapter.getLogs(42)
+
+    expect(window.bridge.runtimeGetLogs).toHaveBeenCalledWith('192.168.1.100', 'jwt-token-123', 42)
+    expect(result).toEqual({ success: true, logs: [] })
+  })
+
+  it('passes undefined minId when omitted', async () => {
+    await adapter.getLogs()
+
+    expect(window.bridge.runtimeGetLogs).toHaveBeenCalledWith('192.168.1.100', '', undefined)
+  })
+
+  it('returns error when no IP configured', async () => {
+    mockIpAddress = ''
+    const result = await adapter.getLogs()
+
+    expect(result).toEqual({ success: false, error: 'No runtime IP address configured' })
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeGetLogs as jest.Mock).mockRejectedValue(new Error('Log fetch failed'))
+    const result = await adapter.getLogs()
+
+    expect(result).toEqual({ success: false, error: 'Log fetch failed' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getSerialPorts
+// ---------------------------------------------------------------------------
+
+describe('getSerialPorts', () => {
+  it('delegates to bridge with IP and token', async () => {
+    const ports = [{ device: '/dev/ttyUSB0', description: 'USB Serial' }]
+    ;(window.bridge.runtimeGetSerialPorts as jest.Mock).mockResolvedValue({ success: true, ports })
+
+    await adapter.login({ username: 'admin', password: 'secret' })
+    const result = await adapter.getSerialPorts()
+
+    expect(window.bridge.runtimeGetSerialPorts).toHaveBeenCalledWith('192.168.1.100', 'jwt-token-123')
+    expect(result).toEqual({ success: true, ports })
+  })
+
+  it('returns error when no IP configured', async () => {
+    mockIpAddress = ''
+    const result = await adapter.getSerialPorts()
+
+    expect(result).toEqual({ success: false, error: 'No runtime IP address configured' })
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeGetSerialPorts as jest.Mock).mockRejectedValue(new Error('Port scan failed'))
+    const result = await adapter.getSerialPorts()
+
+    expect(result).toEqual({ success: false, error: 'Port scan failed' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getCompilationStatus
+// ---------------------------------------------------------------------------
+
+describe('getCompilationStatus', () => {
+  it('delegates to bridge with IP and token', async () => {
+    await adapter.login({ username: 'admin', password: 'secret' })
+    const result = await adapter.getCompilationStatus()
+
+    expect(window.bridge.runtimeGetCompilationStatus).toHaveBeenCalledWith('192.168.1.100', 'jwt-token-123')
+    expect(result).toEqual({ success: true, data: { status: 'SUCCESS', logs: [], exit_code: 0 } })
+  })
+
+  it('returns error when no IP configured', async () => {
+    mockIpAddress = ''
+    const result = await adapter.getCompilationStatus()
+
+    expect(result).toEqual({ success: false, error: 'No runtime IP address configured' })
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeGetCompilationStatus as jest.Mock).mockRejectedValue(new Error('Status check failed'))
+    const result = await adapter.getCompilationStatus()
+
+    expect(result).toEqual({ success: false, error: 'Status check failed' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// clearCredentials
+// ---------------------------------------------------------------------------
+
+describe('clearCredentials', () => {
+  it('clears internal JWT and delegates to bridge', async () => {
+    await adapter.login({ username: 'admin', password: 'secret' })
+    const result = await adapter.clearCredentials()
+
+    expect(window.bridge.runtimeClearCredentials).toHaveBeenCalled()
+    expect(result).toEqual({ success: true })
+
+    // Subsequent calls should use empty token
+    await adapter.getStatus()
+    expect(window.bridge.runtimeGetStatus).toHaveBeenCalledWith('192.168.1.100', '', undefined)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// onTokenRefreshed
+// ---------------------------------------------------------------------------
+
+describe('onTokenRefreshed', () => {
+  it('subscribes to bridge token refresh events', () => {
+    const callback = jest.fn()
+    const unsubscribe = jest.fn()
+    ;(window.bridge.onRuntimeTokenRefreshed as jest.Mock).mockReturnValue(unsubscribe)
+
+    const unsub = adapter.onTokenRefreshed!(callback)
+
+    expect(window.bridge.onRuntimeTokenRefreshed).toHaveBeenCalledWith(expect.any(Function))
+    expect(unsub).toBe(unsubscribe)
+  })
+
+  it('updates internal JWT when token is refreshed', async () => {
+    let bridgeHandler: ((_event: unknown, newToken: string) => void) | null = null
+    ;(window.bridge.onRuntimeTokenRefreshed as jest.Mock).mockImplementation(
+      (handler: (_event: unknown, newToken: string) => void) => {
+        bridgeHandler = handler
+        return jest.fn()
+      },
+    )
+
+    const callback = jest.fn()
+    adapter.onTokenRefreshed!(callback)
+
+    // Simulate token refresh from main process
+    bridgeHandler!({}, 'new-token-456')
+
+    expect(callback).toHaveBeenCalledWith('new-token-456')
+
+    // Subsequent calls should use the refreshed token
+    await adapter.getStatus()
+    expect(window.bridge.runtimeGetStatus).toHaveBeenCalledWith('192.168.1.100', 'new-token-456', undefined)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// IP address getter reactivity
+// ---------------------------------------------------------------------------
+
+describe('IP address getter', () => {
+  it('reads IP address dynamically on each call', async () => {
+    mockIpAddress = '10.0.0.1'
+    await adapter.getUsersInfo()
+    expect(window.bridge.runtimeGetUsersInfo).toHaveBeenCalledWith('10.0.0.1')
+
+    mockIpAddress = '10.0.0.2'
+    await adapter.getUsersInfo()
+    expect(window.bridge.runtimeGetUsersInfo).toHaveBeenCalledWith('10.0.0.2')
+  })
+})

--- a/src2/adapters/editor/runtime-adapter.ts
+++ b/src2/adapters/editor/runtime-adapter.ts
@@ -1,0 +1,134 @@
+/**
+ * Editor RuntimePort adapter — delegates to Electron IPC bridge.
+ *
+ * Communicates with the main process RuntimeModule via window.bridge.runtime*
+ * methods. The main process handles HTTPS calls to the OpenPLC runtime device,
+ * including self-signed certificate support and automatic JWT token refresh.
+ *
+ * Connection context:
+ *   - IP address: provided via getIpAddress() callback injected at creation.
+ *     Set by the store/UI when the user configures the device.
+ *   - JWT token: managed internally. Stored after successful login(),
+ *     updated on token-refresh events, cleared on clearCredentials().
+ */
+
+import type {
+  CompilationStatusResult,
+  LoginParams,
+  LoginResult,
+  RuntimeLogsResult,
+  RuntimePort,
+  RuntimeStatusResult,
+  UsersInfoResult,
+} from '../../providers/platform/ports/runtime-port'
+import type { SerialPort, Unsubscribe } from '../../providers/platform/ports/types'
+
+export function createEditorRuntimeAdapter(getIpAddress: () => string): RuntimePort {
+  let jwtToken = ''
+
+  function requireIp(): string {
+    const ip = getIpAddress()
+    if (!ip) throw new Error('No runtime IP address configured')
+    return ip
+  }
+
+  return {
+    async login(params: LoginParams): Promise<LoginResult> {
+      try {
+        const ip = requireIp()
+        const result = await window.bridge.runtimeLogin(ip, params.username, params.password)
+        if (result.success && result.accessToken) {
+          jwtToken = result.accessToken
+        }
+        return result
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+
+    async createUser(params) {
+      try {
+        const ip = requireIp()
+        return await window.bridge.runtimeCreateUser(ip, params.username, params.password)
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+
+    async getUsersInfo(): Promise<UsersInfoResult> {
+      try {
+        const ip = requireIp()
+        return await window.bridge.runtimeGetUsersInfo(ip)
+      } catch (err) {
+        return { hasUsers: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+
+    async getStatus(includeStats?: boolean): Promise<RuntimeStatusResult> {
+      try {
+        const ip = requireIp()
+        return await window.bridge.runtimeGetStatus(ip, jwtToken, includeStats)
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+
+    async startPlc() {
+      try {
+        const ip = requireIp()
+        return await window.bridge.runtimeStartPlc(ip, jwtToken)
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+
+    async stopPlc() {
+      try {
+        const ip = requireIp()
+        return await window.bridge.runtimeStopPlc(ip, jwtToken)
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+
+    async getLogs(minId?: number): Promise<RuntimeLogsResult> {
+      try {
+        const ip = requireIp()
+        return await window.bridge.runtimeGetLogs(ip, jwtToken, minId)
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+
+    async getSerialPorts(): Promise<{ success: boolean; ports?: SerialPort[]; error?: string }> {
+      try {
+        const ip = requireIp()
+        return await window.bridge.runtimeGetSerialPorts(ip, jwtToken)
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+
+    async getCompilationStatus(): Promise<CompilationStatusResult> {
+      try {
+        const ip = requireIp()
+        return await window.bridge.runtimeGetCompilationStatus(ip, jwtToken)
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+
+    async clearCredentials() {
+      jwtToken = ''
+      return window.bridge.runtimeClearCredentials()
+    },
+
+    onTokenRefreshed(callback: (newToken: string) => void): Unsubscribe {
+      const handler = (_event: unknown, newToken: string) => {
+        jwtToken = newToken
+        callback(newToken)
+      }
+      return window.bridge.onRuntimeTokenRefreshed(handler)
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Editor RuntimePort adapter delegates to `window.bridge.runtime*` IPC methods
- Manages JWT token internally (stored on login, updated on refresh events, cleared on logout)
- IP address injected via getter callback from `editor-platform.ts` (`setRuntimeIpAddress()`)
- Implements `onTokenRefreshed` bridging IPC events to port callbacks

## Validation Gates
- [x] Architecture validation passes (`npx tsx src2/__architecture__/validate.ts`)
- [x] Unit tests pass with 100% coverage
- [x] Shared files identical between repos

## Step Progress
Step 10 of 30 — Phase: adapters

Generated with [Claude Code](https://claude.com/claude-code)