### PR TITLE
migrate(step-12): SimulatorPort adapter implementation

### DIFF
--- a/docs/migration-state.md
+++ b/docs/migration-state.md
@@ -8,7 +8,7 @@ adapters
 
 ## Current Step
 
-11
+12
 
 ## Step Log
 
@@ -26,7 +26,7 @@ adapters
 | 9 | adapters | CompilerPort adapter implementation | done | 2026-03-10 |
 | 10 | adapters | RuntimePort adapter implementation | done | 2026-03-10 |
 | 11 | adapters | DebuggerPort adapter implementation | done | 2026-03-10 |
-| 12 | adapters | SimulatorPort adapter implementation | pending | |
+| 12 | adapters | SimulatorPort adapter implementation | done | 2026-03-10 |
 | 13 | store | UI state slices (Workspace, Editor, Tabs, Modal, Search) | pending | |
 | 14 | store | Data state slices (Project, File, Library, Console, Shared) | pending | |
 | 15 | store | Visual editor slices (FBDFlow, LadderFlow) | pending | |

--- a/src2/adapters/editor-platform.ts
+++ b/src2/adapters/editor-platform.ts
@@ -4,9 +4,6 @@
  * This file creates the concrete PlatformPorts object for the Electron editor.
  * Each port delegates to `window.bridge.*` methods exposed by the preload script.
  *
- * During migration, ports will be implemented one at a time. Unimplemented ports
- * throw "not yet migrated" errors to make it clear what still needs work.
- *
  * Usage:
  *   import { editorPorts } from './adapters/editor-platform'
  *
@@ -27,6 +24,7 @@ import { createEditorProjectAdapter } from './editor/project-adapter'
 import { createEditorRuntimeAdapter } from './editor/runtime-adapter'
 import { createEditorSystemAdapter } from './editor/system-adapter'
 import { createEditorThemeAdapter } from './editor/theme-adapter'
