### PR TITLE
migrate(step-13): UI state slices

### DIFF
--- a/docs/migration-state.md
+++ b/docs/migration-state.md
@@ -4,11 +4,11 @@ Tracks progress of the shared UI migration. Updated by the `/migrate` skill afte
 
 ## Current Phase
 
-adapters
+store
 
 ## Current Step
 
-12
+13
 
 ## Step Log
 
@@ -27,7 +27,7 @@ adapters
 | 10 | adapters | RuntimePort adapter implementation | done | 2026-03-10 |
 | 11 | adapters | DebuggerPort adapter implementation | done | 2026-03-10 |
 | 12 | adapters | SimulatorPort adapter implementation | done | 2026-03-10 |
-| 13 | store | UI state slices (Workspace, Editor, Tabs, Modal, Search) | pending | |
+| 13 | store | UI state slices (Workspace, Editor, Tabs, Modal, Search) | done | 2026-03-10 |
 | 14 | store | Data state slices (Project, File, Library, Console, Shared) | pending | |
 | 15 | store | Visual editor slices (FBDFlow, LadderFlow) | pending | |
 | 16 | store | Platform state slices (Device, History, web-only) | pending | |

--- a/src2/providers/platform/ports/types.ts
+++ b/src2/providers/platform/ports/types.ts
@@ -272,6 +272,52 @@ export interface DebugCompileResult {
 }
 
 // ---------------------------------------------------------------------------
+// Debugger Tree
+// ---------------------------------------------------------------------------
+
+/** Function Block Instance Info — represents a specific FB instance for debugging */
+export interface FbInstanceInfo {
+  fbTypeName: string
+  programName: string
+  programInstanceName: string
+  fbVariableName: string
+  key: string
+}
+
+/** Debug Tree Node — represents a node in the hierarchical debugger variable tree */
+export interface DebugTreeNode {
+  name: string
+  fullPath: string
+  compositeKey: string
+  type: string
+  isComplex: boolean
+  isExpanded?: boolean
+  children?: DebugTreeNode[]
+  debugIndex?: number
+  arrayIndices?: number[]
+}
+
+// ---------------------------------------------------------------------------
+// PLC Logs
+// ---------------------------------------------------------------------------
+
+/** Union type representing logs from either v3 (string) or v4 (array) runtime */
+export type PlcLogs = string | RuntimeLogEntry[]
+
+/** Maximum number of log entries to keep in the client-side buffer */
+export const LOG_BUFFER_CAP = 1000
+
+/** Type guard to check if logs are in v4 format (array of objects) */
+export function isV4Logs(logs: PlcLogs): logs is RuntimeLogEntry[] {
+  return Array.isArray(logs)
+}
+
+/** Type guard to check if logs are in v3 format (plain string) */
+export function isV3Logs(logs: PlcLogs): logs is string {
+  return typeof logs === 'string'
+}
+
+// ---------------------------------------------------------------------------
 // Console
 // ---------------------------------------------------------------------------
 

--- a/src2/store/__tests__/editor-slice.test.ts
+++ b/src2/store/__tests__/editor-slice.test.ts
@@ -1,0 +1,1190 @@
+import { createStore } from 'zustand/vanilla'
+
+import { createEditorSlice } from '../slices/editor/slice'
+import type { EditorModel, EditorSlice } from '../slices/editor/types'
+
+function makeStore() {
+  return createStore<EditorSlice>()(createEditorSlice)
+}
+
+// Helpers to create editor models
+function makeTextualEditor(name: string, overrides?: Partial<{ language: 'il' | 'st' | 'python' | 'cpp'; pouType: 'program' | 'function' | 'function-block' }>): EditorModel {
+  return {
+    type: 'plc-textual',
+    meta: {
+      name,
+      path: `/data/pous/program/st/${name}`,
+      language: overrides?.language ?? 'st',
+      pouType: overrides?.pouType ?? 'program',
+    },
+    variable: { display: 'table', description: '', classFilter: 'All', selectedRow: '-1' },
+  }
+}
+
+function makeGraphicalEditor(name: string, language: 'ld' | 'sfc' | 'fbd' = 'ld'): EditorModel {
+  const base = {
+    type: 'plc-graphical' as const,
+    meta: {
+      name,
+      path: `/data/pous/program/${language}/${name}`,
+      language,
+      pouType: 'program' as const,
+    },
+    variable: { display: 'table' as const, description: '', classFilter: 'All' as const, selectedRow: '-1' },
+  }
+  if (language === 'ld') {
+    return { ...base, graphical: { language: 'ld', openedRungs: [] } }
+  }
+  if (language === 'fbd') {
+    return { ...base, graphical: { language: 'fbd', hoveringElement: { elementId: null, hovering: false }, canEditorZoom: true, canEditorPan: true } }
+  }
+  return { ...base, graphical: { language: 'sfc' } }
+}
+
+function makeResourceEditor(name = 'Resource'): EditorModel {
+  return {
+    type: 'plc-resource',
+    meta: { name, path: '/data/configuration/resource' },
+    variable: { display: 'table', description: '', selectedRow: '-1' },
+    task: { display: 'table', selectedRow: '-1' },
+    instance: { display: 'table', selectedRow: '-1' },
+  }
+}
+
+function makeDatatypeEditor(name: string): EditorModel {
+  return {
+    type: 'plc-datatype',
+    meta: { name, derivation: 'structure' },
+    structure: { selectedRow: '-1', description: '' },
+  }
+}
+
+describe('createEditorSlice', () => {
+  let store: ReturnType<typeof makeStore>
+
+  beforeEach(() => {
+    store = makeStore()
+  })
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+  it('should have correct initial state', () => {
+    const state = store.getState()
+    expect(state.editors).toEqual([])
+    expect(state.editor).toEqual({ type: 'available', meta: { name: 'available' } })
+    expect(state.isMonacoFocused).toBe(false)
+  })
+
+  // -------------------------------------------------------------------------
+  // addModel
+  // -------------------------------------------------------------------------
+  it('addModel adds a new editor to editors array', () => {
+    const editor = makeTextualEditor('Main')
+    store.getState().editorActions.addModel(editor)
+    expect(store.getState().editors).toHaveLength(1)
+    expect(store.getState().editors[0].meta.name).toBe('Main')
+  })
+
+  it('addModel does not add duplicate', () => {
+    const editor = makeTextualEditor('Main')
+    store.getState().editorActions.addModel(editor)
+    store.getState().editorActions.addModel(editor)
+    expect(store.getState().editors).toHaveLength(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // removeModel
+  // -------------------------------------------------------------------------
+  it('removeModel removes an editor by name', () => {
+    store.getState().editorActions.addModel(makeTextualEditor('Main'))
+    store.getState().editorActions.addModel(makeTextualEditor('Helper'))
+    store.getState().editorActions.removeModel('Main')
+    expect(store.getState().editors).toHaveLength(1)
+    expect(store.getState().editors[0].meta.name).toBe('Helper')
+  })
+
+  // -------------------------------------------------------------------------
+  // updateModelVariables
+  // -------------------------------------------------------------------------
+  describe('updateModelVariables', () => {
+    it('updates table variables for plc-resource editor', () => {
+      const resource = makeResourceEditor()
+      store.getState().editorActions.addModel(resource)
+      store.getState().editorActions.setEditor(resource)
+
+      store.getState().editorActions.updateModelVariables({
+        display: 'table',
+        selectedRow: 3,
+        description: 'desc',
+      })
+
+      const editor = store.getState().editor
+      expect(editor.type).toBe('plc-resource')
+      if (editor.type === 'plc-resource') {
+        expect(editor.variable).toEqual({ display: 'table', selectedRow: '3', description: 'desc' })
+      }
+    })
+
+    it('updates code variables for plc-resource editor', () => {
+      const resource = makeResourceEditor()
+      store.getState().editorActions.addModel(resource)
+      store.getState().editorActions.setEditor(resource)
+
+      store.getState().editorActions.updateModelVariables({
+        display: 'code',
+        code: 'VAR x: INT; END_VAR',
+      })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-resource') {
+        expect(editor.variable).toEqual({ display: 'code', code: 'VAR x: INT; END_VAR' })
+      }
+    })
+
+    it('preserves existing code when switching to code display without new code (plc-resource)', () => {
+      const resource = makeResourceEditor()
+      store.getState().editorActions.addModel(resource)
+      store.getState().editorActions.setEditor(resource)
+
+      store.getState().editorActions.updateModelVariables({ display: 'code', code: 'existing code' })
+      store.getState().editorActions.updateModelVariables({ display: 'code' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-resource') {
+        expect(editor.variable).toEqual({ display: 'code', code: 'existing code' })
+      }
+    })
+
+    it('sets code to undefined when switching from table to code without code value (plc-resource)', () => {
+      const resource = makeResourceEditor()
+      store.getState().editorActions.addModel(resource)
+      store.getState().editorActions.setEditor(resource)
+
+      store.getState().editorActions.updateModelVariables({ display: 'code' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-resource') {
+        expect(editor.variable).toEqual({ display: 'code', code: undefined })
+      }
+    })
+
+    it('uses default selectedRow and description for plc-resource table when not provided', () => {
+      const resource = makeResourceEditor()
+      store.getState().editorActions.addModel(resource)
+      store.getState().editorActions.setEditor(resource)
+
+      store.getState().editorActions.updateModelVariables({ display: 'table' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-resource') {
+        expect(editor.variable).toEqual({ display: 'table', selectedRow: '-1', description: '' })
+      }
+    })
+
+    it('updates table variables for plc-textual editor', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariables({
+        display: 'table',
+        selectedRow: 2,
+        classFilter: 'Input',
+        description: 'my desc',
+      })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-textual') {
+        expect(editor.variable).toEqual({
+          display: 'table',
+          selectedRow: '2',
+          classFilter: 'Input',
+          description: 'my desc',
+        })
+      }
+    })
+
+    it('updates code variables for plc-textual editor', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariables({ display: 'code', code: 'my code' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-textual') {
+        expect(editor.variable).toEqual({ display: 'code', code: 'my code' })
+      }
+    })
+
+    it('preserves existing code for plc-textual when no code provided', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariables({ display: 'code', code: 'saved code' })
+      store.getState().editorActions.updateModelVariables({ display: 'code' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-textual') {
+        expect(editor.variable).toEqual({ display: 'code', code: 'saved code' })
+      }
+    })
+
+    it('sets code to undefined when no existing code on plc-textual', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariables({ display: 'code' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-textual') {
+        expect(editor.variable).toEqual({ display: 'code', code: undefined })
+      }
+    })
+
+    it('uses defaults for table when selectedRow/classFilter/description not provided (plc-textual)', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariables({ display: 'table' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-textual') {
+        expect(editor.variable).toEqual({
+          display: 'table',
+          selectedRow: '-1',
+          classFilter: 'All',
+          description: '',
+        })
+      }
+    })
+
+    it('updates table variables for plc-graphical editor', () => {
+      const graphical = makeGraphicalEditor('Main', 'ld')
+      store.getState().editorActions.addModel(graphical)
+      store.getState().editorActions.setEditor(graphical)
+
+      store.getState().editorActions.updateModelVariables({
+        display: 'table',
+        selectedRow: 5,
+        classFilter: 'Output',
+        description: 'graphical desc',
+      })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-graphical') {
+        expect(editor.variable).toEqual({
+          display: 'table',
+          selectedRow: '5',
+          classFilter: 'Output',
+          description: 'graphical desc',
+        })
+      }
+    })
+
+    it('does nothing for available editor type', () => {
+      store.getState().editorActions.updateModelVariables({ display: 'table', selectedRow: 1 })
+      expect(store.getState().editor.type).toBe('available')
+    })
+
+    it('switches plc-resource from code to table, using defaults for prev code display', () => {
+      const resource = makeResourceEditor()
+      store.getState().editorActions.addModel(resource)
+      store.getState().editorActions.setEditor(resource)
+
+      // First switch to code display
+      store.getState().editorActions.updateModelVariables({ display: 'code', code: 'some code' })
+      // Now switch back to table -- prevSelectedRow/prevDescription come from else branches
+      store.getState().editorActions.updateModelVariables({ display: 'table' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-resource' && editor.variable.display === 'table') {
+        expect(editor.variable.selectedRow).toBe('-1')
+        expect(editor.variable.description).toBe('')
+      }
+    })
+
+    it('switches plc-textual from code to table, using defaults for prev code display', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      // First switch to code display
+      store.getState().editorActions.updateModelVariables({ display: 'code', code: 'some code' })
+      // Now switch back to table
+      store.getState().editorActions.updateModelVariables({ display: 'table' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-textual' && editor.variable.display === 'table') {
+        expect(editor.variable.selectedRow).toBe('-1')
+        expect(editor.variable.classFilter).toBe('All')
+        expect(editor.variable.description).toBe('')
+      }
+    })
+
+    it('switches plc-graphical from code to table, using defaults for prev code display', () => {
+      const graphical = makeGraphicalEditor('Main', 'ld')
+      store.getState().editorActions.addModel(graphical)
+      store.getState().editorActions.setEditor(graphical)
+
+      store.getState().editorActions.updateModelVariables({ display: 'code', code: 'some code' })
+      store.getState().editorActions.updateModelVariables({ display: 'table' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-graphical' && editor.variable.display === 'table') {
+        expect(editor.variable.selectedRow).toBe('-1')
+        expect(editor.variable.classFilter).toBe('All')
+        expect(editor.variable.description).toBe('')
+      }
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // updateModelVariablesForName
+  // -------------------------------------------------------------------------
+  describe('updateModelVariablesForName', () => {
+    it('updates the active editor when name matches', () => {
+      const resource = makeResourceEditor('Res')
+      store.getState().editorActions.addModel(resource)
+      store.getState().editorActions.setEditor(resource)
+
+      store.getState().editorActions.updateModelVariablesForName('Res', {
+        display: 'table',
+        selectedRow: 1,
+        description: 'updated',
+      })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-resource') {
+        expect(editor.variable.display).toBe('table')
+        if (editor.variable.display === 'table') {
+          expect(editor.variable.description).toBe('updated')
+        }
+      }
+    })
+
+    it('updates an editor in the editors array when name does not match current editor', () => {
+      const res = makeResourceEditor('Res')
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(res)
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariablesForName('Res', {
+        display: 'table',
+        selectedRow: 7,
+        description: 'indirect',
+      })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'Res')
+      expect(target).toBeDefined()
+      if (target?.type === 'plc-resource' && target.variable.display === 'table') {
+        expect(target.variable.selectedRow).toBe('7')
+      }
+    })
+
+    it('does nothing when name not found', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariablesForName('NonExistent', { display: 'table', selectedRow: 1 })
+      expect(store.getState().editors).toHaveLength(1)
+    })
+
+    it('updates code for plc-resource target in editors array', () => {
+      const res = makeResourceEditor('Res')
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(res)
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariablesForName('Res', { display: 'code', code: 'new code' })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'Res')
+      if (target?.type === 'plc-resource') {
+        expect(target.variable).toEqual({ display: 'code', code: 'new code' })
+      }
+    })
+
+    it('preserves existing code for plc-resource when no code provided', () => {
+      const res = makeResourceEditor('Res')
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(res)
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariablesForName('Res', { display: 'code', code: 'saved' })
+      store.getState().editorActions.updateModelVariablesForName('Res', { display: 'code' })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'Res')
+      if (target?.type === 'plc-resource') {
+        expect(target.variable).toEqual({ display: 'code', code: 'saved' })
+      }
+    })
+
+    it('uses defaults for plc-resource table when not provided', () => {
+      const res = makeResourceEditor('Res')
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(res)
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariablesForName('Res', { display: 'table' })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'Res')
+      if (target?.type === 'plc-resource' && target.variable.display === 'table') {
+        expect(target.variable.selectedRow).toBe('-1')
+        expect(target.variable.description).toBe('')
+      }
+    })
+
+    it('updates plc-textual target with table data', () => {
+      const textual1 = makeTextualEditor('Prog1')
+      const textual2 = makeTextualEditor('Prog2')
+      store.getState().editorActions.addModel(textual1)
+      store.getState().editorActions.addModel(textual2)
+      store.getState().editorActions.setEditor(textual1)
+
+      store.getState().editorActions.updateModelVariablesForName('Prog2', {
+        display: 'table',
+        selectedRow: 3,
+        classFilter: 'Local',
+        description: 'textual desc',
+      })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'Prog2')
+      if (target?.type === 'plc-textual' && target.variable.display === 'table') {
+        expect(target.variable.selectedRow).toBe('3')
+        expect(target.variable.classFilter).toBe('Local')
+        expect(target.variable.description).toBe('textual desc')
+      }
+    })
+
+    it('updates plc-textual target with code data', () => {
+      const textual1 = makeTextualEditor('Prog1')
+      const textual2 = makeTextualEditor('Prog2')
+      store.getState().editorActions.addModel(textual1)
+      store.getState().editorActions.addModel(textual2)
+      store.getState().editorActions.setEditor(textual1)
+
+      store.getState().editorActions.updateModelVariablesForName('Prog2', { display: 'code', code: 'the code' })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'Prog2')
+      if (target?.type === 'plc-textual') {
+        expect(target.variable).toEqual({ display: 'code', code: 'the code' })
+      }
+    })
+
+    it('preserves existing code for plc-textual when no code provided', () => {
+      const textual1 = makeTextualEditor('Prog1')
+      const textual2 = makeTextualEditor('Prog2')
+      store.getState().editorActions.addModel(textual1)
+      store.getState().editorActions.addModel(textual2)
+      store.getState().editorActions.setEditor(textual1)
+
+      store.getState().editorActions.updateModelVariablesForName('Prog2', { display: 'code', code: 'saved' })
+      store.getState().editorActions.updateModelVariablesForName('Prog2', { display: 'code' })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'Prog2')
+      if (target?.type === 'plc-textual') {
+        expect(target.variable).toEqual({ display: 'code', code: 'saved' })
+      }
+    })
+
+    it('uses defaults for plc-textual/plc-graphical table when not provided', () => {
+      const graphical = makeGraphicalEditor('Graph', 'ld')
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(graphical)
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariablesForName('Graph', { display: 'table' })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'Graph')
+      if (target?.type === 'plc-graphical' && target.variable.display === 'table') {
+        expect(target.variable.selectedRow).toBe('-1')
+        expect(target.variable.classFilter).toBe('All')
+        expect(target.variable.description).toBe('')
+      }
+    })
+
+    it('updates plc-graphical target with code data', () => {
+      const graphical = makeGraphicalEditor('Graph', 'ld')
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(graphical)
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariablesForName('Graph', { display: 'code', code: 'graphical code' })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'Graph')
+      if (target?.type === 'plc-graphical') {
+        expect(target.variable).toEqual({ display: 'code', code: 'graphical code' })
+      }
+    })
+
+    it('preserves existing code for plc-graphical when no code provided', () => {
+      const graphical = makeGraphicalEditor('Graph', 'ld')
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(graphical)
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariablesForName('Graph', { display: 'code', code: 'saved' })
+      store.getState().editorActions.updateModelVariablesForName('Graph', { display: 'code' })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'Graph')
+      if (target?.type === 'plc-graphical') {
+        expect(target.variable).toEqual({ display: 'code', code: 'saved' })
+      }
+    })
+
+    it('switches plc-resource target from code to table in editors array', () => {
+      const res = makeResourceEditor('Res')
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(res)
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      // Switch to code first
+      store.getState().editorActions.updateModelVariablesForName('Res', { display: 'code', code: 'code' })
+      // Switch back to table
+      store.getState().editorActions.updateModelVariablesForName('Res', { display: 'table' })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'Res')
+      if (target?.type === 'plc-resource' && target.variable.display === 'table') {
+        expect(target.variable.selectedRow).toBe('-1')
+        expect(target.variable.description).toBe('')
+      }
+    })
+
+    it('switches plc-textual target from code to table in editors array', () => {
+      const textual1 = makeTextualEditor('Prog1')
+      const textual2 = makeTextualEditor('Prog2')
+      store.getState().editorActions.addModel(textual1)
+      store.getState().editorActions.addModel(textual2)
+      store.getState().editorActions.setEditor(textual1)
+
+      store.getState().editorActions.updateModelVariablesForName('Prog2', { display: 'code', code: 'code' })
+      store.getState().editorActions.updateModelVariablesForName('Prog2', { display: 'table' })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'Prog2')
+      if (target?.type === 'plc-textual' && target.variable.display === 'table') {
+        expect(target.variable.selectedRow).toBe('-1')
+        expect(target.variable.classFilter).toBe('All')
+        expect(target.variable.description).toBe('')
+      }
+    })
+
+    it('switches plc-graphical target from code to table in editors array', () => {
+      const graphical = makeGraphicalEditor('Graph', 'ld')
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(graphical)
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariablesForName('Graph', { display: 'code', code: 'code' })
+      store.getState().editorActions.updateModelVariablesForName('Graph', { display: 'table' })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'Graph')
+      if (target?.type === 'plc-graphical' && target.variable.display === 'table') {
+        expect(target.variable.selectedRow).toBe('-1')
+        expect(target.variable.classFilter).toBe('All')
+        expect(target.variable.description).toBe('')
+      }
+    })
+
+    it('skips non-matching editor types (e.g., plc-device, plc-datatype)', () => {
+      const datatype = makeDatatypeEditor('MyType')
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(datatype)
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelVariablesForName('MyType', { display: 'table', selectedRow: 1 })
+
+      const target = store.getState().editors.find((e) => e.meta.name === 'MyType')
+      if (target?.type === 'plc-datatype') {
+        expect(target.structure.selectedRow).toBe('-1')
+      }
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // updateModelTasks
+  // -------------------------------------------------------------------------
+  describe('updateModelTasks', () => {
+    it('updates task to table display with selectedRow', () => {
+      const resource = makeResourceEditor()
+      store.getState().editorActions.addModel(resource)
+      store.getState().editorActions.setEditor(resource)
+
+      store.getState().editorActions.updateModelTasks({ display: 'table', selectedRow: 2 })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-resource') {
+        expect(editor.task).toEqual({ display: 'table', selectedRow: '2' })
+      }
+    })
+
+    it('updates task to table display with default selectedRow when undefined', () => {
+      const resource = makeResourceEditor()
+      store.getState().editorActions.addModel(resource)
+      store.getState().editorActions.setEditor(resource)
+
+      store.getState().editorActions.updateModelTasks({ display: 'table' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-resource') {
+        expect(editor.task).toEqual({ display: 'table', selectedRow: '-1' })
+      }
+    })
+
+    it('updates task to code display', () => {
+      const resource = makeResourceEditor()
+      store.getState().editorActions.addModel(resource)
+      store.getState().editorActions.setEditor(resource)
+
+      store.getState().editorActions.updateModelTasks({ display: 'code' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-resource') {
+        expect(editor.task).toEqual({ display: 'code' })
+      }
+    })
+
+    it('does nothing for non-resource editor', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelTasks({ display: 'table', selectedRow: 1 })
+      expect(store.getState().editor.type).toBe('plc-textual')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // updateModelInstances
+  // -------------------------------------------------------------------------
+  describe('updateModelInstances', () => {
+    it('updates instance to table display with selectedRow', () => {
+      const resource = makeResourceEditor()
+      store.getState().editorActions.addModel(resource)
+      store.getState().editorActions.setEditor(resource)
+
+      store.getState().editorActions.updateModelInstances({ display: 'table', selectedRow: 4 })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-resource') {
+        expect(editor.instance).toEqual({ display: 'table', selectedRow: '4' })
+      }
+    })
+
+    it('updates instance to table display with default selectedRow', () => {
+      const resource = makeResourceEditor()
+      store.getState().editorActions.addModel(resource)
+      store.getState().editorActions.setEditor(resource)
+
+      store.getState().editorActions.updateModelInstances({ display: 'table' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-resource') {
+        expect(editor.instance).toEqual({ display: 'table', selectedRow: '-1' })
+      }
+    })
+
+    it('updates instance to code display', () => {
+      const resource = makeResourceEditor()
+      store.getState().editorActions.addModel(resource)
+      store.getState().editorActions.setEditor(resource)
+
+      store.getState().editorActions.updateModelInstances({ display: 'code' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-resource') {
+        expect(editor.instance).toEqual({ display: 'code' })
+      }
+    })
+
+    it('does nothing for non-resource editor', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelInstances({ display: 'table', selectedRow: 1 })
+      expect(store.getState().editor.type).toBe('plc-textual')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // updateModelStructure
+  // -------------------------------------------------------------------------
+  describe('updateModelStructure', () => {
+    it('updates structure selectedRow and description', () => {
+      const datatype = makeDatatypeEditor('MyStruct')
+      store.getState().editorActions.addModel(datatype)
+      store.getState().editorActions.setEditor(datatype)
+
+      store.getState().editorActions.updateModelStructure({ selectedRow: 3, description: 'my desc' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-datatype') {
+        expect(editor.structure).toEqual({ selectedRow: '3', description: 'my desc' })
+      }
+    })
+
+    it('keeps existing selectedRow when undefined', () => {
+      const datatype = makeDatatypeEditor('MyStruct')
+      store.getState().editorActions.addModel(datatype)
+      store.getState().editorActions.setEditor(datatype)
+
+      store.getState().editorActions.updateModelStructure({ selectedRow: 5 })
+      store.getState().editorActions.updateModelStructure({ description: 'updated' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-datatype') {
+        expect(editor.structure).toEqual({ selectedRow: '5', description: 'updated' })
+      }
+    })
+
+    it('keeps existing description when empty string is provided', () => {
+      const datatype = makeDatatypeEditor('MyStruct')
+      store.getState().editorActions.addModel(datatype)
+      store.getState().editorActions.setEditor(datatype)
+
+      store.getState().editorActions.updateModelStructure({ description: 'orig' })
+      store.getState().editorActions.updateModelStructure({ description: '' })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-datatype') {
+        // empty string is falsy, so it keeps the old description
+        expect(editor.structure.description).toBe('orig')
+      }
+    })
+
+    it('does nothing for non-datatype editor', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelStructure({ selectedRow: 1, description: 'test' })
+      expect(store.getState().editor.type).toBe('plc-textual')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // updateModelLadder
+  // -------------------------------------------------------------------------
+  describe('updateModelLadder', () => {
+    it('adds a new rung when not found', () => {
+      const ld = makeGraphicalEditor('LdProg', 'ld')
+      store.getState().editorActions.addModel(ld)
+      store.getState().editorActions.setEditor(ld)
+
+      store.getState().editorActions.updateModelLadder({ openRung: { rungId: 'r1', open: true } })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-graphical' && editor.graphical.language === 'ld') {
+        expect(editor.graphical.openedRungs).toEqual([{ rungId: 'r1', open: true }])
+      }
+    })
+
+    it('updates an existing rung', () => {
+      const ld = makeGraphicalEditor('LdProg', 'ld')
+      store.getState().editorActions.addModel(ld)
+      store.getState().editorActions.setEditor(ld)
+
+      store.getState().editorActions.updateModelLadder({ openRung: { rungId: 'r1', open: true } })
+      store.getState().editorActions.updateModelLadder({ openRung: { rungId: 'r1', open: false } })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-graphical' && editor.graphical.language === 'ld') {
+        expect(editor.graphical.openedRungs).toEqual([{ rungId: 'r1', open: false }])
+      }
+    })
+
+    it('updates one rung while preserving others in the map', () => {
+      const ld = makeGraphicalEditor('LdProg', 'ld')
+      store.getState().editorActions.addModel(ld)
+      store.getState().editorActions.setEditor(ld)
+
+      store.getState().editorActions.updateModelLadder({ openRung: { rungId: 'r1', open: true } })
+      store.getState().editorActions.updateModelLadder({ openRung: { rungId: 'r2', open: true } })
+      // Update r1 while r2 stays the same (hits the else branch of the ternary in map)
+      store.getState().editorActions.updateModelLadder({ openRung: { rungId: 'r1', open: false } })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-graphical' && editor.graphical.language === 'ld') {
+        expect(editor.graphical.openedRungs).toEqual([
+          { rungId: 'r1', open: false },
+          { rungId: 'r2', open: true },
+        ])
+      }
+    })
+
+    it('does nothing when openRung is undefined', () => {
+      const ld = makeGraphicalEditor('LdProg', 'ld')
+      store.getState().editorActions.addModel(ld)
+      store.getState().editorActions.setEditor(ld)
+
+      store.getState().editorActions.updateModelLadder({})
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-graphical' && editor.graphical.language === 'ld') {
+        expect(editor.graphical.openedRungs).toEqual([])
+      }
+    })
+
+    it('does nothing for non-ld graphical editor', () => {
+      const fbd = makeGraphicalEditor('FbdProg', 'fbd')
+      store.getState().editorActions.addModel(fbd)
+      store.getState().editorActions.setEditor(fbd)
+
+      store.getState().editorActions.updateModelLadder({ openRung: { rungId: 'r1', open: true } })
+      const editor = store.getState().editor
+      if (editor.type === 'plc-graphical' && editor.graphical.language === 'fbd') {
+        expect(editor.graphical).not.toHaveProperty('openedRungs')
+      }
+    })
+
+    it('does nothing for non-graphical editor', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateModelLadder({ openRung: { rungId: 'r1', open: true } })
+      expect(store.getState().editor.type).toBe('plc-textual')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // getIsRungOpen
+  // -------------------------------------------------------------------------
+  describe('getIsRungOpen', () => {
+    it('returns true by default when rung not found', () => {
+      const ld = makeGraphicalEditor('LdProg', 'ld')
+      store.getState().editorActions.addModel(ld)
+      store.getState().editorActions.setEditor(ld)
+
+      expect(store.getState().editorActions.getIsRungOpen({ rungId: 'nonexistent' })).toBe(true)
+    })
+
+    it('returns the open state of a found rung', () => {
+      const ld = makeGraphicalEditor('LdProg', 'ld')
+      store.getState().editorActions.addModel(ld)
+      store.getState().editorActions.setEditor(ld)
+
+      store.getState().editorActions.updateModelLadder({ openRung: { rungId: 'r1', open: false } })
+      expect(store.getState().editorActions.getIsRungOpen({ rungId: 'r1' })).toBe(false)
+    })
+
+    it('returns true for non-ld editor', () => {
+      const fbd = makeGraphicalEditor('FbdProg', 'fbd')
+      store.getState().editorActions.addModel(fbd)
+      store.getState().editorActions.setEditor(fbd)
+
+      expect(store.getState().editorActions.getIsRungOpen({ rungId: 'r1' })).toBe(true)
+    })
+
+    it('returns true for non-graphical editor', () => {
+      expect(store.getState().editorActions.getIsRungOpen({ rungId: 'r1' })).toBe(true)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // updateModelFBD
+  // -------------------------------------------------------------------------
+  describe('updateModelFBD', () => {
+    it('updates hoveringElement', () => {
+      const fbd = makeGraphicalEditor('FbdProg', 'fbd')
+      store.getState().editorActions.addModel(fbd)
+      store.getState().editorActions.setEditor(fbd)
+
+      store.getState().editorActions.updateModelFBD({
+        hoveringElement: { elementId: 'elem1', hovering: true },
+      })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-graphical' && editor.graphical.language === 'fbd') {
+        expect(editor.graphical.hoveringElement).toEqual({ elementId: 'elem1', hovering: true })
+      }
+    })
+
+    it('updates canEditorZoom and canEditorPan', () => {
+      const fbd = makeGraphicalEditor('FbdProg', 'fbd')
+      store.getState().editorActions.addModel(fbd)
+      store.getState().editorActions.setEditor(fbd)
+
+      store.getState().editorActions.updateModelFBD({ canEditorZoom: false, canEditorPan: false })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-graphical' && editor.graphical.language === 'fbd') {
+        expect(editor.graphical.canEditorZoom).toBe(false)
+        expect(editor.graphical.canEditorPan).toBe(false)
+      }
+    })
+
+    it('does nothing for non-fbd graphical editor', () => {
+      const ld = makeGraphicalEditor('LdProg', 'ld')
+      store.getState().editorActions.addModel(ld)
+      store.getState().editorActions.setEditor(ld)
+
+      store.getState().editorActions.updateModelFBD({ canEditorZoom: false })
+      const editor = store.getState().editor
+      if (editor.type === 'plc-graphical' && editor.graphical.language === 'ld') {
+        expect(editor.graphical).not.toHaveProperty('canEditorZoom')
+      }
+    })
+
+    it('does nothing for non-graphical editor', () => {
+      store.getState().editorActions.updateModelFBD({ canEditorZoom: false })
+      expect(store.getState().editor.type).toBe('available')
+    })
+
+    it('does not update hoveringElement when not provided', () => {
+      const fbd = makeGraphicalEditor('FbdProg', 'fbd')
+      store.getState().editorActions.addModel(fbd)
+      store.getState().editorActions.setEditor(fbd)
+
+      store.getState().editorActions.updateModelFBD({ canEditorZoom: false })
+
+      const editor = store.getState().editor
+      if (editor.type === 'plc-graphical' && editor.graphical.language === 'fbd') {
+        expect(editor.graphical.hoveringElement).toEqual({ elementId: null, hovering: false })
+      }
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // updateEditorModel
+  // -------------------------------------------------------------------------
+  describe('updateEditorModel', () => {
+    it('renames editor in editors array and current editor', () => {
+      const textual = makeTextualEditor('OldName')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateEditorModel('OldName', 'NewName')
+
+      expect(store.getState().editors[0].meta.name).toBe('NewName')
+      expect(store.getState().editor.meta.name).toBe('NewName')
+    })
+
+    it('does nothing when currentEditor equals newEditor', () => {
+      const textual = makeTextualEditor('Same')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateEditorModel('Same', 'Same')
+      expect(store.getState().editor.meta.name).toBe('Same')
+    })
+
+    it('does nothing when editor not found in editors array', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateEditorModel('NonExistent', 'NewName')
+      expect(store.getState().editors[0].meta.name).toBe('Main')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // updateEditorName
+  // -------------------------------------------------------------------------
+  describe('updateEditorName', () => {
+    it('renames editor in editors array and current editor', () => {
+      const textual = makeTextualEditor('OldName')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateEditorName('OldName', 'NewName')
+
+      expect(store.getState().editors[0].meta.name).toBe('NewName')
+      expect(store.getState().editor.meta.name).toBe('NewName')
+    })
+
+    it('does nothing when oldName equals newName', () => {
+      const textual = makeTextualEditor('Same')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateEditorName('Same', 'Same')
+      expect(store.getState().editor.meta.name).toBe('Same')
+    })
+
+    it('renames only in editors array when current editor has different name', () => {
+      const first = makeTextualEditor('First')
+      const second = makeTextualEditor('Second')
+      store.getState().editorActions.addModel(first)
+      store.getState().editorActions.addModel(second)
+      store.getState().editorActions.setEditor(first)
+
+      store.getState().editorActions.updateEditorName('Second', 'Renamed')
+
+      expect(store.getState().editor.meta.name).toBe('First')
+      const renamed = store.getState().editors.find((e) => e.meta.name === 'Renamed')
+      expect(renamed).toBeDefined()
+    })
+
+    it('does nothing when editor name not found in editors array and not current', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.updateEditorName('NonExistent', 'NewName')
+      expect(store.getState().editors[0].meta.name).toBe('Main')
+      expect(store.getState().editor.meta.name).toBe('Main')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // setEditor
+  // -------------------------------------------------------------------------
+  describe('setEditor', () => {
+    it('sets a new editor and does not push old available editor to editors', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      expect(store.getState().editor.meta.name).toBe('Main')
+      // The initial 'available' editor should not be saved to editors
+      expect(store.getState().editors).toHaveLength(1)
+    })
+
+    it('swaps current editor back into editors array when switching', () => {
+      const first = makeTextualEditor('First')
+      const second = makeTextualEditor('Second')
+      store.getState().editorActions.addModel(first)
+      store.getState().editorActions.addModel(second)
+      store.getState().editorActions.setEditor(first)
+
+      // Now switch to second editor
+      store.getState().editorActions.setEditor(second)
+      expect(store.getState().editor.meta.name).toBe('Second')
+
+      // First should be stored back in the editors array
+      const firstInEditors = store.getState().editors.find((e) => e.meta.name === 'First')
+      expect(firstInEditors).toBeDefined()
+    })
+
+    it('does nothing when setting the same editor', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      const prevState = store.getState()
+      store.getState().editorActions.setEditor(makeTextualEditor('Main'))
+      // Same name means no-op; state should remain unchanged
+      expect(store.getState().editor.meta.name).toBe(prevState.editor.meta.name)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // clearEditor
+  // -------------------------------------------------------------------------
+  it('clearEditor resets editors array and current editor', () => {
+    store.getState().editorActions.addModel(makeTextualEditor('Main'))
+    store.getState().editorActions.setEditor(makeTextualEditor('Main'))
+    store.getState().editorActions.clearEditor()
+
+    expect(store.getState().editors).toEqual([])
+    expect(store.getState().editor).toEqual({ type: 'available', meta: { name: 'available' } })
+  })
+
+  // -------------------------------------------------------------------------
+  // saveEditorViewState
+  // -------------------------------------------------------------------------
+  describe('saveEditorViewState', () => {
+    it('saves cursor, scroll, and fbd positions', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      const cursor = { lineNumber: 10, column: 5, offset: 100 }
+      const scroll = { top: 200, left: 0 }
+      const fbdPos = { x: 50, y: 50, zoom: 1.5 }
+
+      store.getState().editorActions.saveEditorViewState({
+        prevEditorName: 'Main',
+        cursorPosition: cursor,
+        scrollPosition: scroll,
+        fbdPosition: fbdPos,
+      })
+
+      const model = store.getState().editors.find((e) => e.meta.name === 'Main')
+      expect(model?.cursorPosition).toEqual(cursor)
+      expect(model?.scrollPosition).toEqual(scroll)
+      expect(model?.fbdPosition).toEqual(fbdPos)
+    })
+
+    it('does nothing when editor is available type', () => {
+      // Editor is 'available' by default
+      store.getState().editorActions.saveEditorViewState({
+        prevEditorName: 'available',
+        cursorPosition: { lineNumber: 1, column: 1, offset: 0 },
+      })
+      expect(store.getState().editors).toEqual([])
+    })
+
+    it('does nothing when prevEditorName not found in editors', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      store.getState().editorActions.saveEditorViewState({
+        prevEditorName: 'NonExistent',
+        cursorPosition: { lineNumber: 1, column: 1, offset: 0 },
+      })
+
+      const model = store.getState().editors.find((e) => e.meta.name === 'Main')
+      expect(model?.cursorPosition).toBeUndefined()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // getEditorFromEditors
+  // -------------------------------------------------------------------------
+  describe('getEditorFromEditors', () => {
+    it('returns the current editor when name matches', () => {
+      const textual = makeTextualEditor('Main')
+      store.getState().editorActions.addModel(textual)
+      store.getState().editorActions.setEditor(textual)
+
+      const result = store.getState().editorActions.getEditorFromEditors('Main')
+      expect(result?.meta.name).toBe('Main')
+    })
+
+    it('returns editor from editors array when not current', () => {
+      const first = makeTextualEditor('First')
+      const second = makeTextualEditor('Second')
+      store.getState().editorActions.addModel(first)
+      store.getState().editorActions.addModel(second)
+      store.getState().editorActions.setEditor(first)
+
+      const result = store.getState().editorActions.getEditorFromEditors('Second')
+      expect(result?.meta.name).toBe('Second')
+    })
+
+    it('returns null when editor not found', () => {
+      const result = store.getState().editorActions.getEditorFromEditors('NonExistent')
+      expect(result).toBeNull()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // setMonacoFocused
+  // -------------------------------------------------------------------------
+  it('setMonacoFocused', () => {
+    store.getState().editorActions.setMonacoFocused(true)
+    expect(store.getState().isMonacoFocused).toBe(true)
+
+    store.getState().editorActions.setMonacoFocused(false)
+    expect(store.getState().isMonacoFocused).toBe(false)
+  })
+})

--- a/src2/store/__tests__/modal-slice.test.ts
+++ b/src2/store/__tests__/modal-slice.test.ts
@@ -1,0 +1,129 @@
+import { createStore } from 'zustand/vanilla'
+
+import { createModalSlice } from '../slices/modal/slice'
+import type { ModalSlice, ModalTypes } from '../slices/modal/types'
+
+function makeStore() {
+  return createStore<ModalSlice>()(createModalSlice)
+}
+
+const ALL_MODAL_TYPES: ModalTypes[] = [
+  'ai-consent',
+  'block-ladder-element',
+  'coil-ladder-element',
+  'contact-ladder-element',
+  'block-fbd-element',
+  'create-project',
+  'save-changes-project',
+  'save-changes-file',
+  'confirm-delete-element',
+  'confirm-device-switch',
+  'quit-application',
+  'runtime-create-user',
+  'runtime-login',
+  'server-ip-mismatch',
+  'runtime-connection-lost',
+  'debugger-message',
+  'debugger-ip-input',
+]
+
+describe('createModalSlice', () => {
+  let store: ReturnType<typeof makeStore>
+
+  beforeEach(() => {
+    store = makeStore()
+  })
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+  it('should initialize all modals as closed with null data', () => {
+    const { modals } = store.getState()
+    for (const modalType of ALL_MODAL_TYPES) {
+      expect(modals[modalType]).toEqual({ open: false, data: null })
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // openModal
+  // -------------------------------------------------------------------------
+  it('openModal opens a modal with data', () => {
+    store.getState().modalActions.openModal('create-project', { name: 'test' })
+    const modal = store.getState().modals['create-project']
+    expect(modal.open).toBe(true)
+    expect(modal.data).toEqual({ name: 'test' })
+  })
+
+  it('openModal opens a modal without data', () => {
+    store.getState().modalActions.openModal('quit-application')
+    const modal = store.getState().modals['quit-application']
+    expect(modal.open).toBe(true)
+    expect(modal.data).toBeUndefined()
+  })
+
+  // -------------------------------------------------------------------------
+  // onOpenChange
+  // -------------------------------------------------------------------------
+  it('onOpenChange sets modal open and preserves data when value is true', () => {
+    store.getState().modalActions.openModal('debugger-message', { msg: 'hello' })
+    store.getState().modalActions.onOpenChange('debugger-message', true)
+
+    const modal = store.getState().modals['debugger-message']
+    expect(modal.open).toBe(true)
+    expect(modal.data).toEqual({ msg: 'hello' })
+  })
+
+  it('onOpenChange sets modal closed and clears data when value is false', () => {
+    store.getState().modalActions.openModal('debugger-message', { msg: 'hello' })
+    store.getState().modalActions.onOpenChange('debugger-message', false)
+
+    const modal = store.getState().modals['debugger-message']
+    expect(modal.open).toBe(false)
+    expect(modal.data).toBeNull()
+  })
+
+  it('onOpenChange handles modal with no prior data when value is true', () => {
+    store.getState().modalActions.onOpenChange('ai-consent', true)
+    const modal = store.getState().modals['ai-consent']
+    expect(modal.open).toBe(true)
+    expect(modal.data).toBeNull()
+  })
+
+  // -------------------------------------------------------------------------
+  // closeModal
+  // -------------------------------------------------------------------------
+  it('closeModal closes all modals', () => {
+    store.getState().modalActions.openModal('create-project', { name: 'test' })
+    store.getState().modalActions.openModal('quit-application', 'data')
+    store.getState().modalActions.openModal('debugger-ip-input')
+
+    store.getState().modalActions.closeModal()
+
+    const { modals } = store.getState()
+    for (const modalType of ALL_MODAL_TYPES) {
+      expect(modals[modalType]).toEqual({ open: false, data: null })
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // getModalState
+  // -------------------------------------------------------------------------
+  it('getModalState returns current state of a modal', () => {
+    store.getState().modalActions.openModal('runtime-login', { user: 'admin' })
+    const state = store.getState().modalActions.getModalState('runtime-login')
+    expect(state.open).toBe(true)
+    expect(state.data).toEqual({ user: 'admin' })
+  })
+
+  it('getModalState returns default for a modal that exists but is closed', () => {
+    const state = store.getState().modalActions.getModalState('ai-consent')
+    expect(state.open).toBe(false)
+    expect(state.data).toBeNull()
+  })
+
+  it('getModalState returns fallback for unknown modal key', () => {
+    // Casting to ModalTypes to test the fallback branch for a missing key
+    const state = store.getState().modalActions.getModalState('nonexistent-modal' as ModalTypes)
+    expect(state.open).toBe(false)
+  })
+})

--- a/src2/store/__tests__/search-slice.test.ts
+++ b/src2/store/__tests__/search-slice.test.ts
@@ -1,0 +1,158 @@
+import { createStore } from 'zustand/vanilla'
+
+import { createSearchSlice } from '../slices/search/slice'
+import type { Project, SearchSlice } from '../slices/search/types'
+
+function makeStore() {
+  return createStore<SearchSlice>()(createSearchSlice)
+}
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    searchQuery: 'test',
+    projectName: 'Project1',
+    functions: {
+      pous: {
+        program: [],
+        function: [],
+        'function-block': [],
+      },
+      dataTypes: [],
+      resource: { globalVariable: '', task: '', instance: '' },
+    },
+    searchID: 'id-1',
+    ...overrides,
+  }
+}
+
+describe('createSearchSlice', () => {
+  let store: ReturnType<typeof makeStore>
+
+  beforeEach(() => {
+    store = makeStore()
+  })
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+  it('should have correct initial state', () => {
+    const state = store.getState()
+    expect(state.searchQuery).toBe('')
+    expect(state.searchResults).toEqual([])
+    expect(state.sensitiveCase).toBe(false)
+    expect(state.regularExpression).toBe(false)
+    expect(state.searchNodePosition).toEqual({ x: 0, y: 0 })
+  })
+
+  // -------------------------------------------------------------------------
+  // setSearchQuery
+  // -------------------------------------------------------------------------
+  it('setSearchQuery', () => {
+    store.getState().searchActions.setSearchQuery('hello')
+    expect(store.getState().searchQuery).toBe('hello')
+  })
+
+  // -------------------------------------------------------------------------
+  // setSearchResults
+  // -------------------------------------------------------------------------
+  it('setSearchResults adds a new result', () => {
+    const project = makeProject()
+    store.getState().searchActions.setSearchResults(project)
+    expect(store.getState().searchResults).toHaveLength(1)
+    expect(store.getState().searchResults[0]).toEqual(project)
+  })
+
+  it('setSearchResults replaces an existing result with same searchQuery', () => {
+    const project1 = makeProject({ searchID: 'id-1', searchQuery: 'test', projectName: 'P1' })
+    const project2 = makeProject({ searchID: 'id-2', searchQuery: 'test', projectName: 'P2' })
+
+    store.getState().searchActions.setSearchResults(project1)
+    store.getState().searchActions.setSearchResults(project2)
+
+    expect(store.getState().searchResults).toHaveLength(1)
+    expect(store.getState().searchResults[0].projectName).toBe('P2')
+  })
+
+  it('setSearchResults adds results with different searchQuery', () => {
+    const project1 = makeProject({ searchQuery: 'foo' })
+    const project2 = makeProject({ searchQuery: 'bar' })
+
+    store.getState().searchActions.setSearchResults(project1)
+    store.getState().searchActions.setSearchResults(project2)
+
+    expect(store.getState().searchResults).toHaveLength(2)
+  })
+
+  // -------------------------------------------------------------------------
+  // setSensitiveCase
+  // -------------------------------------------------------------------------
+  it('setSensitiveCase', () => {
+    store.getState().searchActions.setSensitiveCase(true)
+    expect(store.getState().sensitiveCase).toBe(true)
+
+    store.getState().searchActions.setSensitiveCase(false)
+    expect(store.getState().sensitiveCase).toBe(false)
+  })
+
+  // -------------------------------------------------------------------------
+  // setRegularExpression
+  // -------------------------------------------------------------------------
+  it('setRegularExpression', () => {
+    store.getState().searchActions.setRegularExpression(true)
+    expect(store.getState().regularExpression).toBe(true)
+
+    store.getState().searchActions.setRegularExpression(false)
+    expect(store.getState().regularExpression).toBe(false)
+  })
+
+  // -------------------------------------------------------------------------
+  // removeSearchResult
+  // -------------------------------------------------------------------------
+  it('removeSearchResult removes by searchID', () => {
+    const p1 = makeProject({ searchID: 'id-1' })
+    const p2 = makeProject({ searchID: 'id-2', searchQuery: 'other' })
+
+    store.getState().searchActions.setSearchResults(p1)
+    store.getState().searchActions.setSearchResults(p2)
+    expect(store.getState().searchResults).toHaveLength(2)
+
+    store.getState().searchActions.removeSearchResult('id-1')
+    expect(store.getState().searchResults).toHaveLength(1)
+    expect(store.getState().searchResults[0].searchID).toBe('id-2')
+  })
+
+  it('removeSearchResult does nothing when searchID not found', () => {
+    const p1 = makeProject({ searchID: 'id-1' })
+    store.getState().searchActions.setSearchResults(p1)
+    store.getState().searchActions.removeSearchResult('nonexistent')
+    expect(store.getState().searchResults).toHaveLength(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // setSearchNodePosition
+  // -------------------------------------------------------------------------
+  it('setSearchNodePosition', () => {
+    store.getState().searchActions.setSearchNodePosition({ x: 100, y: 200 })
+    expect(store.getState().searchNodePosition).toEqual({ x: 100, y: 200 })
+  })
+
+  // -------------------------------------------------------------------------
+  // clearSearch
+  // -------------------------------------------------------------------------
+  it('clearSearch resets all search state', () => {
+    store.getState().searchActions.setSearchQuery('test')
+    store.getState().searchActions.setSearchResults(makeProject())
+    store.getState().searchActions.setSensitiveCase(true)
+    store.getState().searchActions.setRegularExpression(true)
+    store.getState().searchActions.setSearchNodePosition({ x: 50, y: 50 })
+
+    store.getState().searchActions.clearSearch()
+
+    const state = store.getState()
+    expect(state.searchQuery).toBe('')
+    expect(state.searchResults).toEqual([])
+    expect(state.sensitiveCase).toBe(false)
+    expect(state.regularExpression).toBe(false)
+    expect(state.searchNodePosition).toEqual({ x: 0, y: 0 })
+  })
+})

--- a/src2/store/__tests__/search-utils.test.ts
+++ b/src2/store/__tests__/search-utils.test.ts
@@ -1,0 +1,76 @@
+import { escapeRegExp, extractSearchQuery } from '../slices/search/utils'
+
+describe('search/utils', () => {
+  // -------------------------------------------------------------------------
+  // escapeRegExp
+  // -------------------------------------------------------------------------
+  describe('escapeRegExp', () => {
+    it('escapes all special regex characters', () => {
+      const input = '.*+?^${}()|[]\\'
+      const result = escapeRegExp(input)
+      expect(result).toBe('\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\')
+    })
+
+    it('returns unmodified string when no special characters', () => {
+      expect(escapeRegExp('hello world')).toBe('hello world')
+    })
+
+    it('handles empty string', () => {
+      expect(escapeRegExp('')).toBe('')
+    })
+
+    it('escapes mixed content', () => {
+      expect(escapeRegExp('price is $10.00')).toBe('price is \\$10\\.00')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // extractSearchQuery
+  // -------------------------------------------------------------------------
+  describe('extractSearchQuery', () => {
+    it('highlights matching text in body', () => {
+      const result = extractSearchQuery('Hello World', 'World')
+      expect(result).toContain('World')
+      expect(result).toContain('<span')
+      expect(result).toContain('bg-brand-light')
+    })
+
+    it('is case-insensitive', () => {
+      const result = extractSearchQuery('Hello world', 'WORLD')
+      expect(result).toContain('<span')
+      expect(result).toContain('world')
+    })
+
+    it('highlights multiple matches', () => {
+      const result = extractSearchQuery('abc abc abc', 'abc')
+      // Should have 3 span tags
+      const matches = result.match(/<span/g)
+      expect(matches).toHaveLength(3)
+    })
+
+    it('returns original body when no match found', () => {
+      const result = extractSearchQuery('Hello World', 'xyz')
+      expect(result).toBe('Hello World')
+    })
+
+    it('handles special regex characters in search query', () => {
+      const result = extractSearchQuery('price is $10.00', '$10.00')
+      expect(result).toContain('<span')
+      expect(result).toContain('$10.00')
+    })
+
+    it('handles empty search query', () => {
+      // Empty regex matches everything, so it should highlight around every character boundary
+      const result = extractSearchQuery('Hello', '')
+      // DOMPurify sanitizes the output, result should contain highlight spans
+      expect(result).toContain('<span')
+    })
+
+    it('sanitizes HTML output via DOMPurify', () => {
+      // If the body contains script tags, DOMPurify should strip them
+      const result = extractSearchQuery('<script>alert("xss")</script> World', 'World')
+      expect(result).not.toContain('<script>')
+      expect(result).toContain('World')
+    })
+  })
+})

--- a/src2/store/__tests__/tabs-slice.test.ts
+++ b/src2/store/__tests__/tabs-slice.test.ts
@@ -1,0 +1,144 @@
+import { createStore } from 'zustand/vanilla'
+
+import { createTabsSlice } from '../slices/tabs/slice'
+import type { TabsProps, TabsSlice } from '../slices/tabs/types'
+
+function makeStore() {
+  return createStore<TabsSlice>()(createTabsSlice)
+}
+
+function makeTab(name: string, type: TabsProps['elementType']['type'] = 'program'): TabsProps {
+  switch (type) {
+    case 'program':
+      return { name, elementType: { type: 'program', language: 'st' } }
+    case 'function':
+      return { name, elementType: { type: 'function', language: 'il' } }
+    case 'resource':
+      return { name, elementType: { type: 'resource' } }
+    default:
+      return { name, elementType: { type: 'program', language: 'st' } }
+  }
+}
+
+describe('createTabsSlice', () => {
+  let store: ReturnType<typeof makeStore>
+
+  beforeEach(() => {
+    store = makeStore()
+  })
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+  it('should have correct initial state', () => {
+    const state = store.getState()
+    expect(state.tabs).toEqual([])
+    expect(state.selectedTab).toBeNull()
+  })
+
+  // -------------------------------------------------------------------------
+  // setTabs
+  // -------------------------------------------------------------------------
+  it('setTabs replaces all tabs', () => {
+    const tabs = [makeTab('Tab1'), makeTab('Tab2')]
+    store.getState().tabsActions.setTabs(tabs)
+    expect(store.getState().tabs).toEqual(tabs)
+  })
+
+  // -------------------------------------------------------------------------
+  // updateTabs
+  // -------------------------------------------------------------------------
+  it('updateTabs adds a new tab', () => {
+    const tab = makeTab('New')
+    store.getState().tabsActions.updateTabs(tab)
+    expect(store.getState().tabs).toHaveLength(1)
+    expect(store.getState().tabs[0].name).toBe('New')
+  })
+
+  it('updateTabs does not add duplicate tab', () => {
+    const tab = makeTab('New')
+    store.getState().tabsActions.updateTabs(tab)
+    store.getState().tabsActions.updateTabs(tab)
+    expect(store.getState().tabs).toHaveLength(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // sortTabs
+  // -------------------------------------------------------------------------
+  it('sortTabs replaces tabs with sorted array', () => {
+    const tabs = [makeTab('B'), makeTab('A')]
+    store.getState().tabsActions.setTabs([makeTab('A'), makeTab('B')])
+    store.getState().tabsActions.sortTabs(tabs)
+    expect(store.getState().tabs[0].name).toBe('B')
+    expect(store.getState().tabs[1].name).toBe('A')
+  })
+
+  // -------------------------------------------------------------------------
+  // removeTab
+  // -------------------------------------------------------------------------
+  it('removeTab removes a tab by name', () => {
+    store.getState().tabsActions.setTabs([makeTab('A'), makeTab('B')])
+    store.getState().tabsActions.removeTab('A')
+    expect(store.getState().tabs).toHaveLength(1)
+    expect(store.getState().tabs[0].name).toBe('B')
+  })
+
+  // -------------------------------------------------------------------------
+  // updateTabName
+  // -------------------------------------------------------------------------
+  it('updateTabName renames an existing tab', () => {
+    store.getState().tabsActions.setTabs([makeTab('Old')])
+    store.getState().tabsActions.setSelectedTab('Old')
+    store.getState().tabsActions.updateTabName('Old', 'New')
+
+    expect(store.getState().tabs[0].name).toBe('New')
+    expect(store.getState().selectedTab).toBe('New')
+  })
+
+  it('updateTabName does not update selectedTab when it does not match oldName', () => {
+    store.getState().tabsActions.setTabs([makeTab('A'), makeTab('B')])
+    store.getState().tabsActions.setSelectedTab('B')
+    store.getState().tabsActions.updateTabName('A', 'Renamed')
+
+    expect(store.getState().tabs[0].name).toBe('Renamed')
+    expect(store.getState().selectedTab).toBe('B')
+  })
+
+  it('updateTabName does nothing when tab not found', () => {
+    store.getState().tabsActions.setTabs([makeTab('A')])
+    store.getState().tabsActions.updateTabName('NonExistent', 'New')
+    expect(store.getState().tabs[0].name).toBe('A')
+  })
+
+  // -------------------------------------------------------------------------
+  // clearTabs
+  // -------------------------------------------------------------------------
+  it('clearTabs resets tabs and selectedTab', () => {
+    store.getState().tabsActions.setTabs([makeTab('A')])
+    store.getState().tabsActions.setSelectedTab('A')
+    store.getState().tabsActions.clearTabs()
+
+    expect(store.getState().tabs).toEqual([])
+    expect(store.getState().selectedTab).toBeNull()
+  })
+
+  // -------------------------------------------------------------------------
+  // setSelectedTab
+  // -------------------------------------------------------------------------
+  it('setSelectedTab sets the selected tab', () => {
+    store.getState().tabsActions.setSelectedTab('MyTab')
+    expect(store.getState().selectedTab).toBe('MyTab')
+  })
+
+  // -------------------------------------------------------------------------
+  // getSelectedTab
+  // -------------------------------------------------------------------------
+  it('getSelectedTab returns selected tab name', () => {
+    store.getState().tabsActions.setSelectedTab('TabX')
+    expect(store.getState().tabsActions.getSelectedTab()).toBe('TabX')
+  })
+
+  it('getSelectedTab returns null when no tab selected', () => {
+    expect(store.getState().tabsActions.getSelectedTab()).toBeNull()
+  })
+})

--- a/src2/store/__tests__/tabs-utils.test.ts
+++ b/src2/store/__tests__/tabs-utils.test.ts
@@ -1,0 +1,280 @@
+import {
+  CreateDeviceEditor,
+  CreateEditorModelObject,
+  CreateEditorObjectFromTab,
+  CreatePLCGraphicalObject,
+  CreatePLCTextualObject,
+  CreateRemoteDeviceEditor,
+  CreateResourceEditor,
+  CreateServerEditor,
+} from '../slices/tabs/utils'
+import type { TabsProps } from '../slices/tabs/types'
+
+describe('tabs/utils', () => {
+  // -------------------------------------------------------------------------
+  // CreatePLCTextualObject
+  // -------------------------------------------------------------------------
+  describe('CreatePLCTextualObject', () => {
+    it('creates a plc-textual editor for ST program', () => {
+      const result = CreatePLCTextualObject('Main', 'st', 'program')
+      expect(result).toEqual({
+        type: 'plc-textual',
+        meta: { name: 'Main', language: 'st', path: '/data/pous/program/st/Main', pouType: 'program' },
+        variable: { display: 'table', description: '', classFilter: 'All', selectedRow: '-1' },
+      })
+    })
+
+    it('creates a plc-textual editor for IL function', () => {
+      const result = CreatePLCTextualObject('Func1', 'il', 'function')
+      expect(result.type).toBe('plc-textual')
+      if (result.type === 'plc-textual') {
+        expect(result.meta.language).toBe('il')
+        expect(result.meta.path).toBe('/data/pous/function/il/Func1')
+      }
+    })
+
+    it('creates a plc-textual editor for python function-block', () => {
+      const result = CreatePLCTextualObject('FB1', 'python', 'function-block')
+      expect(result.type).toBe('plc-textual')
+      if (result.type === 'plc-textual') {
+        expect(result.meta.language).toBe('python')
+        expect(result.meta.pouType).toBe('function-block')
+      }
+    })
+
+    it('creates a plc-textual editor for cpp', () => {
+      const result = CreatePLCTextualObject('CppProg', 'cpp', 'program')
+      expect(result.type).toBe('plc-textual')
+      if (result.type === 'plc-textual') {
+        expect(result.meta.language).toBe('cpp')
+      }
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // CreatePLCGraphicalObject
+  // -------------------------------------------------------------------------
+  describe('CreatePLCGraphicalObject', () => {
+    it('creates LD graphical editor with openedRungs', () => {
+      const result = CreatePLCGraphicalObject('LdProg', 'ld', 'program')
+      expect(result.type).toBe('plc-graphical')
+      if (result.type === 'plc-graphical') {
+        expect(result.graphical).toEqual({ language: 'ld', openedRungs: [] })
+        expect(result.meta.path).toBe('/data/pous/program/ld/LdProg')
+      }
+    })
+
+    it('creates FBD graphical editor with hover/zoom/pan', () => {
+      const result = CreatePLCGraphicalObject('FbdProg', 'fbd', 'function')
+      if (result.type === 'plc-graphical') {
+        expect(result.graphical).toEqual({
+          language: 'fbd',
+          hoveringElement: { elementId: null, hovering: false },
+          canEditorZoom: true,
+          canEditorPan: true,
+        })
+      }
+    })
+
+    it('creates SFC graphical editor', () => {
+      const result = CreatePLCGraphicalObject('SfcProg', 'sfc', 'function-block')
+      if (result.type === 'plc-graphical') {
+        expect(result.graphical).toEqual({ language: 'sfc' })
+      }
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // CreateEditorModelObject
+  // -------------------------------------------------------------------------
+  describe('CreateEditorModelObject', () => {
+    it('creates a datatype editor when derivation is provided', () => {
+      const result = CreateEditorModelObject('MyEnum', null, null, 'enumerated')
+      expect(result.type).toBe('plc-datatype')
+      if (result.type === 'plc-datatype') {
+        expect(result.meta.derivation).toBe('enumerated')
+        expect(result.structure).toEqual({ selectedRow: '-1', description: '' })
+      }
+    })
+
+    it('creates a graphical editor for ld language', () => {
+      const result = CreateEditorModelObject('LdProg', 'ld', 'program')
+      expect(result.type).toBe('plc-graphical')
+    })
+
+    it('creates a graphical editor for sfc language', () => {
+      const result = CreateEditorModelObject('SfcProg', 'sfc', 'function')
+      expect(result.type).toBe('plc-graphical')
+    })
+
+    it('creates a graphical editor for fbd language', () => {
+      const result = CreateEditorModelObject('FbdProg', 'fbd', 'function-block')
+      expect(result.type).toBe('plc-graphical')
+    })
+
+    it('creates a textual editor for st language', () => {
+      const result = CreateEditorModelObject('StProg', 'st', 'program')
+      expect(result.type).toBe('plc-textual')
+    })
+
+    it('creates a textual editor for il language', () => {
+      const result = CreateEditorModelObject('IlProg', 'il', 'function')
+      expect(result.type).toBe('plc-textual')
+    })
+
+    it('throws when language and pouType are null without derivation', () => {
+      expect(() => CreateEditorModelObject('NoLang', null, null)).toThrow('Language and pouType must be defined')
+    })
+
+    it('throws when language is null without derivation', () => {
+      expect(() => CreateEditorModelObject('NoLang', null, 'program')).toThrow('Language and pouType must be defined')
+    })
+
+    it('throws when pouType is null without derivation', () => {
+      expect(() => CreateEditorModelObject('NoType', 'st', null)).toThrow('Language and pouType must be defined')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // CreateResourceEditor
+  // -------------------------------------------------------------------------
+  describe('CreateResourceEditor', () => {
+    it('creates a resource editor with default name', () => {
+      const result = CreateResourceEditor()
+      expect(result).toEqual({
+        type: 'plc-resource',
+        meta: { name: 'Resource', path: '/data/configuration/resource' },
+        variable: { display: 'table', description: '', selectedRow: '-1' },
+        task: { display: 'table', selectedRow: '-1' },
+        instance: { display: 'table', selectedRow: '-1' },
+      })
+    })
+
+    it('creates a resource editor with custom name', () => {
+      const result = CreateResourceEditor('CustomRes')
+      expect(result.type).toBe('plc-resource')
+      if (result.type === 'plc-resource') {
+        expect(result.meta.name).toBe('CustomRes')
+      }
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // CreateDeviceEditor
+  // -------------------------------------------------------------------------
+  describe('CreateDeviceEditor', () => {
+    it('creates a device editor for configuration', () => {
+      const result = CreateDeviceEditor('Dev', 'configuration')
+      expect(result).toEqual({
+        type: 'plc-device',
+        meta: { name: 'Dev', derivation: 'configuration' },
+      })
+    })
+
+    it('creates a device editor for pin-mapping', () => {
+      const result = CreateDeviceEditor('Dev', 'pin-mapping')
+      if (result.type === 'plc-device') {
+        expect(result.meta.derivation).toBe('pin-mapping')
+      }
+    })
+
+    it('creates a device editor for orchestrators', () => {
+      const result = CreateDeviceEditor('Dev', 'orchestrators')
+      if (result.type === 'plc-device') {
+        expect(result.meta.derivation).toBe('orchestrators')
+      }
+    })
+
+    it('uses default name when not provided', () => {
+      const result = CreateDeviceEditor(undefined, 'configuration')
+      if (result.type === 'plc-device') {
+        expect(result.meta.name).toBe('device')
+      }
+    })
+
+    it('throws when derivation is falsy', () => {
+      // Force a falsy derivation at runtime to cover the throw branch
+      expect(() => CreateDeviceEditor('Dev', '' as 'configuration')).toThrow('Invalid derivation value')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // CreateRemoteDeviceEditor
+  // -------------------------------------------------------------------------
+  describe('CreateRemoteDeviceEditor', () => {
+    it('creates a remote device editor', () => {
+      const result = CreateRemoteDeviceEditor('RemDev', 'modbus-tcp')
+      expect(result).toEqual({
+        type: 'plc-remote-device',
+        meta: { name: 'RemDev', protocol: 'modbus-tcp' },
+      })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // CreateServerEditor
+  // -------------------------------------------------------------------------
+  describe('CreateServerEditor', () => {
+    it('creates a server editor', () => {
+      const result = CreateServerEditor('Srv', 'opcua')
+      expect(result).toEqual({
+        type: 'plc-server',
+        meta: { name: 'Srv', protocol: 'opcua' },
+      })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // CreateEditorObjectFromTab
+  // -------------------------------------------------------------------------
+  describe('CreateEditorObjectFromTab', () => {
+    it('creates editor from program tab', () => {
+      const tab: TabsProps = { name: 'Prog', elementType: { type: 'program', language: 'st' } }
+      const result = CreateEditorObjectFromTab(tab)
+      expect(result.type).toBe('plc-textual')
+      expect(result.meta.name).toBe('Prog')
+    })
+
+    it('creates editor from function tab', () => {
+      const tab: TabsProps = { name: 'Func', elementType: { type: 'function', language: 'il' } }
+      const result = CreateEditorObjectFromTab(tab)
+      expect(result.type).toBe('plc-textual')
+    })
+
+    it('creates editor from function-block tab', () => {
+      const tab: TabsProps = { name: 'FB', elementType: { type: 'function-block', language: 'ld' } }
+      const result = CreateEditorObjectFromTab(tab)
+      expect(result.type).toBe('plc-graphical')
+    })
+
+    it('creates editor from data-type tab', () => {
+      const tab: TabsProps = { name: 'DT', elementType: { type: 'data-type', derivation: 'structure' } }
+      const result = CreateEditorObjectFromTab(tab)
+      expect(result.type).toBe('plc-datatype')
+    })
+
+    it('creates editor from resource tab', () => {
+      const tab: TabsProps = { name: 'Res', elementType: { type: 'resource' } }
+      const result = CreateEditorObjectFromTab(tab)
+      expect(result.type).toBe('plc-resource')
+    })
+
+    it('creates editor from device tab', () => {
+      const tab: TabsProps = { name: 'Dev', elementType: { type: 'device', derivation: 'pin-mapping' } }
+      const result = CreateEditorObjectFromTab(tab)
+      expect(result.type).toBe('plc-device')
+    })
+
+    it('creates editor from remote-device tab', () => {
+      const tab: TabsProps = { name: 'RD', elementType: { type: 'remote-device', protocol: 'ethercat' } }
+      const result = CreateEditorObjectFromTab(tab)
+      expect(result.type).toBe('plc-remote-device')
+    })
+
+    it('creates editor from server tab', () => {
+      const tab: TabsProps = { name: 'Srv', elementType: { type: 'server', protocol: 's7comm' } }
+      const result = CreateEditorObjectFromTab(tab)
+      expect(result.type).toBe('plc-server')
+    })
+  })
+})

--- a/src2/store/__tests__/workspace-slice.test.ts
+++ b/src2/store/__tests__/workspace-slice.test.ts
@@ -1,0 +1,568 @@
+import { enableMapSet } from 'immer'
+import { createStore } from 'zustand/vanilla'
+
+import type { DebugTreeNode, FbInstanceInfo, RuntimeLogEntry } from '../../providers/platform/ports/types'
+import { LOG_BUFFER_CAP } from '../../providers/platform/ports/types'
+import { createWorkspaceSlice } from '../slices/workspace/slice'
+import type { WorkspaceSlice } from '../slices/workspace/types'
+
+enableMapSet()
+
+function makeStore() {
+  return createStore<WorkspaceSlice>()(createWorkspaceSlice)
+}
+
+describe('createWorkspaceSlice', () => {
+  let store: ReturnType<typeof makeStore>
+
+  beforeEach(() => {
+    store = makeStore()
+  })
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+  it('should have correct initial state', () => {
+    const { workspace } = store.getState()
+    expect(workspace.editingState).toBe('initial-state')
+    expect(workspace.systemConfigs).toEqual({
+      OS: '',
+      arch: '',
+      shouldUseDarkMode: false,
+      isWindowMaximized: false,
+    })
+    expect(workspace.recent).toEqual([])
+    expect(workspace.isCollapsed).toBe(false)
+    expect(workspace.isModalOpen).toEqual([])
+    expect(workspace.discardChanges).toBe(false)
+    expect(workspace.selectedProjectTreeLeaf).toEqual({ label: '', type: null })
+    expect(workspace.close).toEqual({ window: false, app: false, appDarwin: false })
+    expect(workspace.isPlcLogsVisible).toBe(false)
+    expect(workspace.plcLogs).toBe('')
+    expect(workspace.plcLogsLastId).toBeNull()
+    expect(workspace.plcFilters).toEqual({
+      levels: { debug: true, info: true, warning: true, error: true },
+      searchTerm: '',
+      timestampFormat: 'full',
+    })
+    expect(workspace.isDebuggerVisible).toBe(false)
+    expect(workspace.debuggerTargetIp).toBeNull()
+    expect(workspace.debugCContent).toBeNull()
+    expect(workspace.debugVariableIndexes).toEqual(new Map())
+    expect(workspace.debugVariableValues).toEqual(new Map())
+    expect(workspace.debugForcedVariables).toEqual(new Map())
+    expect(workspace.debugTick).toBe(0)
+    expect(workspace.debugVariableTree).toEqual(new Map())
+    expect(workspace.debugExpandedNodes).toEqual(new Map())
+    expect(workspace.fbDebugInstances).toEqual(new Map())
+    expect(workspace.fbSelectedInstance).toEqual(new Map())
+    expect(workspace.debugLocalMd5).toBeNull()
+    expect(workspace.debugGraphList).toEqual([])
+    expect(workspace.debugDataStale).toBe(false)
+    expect(workspace.debugMd5Mismatch).toBeNull()
+  })
+
+  // -------------------------------------------------------------------------
+  // Simple setter actions
+  // -------------------------------------------------------------------------
+  it('setEditingState', () => {
+    store.getState().workspaceActions.setEditingState('unsaved')
+    expect(store.getState().workspace.editingState).toBe('unsaved')
+
+    store.getState().workspaceActions.setEditingState('saved')
+    expect(store.getState().workspace.editingState).toBe('saved')
+
+    store.getState().workspaceActions.setEditingState('save-request')
+    expect(store.getState().workspace.editingState).toBe('save-request')
+  })
+
+  it('setSystemConfigs', () => {
+    const configs = { OS: 'darwin' as const, arch: 'x64' as const, shouldUseDarkMode: true, isWindowMaximized: true }
+    store.getState().workspaceActions.setSystemConfigs(configs)
+    expect(store.getState().workspace.systemConfigs).toEqual(configs)
+  })
+
+  it('setRecent', () => {
+    const recent = [{ lastOpenedAt: '2024-01-01', createdAt: '2024-01-01', path: '/test', name: 'Test' }]
+    store.getState().workspaceActions.setRecent(recent)
+    expect(store.getState().workspace.recent).toEqual(recent)
+  })
+
+  it('setCloseApp', () => {
+    store.getState().workspaceActions.setCloseApp(true)
+    expect(store.getState().workspace.close.app).toBe(true)
+  })
+
+  it('setCloseAppDarwin', () => {
+    store.getState().workspaceActions.setCloseAppDarwin(true)
+    expect(store.getState().workspace.close.appDarwin).toBe(true)
+  })
+
+  it('setCloseWindow', () => {
+    store.getState().workspaceActions.setCloseWindow(true)
+    expect(store.getState().workspace.close.window).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // Toggle actions
+  // -------------------------------------------------------------------------
+  it('switchAppTheme toggles shouldUseDarkMode', () => {
+    expect(store.getState().workspace.systemConfigs.shouldUseDarkMode).toBe(false)
+    store.getState().workspaceActions.switchAppTheme()
+    expect(store.getState().workspace.systemConfigs.shouldUseDarkMode).toBe(true)
+    store.getState().workspaceActions.switchAppTheme()
+    expect(store.getState().workspace.systemConfigs.shouldUseDarkMode).toBe(false)
+  })
+
+  it('toggleMaximizedWindow toggles isWindowMaximized', () => {
+    expect(store.getState().workspace.systemConfigs.isWindowMaximized).toBe(false)
+    store.getState().workspaceActions.toggleMaximizedWindow()
+    expect(store.getState().workspace.systemConfigs.isWindowMaximized).toBe(true)
+    store.getState().workspaceActions.toggleMaximizedWindow()
+    expect(store.getState().workspace.systemConfigs.isWindowMaximized).toBe(false)
+  })
+
+  it('toggleCollapse toggles isCollapsed', () => {
+    expect(store.getState().workspace.isCollapsed).toBe(false)
+    store.getState().workspaceActions.toggleCollapse()
+    expect(store.getState().workspace.isCollapsed).toBe(true)
+    store.getState().workspaceActions.toggleCollapse()
+    expect(store.getState().workspace.isCollapsed).toBe(false)
+  })
+
+  it('toggleDiscardChanges toggles discardChanges', () => {
+    expect(store.getState().workspace.discardChanges).toBe(false)
+    store.getState().workspaceActions.toggleDiscardChanges()
+    expect(store.getState().workspace.discardChanges).toBe(true)
+    store.getState().workspaceActions.toggleDiscardChanges()
+    expect(store.getState().workspace.discardChanges).toBe(false)
+  })
+
+  // -------------------------------------------------------------------------
+  // setModalOpen
+  // -------------------------------------------------------------------------
+  it('setModalOpen adds a new modal entry when not found', () => {
+    store.getState().workspaceActions.setModalOpen('my-modal', true)
+    expect(store.getState().workspace.isModalOpen).toEqual([{ modalName: 'my-modal', modalState: true }])
+  })
+
+  it('setModalOpen updates an existing modal entry', () => {
+    store.getState().workspaceActions.setModalOpen('my-modal', true)
+    store.getState().workspaceActions.setModalOpen('my-modal', false)
+    expect(store.getState().workspace.isModalOpen).toEqual([{ modalName: 'my-modal', modalState: false }])
+  })
+
+  // -------------------------------------------------------------------------
+  // setSelectedProjectTreeLeaf
+  // -------------------------------------------------------------------------
+  it('setSelectedProjectTreeLeaf', () => {
+    const leaf = { label: 'Main', type: 'program' as const }
+    store.getState().workspaceActions.setSelectedProjectTreeLeaf(leaf)
+    expect(store.getState().workspace.selectedProjectTreeLeaf).toEqual(leaf)
+  })
+
+  // -------------------------------------------------------------------------
+  // PLC Logs
+  // -------------------------------------------------------------------------
+  it('setPlcLogsVisible', () => {
+    store.getState().workspaceActions.setPlcLogsVisible(true)
+    expect(store.getState().workspace.isPlcLogsVisible).toBe(true)
+  })
+
+  it('setPlcLogs with string', () => {
+    store.getState().workspaceActions.setPlcLogs('hello logs')
+    expect(store.getState().workspace.plcLogs).toBe('hello logs')
+  })
+
+  it('setPlcLogs with v4 array', () => {
+    const entries: RuntimeLogEntry[] = [{ id: 1, timestamp: '2024-01-01', level: 'INFO', message: 'test' }]
+    store.getState().workspaceActions.setPlcLogs(entries)
+    expect(store.getState().workspace.plcLogs).toEqual(entries)
+  })
+
+  it('setPlcLogsLastId', () => {
+    store.getState().workspaceActions.setPlcLogsLastId(42)
+    expect(store.getState().workspace.plcLogsLastId).toBe(42)
+
+    store.getState().workspaceActions.setPlcLogsLastId(null)
+    expect(store.getState().workspace.plcLogsLastId).toBeNull()
+  })
+
+  describe('appendPlcLogs', () => {
+    it('appends v4 logs to existing v4 logs', () => {
+      const initial: RuntimeLogEntry[] = [{ id: 1, timestamp: 't1', level: 'INFO', message: 'a' }]
+      const appended: RuntimeLogEntry[] = [{ id: 2, timestamp: 't2', level: 'DEBUG', message: 'b' }]
+      store.getState().workspaceActions.setPlcLogs(initial)
+      store.getState().workspaceActions.appendPlcLogs(appended)
+      expect(store.getState().workspace.plcLogs).toEqual([...initial, ...appended])
+    })
+
+    it('caps v4 logs at LOG_BUFFER_CAP', () => {
+      const initial: RuntimeLogEntry[] = Array.from({ length: LOG_BUFFER_CAP }, (_, i) => ({
+        id: i,
+        timestamp: `t${i}`,
+        level: 'INFO' as const,
+        message: `msg${i}`,
+      }))
+      store.getState().workspaceActions.setPlcLogs(initial)
+      const extra: RuntimeLogEntry[] = [
+        { id: LOG_BUFFER_CAP, timestamp: 'tx', level: 'ERROR', message: 'extra' },
+      ]
+      store.getState().workspaceActions.appendPlcLogs(extra)
+      const logs = store.getState().workspace.plcLogs as RuntimeLogEntry[]
+      expect(logs.length).toBe(LOG_BUFFER_CAP)
+      expect(logs[logs.length - 1].message).toBe('extra')
+    })
+
+    it('does not slice v4 logs when combined length is within cap', () => {
+      const initial: RuntimeLogEntry[] = [{ id: 1, timestamp: 't1', level: 'INFO', message: 'a' }]
+      const appended: RuntimeLogEntry[] = [{ id: 2, timestamp: 't2', level: 'INFO', message: 'b' }]
+      store.getState().workspaceActions.setPlcLogs(initial)
+      store.getState().workspaceActions.appendPlcLogs(appended)
+      expect((store.getState().workspace.plcLogs as RuntimeLogEntry[]).length).toBe(2)
+    })
+
+    it('appends string logs to existing string logs', () => {
+      store.getState().workspaceActions.setPlcLogs('hello ')
+      store.getState().workspaceActions.appendPlcLogs('world')
+      expect(store.getState().workspace.plcLogs).toBe('hello world')
+    })
+
+    it('replaces logs when types are mismatched (string + v4)', () => {
+      store.getState().workspaceActions.setPlcLogs('string logs')
+      const v4Logs: RuntimeLogEntry[] = [{ id: 1, timestamp: 't1', level: 'INFO', message: 'a' }]
+      store.getState().workspaceActions.appendPlcLogs(v4Logs)
+      expect(store.getState().workspace.plcLogs).toEqual(v4Logs)
+    })
+
+    it('replaces logs when types are mismatched (v4 + string)', () => {
+      const v4Logs: RuntimeLogEntry[] = [{ id: 1, timestamp: 't1', level: 'INFO', message: 'a' }]
+      store.getState().workspaceActions.setPlcLogs(v4Logs)
+      store.getState().workspaceActions.appendPlcLogs('string logs')
+      expect(store.getState().workspace.plcLogs).toBe('string logs')
+    })
+  })
+
+  it('clearPlcLogs', () => {
+    store.getState().workspaceActions.setPlcLogs('some logs')
+    store.getState().workspaceActions.setPlcLogsLastId(10)
+    store.getState().workspaceActions.clearPlcLogs()
+    expect(store.getState().workspace.plcLogs).toBe('')
+    expect(store.getState().workspace.plcLogsLastId).toBeNull()
+  })
+
+  it('setPlcLevelFilter', () => {
+    store.getState().workspaceActions.setPlcLevelFilter('debug', false)
+    expect(store.getState().workspace.plcFilters.levels.debug).toBe(false)
+
+    store.getState().workspaceActions.setPlcLevelFilter('error', false)
+    expect(store.getState().workspace.plcFilters.levels.error).toBe(false)
+
+    store.getState().workspaceActions.setPlcLevelFilter('info', false)
+    expect(store.getState().workspace.plcFilters.levels.info).toBe(false)
+
+    store.getState().workspaceActions.setPlcLevelFilter('warning', false)
+    expect(store.getState().workspace.plcFilters.levels.warning).toBe(false)
+  })
+
+  it('setPlcSearchTerm', () => {
+    store.getState().workspaceActions.setPlcSearchTerm('error')
+    expect(store.getState().workspace.plcFilters.searchTerm).toBe('error')
+  })
+
+  it('setPlcTimestampFormat', () => {
+    store.getState().workspaceActions.setPlcTimestampFormat('time')
+    expect(store.getState().workspace.plcFilters.timestampFormat).toBe('time')
+
+    store.getState().workspaceActions.setPlcTimestampFormat('none')
+    expect(store.getState().workspace.plcFilters.timestampFormat).toBe('none')
+  })
+
+  // -------------------------------------------------------------------------
+  // Debug actions
+  // -------------------------------------------------------------------------
+  it('setDebuggerVisible', () => {
+    store.getState().workspaceActions.setDebuggerVisible(true)
+    expect(store.getState().workspace.isDebuggerVisible).toBe(true)
+  })
+
+  it('setDebuggerTargetIp', () => {
+    store.getState().workspaceActions.setDebuggerTargetIp('192.168.0.1')
+    expect(store.getState().workspace.debuggerTargetIp).toBe('192.168.0.1')
+
+    store.getState().workspaceActions.setDebuggerTargetIp(null)
+    expect(store.getState().workspace.debuggerTargetIp).toBeNull()
+  })
+
+  it('setDebugCContent', () => {
+    store.getState().workspaceActions.setDebugCContent('some C code')
+    expect(store.getState().workspace.debugCContent).toBe('some C code')
+
+    store.getState().workspaceActions.setDebugCContent(null)
+    expect(store.getState().workspace.debugCContent).toBeNull()
+  })
+
+  it('setDebugVariableIndexes', () => {
+    const indexes = new Map([['var1', 0], ['var2', 1]])
+    store.getState().workspaceActions.setDebugVariableIndexes(indexes)
+    expect(store.getState().workspace.debugVariableIndexes).toEqual(indexes)
+  })
+
+  it('setDebugVariableValues merges values into existing map', () => {
+    const initial = new Map([['var1', 'val1']])
+    store.getState().workspaceActions.setDebugVariableValues(initial)
+    expect(store.getState().workspace.debugVariableValues.get('var1')).toBe('val1')
+
+    const update = new Map([['var2', 'val2']])
+    store.getState().workspaceActions.setDebugVariableValues(update)
+    expect(store.getState().workspace.debugVariableValues.get('var1')).toBe('val1')
+    expect(store.getState().workspace.debugVariableValues.get('var2')).toBe('val2')
+  })
+
+  it('setDebugForcedVariables', () => {
+    const forced = new Map([['var1', true]])
+    store.getState().workspaceActions.setDebugForcedVariables(forced)
+    expect(store.getState().workspace.debugForcedVariables).toEqual(forced)
+  })
+
+  it('setDebugTick', () => {
+    store.getState().workspaceActions.setDebugTick(42)
+    expect(store.getState().workspace.debugTick).toBe(42)
+  })
+
+  it('setDebugVariableTree', () => {
+    const node: DebugTreeNode = {
+      name: 'var1',
+      fullPath: 'PROGRAM0.var1',
+      compositeKey: 'PROGRAM0::var1',
+      type: 'BOOL',
+      isComplex: false,
+    }
+    const tree = new Map([['var1', node]])
+    store.getState().workspaceActions.setDebugVariableTree(tree)
+    expect(store.getState().workspace.debugVariableTree).toEqual(tree)
+  })
+
+  it('setDebugExpandedNodes', () => {
+    const expandedNodes = new Map([['node1', true], ['node2', false]])
+    store.getState().workspaceActions.setDebugExpandedNodes(expandedNodes)
+    expect(store.getState().workspace.debugExpandedNodes).toEqual(expandedNodes)
+  })
+
+  it('toggleDebugExpandedNode toggles an existing node', () => {
+    const expandedNodes = new Map([['node1', true]])
+    store.getState().workspaceActions.setDebugExpandedNodes(expandedNodes)
+    store.getState().workspaceActions.toggleDebugExpandedNode('node1')
+    expect(store.getState().workspace.debugExpandedNodes.get('node1')).toBe(false)
+  })
+
+  it('toggleDebugExpandedNode defaults to false for a missing node and toggles to true', () => {
+    store.getState().workspaceActions.toggleDebugExpandedNode('missing-node')
+    expect(store.getState().workspace.debugExpandedNodes.get('missing-node')).toBe(true)
+  })
+
+  it('setFbDebugInstances', () => {
+    const info: FbInstanceInfo = {
+      fbTypeName: 'TON',
+      programName: 'PROGRAM0',
+      programInstanceName: 'inst0',
+      fbVariableName: 'timer1',
+      key: 'PROGRAM0::timer1',
+    }
+    const instances = new Map([['TON', [info]]])
+    store.getState().workspaceActions.setFbDebugInstances(instances)
+    expect(store.getState().workspace.fbDebugInstances).toEqual(instances)
+  })
+
+  it('setFbSelectedInstance', () => {
+    store.getState().workspaceActions.setFbSelectedInstance('TON', 'PROGRAM0::timer1')
+    expect(store.getState().workspace.fbSelectedInstance.get('TON')).toBe('PROGRAM0::timer1')
+  })
+
+  it('setDebugLocalMd5', () => {
+    store.getState().workspaceActions.setDebugLocalMd5('abc123')
+    expect(store.getState().workspace.debugLocalMd5).toBe('abc123')
+
+    store.getState().workspaceActions.setDebugLocalMd5(null)
+    expect(store.getState().workspace.debugLocalMd5).toBeNull()
+  })
+
+  it('setDebugGraphList', () => {
+    store.getState().workspaceActions.setDebugGraphList(['var1', 'var2'])
+    expect(store.getState().workspace.debugGraphList).toEqual(['var1', 'var2'])
+  })
+
+  it('setDebugDataStale', () => {
+    store.getState().workspaceActions.setDebugDataStale(true)
+    expect(store.getState().workspace.debugDataStale).toBe(true)
+  })
+
+  it('setDebugMd5Mismatch', () => {
+    const mismatch = { runtimeMd5: 'abc', localMd5: 'def' }
+    store.getState().workspaceActions.setDebugMd5Mismatch(mismatch)
+    expect(store.getState().workspace.debugMd5Mismatch).toEqual(mismatch)
+
+    store.getState().workspaceActions.setDebugMd5Mismatch(null)
+    expect(store.getState().workspace.debugMd5Mismatch).toBeNull()
+  })
+
+  // -------------------------------------------------------------------------
+  // clearDebugState
+  // -------------------------------------------------------------------------
+  it('clearDebugState resets all debug fields', () => {
+    store.getState().workspaceActions.setDebuggerVisible(true)
+    store.getState().workspaceActions.setDebuggerTargetIp('192.168.0.1')
+    store.getState().workspaceActions.setDebugCContent('code')
+    store.getState().workspaceActions.setDebugVariableIndexes(new Map([['x', 1]]))
+    store.getState().workspaceActions.setDebugVariableValues(new Map([['x', 'true']]))
+    store.getState().workspaceActions.setDebugForcedVariables(new Map([['x', true]]))
+    store.getState().workspaceActions.setDebugTick(100)
+    store.getState().workspaceActions.setDebugVariableTree(
+      new Map([
+        [
+          'x',
+          { name: 'x', fullPath: 'x', compositeKey: 'x', type: 'BOOL', isComplex: false },
+        ],
+      ]),
+    )
+    store.getState().workspaceActions.setDebugExpandedNodes(new Map([['n', true]]))
+    store.getState().workspaceActions.setFbDebugInstances(
+      new Map([
+        [
+          'FB',
+          [
+            {
+              fbTypeName: 'FB',
+              programName: 'P',
+              programInstanceName: 'I',
+              fbVariableName: 'V',
+              key: 'K',
+            },
+          ],
+        ],
+      ]),
+    )
+    store.getState().workspaceActions.setFbSelectedInstance('FB', 'K')
+    store.getState().workspaceActions.setDebugLocalMd5('md5')
+    store.getState().workspaceActions.setDebugGraphList(['a'])
+    store.getState().workspaceActions.setDebugDataStale(true)
+    store.getState().workspaceActions.setDebugMd5Mismatch({ runtimeMd5: 'r', localMd5: 'l' })
+
+    store.getState().workspaceActions.clearDebugState()
+
+    const { workspace } = store.getState()
+    expect(workspace.isDebuggerVisible).toBe(false)
+    expect(workspace.debuggerTargetIp).toBeNull()
+    expect(workspace.debugCContent).toBeNull()
+    expect(workspace.debugVariableIndexes.size).toBe(0)
+    expect(workspace.debugVariableValues.size).toBe(0)
+    expect(workspace.debugForcedVariables.size).toBe(0)
+    expect(workspace.debugTick).toBe(0)
+    expect(workspace.debugVariableTree.size).toBe(0)
+    expect(workspace.debugExpandedNodes.size).toBe(0)
+    expect(workspace.fbDebugInstances.size).toBe(0)
+    expect(workspace.fbSelectedInstance.size).toBe(0)
+    expect(workspace.debugLocalMd5).toBeNull()
+    expect(workspace.debugGraphList).toEqual([])
+    expect(workspace.debugDataStale).toBe(false)
+    expect(workspace.debugMd5Mismatch).toBeNull()
+  })
+
+  // -------------------------------------------------------------------------
+  // clearFbDebugContext
+  // -------------------------------------------------------------------------
+  it('clearFbDebugContext resets only FB-related maps', () => {
+    store.getState().workspaceActions.setFbDebugInstances(
+      new Map([
+        [
+          'FB',
+          [
+            {
+              fbTypeName: 'FB',
+              programName: 'P',
+              programInstanceName: 'I',
+              fbVariableName: 'V',
+              key: 'K',
+            },
+          ],
+        ],
+      ]),
+    )
+    store.getState().workspaceActions.setFbSelectedInstance('FB', 'K')
+
+    store.getState().workspaceActions.clearFbDebugContext()
+    expect(store.getState().workspace.fbDebugInstances.size).toBe(0)
+    expect(store.getState().workspace.fbSelectedInstance.size).toBe(0)
+  })
+
+  // -------------------------------------------------------------------------
+  // removeDebugVariable
+  // -------------------------------------------------------------------------
+  it('removeDebugVariable removes from all relevant maps', () => {
+    const key = 'PROGRAM0::myVar'
+    store.getState().workspaceActions.setDebugVariableIndexes(new Map([[key, 5]]))
+    store.getState().workspaceActions.setDebugVariableValues(new Map([[key, '42']]))
+    store.getState().workspaceActions.setDebugForcedVariables(new Map([[key, true]]))
+    store.getState().workspaceActions.setDebugVariableTree(
+      new Map([[key, { name: 'myVar', fullPath: key, compositeKey: key, type: 'INT', isComplex: false }]]),
+    )
+    store.getState().workspaceActions.setDebugExpandedNodes(new Map([[key, true]]))
+
+    store.getState().workspaceActions.removeDebugVariable(key)
+
+    const { workspace } = store.getState()
+    expect(workspace.debugVariableIndexes.has(key)).toBe(false)
+    expect(workspace.debugVariableValues.has(key)).toBe(false)
+    expect(workspace.debugForcedVariables.has(key)).toBe(false)
+    expect(workspace.debugVariableTree.has(key)).toBe(false)
+    expect(workspace.debugExpandedNodes.has(key)).toBe(false)
+  })
+
+  // -------------------------------------------------------------------------
+  // clearWorkspace
+  // -------------------------------------------------------------------------
+  it('clearWorkspace resets workspace fields including debug and logs', () => {
+    store.getState().workspaceActions.setEditingState('unsaved')
+    store.getState().workspaceActions.setSelectedProjectTreeLeaf({ label: 'Main', type: 'program' })
+    store.getState().workspaceActions.setDebuggerVisible(true)
+    store.getState().workspaceActions.setDebuggerTargetIp('10.0.0.1')
+    store.getState().workspaceActions.setDebugCContent('code')
+    store.getState().workspaceActions.setDebugTick(99)
+    store.getState().workspaceActions.setDebugLocalMd5('md5')
+    store.getState().workspaceActions.setDebugGraphList(['g'])
+    store.getState().workspaceActions.setDebugDataStale(true)
+    store.getState().workspaceActions.setDebugMd5Mismatch({ runtimeMd5: 'a', localMd5: 'b' })
+    store.getState().workspaceActions.setPlcLogsVisible(true)
+    store.getState().workspaceActions.setPlcLogs('logs')
+    store.getState().workspaceActions.setPlcLogsLastId(5)
+
+    store.getState().workspaceActions.clearWorkspace()
+
+    const { workspace } = store.getState()
+    expect(workspace.editingState).toBe('initial-state')
+    expect(workspace.selectedProjectTreeLeaf).toEqual({ label: '', type: null })
+    expect(workspace.isDebuggerVisible).toBe(false)
+    expect(workspace.debuggerTargetIp).toBeNull()
+    expect(workspace.debugCContent).toBeNull()
+    expect(workspace.debugVariableIndexes.size).toBe(0)
+    expect(workspace.debugVariableValues.size).toBe(0)
+    expect(workspace.debugForcedVariables.size).toBe(0)
+    expect(workspace.debugTick).toBe(0)
+    expect(workspace.debugVariableTree.size).toBe(0)
+    expect(workspace.debugExpandedNodes.size).toBe(0)
+    expect(workspace.fbDebugInstances.size).toBe(0)
+    expect(workspace.fbSelectedInstance.size).toBe(0)
+    expect(workspace.debugLocalMd5).toBeNull()
+    expect(workspace.debugGraphList).toEqual([])
+    expect(workspace.debugDataStale).toBe(false)
+    expect(workspace.debugMd5Mismatch).toBeNull()
+    expect(workspace.isPlcLogsVisible).toBe(false)
+    expect(workspace.plcLogs).toBe('')
+    expect(workspace.plcLogsLastId).toBeNull()
+    expect(workspace.plcFilters).toEqual({
+      levels: { debug: true, info: true, warning: true, error: true },
+      searchTerm: '',
+      timestampFormat: 'full',
+    })
+  })
+})

--- a/src2/store/slices/editor/index.ts
+++ b/src2/store/slices/editor/index.ts
@@ -1,0 +1,16 @@
+export { createEditorSlice } from './slice'
+export type {
+  CursorPosition,
+  EditorActions,
+  EditorModel,
+  EditorSlice,
+  EditorState,
+  FbdPosition,
+  GlobalVariablesTableType,
+  GraphicalType,
+  InstanceType,
+  ScrollPosition,
+  StructureTableType,
+  TaskType,
+  VariablesTable,
+} from './types'

--- a/src2/store/slices/editor/slice.ts
+++ b/src2/store/slices/editor/slice.ts
@@ -1,0 +1,296 @@
+import { produce } from 'immer'
+import { StateCreator } from 'zustand'
+
+import type { EditorSlice, EditorState } from './types'
+
+export const createEditorSlice: StateCreator<EditorSlice, [], [], EditorSlice> = (setState, getState) => ({
+  editors: [],
+  editor: {
+    type: 'available',
+    meta: {
+      name: 'available',
+    },
+  },
+  isMonacoFocused: false,
+
+  editorActions: {
+    addModel: (editor) =>
+      setState(
+        produce((state: EditorState) => {
+          const model = state.editors.find((model) => model.meta.name === editor.meta.name)
+          if (model) return
+          state.editors.push(editor)
+        }),
+      ),
+
+    removeModel: (name) =>
+      setState(
+        produce((state: EditorState) => {
+          state.editors = state.editors.filter((model) => model.meta.name !== name)
+        }),
+      ),
+
+    updateModelVariables: (variables) => {
+      setState(
+        produce((state: EditorState) => {
+          const { editor } = state
+
+          if (editor.type === 'plc-resource') {
+            if (variables.display === 'table') {
+              const prevSelectedRow = editor.variable.display === 'table' ? editor.variable.selectedRow : '-1'
+              const prevDescription = editor.variable.display === 'table' ? editor.variable.description : ''
+              editor.variable = {
+                display: 'table',
+                selectedRow: variables.selectedRow?.toString() ?? prevSelectedRow,
+                description: variables.description ?? prevDescription,
+              }
+            } else {
+              const existingCode = editor.variable.display === 'code' ? editor.variable.code : undefined
+              editor.variable = {
+                display: 'code',
+                code: variables.code !== undefined ? variables.code : existingCode,
+              }
+            }
+          } else if (editor.type === 'plc-textual' || editor.type === 'plc-graphical') {
+            if (variables.display === 'table') {
+              const prevSelectedRow = editor.variable.display === 'table' ? editor.variable.selectedRow : '-1'
+              const prevClassFilter = editor.variable.display === 'table' ? editor.variable.classFilter : 'All'
+              const prevDescription = editor.variable.display === 'table' ? editor.variable.description : ''
+              editor.variable = {
+                display: 'table',
+                selectedRow: variables.selectedRow?.toString() ?? prevSelectedRow,
+                classFilter: variables.classFilter ?? prevClassFilter,
+                description: variables.description ?? prevDescription,
+              }
+            } else {
+              const existingCode = editor.variable.display === 'code' ? editor.variable.code : undefined
+              editor.variable = {
+                display: 'code',
+                code: variables.code !== undefined ? variables.code : existingCode,
+              }
+            }
+          }
+        }),
+      )
+    },
+
+    updateModelVariablesForName: (name, variables) =>
+      setState(
+        produce((state: EditorState) => {
+          const targetEditor =
+            state.editor.meta.name === name ? state.editor : state.editors.find((e) => e.meta.name === name)
+
+          if (!targetEditor) return
+
+          if (targetEditor.type === 'plc-resource') {
+            if (variables.display === 'table') {
+              const prevSelectedRow = targetEditor.variable.display === 'table' ? targetEditor.variable.selectedRow : '-1'
+              const prevDescription = targetEditor.variable.display === 'table' ? targetEditor.variable.description : ''
+              targetEditor.variable = {
+                display: 'table',
+                selectedRow: variables.selectedRow?.toString() ?? prevSelectedRow,
+                description: variables.description ?? prevDescription,
+              }
+            } else {
+              const existingCode = targetEditor.variable.display === 'code' ? targetEditor.variable.code : undefined
+              targetEditor.variable = {
+                display: 'code',
+                code: variables.code !== undefined ? variables.code : existingCode,
+              }
+            }
+          } else if (targetEditor.type === 'plc-textual' || targetEditor.type === 'plc-graphical') {
+            if (variables.display === 'table') {
+              const prevSelectedRow = targetEditor.variable.display === 'table' ? targetEditor.variable.selectedRow : '-1'
+              const prevClassFilter = targetEditor.variable.display === 'table' ? targetEditor.variable.classFilter : 'All'
+              const prevDescription = targetEditor.variable.display === 'table' ? targetEditor.variable.description : ''
+              targetEditor.variable = {
+                display: 'table',
+                selectedRow: variables.selectedRow?.toString() ?? prevSelectedRow,
+                classFilter: variables.classFilter ?? prevClassFilter,
+                description: variables.description ?? prevDescription,
+              }
+            } else {
+              const existingCode = targetEditor.variable.display === 'code' ? targetEditor.variable.code : undefined
+              targetEditor.variable = {
+                display: 'code',
+                code: variables.code !== undefined ? variables.code : existingCode,
+              }
+            }
+          }
+        }),
+      ),
+
+    updateModelTasks: (tasks) =>
+      setState(
+        produce((state: EditorState) => {
+          const { editor } = state
+          if (editor.type === 'plc-resource') {
+            if (tasks.display === 'table') {
+              editor.task = {
+                ...editor.task,
+                display: 'table',
+                selectedRow: tasks.selectedRow !== undefined ? tasks.selectedRow.toString() : '-1',
+              }
+            } else {
+              editor.task = { display: 'code' }
+            }
+          }
+        }),
+      ),
+
+    updateModelInstances: (instances) =>
+      setState(
+        produce((state: EditorState) => {
+          const { editor } = state
+          if (editor.type === 'plc-resource') {
+            if (instances.display === 'table') {
+              editor.instance = {
+                ...editor.instance,
+                display: 'table',
+                selectedRow: instances.selectedRow !== undefined ? instances.selectedRow.toString() : '-1',
+              }
+            } else {
+              editor.instance = { display: 'code' }
+            }
+          }
+        }),
+      ),
+
+    updateModelStructure: ({ selectedRow, description }) =>
+      setState(
+        produce((state: EditorState) => {
+          const { editor } = state
+          if (editor.type === 'plc-datatype') {
+            editor.structure = {
+              selectedRow: selectedRow !== undefined ? selectedRow.toString() : editor.structure.selectedRow,
+              description: description ? description : editor.structure.description,
+            }
+          }
+        }),
+      ),
+
+    updateModelLadder: ({ openRung }) =>
+      setState(
+        produce((state: EditorState) => {
+          const { editor } = state
+          if (editor.type === 'plc-graphical' && editor.graphical.language === 'ld') {
+            if (openRung) {
+              const { rungId, open } = openRung
+              const rung = editor.graphical.openedRungs.find((r) => r.rungId === rungId)
+              if (rung) {
+                editor.graphical.openedRungs = editor.graphical.openedRungs.map((r) =>
+                  r.rungId === rungId ? { ...r, open } : r,
+                )
+              } else {
+                editor.graphical.openedRungs.push({ rungId, open })
+              }
+            }
+          }
+        }),
+      ),
+
+    getIsRungOpen: ({ rungId }) => {
+      const { editor } = getState()
+      if (editor.type === 'plc-graphical' && editor.graphical.language === 'ld') {
+        const rung = editor.graphical.openedRungs.find((r) => r.rungId === rungId)
+        if (rung) return rung.open
+      }
+      return true
+    },
+
+    updateModelFBD: ({ hoveringElement, canEditorZoom, canEditorPan }) =>
+      setState(
+        produce((state: EditorState) => {
+          const { editor } = state
+          if (editor.type === 'plc-graphical' && editor.graphical.language === 'fbd') {
+            if (canEditorZoom !== undefined) editor.graphical.canEditorZoom = canEditorZoom
+            if (canEditorPan !== undefined) editor.graphical.canEditorPan = canEditorPan
+            if (hoveringElement) {
+              editor.graphical.hoveringElement = {
+                elementId: hoveringElement.elementId,
+                hovering: hoveringElement.hovering,
+              }
+            }
+          }
+        }),
+      ),
+
+    updateEditorModel: (currentEditor, newEditor) => {
+      if (currentEditor === newEditor) return
+      setState(
+        produce((state: EditorState) => {
+          const { editor, editors } = state
+          const oldEditorModel = editors.findIndex((model) => model.meta.name === currentEditor)
+          if (oldEditorModel === -1) return
+          Object.assign(editors[oldEditorModel], { meta: { ...editors[oldEditorModel].meta, name: newEditor } })
+          Object.assign(editor, { meta: { ...editor.meta, name: newEditor } })
+        }),
+      )
+    },
+
+    updateEditorName: (oldName, newName) => {
+      if (oldName === newName) return
+      setState(
+        produce((state: EditorState) => {
+          const { editor, editors } = state
+          const editorIndex = editors.findIndex((model) => model.meta.name === oldName)
+          if (editorIndex !== -1) {
+            Object.assign(editors[editorIndex], { meta: { ...editors[editorIndex].meta, name: newName } })
+          }
+          if (editor.meta.name === oldName) {
+            Object.assign(editor, { meta: { ...editor.meta, name: newName } })
+          }
+        }),
+      )
+    },
+
+    setEditor: (newEditor) =>
+      setState(
+        produce((state: EditorState) => {
+          const oldEditor = state.editor
+          if (oldEditor.meta.name === newEditor.meta.name) return
+
+          if (oldEditor.type !== 'available') {
+            state.editors = state.editors.map((model) =>
+              model.meta.name === oldEditor.meta.name ? oldEditor : model,
+            )
+          }
+
+          state.editor = newEditor
+        }),
+      ),
+
+    clearEditor: () =>
+      setState(
+        produce((state: EditorState) => {
+          state.editors = []
+          state.editor = { type: 'available', meta: { name: 'available' } }
+        }),
+      ),
+
+    saveEditorViewState: ({ prevEditorName, cursorPosition, scrollPosition, fbdPosition }) =>
+      setState(
+        produce((state: EditorState) => {
+          const currentEditor = state.editor
+          if (currentEditor.type === 'available') return
+
+          const index = state.editors.findIndex((e) => e.meta.name === prevEditorName)
+          if (index === -1) return
+
+          state.editors[index].cursorPosition = cursorPosition
+          state.editors[index].scrollPosition = scrollPosition
+          state.editors[index].fbdPosition = fbdPosition
+        }),
+      ),
+
+    getEditorFromEditors: (name) => {
+      const { editor, editors } = getState()
+      if (name === editor.meta.name) return editor
+      return editors.find((model) => model.meta.name === name) ?? null
+    },
+
+    setMonacoFocused: (focused) => {
+      setState({ isMonacoFocused: focused })
+    },
+  },
+})

--- a/src2/store/slices/editor/types.ts
+++ b/src2/store/slices/editor/types.ts
@@ -1,0 +1,215 @@
+// ---------------------------------------------------------------------------
+// Variables
+// ---------------------------------------------------------------------------
+
+export type VariablesTable =
+  | {
+      display: 'table'
+      description: string
+      classFilter: 'All' | 'Local' | 'Input' | 'Output' | 'InOut' | 'External' | 'Temp'
+      selectedRow: string
+    }
+  | {
+      display: 'code'
+      code?: string
+    }
+
+export type GlobalVariablesTableType =
+  | {
+      display: 'table'
+      description: string
+      selectedRow: string
+    }
+  | {
+      display: 'code'
+      code?: string
+    }
+
+export type StructureTableType = {
+  description: string
+  selectedRow: string
+}
+
+export type TaskType =
+  | { display: 'table'; selectedRow: string }
+  | { display: 'code' }
+
+export type InstanceType =
+  | { display: 'table'; selectedRow: string }
+  | { display: 'code' }
+
+// ---------------------------------------------------------------------------
+// Graphical schemas
+// ---------------------------------------------------------------------------
+
+export type GraphicalType =
+  | {
+      language: 'ld'
+      openedRungs: Array<{ rungId: string; open: boolean }>
+    }
+  | {
+      language: 'sfc'
+    }
+  | {
+      language: 'fbd'
+      hoveringElement: { elementId: string | null; hovering: boolean }
+      canEditorZoom: boolean
+      canEditorPan: boolean
+    }
+
+// ---------------------------------------------------------------------------
+// Cursor / scroll / FBD position
+// ---------------------------------------------------------------------------
+
+export type CursorPosition = {
+  lineNumber: number
+  column: number
+  offset: number
+}
+
+export type ScrollPosition = {
+  top: number
+  left: number
+}
+
+export type FbdPosition = {
+  x: number
+  y: number
+  zoom: number
+}
+
+// ---------------------------------------------------------------------------
+// Editor model — discriminated union for all POU types
+// ---------------------------------------------------------------------------
+
+type EditorModelBase = {
+  cursorPosition?: CursorPosition
+  scrollPosition?: ScrollPosition
+  fbdPosition?: FbdPosition
+}
+
+export type EditorModel = EditorModelBase &
+  (
+    | {
+        type: 'available'
+        meta: { name: string }
+      }
+    | {
+        type: 'plc-textual'
+        meta: {
+          name: string
+          path: string
+          language: 'il' | 'st' | 'python' | 'cpp'
+          pouType: 'program' | 'function' | 'function-block'
+        }
+        variable: VariablesTable
+      }
+    | {
+        type: 'plc-graphical'
+        meta: {
+          name: string
+          path: string
+          language: 'ld' | 'sfc' | 'fbd'
+          pouType: 'program' | 'function' | 'function-block'
+        }
+        variable: VariablesTable
+        graphical: GraphicalType
+      }
+    | {
+        type: 'plc-datatype'
+        meta: {
+          name: string
+          derivation: 'enumerated' | 'structure' | 'array'
+        }
+        structure: StructureTableType
+      }
+    | {
+        type: 'plc-resource'
+        meta: {
+          name: string
+          path: string
+        }
+        variable: GlobalVariablesTableType
+        task: TaskType
+        instance: InstanceType
+      }
+    | {
+        type: 'plc-device'
+        meta: {
+          name: string
+          derivation: 'configuration' | 'pin-mapping' | 'orchestrators'
+        }
+      }
+    | {
+        type: 'plc-server'
+        meta: {
+          name: string
+          protocol: 'modbus-tcp' | 's7comm' | 'ethernet-ip' | 'opcua'
+        }
+      }
+    | {
+        type: 'plc-remote-device'
+        meta: {
+          name: string
+          protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet'
+        }
+      }
+  )
+
+// ---------------------------------------------------------------------------
+// Editor State & Actions
+// ---------------------------------------------------------------------------
+
+export type EditorState = {
+  editors: EditorModel[]
+  editor: EditorModel
+  isMonacoFocused: boolean
+}
+
+export type EditorActions = {
+  addModel: (editor: EditorModel) => void
+  removeModel: (name: string) => void
+  updateEditorModel: (currentEditor: string, newEditor: string) => void
+  updateEditorName: (oldName: string, newName: string) => void
+  updateModelVariables: (variables: {
+    display: 'code' | 'table'
+    selectedRow?: number
+    classFilter?: 'All' | 'Local' | 'Input' | 'Output' | 'InOut' | 'External' | 'Temp'
+    description?: string
+    code?: string
+  }) => void
+  updateModelVariablesForName: (
+    name: string,
+    variables: {
+      display: 'code' | 'table'
+      selectedRow?: number
+      classFilter?: 'All' | 'Local' | 'Input' | 'Output' | 'InOut' | 'External' | 'Temp'
+      description?: string
+      code?: string
+    },
+  ) => void
+  updateModelStructure: (data: { selectedRow?: number; description?: string }) => void
+  updateModelTasks: (tasks: { selectedRow?: number; display: 'code' | 'table' }) => void
+  updateModelInstances: (instances: { selectedRow?: number; display: 'code' | 'table' }) => void
+  updateModelLadder: (data: { openRung?: { rungId: string; open: boolean } }) => void
+  getIsRungOpen: (data: { rungId: string }) => boolean
+  updateModelFBD: (data: {
+    hoveringElement?: { elementId: string | null; hovering: boolean }
+    canEditorZoom?: boolean
+    canEditorPan?: boolean
+  }) => void
+  setEditor: (newEditor: EditorModel) => void
+  clearEditor: () => void
+  saveEditorViewState: (data: {
+    prevEditorName: string
+    cursorPosition?: CursorPosition
+    scrollPosition?: ScrollPosition
+    fbdPosition?: FbdPosition
+  }) => void
+  getEditorFromEditors: (name: string) => EditorModel | null
+  setMonacoFocused: (focused: boolean) => void
+}
+
+export type EditorSlice = EditorState & {
+  editorActions: EditorActions
+}

--- a/src2/store/slices/index.ts
+++ b/src2/store/slices/index.ts
@@ -1,0 +1,5 @@
+export { createEditorSlice } from './editor'
+export { createModalSlice } from './modal'
+export { createSearchSlice } from './search'
+export { createTabsSlice } from './tabs'
+export { createWorkspaceSlice } from './workspace'

--- a/src2/store/slices/modal/index.ts
+++ b/src2/store/slices/modal/index.ts
@@ -1,0 +1,2 @@
+export { createModalSlice } from './slice'
+export type { ModalActions, ModalSlice, ModalsState, ModalTypes } from './types'

--- a/src2/store/slices/modal/slice.ts
+++ b/src2/store/slices/modal/slice.ts
@@ -1,0 +1,73 @@
+import { produce } from 'immer'
+import { StateCreator } from 'zustand'
+
+import type { ModalSlice, ModalTypes } from './types'
+
+const ALL_MODAL_TYPES: ModalTypes[] = [
+  'ai-consent',
+  'block-ladder-element',
+  'coil-ladder-element',
+  'contact-ladder-element',
+  'block-fbd-element',
+  'create-project',
+  'save-changes-project',
+  'save-changes-file',
+  'confirm-delete-element',
+  'confirm-device-switch',
+  'quit-application',
+  'runtime-create-user',
+  'runtime-login',
+  'server-ip-mismatch',
+  'runtime-connection-lost',
+  'debugger-message',
+  'debugger-ip-input',
+]
+
+function createDefaultModals() {
+  const modals = {} as ModalSlice['modals']
+  for (const type of ALL_MODAL_TYPES) {
+    modals[type] = { open: false, data: null }
+  }
+  return modals
+}
+
+const createModalSlice: StateCreator<ModalSlice, [], [], ModalSlice> = (setState, getState) => ({
+  modals: createDefaultModals(),
+
+  modalActions: {
+    openModal: (modal, data) => {
+      setState(
+        produce(({ modals }: ModalSlice) => {
+          modals[modal] = { open: true, data }
+        }),
+      )
+    },
+
+    onOpenChange: (modal, value) => {
+      setState(
+        produce(({ modals }: ModalSlice) => {
+          modals[modal] = {
+            open: value,
+            data: value ? modals[modal]?.data : null,
+          }
+        }),
+      )
+    },
+
+    closeModal: () => {
+      setState(
+        produce(({ modals }: ModalSlice) => {
+          for (const modal of ALL_MODAL_TYPES) {
+            modals[modal] = { open: false, data: null }
+          }
+        }),
+      )
+    },
+
+    getModalState: (modal) => {
+      return getState().modals[modal] || { open: false }
+    },
+  },
+})
+
+export { createModalSlice }

--- a/src2/store/slices/modal/types.ts
+++ b/src2/store/slices/modal/types.ts
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------------
+// Modal types — superset of both editor and web
+// ---------------------------------------------------------------------------
+
+export type ModalTypes =
+  | 'ai-consent'
+  | 'block-ladder-element'
+  | 'coil-ladder-element'
+  | 'contact-ladder-element'
+  | 'block-fbd-element'
+  | 'create-project'
+  | 'save-changes-project'
+  | 'save-changes-file'
+  | 'confirm-delete-element'
+  | 'confirm-device-switch'
+  | 'quit-application'
+  | 'runtime-create-user'
+  | 'runtime-login'
+  | 'server-ip-mismatch'
+  | 'runtime-connection-lost'
+  | 'debugger-message'
+  | 'debugger-ip-input'
+
+export type ModalsState = Record<ModalTypes, { open: boolean; data: unknown }>
+
+export type ModalActions = {
+  openModal: (modal: ModalTypes, data?: unknown) => void
+  onOpenChange: (modal: ModalTypes, value: boolean) => void
+  closeModal: () => void
+  getModalState: (modal: ModalTypes) => { open: boolean; data?: unknown }
+}
+
+export type ModalSlice = {
+  modals: ModalsState
+  modalActions: ModalActions
+}

--- a/src2/store/slices/search/index.ts
+++ b/src2/store/slices/search/index.ts
@@ -1,0 +1,2 @@
+export { createSearchSlice } from './slice'
+export type { Project, SearchActions, SearchSlice, SearchState } from './types'

--- a/src2/store/slices/search/slice.ts
+++ b/src2/store/slices/search/slice.ts
@@ -1,0 +1,77 @@
+import { produce } from 'immer'
+import { StateCreator } from 'zustand'
+
+import type { SearchSlice } from './types'
+
+const createSearchSlice: StateCreator<SearchSlice, [], [], SearchSlice> = (setState) => ({
+  searchQuery: '',
+  searchResults: [],
+  sensitiveCase: false,
+  regularExpression: false,
+  searchNodePosition: { x: 0, y: 0 },
+
+  searchActions: {
+    setSearchQuery: (searchQuery) => {
+      setState(
+        produce((state: SearchSlice) => {
+          state.searchQuery = searchQuery
+        }),
+      )
+    },
+
+    setSearchResults: (newSearchResult) => {
+      setState(
+        produce((state: SearchSlice) => {
+          const index = state.searchResults.findIndex((result) => result.searchQuery === newSearchResult.searchQuery)
+          if (index !== -1) {
+            state.searchResults.splice(index, 1)
+          }
+          state.searchResults.push(newSearchResult)
+        }),
+      )
+    },
+
+    setSensitiveCase: (sensitiveCase) => {
+      setState(
+        produce((state: SearchSlice) => {
+          state.sensitiveCase = sensitiveCase
+        }),
+      )
+    },
+
+    setRegularExpression: (regularExpression) => {
+      setState(
+        produce((state: SearchSlice) => {
+          state.regularExpression = regularExpression
+        }),
+      )
+    },
+
+    removeSearchResult: (itemID) =>
+      setState((state) => ({
+        searchResults: state.searchResults.filter((item) => item.searchID !== itemID),
+      })),
+
+    setSearchNodePosition: (searchNodePosition) => {
+      setState(
+        produce((state: SearchSlice) => {
+          state.searchNodePosition = searchNodePosition
+        }),
+      )
+    },
+
+    clearSearch: () => {
+      setState(
+        produce((state: SearchSlice) => {
+          state.searchQuery = ''
+          state.searchResults = []
+          state.sensitiveCase = false
+          state.regularExpression = false
+          state.searchNodePosition = { x: 0, y: 0 }
+        }),
+      )
+    },
+  },
+})
+
+export { createSearchSlice }

--- a/src2/store/slices/search/types.ts
+++ b/src2/store/slices/search/types.ts
@@ -1,0 +1,44 @@
+export type Project = {
+  searchQuery: string
+  projectName: string
+  functions: {
+    pous: Record<'program' | 'function' | 'function-block', Array<{
+      name: string
+      language: 'ld' | 'sfc' | 'fbd' | 'il' | 'st' | 'python' | 'cpp'
+      pouType: 'program' | 'function' | 'function-block'
+      body: string
+      variable: string | null
+    }>>
+    dataTypes: Array<{
+      name: string
+      type: 'array' | 'structure' | 'enumerated'
+    }>
+    resource: {
+      globalVariable: string
+      task: string
+      instance: string
+    }
+  }
+  searchCounts?: number
+  searchID: string
+}
+
+export type SearchState = {
+  searchQuery: string
+  searchResults: Project[]
+  sensitiveCase: boolean
+  regularExpression: boolean
+  searchNodePosition: { x: number; y: number }
+}
+
+export type SearchActions = {
+  setSearchQuery: (query: string) => void
+  setSearchResults: (project: Project) => void
+  setSensitiveCase: (sensitiveCase: boolean) => void
+  setRegularExpression: (regularExpression: boolean) => void
+  removeSearchResult: (itemID: string) => void
+  setSearchNodePosition: (position: { x: number; y: number }) => void
+  clearSearch: () => void
+}
+
+export type SearchSlice = SearchState & { searchActions: SearchActions }

--- a/src2/store/slices/search/utils.ts
+++ b/src2/store/slices/search/utils.ts
@@ -1,0 +1,23 @@
+import DOMPurify from 'dompurify'
+
+const escapeRegExp = (string: string) => {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+const extractSearchQuery = (body: string, searchQuery: string): string => {
+  const escapedSearchQuery = escapeRegExp(searchQuery)
+  const regex = new RegExp(`(${escapedSearchQuery})`, 'gi')
+  const match = body.match(regex)
+  if (match) {
+    const highlightedHTML = body.replace(
+      regex,
+      (matched) => `<span class='bg-brand-light dark:bg-brand-medium-dark border-0 rounded-sm'>${matched}</span>`,
+    )
+
+    return DOMPurify.sanitize(highlightedHTML)
+  }
+
+  return body
+}
+
+export { escapeRegExp, extractSearchQuery }

--- a/src2/store/slices/tabs/index.ts
+++ b/src2/store/slices/tabs/index.ts
@@ -1,0 +1,2 @@
+export { createTabsSlice } from './slice'
+export type { TabsActions, TabsProps, TabsSlice, TabsState } from './types'

--- a/src2/store/slices/tabs/slice.ts
+++ b/src2/store/slices/tabs/slice.ts
@@ -1,0 +1,81 @@
+import { produce } from 'immer'
+import { StateCreator } from 'zustand'
+
+import type { TabsSlice } from './types'
+
+export const createTabsSlice: StateCreator<TabsSlice, [], [], TabsSlice> = (setState, getState) => ({
+  tabs: [],
+  selectedTab: null,
+
+  tabsActions: {
+    setTabs: (tabs) => {
+      setState(
+        produce((slice: TabsSlice) => {
+          slice.tabs = tabs
+        }),
+      )
+    },
+
+    updateTabs: (tab) => {
+      setState(
+        produce((slice: TabsSlice) => {
+          const tabExists = slice.tabs.find((t) => t.name === tab.name)
+          if (tabExists) return
+          slice.tabs = [...slice.tabs, tab]
+        }),
+      )
+    },
+
+    sortTabs: (tabs) => {
+      setState(
+        produce((slice: TabsSlice) => {
+          slice.tabs = tabs
+        }),
+      )
+    },
+
+    removeTab: (tabToRemove) => {
+      setState(
+        produce((slice: TabsSlice) => {
+          slice.tabs = slice.tabs.filter((t) => t.name !== tabToRemove)
+        }),
+      )
+    },
+
+    updateTabName: (oldName, newName) => {
+      setState(
+        produce((state: TabsSlice) => {
+          const tabExists = state.tabs.find((tab) => tab.name === oldName)
+          if (!tabExists) return
+
+          state.tabs = state.tabs.map((tab) => (tab.name === oldName ? { ...tab, name: newName } : tab))
+
+          if (state.selectedTab === oldName) {
+            state.selectedTab = newName
+          }
+        }),
+      )
+    },
+
+    clearTabs: () => {
+      setState(
+        produce((slice: TabsSlice) => {
+          slice.tabs = []
+          slice.selectedTab = null
+        }),
+      )
+    },
+
+    setSelectedTab: (tabName) => {
+      setState(
+        produce((slice: TabsSlice) => {
+          slice.selectedTab = tabName
+        }),
+      )
+    },
+
+    getSelectedTab: () => {
+      return getState().selectedTab
+    },
+  },
+})

--- a/src2/store/slices/tabs/types.ts
+++ b/src2/store/slices/tabs/types.ts
@@ -1,0 +1,42 @@
+// ---------------------------------------------------------------------------
+// Tab element types — superset of both editor and web
+// ---------------------------------------------------------------------------
+
+export type TabsProps = {
+  name: string
+  path?: string
+  elementType:
+    | { type: 'program'; language: 'il' | 'st' | 'ld' | 'sfc' | 'fbd' | 'python' | 'cpp' }
+    | { type: 'function'; language: 'il' | 'st' | 'ld' | 'sfc' | 'fbd' | 'python' | 'cpp' }
+    | { type: 'function-block'; language: 'il' | 'st' | 'ld' | 'sfc' | 'fbd' | 'python' | 'cpp' }
+    | { type: 'data-type'; derivation: 'enumerated' | 'structure' | 'array' }
+    | { type: 'resource' }
+    | { type: 'device'; derivation: 'configuration' | 'pin-mapping' | 'orchestrators' }
+    | { type: 'server'; protocol: 'modbus-tcp' | 's7comm' | 'ethernet-ip' | 'opcua' }
+    | { type: 'remote-device'; protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet' }
+  configuration?: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// Tabs state & actions
+// ---------------------------------------------------------------------------
+
+export type TabsState = {
+  tabs: TabsProps[]
+  selectedTab: string | null
+}
+
+export type TabsActions = {
+  setTabs: (tabs: TabsProps[]) => void
+  updateTabs: (tab: TabsProps) => void
+  sortTabs: (tabs: TabsProps[]) => void
+  removeTab: (tabToRemove: string) => void
+  updateTabName: (oldName: string, newName: string) => void
+  clearTabs: () => void
+  setSelectedTab: (tabName: string) => void
+  getSelectedTab: () => string | null
+}
+
+export type TabsSlice = TabsState & {
+  tabsActions: TabsActions
+}

--- a/src2/store/slices/tabs/utils.ts
+++ b/src2/store/slices/tabs/utils.ts
@@ -1,0 +1,141 @@
+import type { EditorModel } from '../editor/types'
+import type { TabsProps } from './types'
+
+const CreatePLCTextualObject = (
+  name: string,
+  language: 'il' | 'st' | 'python' | 'cpp',
+  pouType: 'program' | 'function' | 'function-block',
+): EditorModel => ({
+  type: 'plc-textual',
+  meta: {
+    name,
+    language,
+    path: `/data/pous/${pouType}/${language}/${name}`,
+    pouType,
+  },
+  variable: {
+    display: 'table',
+    description: '',
+    classFilter: 'All',
+    selectedRow: '-1',
+  },
+})
+
+const CreatePLCGraphicalObject = (
+  name: string,
+  language: 'ld' | 'sfc' | 'fbd',
+  pouType: 'program' | 'function' | 'function-block',
+): EditorModel => ({
+  type: 'plc-graphical',
+  meta: {
+    name,
+    language,
+    path: `/data/pous/${pouType}/${language}/${name}`,
+    pouType,
+  },
+  variable: {
+    display: 'table',
+    description: '',
+    classFilter: 'All',
+    selectedRow: '-1',
+  },
+  graphical:
+    language === 'ld'
+      ? { language, openedRungs: [] }
+      : language === 'fbd'
+        ? { language, hoveringElement: { elementId: null, hovering: false }, canEditorZoom: true, canEditorPan: true }
+        : { language },
+})
+
+const CreateEditorModelObject = (
+  name: string,
+  language: 'il' | 'st' | 'ld' | 'sfc' | 'fbd' | 'python' | 'cpp' | null,
+  pouType: 'program' | 'function' | 'function-block' | null,
+  derivation?: 'enumerated' | 'structure' | 'array',
+): EditorModel => {
+  if (derivation) {
+    return {
+      type: 'plc-datatype',
+      meta: { name, derivation },
+      structure: { selectedRow: '-1', description: '' },
+    }
+  }
+
+  if (!language || !pouType) {
+    throw new Error('Language and pouType must be defined')
+  }
+
+  if (['ld', 'sfc', 'fbd'].includes(language)) {
+    return CreatePLCGraphicalObject(name, language as 'ld' | 'sfc' | 'fbd', pouType)
+  }
+
+  return CreatePLCTextualObject(name, language as 'il' | 'st' | 'python' | 'cpp', pouType)
+}
+
+const CreateResourceEditor = (name = 'Resource'): EditorModel => ({
+  type: 'plc-resource',
+  meta: { name, path: `/data/configuration/resource` },
+  variable: { display: 'table', description: '', selectedRow: '-1' },
+  task: { display: 'table', selectedRow: '-1' },
+  instance: { display: 'table', selectedRow: '-1' },
+})
+
+const CreateDeviceEditor = (
+  name = 'device',
+  derivation: 'configuration' | 'pin-mapping' | 'orchestrators',
+): EditorModel => {
+  if (!derivation) throw new Error('Invalid derivation value')
+  return {
+    type: 'plc-device',
+    meta: { name, derivation },
+  }
+}
+
+const CreateRemoteDeviceEditor = (
+  name: string,
+  protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet',
+): EditorModel => ({
+  type: 'plc-remote-device',
+  meta: { name, protocol },
+})
+
+const CreateServerEditor = (
+  name: string,
+  protocol: 'modbus-tcp' | 's7comm' | 'ethernet-ip' | 'opcua',
+): EditorModel => ({
+  type: 'plc-server',
+  meta: { name, protocol },
+})
+
+const CreateEditorObjectFromTab = (tab: TabsProps): EditorModel => {
+  const { elementType, name } = tab
+  switch (elementType.type) {
+    case 'program':
+      return CreateEditorModelObject(name, elementType.language, 'program')
+    case 'function':
+      return CreateEditorModelObject(name, elementType.language, 'function')
+    case 'function-block':
+      return CreateEditorModelObject(name, elementType.language, 'function-block')
+    case 'data-type':
+      return CreateEditorModelObject(name, null, null, elementType.derivation)
+    case 'resource':
+      return CreateResourceEditor(name)
+    case 'device':
+      return CreateDeviceEditor(name, elementType.derivation)
+    case 'remote-device':
+      return CreateRemoteDeviceEditor(name, elementType.protocol)
+    case 'server':
+      return CreateServerEditor(name, elementType.protocol)
+  }
+}
+
+export {
+  CreateDeviceEditor,
+  CreateEditorModelObject,
+  CreateEditorObjectFromTab,
+  CreatePLCGraphicalObject,
+  CreatePLCTextualObject,
+  CreateRemoteDeviceEditor,
+  CreateResourceEditor,
+  CreateServerEditor,
+}

--- a/src2/store/slices/workspace/index.ts
+++ b/src2/store/slices/workspace/index.ts
@@ -1,0 +1,2 @@
+export { createWorkspaceSlice } from './slice'
+export type { PlcFilters, SystemConfigs, WorkspaceActions, WorkspaceResponse, WorkspaceSlice, WorkspaceState } from './types'

--- a/src2/store/slices/workspace/slice.ts
+++ b/src2/store/slices/workspace/slice.ts
@@ -1,0 +1,402 @@
+import type { DebugTreeNode, FbInstanceInfo, PlcLogs } from '../../../providers/platform/ports/types'
+import { isV4Logs, LOG_BUFFER_CAP } from '../../../providers/platform/ports/types'
+import { produce } from 'immer'
+import { StateCreator } from 'zustand'
+
+import type { WorkspaceSlice } from './types'
+
+const createWorkspaceSlice: StateCreator<WorkspaceSlice, [], [], WorkspaceSlice> = (setState) => ({
+  workspace: {
+    editingState: 'initial-state',
+    systemConfigs: {
+      OS: '',
+      arch: '',
+      shouldUseDarkMode: false,
+      isWindowMaximized: false,
+    },
+    recent: [],
+    isCollapsed: false,
+    isModalOpen: [],
+    discardChanges: false,
+    selectedProjectTreeLeaf: {
+      label: '',
+      type: null,
+    },
+    close: {
+      window: false,
+      app: false,
+      appDarwin: false,
+    },
+    // PLC Logs
+    isPlcLogsVisible: false,
+    plcLogs: '',
+    plcLogsLastId: null,
+    plcFilters: {
+      levels: { debug: true, info: true, warning: true, error: true },
+      searchTerm: '',
+      timestampFormat: 'full',
+    },
+    // Debug state
+    isDebuggerVisible: false,
+    debuggerTargetIp: null,
+    debugCContent: null,
+    debugVariableIndexes: new Map(),
+    debugVariableValues: new Map(),
+    debugForcedVariables: new Map(),
+    debugTick: 0,
+    debugVariableTree: new Map(),
+    debugExpandedNodes: new Map(),
+    fbDebugInstances: new Map(),
+    fbSelectedInstance: new Map(),
+    debugLocalMd5: null,
+    debugGraphList: [],
+    debugDataStale: false,
+    debugMd5Mismatch: null,
+  },
+
+  workspaceActions: {
+    setEditingState: (editingState) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.editingState = editingState
+        }),
+      )
+    },
+    setSystemConfigs: (systemConfigsData) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.systemConfigs = systemConfigsData
+        }),
+      )
+    },
+    setRecent: (recent) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.recent = recent
+        }),
+      )
+    },
+    setCloseApp: (value) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.close.app = value
+        }),
+      )
+    },
+    setCloseAppDarwin: (value) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.close.appDarwin = value
+        }),
+      )
+    },
+    setCloseWindow: (value) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.close.window = value
+        }),
+      )
+    },
+    switchAppTheme: () => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.systemConfigs.shouldUseDarkMode = !workspace.systemConfigs.shouldUseDarkMode
+        }),
+      )
+    },
+    toggleMaximizedWindow: () => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.systemConfigs.isWindowMaximized = !workspace.systemConfigs.isWindowMaximized
+        }),
+      )
+    },
+    toggleCollapse: () => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.isCollapsed = !workspace.isCollapsed
+        }),
+      )
+    },
+    toggleDiscardChanges: () => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.discardChanges = !workspace.discardChanges
+        }),
+      )
+    },
+    setModalOpen: (modalName: string, modalState: boolean) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          const modalIndex = workspace.isModalOpen.findIndex((modal) => modal.modalName === modalName)
+          if (modalIndex !== -1) {
+            workspace.isModalOpen[modalIndex].modalState = modalState
+          } else {
+            workspace.isModalOpen.push({ modalName, modalState })
+          }
+        }),
+      )
+    },
+    setSelectedProjectTreeLeaf: (selectedProjectTreeLeaf) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.selectedProjectTreeLeaf = selectedProjectTreeLeaf
+        }),
+      )
+    },
+    clearWorkspace: () => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.editingState = 'initial-state'
+          workspace.selectedProjectTreeLeaf = { label: '', type: null }
+          workspace.isDebuggerVisible = false
+          workspace.debuggerTargetIp = null
+          workspace.debugCContent = null
+          workspace.debugVariableIndexes = new Map()
+          workspace.debugVariableValues = new Map()
+          workspace.debugForcedVariables = new Map()
+          workspace.debugTick = 0
+          workspace.debugVariableTree = new Map()
+          workspace.debugExpandedNodes = new Map()
+          workspace.fbDebugInstances = new Map()
+          workspace.fbSelectedInstance = new Map()
+          workspace.debugLocalMd5 = null
+          workspace.debugGraphList = []
+          workspace.debugDataStale = false
+          workspace.debugMd5Mismatch = null
+          workspace.isPlcLogsVisible = false
+          workspace.plcLogs = ''
+          workspace.plcLogsLastId = null
+          workspace.plcFilters = {
+            levels: { debug: true, info: true, warning: true, error: true },
+            searchTerm: '',
+            timestampFormat: 'full',
+          }
+        }),
+      )
+    },
+    // PLC Logs
+    setPlcLogsVisible: (isVisible: boolean) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.isPlcLogsVisible = isVisible
+        }),
+      )
+    },
+    setPlcLogs: (logs: PlcLogs) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.plcLogs = logs
+        }),
+      )
+    },
+    setPlcLogsLastId: (lastId: number | null) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.plcLogsLastId = lastId
+        }),
+      )
+    },
+    appendPlcLogs: (newLogs: PlcLogs) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          if (isV4Logs(newLogs) && isV4Logs(workspace.plcLogs)) {
+            const combined = [...workspace.plcLogs, ...newLogs]
+            workspace.plcLogs = combined.length > LOG_BUFFER_CAP ? combined.slice(-LOG_BUFFER_CAP) : combined
+          } else if (typeof newLogs === 'string' && typeof workspace.plcLogs === 'string') {
+            workspace.plcLogs = workspace.plcLogs + newLogs
+          } else {
+            workspace.plcLogs = newLogs
+          }
+        }),
+      )
+    },
+    clearPlcLogs: () => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.plcLogs = ''
+          workspace.plcLogsLastId = null
+        }),
+      )
+    },
+    setPlcLevelFilter: (level: 'debug' | 'info' | 'warning' | 'error', enabled: boolean) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.plcFilters.levels[level] = enabled
+        }),
+      )
+    },
+    setPlcSearchTerm: (term: string) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.plcFilters.searchTerm = term
+        }),
+      )
+    },
+    setPlcTimestampFormat: (format: 'full' | 'time' | 'none') => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.plcFilters.timestampFormat = format
+        }),
+      )
+    },
+    // Debug actions
+    setDebuggerVisible: (isVisible: boolean) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.isDebuggerVisible = isVisible
+        }),
+      )
+    },
+    setDebuggerTargetIp: (targetIp: string | null) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.debuggerTargetIp = targetIp
+        }),
+      )
+    },
+    setDebugCContent: (content: string | null) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.debugCContent = content
+        }),
+      )
+    },
+    setDebugVariableIndexes: (indexes: Map<string, number>) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.debugVariableIndexes = indexes
+        }),
+      )
+    },
+    setDebugVariableValues: (values: Map<string, string>) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          for (const [key, val] of values) {
+            workspace.debugVariableValues.set(key, val)
+          }
+        }),
+      )
+    },
+    setDebugForcedVariables: (forced: Map<string, boolean>) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.debugForcedVariables = forced
+        }),
+      )
+    },
+    setDebugTick: (tick: number) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.debugTick = tick
+        }),
+      )
+    },
+    setDebugVariableTree: (tree: Map<string, DebugTreeNode>) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.debugVariableTree = tree
+        }),
+      )
+    },
+    setDebugExpandedNodes: (expandedNodes: Map<string, boolean>) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.debugExpandedNodes = expandedNodes
+        }),
+      )
+    },
+    toggleDebugExpandedNode: (compositeKey: string) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          const currentValue = workspace.debugExpandedNodes.get(compositeKey) ?? false
+          workspace.debugExpandedNodes.set(compositeKey, !currentValue)
+        }),
+      )
+    },
+    setFbDebugInstances: (instances: Map<string, FbInstanceInfo[]>) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.fbDebugInstances = instances
+        }),
+      )
+    },
+    setFbSelectedInstance: (fbTypeName: string, key: string) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.fbSelectedInstance.set(fbTypeName, key)
+        }),
+      )
+    },
+    setDebugLocalMd5: (md5: string | null) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.debugLocalMd5 = md5
+        }),
+      )
+    },
+    setDebugGraphList: (list: string[]) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.debugGraphList = list
+        }),
+      )
+    },
+    setDebugDataStale: (stale: boolean) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.debugDataStale = stale
+        }),
+      )
+    },
+    setDebugMd5Mismatch: (mismatch: { runtimeMd5: string; localMd5: string } | null) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.debugMd5Mismatch = mismatch
+        }),
+      )
+    },
+    clearDebugState: () => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.isDebuggerVisible = false
+          workspace.debuggerTargetIp = null
+          workspace.debugCContent = null
+          workspace.debugVariableIndexes = new Map()
+          workspace.debugVariableValues = new Map()
+          workspace.debugForcedVariables = new Map()
+          workspace.debugTick = 0
+          workspace.debugVariableTree = new Map()
+          workspace.debugExpandedNodes = new Map()
+          workspace.fbDebugInstances = new Map()
+          workspace.fbSelectedInstance = new Map()
+          workspace.debugLocalMd5 = null
+          workspace.debugGraphList = []
+          workspace.debugDataStale = false
+          workspace.debugMd5Mismatch = null
+        }),
+      )
+    },
+    clearFbDebugContext: () => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.fbDebugInstances = new Map()
+          workspace.fbSelectedInstance = new Map()
+        }),
+      )
+    },
+    removeDebugVariable: (compositeKey: string) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.debugVariableIndexes.delete(compositeKey)
+          workspace.debugVariableValues.delete(compositeKey)
+          workspace.debugForcedVariables.delete(compositeKey)
+          workspace.debugVariableTree.delete(compositeKey)
+          workspace.debugExpandedNodes.delete(compositeKey)
+        }),
+      )
+    },
+  },
+})
+
+export { createWorkspaceSlice }