+import { createEditorSimulatorAdapter } from './editor/simulator-adapter'
 import { createEditorWindowAdapter } from './editor/window-adapter'
 
 /**
@@ -44,39 +42,14 @@ export function setDebugConnectionConfig(config: EditorDebugConnectionConfig | n
   _debugConnectionConfig = config
 }
 
-function notMigrated(portName: string): never {
-  throw new Error(`[EditorAdapter] ${portName} is not yet migrated. Implement the adapter to use this port.`)
-}
-
-function createStubPort<T extends object>(portName: string): T {
-  return new Proxy({} as T, {
-    get(_, prop) {
-      if (typeof prop === 'string') {
-        return () => notMigrated(`${portName}.${prop}`)
-      }
-      return undefined
-    },
-  })
-}
-
 /**
- * Editor platform ports — Electron IPC bridge implementations.
- *
- * Ports are stubbed with proxy objects that throw descriptive errors
- * when called. Replace each stub with a real implementation as you
- * migrate that vertical slice.
- *
- * Example — migrating CompilerPort:
- *
- *   import { createEditorCompilerAdapter } from './compiler-adapter'
- *   // Then replace the stub below:
- *   compiler: createEditorCompilerAdapter(),
+ * Editor platform ports — all port interfaces wired to Electron IPC bridge.
  */
 export const editorPorts: PlatformPorts = {
   compiler: createEditorCompilerAdapter(),
   runtime: createEditorRuntimeAdapter(() => _runtimeIpAddress),
   debugger: createEditorDebuggerAdapter(() => _debugConnectionConfig),
-  simulator: createStubPort('SimulatorPort'),
+  simulator: createEditorSimulatorAdapter(),
   project: createEditorProjectAdapter(),
   device: createEditorDeviceAdapter(),
   system: createEditorSystemAdapter(),

--- a/src2/adapters/editor/__tests__/simulator-adapter.test.ts
+++ b/src2/adapters/editor/__tests__/simulator-adapter.test.ts
@@ -1,0 +1,215 @@
+import { createEditorSimulatorAdapter } from '../simulator-adapter'
+import type { SimulatorPort } from '../../../providers/platform/ports/simulator-port'
+
+let adapter: SimulatorPort
+let simulatorStoppedCallback: (() => void) | null
+let unsubscribeFromMain: jest.Mock
+
+beforeEach(() => {
+  simulatorStoppedCallback = null
+  unsubscribeFromMain = jest.fn()
+
+  window.bridge = {
+    simulatorLoadFirmware: jest.fn().mockResolvedValue({ success: true }),
+    simulatorStop: jest.fn().mockResolvedValue({ success: true }),
+    simulatorIsRunning: jest.fn().mockResolvedValue(true),
+    onSimulatorStopped: jest.fn().mockImplementation((cb: () => void) => {
+      simulatorStoppedCallback = cb
+      return unsubscribeFromMain
+    }),
+  } as unknown as typeof window.bridge
+
+  adapter = createEditorSimulatorAdapter()
+})
+
+// ---------------------------------------------------------------------------
+// loadFirmware
+// ---------------------------------------------------------------------------
+
+describe('loadFirmware', () => {
+  it('delegates to bridge with hex path', async () => {
+    const result = await adapter.loadFirmware('/path/to/firmware.hex')
+
+    expect(window.bridge.simulatorLoadFirmware).toHaveBeenCalledWith('/path/to/firmware.hex')
+    expect(result).toEqual({ success: true })
+  })
+
+  it('sets running state on success', async () => {
+    expect(adapter.isRunning()).toBe(false)
+
+    await adapter.loadFirmware('/path/to/firmware.hex')
+
+    expect(adapter.isRunning()).toBe(true)
+  })
+
+  it('does not set running state on failure', async () => {
+    ;(window.bridge.simulatorLoadFirmware as jest.Mock).mockResolvedValue({
+      success: false,
+      error: 'Invalid HEX file',
+    })
+
+    const result = await adapter.loadFirmware('/bad/path.hex')
+
+    expect(adapter.isRunning()).toBe(false)
+    expect(result).toEqual({ success: false, error: 'Invalid HEX file' })
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.simulatorLoadFirmware as jest.Mock).mockRejectedValue(new Error('IPC failed'))
+
+    const result = await adapter.loadFirmware('/path/to/firmware.hex')
+
+    expect(result).toEqual({ success: false, error: 'IPC failed' })
+    expect(adapter.isRunning()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// stop
+// ---------------------------------------------------------------------------
+
+describe('stop', () => {
+  it('delegates to bridge', async () => {
+    await adapter.loadFirmware('/path/to/firmware.hex')
+    const result = await adapter.stop()
+
+    expect(window.bridge.simulatorStop).toHaveBeenCalled()
+    expect(result).toEqual({ success: true })
+  })
+
+  it('clears running state', async () => {
+    await adapter.loadFirmware('/path/to/firmware.hex')
+    expect(adapter.isRunning()).toBe(true)
+
+    await adapter.stop()
+    expect(adapter.isRunning()).toBe(false)
+  })
+
+  it('fires stop callbacks', async () => {
+    const cb = jest.fn()
+    adapter.onStopped(cb)
+
+    await adapter.loadFirmware('/path/to/firmware.hex')
+    await adapter.stop()
+
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns success even on bridge error', async () => {
+    ;(window.bridge.simulatorStop as jest.Mock).mockRejectedValue(new Error('IPC error'))
+
+    const result = await adapter.stop()
+
+    expect(result).toEqual({ success: true })
+    expect(adapter.isRunning()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isRunning
+// ---------------------------------------------------------------------------
+
+describe('isRunning', () => {
+  it('returns false initially', () => {
+    expect(adapter.isRunning()).toBe(false)
+  })
+
+  it('returns true after successful load', async () => {
+    await adapter.loadFirmware('/path/to/firmware.hex')
+    expect(adapter.isRunning()).toBe(true)
+  })
+
+  it('returns false after stop', async () => {
+    await adapter.loadFirmware('/path/to/firmware.hex')
+    await adapter.stop()
+    expect(adapter.isRunning()).toBe(false)
+  })
+
+  it('returns false after main process stopped event', async () => {
+    await adapter.loadFirmware('/path/to/firmware.hex')
+    expect(adapter.isRunning()).toBe(true)
+
+    simulatorStoppedCallback?.()
+    expect(adapter.isRunning()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// onStopped
+// ---------------------------------------------------------------------------
+
+describe('onStopped', () => {
+  it('subscribes to main process stopped events', () => {
+    expect(window.bridge.onSimulatorStopped).toHaveBeenCalled()
+  })
+
+  it('fires callback when main process signals stopped', async () => {
+    const cb = jest.fn()
+    adapter.onStopped(cb)
+
+    await adapter.loadFirmware('/path/to/firmware.hex')
+    simulatorStoppedCallback?.()
+
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns unsubscribe function that removes callback', async () => {
+    const cb = jest.fn()
+    const unsub = adapter.onStopped(cb)
+
+    unsub()
+
+    await adapter.loadFirmware('/path/to/firmware.hex')
+    simulatorStoppedCallback?.()
+
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('supports multiple callbacks', async () => {
+    const cb1 = jest.fn()
+    const cb2 = jest.fn()
+    adapter.onStopped(cb1)
+    adapter.onStopped(cb2)
+
+    await adapter.loadFirmware('/path/to/firmware.hex')
+    simulatorStoppedCallback?.()
+
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(cb2).toHaveBeenCalledTimes(1)
+  })
+
+  it('unsubscribes only the targeted callback', async () => {
+    const cb1 = jest.fn()
+    const cb2 = jest.fn()
+    adapter.onStopped(cb1)
+    const unsub2 = adapter.onStopped(cb2)
+
+    unsub2()
+
+    await adapter.loadFirmware('/path/to/firmware.hex')
+    simulatorStoppedCallback?.()
+
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(cb2).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// connectDebugger
+// ---------------------------------------------------------------------------
+
+describe('connectDebugger', () => {
+  it('is a no-op (resolves without calling bridge)', async () => {
+    await expect(adapter.connectDebugger()).resolves.toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// disconnectDebugger
+// ---------------------------------------------------------------------------
+
+describe('disconnectDebugger', () => {
+  it('is a no-op (does not throw)', () => {
+    expect(() => adapter.disconnectDebugger()).not.toThrow()
+  })
+})

--- a/src2/adapters/editor/simulator-adapter.ts
+++ b/src2/adapters/editor/simulator-adapter.ts
@@ -1,0 +1,77 @@
+/**
+ * Editor SimulatorPort adapter — delegates to Electron IPC bridge.
+ *
+ * The main process runs the avr8js ATmega2560 emulator as a singleton.
+ * Firmware is loaded from a .hex file path on disk. The virtual serial port
+ * and ModbusRtuClient are managed internally by the main process.
+ *
+ * Running state is tracked locally for synchronous access (the IPC bridge
+ * method returns a Promise, but the port contract requires a sync boolean).
+ *
+ * connectDebugger/disconnectDebugger are no-ops: the main process automatically
+ * wires the VirtualSerialPort when debuggerConnect is called with 'simulator' type.
+ */
+
+import type { SimulatorPort } from '../../providers/platform/ports/simulator-port'
+import type { Unsubscribe } from '../../providers/platform/ports/types'
+
+export function createEditorSimulatorAdapter(): SimulatorPort {
+  let running = false
+  const stopCallbacks: Array<() => void> = []
+
+  // Subscribe to main process simulator stop events once on creation
+  const unsubscribeFromMain = window.bridge.onSimulatorStopped(() => {
+    running = false
+    for (const cb of stopCallbacks) cb()
+  })
+
+  // Keep the unsubscribe reference to allow cleanup if needed
+  void unsubscribeFromMain
+
+  return {
+    async loadFirmware(hexPath: string): Promise<{ success: boolean; error?: string }> {
+      try {
+        const result = await window.bridge.simulatorLoadFirmware(hexPath)
+        if (result.success) running = true
+        return result
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+
+    async stop(): Promise<{ success: boolean }> {
+      try {
+        const result = await window.bridge.simulatorStop()
+        running = false
+        for (const cb of stopCallbacks) cb()
+        return result
+      } catch {
+        running = false
+        for (const cb of stopCallbacks) cb()
+        return { success: true }
+      }
+    },
+
+    isRunning(): boolean {
+      return running
+    },
+
+    onStopped(callback: () => void): Unsubscribe {
+      stopCallbacks.push(callback)
+      return () => {
+        const idx = stopCallbacks.indexOf(callback)
+        if (idx >= 0) stopCallbacks.splice(idx, 1)
+      }
+    },
+
+    async connectDebugger(): Promise<void> {
+      // No-op for editor: the main process wires the VirtualSerialPort
+      // when debuggerConnect is called with 'simulator' connection type.
+    },
+
+    disconnectDebugger(): void {
+      // No-op for editor: cleanup is handled by the main process
+      // when debuggerDisconnect is called.
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Editor adapter delegates to `window.bridge.simulator*` IPC methods with local running state tracking
- `connectDebugger`/`disconnectDebugger` are no-ops (main process handles VirtualSerialPort wiring)
- Removed stub scaffolding from `editor-platform.ts` — all 10 ports now have real adapters

## Validation Gates
- [x] Architecture validation passes (`npx tsx src2/__architecture__/validate.ts`)
- [x] Unit tests pass with 100% coverage
- [x] Shared files identical between repos

## Step Progress
Step 12 of 30 — Phase: adapters (final adapter step)

Generated with [Claude Code](https://claude.com/claude-code)