--- a/src2/store/slices/workspace/types.ts
+++ b/src2/store/slices/workspace/types.ts
@@ -1,0 +1,150 @@
+import type { DebugTreeNode, FbInstanceInfo, PlcLogs, Platform, Architecture } from '../../../providers/platform/ports/types'
+
+// ---------------------------------------------------------------------------
+// PLC Log Filters
+// ---------------------------------------------------------------------------
+
+export type PlcFilters = {
+  levels: {
+    debug: boolean
+    info: boolean
+    warning: boolean
+    error: boolean
+  }
+  searchTerm: string
+  timestampFormat: 'full' | 'time' | 'none'
+}
+
+// ---------------------------------------------------------------------------
+// Project tree
+// ---------------------------------------------------------------------------
+
+export type WorkspaceProjectTreeLeafType =
+  | 'function'
+  | 'function-block'
+  | 'program'
+  | 'data-type'
+  | 'device'
+  | 'resource'
+  | 'server'
+  | 'remote-device'
+  | null
+
+// ---------------------------------------------------------------------------
+// System configuration
+// ---------------------------------------------------------------------------
+
+export type SystemConfigs = {
+  OS: Platform
+  arch: Architecture
+  shouldUseDarkMode: boolean
+  isWindowMaximized: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Workspace State (superset of both editor and web)
+// ---------------------------------------------------------------------------
+
+export type WorkspaceState = {
+  workspace: {
+    editingState: 'save-request' | 'saved' | 'unsaved' | 'initial-state'
+    systemConfigs: SystemConfigs
+    recent: Array<{ lastOpenedAt: string; createdAt: string; path: string; name: string }>
+    isCollapsed: boolean
+    isModalOpen: Array<{ modalName: string; modalState: boolean }>
+    discardChanges: boolean
+    selectedProjectTreeLeaf: {
+      label: string
+      type: WorkspaceProjectTreeLeafType
+    }
+    close: {
+      window: boolean
+      app: boolean
+      appDarwin: boolean
+    }
+    // PLC Logs
+    isPlcLogsVisible: boolean
+    plcLogs: PlcLogs
+    plcLogsLastId: number | null
+    plcFilters: PlcFilters
+    // Debug state (union of editor + web fields)
+    isDebuggerVisible: boolean
+    debuggerTargetIp: string | null
+    debugCContent: string | null
+    debugVariableIndexes: Map<string, number>
+    debugVariableValues: Map<string, string>
+    debugForcedVariables: Map<string, boolean>
+    debugTick: number
+    debugVariableTree: Map<string, DebugTreeNode>
+    debugExpandedNodes: Map<string, boolean>
+    fbDebugInstances: Map<string, FbInstanceInfo[]>
+    fbSelectedInstance: Map<string, string>
+    debugLocalMd5: string | null
+    debugGraphList: string[]
+    debugDataStale: boolean
+    debugMd5Mismatch: { runtimeMd5: string; localMd5: string } | null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Workspace Response
+// ---------------------------------------------------------------------------
+
+export type WorkspaceResponse = {
+  ok: boolean
+  title?: string
+  message?: string
+}
+
+// ---------------------------------------------------------------------------
+// Workspace Actions (superset of both editor and web)
+// ---------------------------------------------------------------------------
+
+export type WorkspaceActions = {
+  setEditingState: (editingState: WorkspaceState['workspace']['editingState']) => void
+  setRecent: (recent: WorkspaceState['workspace']['recent']) => void
+  setSystemConfigs: (config: SystemConfigs) => void
+  setCloseWindow: (value: boolean) => void
+  setCloseApp: (value: boolean) => void
+  setCloseAppDarwin: (value: boolean) => void
+  switchAppTheme: () => void
+  toggleMaximizedWindow: () => void
+  toggleCollapse: () => void
+  toggleDiscardChanges: () => void
+  setModalOpen: (modalName: string, modalState: boolean) => void
+  setSelectedProjectTreeLeaf: (leaf: { label: string; type: WorkspaceProjectTreeLeafType }) => void
+  clearWorkspace: () => void
+  // PLC Logs
+  setPlcLogsVisible: (isVisible: boolean) => void
+  setPlcLogs: (logs: PlcLogs) => void
+  setPlcLogsLastId: (lastId: number | null) => void
+  appendPlcLogs: (newLogs: PlcLogs) => void
+  clearPlcLogs: () => void
+  setPlcLevelFilter: (level: 'debug' | 'info' | 'warning' | 'error', enabled: boolean) => void
+  setPlcSearchTerm: (term: string) => void
+  setPlcTimestampFormat: (format: 'full' | 'time' | 'none') => void
+  // Debug actions
+  setDebuggerVisible: (isVisible: boolean) => void
+  setDebuggerTargetIp: (targetIp: string | null) => void
+  setDebugCContent: (content: string | null) => void
+  setDebugVariableIndexes: (indexes: Map<string, number>) => void
+  setDebugVariableValues: (values: Map<string, string>) => void
+  setDebugForcedVariables: (forced: Map<string, boolean>) => void
+  setDebugTick: (tick: number) => void
+  setDebugVariableTree: (tree: Map<string, DebugTreeNode>) => void
+  setDebugExpandedNodes: (expandedNodes: Map<string, boolean>) => void
+  toggleDebugExpandedNode: (compositeKey: string) => void
+  setFbDebugInstances: (instances: Map<string, FbInstanceInfo[]>) => void
+  setFbSelectedInstance: (fbTypeName: string, key: string) => void
+  setDebugLocalMd5: (md5: string | null) => void
+  setDebugGraphList: (list: string[]) => void
+  setDebugDataStale: (stale: boolean) => void
+  setDebugMd5Mismatch: (mismatch: { runtimeMd5: string; localMd5: string } | null) => void
+  clearDebugState: () => void
+  clearFbDebugContext: () => void
+  removeDebugVariable: (compositeKey: string) => void
+}
+
+export type WorkspaceSlice = WorkspaceState & {
+  workspaceActions: WorkspaceActions
+}


### PR DESCRIPTION
## Summary
- Add DebugTreeNode, FbInstanceInfo, PlcLogs types and helpers to shared ports/types.ts
- Create unified Workspace slice (superset of editor + web debug/log/UI state)
- Create unified Editor slice with all model types, view state, and Monaco focus
- Create unified Tabs slice with selectedTab and full element type coverage
- Create unified Modal slice with 17 modal types from both platforms
- Create unified Search slice with query, results, and DOMPurify highlighting utils
- Create tab-to-editor factory utils (CreateEditorObjectFromTab and helpers)
- All store types use plain TypeScript (dropped zod dependency from store layer)

## Validation Gates
- [x] Architecture validation passes (`npx tsx src2/__architecture__/validate.ts`)
- [x] Unit tests pass with 100% coverage (374 tests, 452 stmts / 206 branches / 195 funcs / 412 lines)
- [x] Shared files identical between repos

## Step Progress
Step 13 of 30 — Phase: store

Generated with [Claude Code](https://claude.com/claude-code)