### PR TITLE
migrate(step-15): Visual editor slices (FBDFlow, LadderFlow)

### DIFF
--- a/docs/migration-state.md
+++ b/docs/migration-state.md
@@ -8,7 +8,7 @@ store
 
 ## Current Step
 
-14
+15
 
 ## Step Log
 
@@ -29,7 +29,7 @@ store
 | 12 | adapters | SimulatorPort adapter implementation | done | 2026-03-10 |
 | 13 | store | UI state slices (Workspace, Editor, Tabs, Modal, Search) | done | 2026-03-10 |
 | 14 | store | Data state slices (Project, File, Library, Console, Shared) | done | 2026-03-10 |
-| 15 | store | Visual editor slices (FBDFlow, LadderFlow) | pending | |
+| 15 | store | Visual editor slices (FBDFlow, LadderFlow) | done | 2026-03-11 |
 | 16 | store | Platform state slices (Device, History, web-only) | pending | |
 | 17 | resources | Copy shared resources (styles, assets, locales, declarations) to src2/ | pending | |
 | 18 | components | Atoms batch 1 — shared identical components | pending | |

--- a/src2/store/__tests__/fbd-slice.test.ts
+++ b/src2/store/__tests__/fbd-slice.test.ts
@@ -1,0 +1,635 @@
+import type { Edge, Node } from '@xyflow/react'
+import { produce } from 'immer'
+import { createStore } from 'zustand/vanilla'
+
+import { createFBDFlowSlice } from '../slices/fbd/slice'
+import type { FBDFlowSlice, FBDFlowType, FBDRungState } from '../slices/fbd/types'
+
+function makeStore() {
+  return createStore<FBDFlowSlice>()(createFBDFlowSlice)
+}
+
+function makeNode(overrides?: Partial<Node>): Node {
+  return {
+    id: overrides?.id ?? 'node-1',
+    type: overrides?.type ?? 'block',
+    position: overrides?.position ?? { x: 0, y: 0 },
+    data: overrides?.data ?? { draggable: true },
+    draggable: overrides?.draggable ?? true,
+    selectable: overrides?.selectable ?? true,
+  }
+}
+
+function makeEdge(overrides?: Partial<Edge>): Edge {
+  return {
+    id: overrides?.id ?? 'edge-1',
+    source: overrides?.source ?? 'node-1',
+    target: overrides?.target ?? 'node-2',
+    sourceHandle: overrides?.sourceHandle ?? 'handle-1',
+    targetHandle: overrides?.targetHandle ?? 'handle-2',
+  }
+}
+
+function makeRung(overrides?: Partial<FBDRungState>): FBDRungState {
+  return {
+    comment: overrides?.comment ?? '',
+    selectedNodes: overrides?.selectedNodes ?? [],
+    nodes: overrides?.nodes ?? [],
+    edges: overrides?.edges ?? [],
+  }
+}
+
+function makeFlow(overrides?: Partial<FBDFlowType>): FBDFlowType {
+  return {
+    name: overrides?.name ?? 'flow-1',
+    updated: overrides?.updated ?? false,
+    rung: overrides?.rung ?? makeRung(),
+  }
+}
+
+describe('createFBDFlowSlice', () => {
+  let store: ReturnType<typeof makeStore>
+
+  beforeEach(() => {
+    store = makeStore()
+  })
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+  it('should have correct initial state', () => {
+    const state = store.getState()
+    expect(state.fbdFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // clearFBDFlows
+  // -------------------------------------------------------------------------
+  it('clearFBDFlows removes all flows', () => {
+    store.getState().fbdFlowActions.addFBDFlow(makeFlow({ name: 'a' }))
+    store.getState().fbdFlowActions.addFBDFlow(makeFlow({ name: 'b' }))
+
+    store.getState().fbdFlowActions.clearFBDFlows()
+
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  it('clearFBDFlows on empty state is a no-op', () => {
+    store.getState().fbdFlowActions.clearFBDFlows()
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // addFBDFlow
+  // -------------------------------------------------------------------------
+  it('addFBDFlow adds a new flow', () => {
+    store.getState().fbdFlowActions.addFBDFlow(makeFlow({ name: 'test' }))
+
+    const { fbdFlows } = store.getState()
+    expect(fbdFlows).toHaveLength(1)
+    expect(fbdFlows[0].name).toBe('test')
+  })
+
+  it('addFBDFlow clears selectedNodes on added flow', () => {
+    const rung = makeRung({ selectedNodes: [makeNode()] })
+    store.getState().fbdFlowActions.addFBDFlow(makeFlow({ name: 'test', rung }))
+
+    const { fbdFlows } = store.getState()
+    expect(fbdFlows[0].rung.selectedNodes).toEqual([])
+  })
+
+  it('addFBDFlow replaces existing flow with same name', () => {
+    store.getState().fbdFlowActions.addFBDFlow(makeFlow({ name: 'test', updated: false }))
+    store.getState().fbdFlowActions.addFBDFlow(makeFlow({ name: 'test', updated: true }))
+
+    const { fbdFlows } = store.getState()
+    expect(fbdFlows).toHaveLength(1)
+    expect(fbdFlows[0].updated).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // removeFBDFlow
+  // -------------------------------------------------------------------------
+  it('removeFBDFlow removes flow by name', () => {
+    store.getState().fbdFlowActions.addFBDFlow(makeFlow({ name: 'keep' }))
+    store.getState().fbdFlowActions.addFBDFlow(makeFlow({ name: 'remove' }))
+
+    store.getState().fbdFlowActions.removeFBDFlow('remove')
+
+    const { fbdFlows } = store.getState()
+    expect(fbdFlows).toHaveLength(1)
+    expect(fbdFlows[0].name).toBe('keep')
+  })
+
+  it('removeFBDFlow does nothing for nonexistent name', () => {
+    store.getState().fbdFlowActions.addFBDFlow(makeFlow({ name: 'existing' }))
+
+    store.getState().fbdFlowActions.removeFBDFlow('nonexistent')
+
+    expect(store.getState().fbdFlows).toHaveLength(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // startFBDRung
+  // -------------------------------------------------------------------------
+  it('startFBDRung creates a new flow if none exists', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+
+    const { fbdFlows } = store.getState()
+    expect(fbdFlows).toHaveLength(1)
+    expect(fbdFlows[0].name).toBe('editor-1')
+    expect(fbdFlows[0].rung.nodes).toEqual([])
+    expect(fbdFlows[0].rung.edges).toEqual([])
+    expect(fbdFlows[0].rung.comment).toBe('')
+    expect(fbdFlows[0].rung.selectedNodes).toEqual([])
+  })
+
+  it('startFBDRung resets rung of existing flow', () => {
+    const rung = makeRung({ comment: 'old', nodes: [makeNode()], edges: [makeEdge()] })
+    store.getState().fbdFlowActions.addFBDFlow(makeFlow({ name: 'editor-1', rung }))
+
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+
+    const flow = store.getState().fbdFlows[0]
+    expect(flow.rung.nodes).toEqual([])
+    expect(flow.rung.edges).toEqual([])
+    expect(flow.rung.comment).toBe('')
+  })
+
+  // -------------------------------------------------------------------------
+  // setRung
+  // -------------------------------------------------------------------------
+  it('setRung replaces the rung and marks flow updated', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    const newRung = makeRung({ comment: 'new comment', nodes: [makeNode()] })
+
+    store.getState().fbdFlowActions.setRung({ editorName: 'editor-1', rung: newRung })
+
+    const flow = store.getState().fbdFlows[0]
+    expect(flow.rung.comment).toBe('new comment')
+    expect(flow.rung.nodes).toHaveLength(1)
+    expect(flow.updated).toBe(true)
+  })
+
+  it('setRung does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.setRung({ editorName: 'nonexistent', rung: makeRung() })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // addComment
+  // -------------------------------------------------------------------------
+  it('addComment sets the rung comment', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+
+    store.getState().fbdFlowActions.addComment({ editorName: 'editor-1', comment: 'hello' })
+
+    expect(store.getState().fbdFlows[0].rung.comment).toBe('hello')
+    expect(store.getState().fbdFlows[0].updated).toBe(true)
+  })
+
+  it('addComment does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.addComment({ editorName: 'nonexistent', comment: 'hello' })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // onConnect
+  // -------------------------------------------------------------------------
+  it('onConnect adds a connection edge', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+
+    store.getState().fbdFlowActions.onConnect({
+      editorName: 'editor-1',
+      changes: {
+        source: 'node-1',
+        target: 'node-2',
+        sourceHandle: 'h1',
+        targetHandle: 'h2',
+      },
+    })
+
+    const { edges } = store.getState().fbdFlows[0].rung
+    expect(edges).toHaveLength(1)
+    expect(edges[0].source).toBe('node-1')
+    expect(edges[0].target).toBe('node-2')
+  })
+
+  // -------------------------------------------------------------------------
+  // setNodes
+  // -------------------------------------------------------------------------
+  it('setNodes replaces all nodes', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    const nodes = [makeNode({ id: 'a' }), makeNode({ id: 'b' })]
+
+    store.getState().fbdFlowActions.setNodes({ editorName: 'editor-1', nodes })
+
+    expect(store.getState().fbdFlows[0].rung.nodes).toHaveLength(2)
+    expect(store.getState().fbdFlows[0].updated).toBe(true)
+  })
+
+  it('setNodes does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.setNodes({ editorName: 'nonexistent', nodes: [] })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // updateNode
+  // -------------------------------------------------------------------------
+  it('updateNode replaces a specific node', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    store.getState().fbdFlowActions.setNodes({
+      editorName: 'editor-1',
+      nodes: [makeNode({ id: 'n1', data: { label: 'old' } })],
+    })
+
+    const updated = makeNode({ id: 'n1', data: { label: 'new' } })
+    store.getState().fbdFlowActions.updateNode({ editorName: 'editor-1', nodeId: 'n1', node: updated })
+
+    expect(store.getState().fbdFlows[0].rung.nodes[0].data.label).toBe('new')
+    expect(store.getState().fbdFlows[0].updated).toBe(true)
+  })
+
+  it('updateNode does nothing for nonexistent node', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    store.getState().fbdFlowActions.setNodes({
+      editorName: 'editor-1',
+      nodes: [makeNode({ id: 'n1' })],
+    })
+
+    store.getState().fbdFlowActions.updateNode({ editorName: 'editor-1', nodeId: 'missing', node: makeNode() })
+
+    expect(store.getState().fbdFlows[0].rung.nodes).toHaveLength(1)
+    expect(store.getState().fbdFlows[0].rung.nodes[0].id).toBe('n1')
+  })
+
+  // -------------------------------------------------------------------------
+  // addNode
+  // -------------------------------------------------------------------------
+  it('addNode pushes a node and selects it', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    store.getState().fbdFlowActions.setNodes({
+      editorName: 'editor-1',
+      nodes: [makeNode({ id: 'existing' })],
+    })
+
+    store.getState().fbdFlowActions.addNode({ editorName: 'editor-1', node: makeNode({ id: 'new' }) })
+
+    const flow = store.getState().fbdFlows[0]
+    expect(flow.rung.nodes).toHaveLength(2)
+    expect(flow.rung.nodes.find((n) => n.id === 'new')?.selected).toBe(true)
+    expect(flow.rung.nodes.find((n) => n.id === 'existing')?.selected).toBe(false)
+    expect(flow.rung.selectedNodes).toHaveLength(1)
+    expect(flow.rung.selectedNodes[0].id).toBe('new')
+    expect(flow.updated).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // removeNodes
+  // -------------------------------------------------------------------------
+  it('removeNodes removes specified nodes and their selected entries', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    const n1 = makeNode({ id: 'n1' })
+    const n2 = makeNode({ id: 'n2' })
+    const n3 = makeNode({ id: 'n3' })
+    store.getState().fbdFlowActions.setNodes({ editorName: 'editor-1', nodes: [n1, n2, n3] })
+
+    store.getState().fbdFlowActions.removeNodes({ editorName: 'editor-1', nodes: [n1, n3] })
+
+    const flow = store.getState().fbdFlows[0]
+    expect(flow.rung.nodes).toHaveLength(1)
+    expect(flow.rung.nodes[0].id).toBe('n2')
+    expect(flow.updated).toBe(true)
+  })
+
+  it('removeNodes also removes from selectedNodes', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    const n1 = makeNode({ id: 'n1', data: { draggable: true } })
+    const n2 = makeNode({ id: 'n2', data: { draggable: true } })
+    store.getState().fbdFlowActions.setNodes({ editorName: 'editor-1', nodes: [n1, n2] })
+    store.getState().fbdFlowActions.addSelectedNode({ editorName: 'editor-1', node: n1 })
+    store.getState().fbdFlowActions.addSelectedNode({ editorName: 'editor-1', node: n2 })
+
+    store.getState().fbdFlowActions.removeNodes({ editorName: 'editor-1', nodes: [n1] })
+
+    const flow = store.getState().fbdFlows[0]
+    expect(flow.rung.nodes).toHaveLength(1)
+    expect(flow.rung.selectedNodes).toHaveLength(1)
+    expect(flow.rung.selectedNodes[0].id).toBe('n2')
+  })
+
+  it('removeNodes does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.removeNodes({ editorName: 'nonexistent', nodes: [makeNode()] })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // addSelectedNode
+  // -------------------------------------------------------------------------
+  it('addSelectedNode adds to selectedNodes and marks node as selected', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    const node = makeNode({ id: 'n1', data: { draggable: true } })
+    store.getState().fbdFlowActions.setNodes({ editorName: 'editor-1', nodes: [node] })
+
+    store.getState().fbdFlowActions.addSelectedNode({ editorName: 'editor-1', node })
+
+    const flow = store.getState().fbdFlows[0]
+    expect(flow.rung.selectedNodes).toHaveLength(1)
+    expect(flow.rung.selectedNodes[0].id).toBe('n1')
+    expect(flow.rung.nodes[0].selected).toBe(true)
+  })
+
+  it('addSelectedNode only marks the target node as selected, leaves others unchanged', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    const n1 = makeNode({ id: 'n1', data: { draggable: true } })
+    const n2 = makeNode({ id: 'n2', data: { draggable: false } })
+    store.getState().fbdFlowActions.setNodes({ editorName: 'editor-1', nodes: [n1, n2] })
+
+    store.getState().fbdFlowActions.addSelectedNode({ editorName: 'editor-1', node: n1 })
+
+    const flow = store.getState().fbdFlows[0]
+    expect(flow.rung.nodes.find((n) => n.id === 'n1')?.selected).toBe(true)
+    expect(flow.rung.nodes.find((n) => n.id === 'n2')?.selected).toBeUndefined()
+  })
+
+  it('addSelectedNode does not duplicate already selected node', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    const node = makeNode({ id: 'n1', data: { draggable: true } })
+    store.getState().fbdFlowActions.setNodes({ editorName: 'editor-1', nodes: [node] })
+
+    store.getState().fbdFlowActions.addSelectedNode({ editorName: 'editor-1', node })
+    store.getState().fbdFlowActions.addSelectedNode({ editorName: 'editor-1', node })
+
+    expect(store.getState().fbdFlows[0].rung.selectedNodes).toHaveLength(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // removeSelectedNode
+  // -------------------------------------------------------------------------
+  it('removeSelectedNode removes from selectedNodes and deselects node', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    const node = makeNode({ id: 'n1', data: { draggable: true } })
+    store.getState().fbdFlowActions.setNodes({ editorName: 'editor-1', nodes: [node] })
+    store.getState().fbdFlowActions.addSelectedNode({ editorName: 'editor-1', node })
+
+    store.getState().fbdFlowActions.removeSelectedNode({ editorName: 'editor-1', node })
+
+    const flow = store.getState().fbdFlows[0]
+    expect(flow.rung.selectedNodes).toHaveLength(0)
+    expect(flow.rung.nodes[0].selected).toBe(false)
+  })
+
+  it('removeSelectedNode leaves other nodes unchanged', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    const n1 = makeNode({ id: 'n1', data: { draggable: true } })
+    const n2 = makeNode({ id: 'n2', data: { draggable: true } })
+    store.getState().fbdFlowActions.setNodes({ editorName: 'editor-1', nodes: [n1, n2] })
+    store.getState().fbdFlowActions.addSelectedNode({ editorName: 'editor-1', node: n1 })
+    store.getState().fbdFlowActions.addSelectedNode({ editorName: 'editor-1', node: n2 })
+
+    store.getState().fbdFlowActions.removeSelectedNode({ editorName: 'editor-1', node: n1 })
+
+    const flow = store.getState().fbdFlows[0]
+    expect(flow.rung.nodes.find((n) => n.id === 'n1')?.selected).toBe(false)
+    // n2 was added via addSelectedNode, which set selected=true on its matching node
+    expect(flow.rung.nodes.find((n) => n.id === 'n2')?.selected).toBe(true)
+    expect(flow.rung.selectedNodes).toHaveLength(1)
+    expect(flow.rung.selectedNodes[0].id).toBe('n2')
+  })
+
+  it('removeSelectedNode does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.removeSelectedNode({ editorName: 'nonexistent', node: makeNode() })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // setSelectedNodes
+  // -------------------------------------------------------------------------
+  it('setSelectedNodes replaces all selected nodes', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    const n1 = makeNode({ id: 'n1', data: { draggable: true } })
+    const n2 = makeNode({ id: 'n2', data: { draggable: false } })
+    store.getState().fbdFlowActions.setNodes({ editorName: 'editor-1', nodes: [n1, n2] })
+
+    store.getState().fbdFlowActions.setSelectedNodes({ editorName: 'editor-1', nodes: [n1] })
+
+    const flow = store.getState().fbdFlows[0]
+    expect(flow.rung.selectedNodes).toHaveLength(1)
+    expect(flow.rung.nodes.find((n) => n.id === 'n1')?.selected).toBe(true)
+    expect(flow.rung.nodes.find((n) => n.id === 'n2')?.selected).toBe(false)
+  })
+
+  // -------------------------------------------------------------------------
+  // setEdges
+  // -------------------------------------------------------------------------
+  it('setEdges replaces all edges', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    const edges = [makeEdge({ id: 'e1' }), makeEdge({ id: 'e2' })]
+
+    store.getState().fbdFlowActions.setEdges({ editorName: 'editor-1', edges })
+
+    expect(store.getState().fbdFlows[0].rung.edges).toHaveLength(2)
+    expect(store.getState().fbdFlows[0].updated).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // updateEdge
+  // -------------------------------------------------------------------------
+  it('updateEdge replaces a specific edge', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    store.getState().fbdFlowActions.setEdges({
+      editorName: 'editor-1',
+      edges: [makeEdge({ id: 'e1', source: 'a' })],
+    })
+
+    const updated = makeEdge({ id: 'e1', source: 'b' })
+    store.getState().fbdFlowActions.updateEdge({ editorName: 'editor-1', edgeId: 'e1', edge: updated })
+
+    expect(store.getState().fbdFlows[0].rung.edges[0].source).toBe('b')
+  })
+
+  it('updateEdge does nothing for nonexistent edge', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    store.getState().fbdFlowActions.setEdges({
+      editorName: 'editor-1',
+      edges: [makeEdge({ id: 'e1' })],
+    })
+
+    store.getState().fbdFlowActions.updateEdge({ editorName: 'editor-1', edgeId: 'missing', edge: makeEdge() })
+
+    expect(store.getState().fbdFlows[0].rung.edges).toHaveLength(1)
+    expect(store.getState().fbdFlows[0].rung.edges[0].id).toBe('e1')
+  })
+
+  // -------------------------------------------------------------------------
+  // addEdge
+  // -------------------------------------------------------------------------
+  it('addEdge pushes a new edge', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+
+    store.getState().fbdFlowActions.addEdge({ editorName: 'editor-1', edge: makeEdge({ id: 'e1' }) })
+
+    expect(store.getState().fbdFlows[0].rung.edges).toHaveLength(1)
+    expect(store.getState().fbdFlows[0].updated).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // removeEdges
+  // -------------------------------------------------------------------------
+  it('removeEdges removes specified edges', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    store.getState().fbdFlowActions.setEdges({
+      editorName: 'editor-1',
+      edges: [makeEdge({ id: 'e1' }), makeEdge({ id: 'e2' }), makeEdge({ id: 'e3' })],
+    })
+
+    store.getState().fbdFlowActions.removeEdges({
+      editorName: 'editor-1',
+      edges: [makeEdge({ id: 'e1' }), makeEdge({ id: 'e3' })],
+    })
+
+    const { edges } = store.getState().fbdFlows[0].rung
+    expect(edges).toHaveLength(1)
+    expect(edges[0].id).toBe('e2')
+  })
+
+  // -------------------------------------------------------------------------
+  // setFlowUpdated
+  // -------------------------------------------------------------------------
+  it('setFlowUpdated sets the updated flag', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+
+    store.getState().fbdFlowActions.setFlowUpdated({ editorName: 'editor-1', updated: false })
+    expect(store.getState().fbdFlows[0].updated).toBe(false)
+
+    store.getState().fbdFlowActions.setFlowUpdated({ editorName: 'editor-1', updated: true })
+    expect(store.getState().fbdFlows[0].updated).toBe(true)
+  })
+
+  it('setFlowUpdated does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.setFlowUpdated({ editorName: 'nonexistent', updated: true })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // applyFBDFlowSnapshot
+  // -------------------------------------------------------------------------
+  it('applyFBDFlowSnapshot adds a new flow when snapshot is provided and flow does not exist', () => {
+    const snapshot = makeFlow({ name: 'other', rung: makeRung({ comment: 'snap', selectedNodes: [makeNode()] }) })
+
+    store.getState().fbdFlowActions.applyFBDFlowSnapshot({ editorName: 'editor-1', snapshot })
+
+    const flow = store.getState().fbdFlows[0]
+    expect(flow.name).toBe('editor-1')
+    expect(flow.rung.comment).toBe('snap')
+    expect(flow.rung.selectedNodes).toEqual([])
+    expect(flow.updated).toBe(true)
+  })
+
+  it('applyFBDFlowSnapshot replaces existing flow when snapshot is provided', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    const snapshot = makeFlow({ rung: makeRung({ comment: 'replaced' }) })
+
+    store.getState().fbdFlowActions.applyFBDFlowSnapshot({ editorName: 'editor-1', snapshot })
+
+    expect(store.getState().fbdFlows).toHaveLength(1)
+    expect(store.getState().fbdFlows[0].rung.comment).toBe('replaced')
+  })
+
+  it('applyFBDFlowSnapshot removes flow when snapshot is null', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+
+    store.getState().fbdFlowActions.applyFBDFlowSnapshot({ editorName: 'editor-1', snapshot: null })
+
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  it('applyFBDFlowSnapshot with null snapshot does nothing when flow does not exist', () => {
+    store.getState().fbdFlowActions.applyFBDFlowSnapshot({ editorName: 'nonexistent', snapshot: null })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // Guard clause coverage — nonexistent editor
+  // -------------------------------------------------------------------------
+  it('onConnect does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.onConnect({
+      editorName: 'nonexistent',
+      changes: { source: 'a', target: 'b', sourceHandle: 'h1', targetHandle: 'h2' },
+    })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  it('updateNode does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.updateNode({ editorName: 'nonexistent', nodeId: 'n', node: makeNode() })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  it('addNode does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.addNode({ editorName: 'nonexistent', node: makeNode() })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  it('addSelectedNode does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.addSelectedNode({ editorName: 'nonexistent', node: makeNode() })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  it('setSelectedNodes does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.setSelectedNodes({ editorName: 'nonexistent', nodes: [] })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  it('setEdges does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.setEdges({ editorName: 'nonexistent', edges: [] })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  it('updateEdge does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.updateEdge({ editorName: 'nonexistent', edgeId: 'e', edge: makeEdge() })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  it('addEdge does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.addEdge({ editorName: 'nonexistent', edge: makeEdge() })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  it('removeEdges does nothing for nonexistent editor', () => {
+    store.getState().fbdFlowActions.removeEdges({ editorName: 'nonexistent', edges: [] })
+    expect(store.getState().fbdFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // Defensive guard coverage — unreachable under TypeScript but present as runtime safety
+  // -------------------------------------------------------------------------
+  it('addSelectedNode initializes selectedNodes when undefined', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    // Artificially nullify selectedNodes to exercise the defensive guard
+    store.setState(
+      produce((state: FBDFlowSlice) => {
+        state.fbdFlows[0].rung.selectedNodes = undefined as unknown as Node[]
+      }),
+    )
+    const node = makeNode({ id: 'n1', data: { draggable: true } })
+    store.getState().fbdFlowActions.setNodes({ editorName: 'editor-1', nodes: [node] })
+    store.getState().fbdFlowActions.addSelectedNode({ editorName: 'editor-1', node })
+
+    expect(store.getState().fbdFlows[0].rung.selectedNodes).toBeDefined()
+  })
+
+  it('setSelectedNodes initializes selectedNodes when undefined', () => {
+    store.getState().fbdFlowActions.startFBDRung({ editorName: 'editor-1' })
+    const node = makeNode({ id: 'n1', data: { draggable: true } })
+    store.getState().fbdFlowActions.setNodes({ editorName: 'editor-1', nodes: [node] })
+    // Artificially nullify selectedNodes to exercise the defensive guard
+    store.setState(
+      produce((state: FBDFlowSlice) => {
+        state.fbdFlows[0].rung.selectedNodes = undefined as unknown as Node[]
+      }),
+    )
+    store.getState().fbdFlowActions.setSelectedNodes({ editorName: 'editor-1', nodes: [node] })
+
+    expect(store.getState().fbdFlows[0].rung.selectedNodes).toBeDefined()
+  })
+})

--- a/src2/store/__tests__/fbd-types.test.ts
+++ b/src2/store/__tests__/fbd-types.test.ts
@@ -1,0 +1,106 @@
+import {
+  zodFBDFlowSchema,
+  zodFBDFlowStateSchema,
+  zodFBDNodeTypesSchema,
+  zodFBDRungStateSchema,
+} from '../slices/fbd/types'
+
+describe('FBD Zod schemas', () => {
+  const validNode = {
+    id: 'n1',
+    type: 'block',
+    position: { x: 0, y: 0 },
+    draggable: true,
+    selectable: true,
+    data: {},
+  }
+
+  const validEdge = {
+    id: 'e1',
+    source: 'n1',
+    sourceHandle: 'h1',
+    target: 'n2',
+    targetHandle: 'h2',
+  }
+
+  describe('zodFBDRungStateSchema', () => {
+    it('validates a valid rung', () => {
+      const result = zodFBDRungStateSchema.safeParse({
+        comment: 'test comment',
+        nodes: [validNode],
+        edges: [validEdge],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('applies default comment', () => {
+      const result = zodFBDRungStateSchema.safeParse({
+        nodes: [],
+        edges: [],
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.comment).toBe('')
+      }
+    })
+
+    it('rejects rung with invalid nodes', () => {
+      const result = zodFBDRungStateSchema.safeParse({
+        comment: '',
+        nodes: [{ invalid: true }],
+        edges: [],
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('zodFBDFlowSchema', () => {
+    it('validates a valid flow', () => {
+      const result = zodFBDFlowSchema.safeParse({
+        name: 'test-flow',
+        rung: { comment: '', nodes: [], edges: [] },
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects flow without name', () => {
+      const result = zodFBDFlowSchema.safeParse({
+        rung: { comment: '', nodes: [], edges: [] },
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('zodFBDFlowStateSchema', () => {
+    it('validates a valid flow state', () => {
+      const result = zodFBDFlowStateSchema.safeParse({
+        fbdFlows: [
+          {
+            name: 'flow-1',
+            rung: { comment: '', nodes: [], edges: [] },
+          },
+        ],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('validates empty flow state', () => {
+      const result = zodFBDFlowStateSchema.safeParse({ fbdFlows: [] })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('zodFBDNodeTypesSchema', () => {
+    const validTypes = ['block', 'comment', 'connector', 'connection', 'input-variable', 'output-variable', 'inout-variable']
+
+    it.each(validTypes)('accepts valid node type: %s', (type) => {
+      const result = zodFBDNodeTypesSchema.safeParse(type)
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects invalid node type', () => {
+      const result = zodFBDNodeTypesSchema.safeParse('invalid-type')
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/src2/store/__tests__/ladder-slice.test.ts
+++ b/src2/store/__tests__/ladder-slice.test.ts
@@ -1,0 +1,818 @@
+import type { Edge, Node } from '@xyflow/react'
+import { produce } from 'immer'
+import { createStore } from 'zustand/vanilla'
+
+import { createLadderFlowSlice } from '../slices/ladder/slice'
+import type { LadderFlowSlice, LadderFlowType, RungLadderState } from '../slices/ladder/types'
+
+function makeStore() {
+  return createStore<LadderFlowSlice>()(createLadderFlowSlice)
+}
+
+function makeNode(overrides?: Partial<Node>): Node {
+  return {
+    id: overrides?.id ?? 'node-1',
+    type: overrides?.type ?? 'block',
+    position: overrides?.position ?? { x: 0, y: 0 },
+    data: overrides?.data ?? { draggable: true },
+    draggable: overrides?.draggable ?? true,
+    selectable: overrides?.selectable ?? true,
+  }
+}
+
+function makeEdge(overrides?: Partial<Edge>): Edge {
+  return {
+    id: overrides?.id ?? 'edge-1',
+    source: overrides?.source ?? 'node-1',
+    target: overrides?.target ?? 'node-2',
+    sourceHandle: overrides?.sourceHandle ?? 'handle-1',
+    targetHandle: overrides?.targetHandle ?? 'handle-2',
+  }
+}
+
+function makeRung(overrides?: Partial<RungLadderState>): RungLadderState {
+  return {
+    id: overrides?.id ?? 'rung-1',
+    comment: overrides?.comment ?? '',
+    defaultBounds: overrides?.defaultBounds ?? [800, 200],
+    reactFlowViewport: overrides?.reactFlowViewport ?? [800, 200],
+    selectedNodes: overrides?.selectedNodes ?? [],
+    nodes: overrides?.nodes ?? [
+      makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
+      makeNode({ id: 'right-rail-rung-1', type: 'powerRail' }),
+    ],
+    edges: overrides?.edges ?? [],
+  }
+}
+
+function makeFlow(overrides?: Partial<LadderFlowType>): LadderFlowType {
+  return {
+    name: overrides?.name ?? 'flow-1',
+    updated: overrides?.updated ?? false,
+    rungs: overrides?.rungs ?? [],
+  }
+}
+
+function seedFlowWithRung(store: ReturnType<typeof makeStore>, editorName = 'editor-1', rung?: RungLadderState) {
+  const r = rung ?? makeRung()
+  store.getState().ladderFlowActions.startLadderRung({ editorName, rung: r })
+  return r
+}
+
+describe('createLadderFlowSlice', () => {
+  let store: ReturnType<typeof makeStore>
+
+  beforeEach(() => {
+    store = makeStore()
+  })
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+  it('should have correct initial state', () => {
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // clearLadderFlows
+  // -------------------------------------------------------------------------
+  it('clearLadderFlows removes all flows', () => {
+    store.getState().ladderFlowActions.addLadderFlow(makeFlow({ name: 'a' }))
+    store.getState().ladderFlowActions.addLadderFlow(makeFlow({ name: 'b' }))
+
+    store.getState().ladderFlowActions.clearLadderFlows()
+
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('clearLadderFlows on empty state is a no-op', () => {
+    store.getState().ladderFlowActions.clearLadderFlows()
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // addLadderFlow
+  // -------------------------------------------------------------------------
+  it('addLadderFlow adds a new flow', () => {
+    store.getState().ladderFlowActions.addLadderFlow(makeFlow({ name: 'test', rungs: [makeRung()] }))
+
+    const { ladderFlows } = store.getState()
+    expect(ladderFlows).toHaveLength(1)
+    expect(ladderFlows[0].name).toBe('test')
+    expect(ladderFlows[0].rungs).toHaveLength(1)
+  })
+
+  it('addLadderFlow clears selectedNodes on all rungs', () => {
+    const rung = makeRung({ selectedNodes: [makeNode()] })
+    store.getState().ladderFlowActions.addLadderFlow(makeFlow({ name: 'test', rungs: [rung] }))
+
+    expect(store.getState().ladderFlows[0].rungs[0].selectedNodes).toEqual([])
+  })
+
+  it('addLadderFlow replaces existing flow with same name', () => {
+    store.getState().ladderFlowActions.addLadderFlow(makeFlow({ name: 'test', updated: false }))
+    store.getState().ladderFlowActions.addLadderFlow(makeFlow({ name: 'test', updated: true }))
+
+    const { ladderFlows } = store.getState()
+    expect(ladderFlows).toHaveLength(1)
+    expect(ladderFlows[0].updated).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // removeLadderFlow
+  // -------------------------------------------------------------------------
+  it('removeLadderFlow removes flow by name', () => {
+    store.getState().ladderFlowActions.addLadderFlow(makeFlow({ name: 'keep' }))
+    store.getState().ladderFlowActions.addLadderFlow(makeFlow({ name: 'remove' }))
+
+    store.getState().ladderFlowActions.removeLadderFlow('remove')
+
+    const { ladderFlows } = store.getState()
+    expect(ladderFlows).toHaveLength(1)
+    expect(ladderFlows[0].name).toBe('keep')
+  })
+
+  it('removeLadderFlow does nothing for nonexistent name', () => {
+    store.getState().ladderFlowActions.addLadderFlow(makeFlow({ name: 'existing' }))
+
+    store.getState().ladderFlowActions.removeLadderFlow('nonexistent')
+
+    expect(store.getState().ladderFlows).toHaveLength(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // startLadderRung
+  // -------------------------------------------------------------------------
+  it('startLadderRung creates a flow and adds the rung', () => {
+    const rung = makeRung({ id: 'rung-1' })
+    store.getState().ladderFlowActions.startLadderRung({ editorName: 'editor-1', rung })
+
+    const { ladderFlows } = store.getState()
+    expect(ladderFlows).toHaveLength(1)
+    expect(ladderFlows[0].name).toBe('editor-1')
+    expect(ladderFlows[0].rungs).toHaveLength(1)
+    expect(ladderFlows[0].rungs[0].id).toBe('rung-1')
+  })
+
+  it('startLadderRung appends rung to existing flow', () => {
+    const rung1 = makeRung({ id: 'rung-1' })
+    const rung2 = makeRung({ id: 'rung-2' })
+
+    store.getState().ladderFlowActions.startLadderRung({ editorName: 'editor-1', rung: rung1 })
+    store.getState().ladderFlowActions.startLadderRung({ editorName: 'editor-1', rung: rung2 })
+
+    const { ladderFlows } = store.getState()
+    expect(ladderFlows).toHaveLength(1)
+    expect(ladderFlows[0].rungs).toHaveLength(2)
+  })
+
+  // -------------------------------------------------------------------------
+  // setRungs
+  // -------------------------------------------------------------------------
+  it('setRungs replaces all rungs when valid', () => {
+    seedFlowWithRung(store)
+
+    const newRungs = [
+      makeRung({ id: 'new-1' }),
+      makeRung({
+        id: 'new-2',
+        nodes: [
+          makeNode({ id: 'left-rail-new-2', type: 'powerRail' }),
+          makeNode({ id: 'right-rail-new-2', type: 'powerRail' }),
+        ],
+      }),
+    ]
+
+    store.getState().ladderFlowActions.setRungs({ editorName: 'editor-1', rungs: newRungs })
+
+    const flow = store.getState().ladderFlows[0]
+    expect(flow.rungs).toHaveLength(2)
+    expect(flow.updated).toBe(true)
+  })
+
+  it('setRungs rejects rungs missing rail nodes', () => {
+    seedFlowWithRung(store)
+
+    const invalidRungs = [makeRung({ id: 'bad', nodes: [makeNode({ id: 'no-rail', type: 'block' })] })]
+
+    store.getState().ladderFlowActions.setRungs({ editorName: 'editor-1', rungs: invalidRungs })
+
+    // Should still have original rung
+    expect(store.getState().ladderFlows[0].rungs).toHaveLength(1)
+    expect(store.getState().ladderFlows[0].rungs[0].id).toBe('rung-1')
+  })
+
+  it('setRungs does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.setRungs({ editorName: 'nonexistent', rungs: [makeRung()] })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // removeRung
+  // -------------------------------------------------------------------------
+  it('removeRung removes a rung by id', () => {
+    seedFlowWithRung(store, 'editor-1', makeRung({ id: 'rung-1' }))
+    store.getState().ladderFlowActions.startLadderRung({ editorName: 'editor-1', rung: makeRung({ id: 'rung-2' }) })
+
+    store.getState().ladderFlowActions.removeRung('editor-1', 'rung-1')
+
+    const flow = store.getState().ladderFlows[0]
+    expect(flow.rungs).toHaveLength(1)
+    expect(flow.rungs[0].id).toBe('rung-2')
+    expect(flow.updated).toBe(true)
+  })
+
+  it('removeRung does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+
+    store.getState().ladderFlowActions.removeRung('editor-1', 'nonexistent')
+
+    expect(store.getState().ladderFlows[0].rungs).toHaveLength(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // addComment
+  // -------------------------------------------------------------------------
+  it('addComment sets the rung comment', () => {
+    seedFlowWithRung(store)
+
+    store.getState().ladderFlowActions.addComment({ editorName: 'editor-1', rungId: 'rung-1', comment: 'hello' })
+
+    expect(store.getState().ladderFlows[0].rungs[0].comment).toBe('hello')
+    expect(store.getState().ladderFlows[0].updated).toBe(true)
+  })
+
+  it('addComment does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+
+    store.getState().ladderFlowActions.addComment({ editorName: 'editor-1', rungId: 'missing', comment: 'hello' })
+
+    expect(store.getState().ladderFlows[0].rungs[0].comment).toBe('')
+  })
+
+  // -------------------------------------------------------------------------
+  // duplicateRung
+  // -------------------------------------------------------------------------
+  it('duplicateRung inserts new rung after the source rung', () => {
+    seedFlowWithRung(store, 'editor-1', makeRung({ id: 'rung-1' }))
+    store.getState().ladderFlowActions.startLadderRung({ editorName: 'editor-1', rung: makeRung({ id: 'rung-2' }) })
+
+    const newRung = makeRung({ id: 'rung-dup' })
+    store.getState().ladderFlowActions.duplicateRung({ editorName: 'editor-1', rungId: 'rung-1', newRung })
+
+    const flow = store.getState().ladderFlows[0]
+    expect(flow.rungs).toHaveLength(3)
+    expect(flow.rungs[0].id).toBe('rung-1')
+    expect(flow.rungs[1].id).toBe('rung-dup')
+    expect(flow.rungs[2].id).toBe('rung-2')
+    expect(flow.updated).toBe(true)
+  })
+
+  it('duplicateRung does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+
+    store
+      .getState()
+      .ladderFlowActions.duplicateRung({ editorName: 'editor-1', rungId: 'missing', newRung: makeRung() })
+
+    expect(store.getState().ladderFlows[0].rungs).toHaveLength(1)
+  })
+
+  it('duplicateRung does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.duplicateRung({ editorName: 'nonexistent', rungId: 'rung-1', newRung: makeRung() })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // onNodesChange
+  // -------------------------------------------------------------------------
+  it('onNodesChange applies node changes', () => {
+    seedFlowWithRung(store)
+
+    store.getState().ladderFlowActions.onNodesChange({
+      editorName: 'editor-1',
+      rungId: 'rung-1',
+      changes: [{ type: 'position', id: 'left-rail-rung-1', position: { x: 100, y: 100 } }],
+    })
+
+    const node = store.getState().ladderFlows[0].rungs[0].nodes.find((n) => n.id === 'left-rail-rung-1')
+    expect(node?.position).toEqual({ x: 100, y: 100 })
+  })
+
+  it('onNodesChange does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+
+    store.getState().ladderFlowActions.onNodesChange({
+      editorName: 'editor-1',
+      rungId: 'missing',
+      changes: [{ type: 'remove', id: 'whatever' }],
+    })
+
+    expect(store.getState().ladderFlows[0].rungs[0].nodes).toHaveLength(2)
+  })
+
+  // -------------------------------------------------------------------------
+  // onEdgesChange
+  // -------------------------------------------------------------------------
+  it('onEdgesChange applies edge changes', () => {
+    const rung = makeRung({ edges: [makeEdge({ id: 'e1' })] })
+    seedFlowWithRung(store, 'editor-1', rung)
+
+    store.getState().ladderFlowActions.onEdgesChange({
+      editorName: 'editor-1',
+      rungId: 'rung-1',
+      changes: [{ type: 'remove', id: 'e1' }],
+    })
+
+    expect(store.getState().ladderFlows[0].rungs[0].edges).toHaveLength(0)
+  })
+
+  // -------------------------------------------------------------------------
+  // onConnect
+  // -------------------------------------------------------------------------
+  it('onConnect adds a connection edge', () => {
+    seedFlowWithRung(store)
+
+    store.getState().ladderFlowActions.onConnect({
+      editorName: 'editor-1',
+      rungId: 'rung-1',
+      changes: { source: 'node-a', target: 'node-b', sourceHandle: 'h1', targetHandle: 'h2' },
+    })
+
+    expect(store.getState().ladderFlows[0].rungs[0].edges).toHaveLength(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // setNodes
+  // -------------------------------------------------------------------------
+  it('setNodes replaces all nodes in a rung', () => {
+    seedFlowWithRung(store)
+    const nodes = [makeNode({ id: 'a' }), makeNode({ id: 'b' })]
+
+    store.getState().ladderFlowActions.setNodes({ editorName: 'editor-1', rungId: 'rung-1', nodes })
+
+    expect(store.getState().ladderFlows[0].rungs[0].nodes).toHaveLength(2)
+    expect(store.getState().ladderFlows[0].updated).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // updateNode
+  // -------------------------------------------------------------------------
+  it('updateNode replaces a specific node in a rung', () => {
+    const rung = makeRung({
+      nodes: [
+        makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
+        makeNode({ id: 'right-rail-rung-1', type: 'powerRail' }),
+        makeNode({ id: 'n1', data: { label: 'old' } }),
+      ],
+    })
+    seedFlowWithRung(store, 'editor-1', rung)
+
+    const updated = makeNode({ id: 'n1', data: { label: 'new' } })
+    store.getState().ladderFlowActions.updateNode({ editorName: 'editor-1', rungId: 'rung-1', nodeId: 'n1', node: updated })
+
+    const nodes = store.getState().ladderFlows[0].rungs[0].nodes
+    expect(nodes.find((n) => n.id === 'n1')?.data.label).toBe('new')
+  })
+
+  it('updateNode does nothing for nonexistent node', () => {
+    seedFlowWithRung(store)
+
+    store
+      .getState()
+      .ladderFlowActions.updateNode({ editorName: 'editor-1', rungId: 'rung-1', nodeId: 'missing', node: makeNode() })
+
+    expect(store.getState().ladderFlows[0].rungs[0].nodes).toHaveLength(2)
+  })
+
+  // -------------------------------------------------------------------------
+  // addNode
+  // -------------------------------------------------------------------------
+  it('addNode pushes a node and selects it, deselects others', () => {
+    seedFlowWithRung(store)
+    const newNode = makeNode({ id: 'new-node' })
+
+    store.getState().ladderFlowActions.addNode({ editorName: 'editor-1', rungId: 'rung-1', node: newNode })
+
+    const rung = store.getState().ladderFlows[0].rungs[0]
+    expect(rung.nodes).toHaveLength(3)
+    expect(rung.nodes.find((n) => n.id === 'new-node')?.selected).toBe(true)
+    expect(rung.nodes.find((n) => n.id === 'left-rail-rung-1')?.selected).toBe(false)
+    expect(store.getState().ladderFlows[0].updated).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // removeNodes
+  // -------------------------------------------------------------------------
+  it('removeNodes removes specified nodes and their connected edges', () => {
+    const rung = makeRung({
+      nodes: [
+        makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
+        makeNode({ id: 'right-rail-rung-1', type: 'powerRail' }),
+        makeNode({ id: 'n1' }),
+        makeNode({ id: 'n2' }),
+      ],
+      edges: [
+        makeEdge({ id: 'e1', source: 'n1', target: 'n2' }),
+        makeEdge({ id: 'e2', source: 'left-rail-rung-1', target: 'n1' }),
+      ],
+    })
+    seedFlowWithRung(store, 'editor-1', rung)
+
+    store
+      .getState()
+      .ladderFlowActions.removeNodes({ editorName: 'editor-1', rungId: 'rung-1', nodes: [makeNode({ id: 'n1' })] })
+
+    const updatedRung = store.getState().ladderFlows[0].rungs[0]
+    expect(updatedRung.nodes.map((n) => n.id)).toEqual(['left-rail-rung-1', 'right-rail-rung-1', 'n2'])
+    expect(updatedRung.edges).toHaveLength(0) // Both edges reference n1
+    expect(store.getState().ladderFlows[0].updated).toBe(true)
+  })
+
+  it('removeNodes also cleans up selectedNodes', () => {
+    const n1 = makeNode({ id: 'n1' })
+    const rung = makeRung({
+      nodes: [makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }), makeNode({ id: 'right-rail-rung-1', type: 'powerRail' }), n1],
+      selectedNodes: [n1],
+    })
+    seedFlowWithRung(store, 'editor-1', rung)
+
+    store.getState().ladderFlowActions.removeNodes({ editorName: 'editor-1', rungId: 'rung-1', nodes: [n1] })
+
+    expect(store.getState().ladderFlows[0].rungs[0].selectedNodes).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // setSelectedNodes
+  // -------------------------------------------------------------------------
+  it('setSelectedNodes with single node preserves draggable from data', () => {
+    const n1 = makeNode({ id: 'n1', data: { draggable: true } })
+    const n2 = makeNode({ id: 'n2', data: { draggable: false } })
+    const rung = makeRung({
+      nodes: [makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }), makeNode({ id: 'right-rail-rung-1', type: 'powerRail' }), n1, n2],
+    })
+    seedFlowWithRung(store, 'editor-1', rung)
+
+    store.getState().ladderFlowActions.setSelectedNodes({ editorName: 'editor-1', rungId: 'rung-1', nodes: [n1] })
+
+    const updatedRung = store.getState().ladderFlows[0].rungs[0]
+    expect(updatedRung.selectedNodes).toHaveLength(1)
+    const selectedNode = updatedRung.nodes.find((n) => n.id === 'n1')
+    expect(selectedNode?.selected).toBe(true)
+    expect(selectedNode?.draggable).toBe(true)
+    const otherNode = updatedRung.nodes.find((n) => n.id === 'n2')
+    expect(otherNode?.selected).toBe(false)
+    expect(otherNode?.draggable).toBe(false)
+  })
+
+  it('setSelectedNodes with multiple nodes sets draggable to false for all', () => {
+    const n1 = makeNode({ id: 'n1', data: { draggable: true } })
+    const n2 = makeNode({ id: 'n2', data: { draggable: true } })
+    const rung = makeRung({
+      nodes: [makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }), makeNode({ id: 'right-rail-rung-1', type: 'powerRail' }), n1, n2],
+    })
+    seedFlowWithRung(store, 'editor-1', rung)
+
+    store
+      .getState()
+      .ladderFlowActions.setSelectedNodes({ editorName: 'editor-1', rungId: 'rung-1', nodes: [n1, n2] })
+
+    const updatedRung = store.getState().ladderFlows[0].rungs[0]
+    expect(updatedRung.selectedNodes).toHaveLength(2)
+    for (const n of updatedRung.nodes) {
+      expect(n.draggable).toBe(false)
+    }
+  })
+
+  it('setSelectedNodes clears other rungs selected state when nodes are selected', () => {
+    seedFlowWithRung(store, 'editor-1', makeRung({ id: 'rung-1' }))
+    store
+      .getState()
+      .ladderFlowActions.startLadderRung({ editorName: 'editor-1', rung: makeRung({ id: 'rung-2' }) })
+
+    const node = makeNode({ id: 'n1', data: { draggable: true } })
+    store.getState().ladderFlowActions.setNodes({
+      editorName: 'editor-1',
+      rungId: 'rung-1',
+      nodes: [...store.getState().ladderFlows[0].rungs[0].nodes, node],
+    })
+
+    store.getState().ladderFlowActions.setSelectedNodes({ editorName: 'editor-1', rungId: 'rung-1', nodes: [node] })
+
+    const flow = store.getState().ladderFlows[0]
+    expect(flow.rungs[1].selectedNodes).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // setEdges
+  // -------------------------------------------------------------------------
+  it('setEdges replaces all edges in a rung', () => {
+    seedFlowWithRung(store)
+    const edges = [makeEdge({ id: 'e1' }), makeEdge({ id: 'e2' })]
+
+    store.getState().ladderFlowActions.setEdges({ editorName: 'editor-1', rungId: 'rung-1', edges })
+
+    expect(store.getState().ladderFlows[0].rungs[0].edges).toHaveLength(2)
+    expect(store.getState().ladderFlows[0].updated).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // updateEdge
+  // -------------------------------------------------------------------------
+  it('updateEdge replaces a specific edge in a rung', () => {
+    const rung = makeRung({ edges: [makeEdge({ id: 'e1', source: 'old' })] })
+    seedFlowWithRung(store, 'editor-1', rung)
+
+    const updated = makeEdge({ id: 'e1', source: 'new' })
+    store
+      .getState()
+      .ladderFlowActions.updateEdge({ editorName: 'editor-1', rungId: 'rung-1', edgeId: 'e1', edge: updated })
+
+    expect(store.getState().ladderFlows[0].rungs[0].edges[0].source).toBe('new')
+  })
+
+  it('updateEdge does nothing for nonexistent edge', () => {
+    const rung = makeRung({ edges: [makeEdge({ id: 'e1' })] })
+    seedFlowWithRung(store, 'editor-1', rung)
+
+    store
+      .getState()
+      .ladderFlowActions.updateEdge({ editorName: 'editor-1', rungId: 'rung-1', edgeId: 'missing', edge: makeEdge() })
+
+    expect(store.getState().ladderFlows[0].rungs[0].edges).toHaveLength(1)
+    expect(store.getState().ladderFlows[0].rungs[0].edges[0].id).toBe('e1')
+  })
+
+  // -------------------------------------------------------------------------
+  // addEdge
+  // -------------------------------------------------------------------------
+  it('addEdge pushes a new edge to a rung', () => {
+    seedFlowWithRung(store)
+
+    store.getState().ladderFlowActions.addEdge({ editorName: 'editor-1', rungId: 'rung-1', edge: makeEdge({ id: 'e1' }) })
+
+    expect(store.getState().ladderFlows[0].rungs[0].edges).toHaveLength(1)
+    expect(store.getState().ladderFlows[0].updated).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // updateReactFlowViewport
+  // -------------------------------------------------------------------------
+  it('updateReactFlowViewport updates the viewport', () => {
+    seedFlowWithRung(store)
+
+    store
+      .getState()
+      .ladderFlowActions.updateReactFlowViewport({ editorName: 'editor-1', rungId: 'rung-1', reactFlowViewport: [1200, 400] })
+
+    expect(store.getState().ladderFlows[0].rungs[0].reactFlowViewport).toEqual([1200, 400])
+  })
+
+  it('updateReactFlowViewport does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+
+    store
+      .getState()
+      .ladderFlowActions.updateReactFlowViewport({ editorName: 'editor-1', rungId: 'missing', reactFlowViewport: [1200, 400] })
+
+    expect(store.getState().ladderFlows[0].rungs[0].reactFlowViewport).toEqual([800, 200])
+  })
+
+  // -------------------------------------------------------------------------
+  // setFlowUpdated
+  // -------------------------------------------------------------------------
+  it('setFlowUpdated sets the updated flag', () => {
+    seedFlowWithRung(store)
+
+    store.getState().ladderFlowActions.setFlowUpdated({ editorName: 'editor-1', updated: false })
+    expect(store.getState().ladderFlows[0].updated).toBe(false)
+
+    store.getState().ladderFlowActions.setFlowUpdated({ editorName: 'editor-1', updated: true })
+    expect(store.getState().ladderFlows[0].updated).toBe(true)
+  })
+
+  it('setFlowUpdated does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.setFlowUpdated({ editorName: 'nonexistent', updated: true })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // applyLadderFlowSnapshot
+  // -------------------------------------------------------------------------
+  it('applyLadderFlowSnapshot adds a new flow when snapshot is provided and flow does not exist', () => {
+    const snapshot = makeFlow({
+      name: 'other',
+      rungs: [makeRung({ comment: 'snap', selectedNodes: [makeNode()] })],
+    })
+
+    store.getState().ladderFlowActions.applyLadderFlowSnapshot({ editorName: 'editor-1', snapshot })
+
+    const flow = store.getState().ladderFlows[0]
+    expect(flow.name).toBe('editor-1')
+    expect(flow.rungs[0].comment).toBe('snap')
+    expect(flow.rungs[0].selectedNodes).toEqual([])
+  })
+
+  it('applyLadderFlowSnapshot replaces existing flow when snapshot is provided', () => {
+    seedFlowWithRung(store)
+    const snapshot = makeFlow({ rungs: [makeRung({ comment: 'replaced' })] })
+
+    store.getState().ladderFlowActions.applyLadderFlowSnapshot({ editorName: 'editor-1', snapshot })
+
+    expect(store.getState().ladderFlows).toHaveLength(1)
+    expect(store.getState().ladderFlows[0].rungs[0].comment).toBe('replaced')
+  })
+
+  it('applyLadderFlowSnapshot removes flow when snapshot is null', () => {
+    seedFlowWithRung(store)
+
+    store.getState().ladderFlowActions.applyLadderFlowSnapshot({ editorName: 'editor-1', snapshot: null })
+
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('applyLadderFlowSnapshot with null snapshot does nothing when flow does not exist', () => {
+    store.getState().ladderFlowActions.applyLadderFlowSnapshot({ editorName: 'nonexistent', snapshot: null })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // Guard clause coverage — nonexistent editor/rung
+  // -------------------------------------------------------------------------
+  it('addComment does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.addComment({ editorName: 'nonexistent', rungId: 'r', comment: 'x' })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('removeRung does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.removeRung('nonexistent', 'r')
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('onNodesChange does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.onNodesChange({ editorName: 'nonexistent', rungId: 'r', changes: [] })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('onEdgesChange does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.onEdgesChange({ editorName: 'nonexistent', rungId: 'r', changes: [] })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('onEdgesChange does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+    store.getState().ladderFlowActions.onEdgesChange({ editorName: 'editor-1', rungId: 'missing', changes: [] })
+    expect(store.getState().ladderFlows[0].rungs[0].edges).toEqual([])
+  })
+
+  it('onConnect does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.onConnect({
+      editorName: 'nonexistent',
+      rungId: 'r',
+      changes: { source: 'a', target: 'b', sourceHandle: 'h1', targetHandle: 'h2' },
+    })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('onConnect does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+    store.getState().ladderFlowActions.onConnect({
+      editorName: 'editor-1',
+      rungId: 'missing',
+      changes: { source: 'a', target: 'b', sourceHandle: 'h1', targetHandle: 'h2' },
+    })
+    expect(store.getState().ladderFlows[0].rungs[0].edges).toEqual([])
+  })
+
+  it('setNodes does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.setNodes({ editorName: 'nonexistent', rungId: 'r', nodes: [] })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('setNodes does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+    store.getState().ladderFlowActions.setNodes({ editorName: 'editor-1', rungId: 'missing', nodes: [] })
+    expect(store.getState().ladderFlows[0].rungs[0].nodes).toHaveLength(2)
+  })
+
+  it('updateNode does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.updateNode({ editorName: 'nonexistent', rungId: 'r', nodeId: 'n', node: makeNode() })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('updateNode does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+    store.getState().ladderFlowActions.updateNode({ editorName: 'editor-1', rungId: 'missing', nodeId: 'n', node: makeNode() })
+    expect(store.getState().ladderFlows[0].rungs[0].nodes).toHaveLength(2)
+  })
+
+  it('addNode does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.addNode({ editorName: 'nonexistent', rungId: 'r', node: makeNode() })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('addNode does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+    store.getState().ladderFlowActions.addNode({ editorName: 'editor-1', rungId: 'missing', node: makeNode() })
+    expect(store.getState().ladderFlows[0].rungs[0].nodes).toHaveLength(2)
+  })
+
+  it('removeNodes does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.removeNodes({ editorName: 'nonexistent', rungId: 'r', nodes: [] })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('removeNodes does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+    store.getState().ladderFlowActions.removeNodes({ editorName: 'editor-1', rungId: 'missing', nodes: [makeNode()] })
+    expect(store.getState().ladderFlows[0].rungs[0].nodes).toHaveLength(2)
+  })
+
+  it('setSelectedNodes does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.setSelectedNodes({ editorName: 'nonexistent', rungId: 'r', nodes: [] })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('setSelectedNodes does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+    store.getState().ladderFlowActions.setSelectedNodes({ editorName: 'editor-1', rungId: 'missing', nodes: [] })
+    expect(store.getState().ladderFlows[0].rungs[0].selectedNodes).toEqual([])
+  })
+
+  it('setSelectedNodes with empty array does not clear other rungs', () => {
+    seedFlowWithRung(store, 'editor-1', makeRung({ id: 'rung-1' }))
+    store.getState().ladderFlowActions.startLadderRung({ editorName: 'editor-1', rung: makeRung({ id: 'rung-2' }) })
+
+    store.getState().ladderFlowActions.setSelectedNodes({ editorName: 'editor-1', rungId: 'rung-1', nodes: [] })
+
+    const flow = store.getState().ladderFlows[0]
+    expect(flow.rungs).toHaveLength(2)
+  })
+
+  it('setEdges does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.setEdges({ editorName: 'nonexistent', rungId: 'r', edges: [] })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('setEdges does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+    store.getState().ladderFlowActions.setEdges({ editorName: 'editor-1', rungId: 'missing', edges: [] })
+    expect(store.getState().ladderFlows[0].rungs[0].edges).toEqual([])
+  })
+
+  it('updateEdge does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.updateEdge({ editorName: 'nonexistent', rungId: 'r', edgeId: 'e', edge: makeEdge() })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('updateEdge does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+    store.getState().ladderFlowActions.updateEdge({ editorName: 'editor-1', rungId: 'missing', edgeId: 'e', edge: makeEdge() })
+    expect(store.getState().ladderFlows[0].rungs[0].edges).toEqual([])
+  })
+
+  it('addEdge does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.addEdge({ editorName: 'nonexistent', rungId: 'r', edge: makeEdge() })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  it('addEdge does nothing for nonexistent rung', () => {
+    seedFlowWithRung(store)
+    store.getState().ladderFlowActions.addEdge({ editorName: 'editor-1', rungId: 'missing', edge: makeEdge() })
+    expect(store.getState().ladderFlows[0].rungs[0].edges).toEqual([])
+  })
+
+  it('updateReactFlowViewport does nothing for nonexistent editor', () => {
+    store.getState().ladderFlowActions.updateReactFlowViewport({ editorName: 'nonexistent', rungId: 'r', reactFlowViewport: [100, 100] })
+    expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // Defensive guard coverage — unreachable under TypeScript but present as runtime safety
+  // -------------------------------------------------------------------------
+  it('setRungs rejects non-array rungs at runtime', () => {
+    seedFlowWithRung(store)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.getState().ladderFlowActions.setRungs({ editorName: 'editor-1', rungs: 'not-an-array' as any })
+    expect(store.getState().ladderFlows[0].rungs).toHaveLength(1)
+  })
+
+  it('setSelectedNodes initializes selectedNodes when undefined', () => {
+    seedFlowWithRung(store)
+    const node = makeNode({ id: 'n1', data: { draggable: true } })
+    store.getState().ladderFlowActions.setNodes({
+      editorName: 'editor-1',
+      rungId: 'rung-1',
+      nodes: [...store.getState().ladderFlows[0].rungs[0].nodes, node],
+    })
+    // Artificially nullify selectedNodes to exercise the defensive guard
+    store.setState(
+      produce((state: LadderFlowSlice) => {
+        state.ladderFlows[0].rungs[0].selectedNodes = undefined as unknown as Node[]
+      }),
+    )
+    store.getState().ladderFlowActions.setSelectedNodes({ editorName: 'editor-1', rungId: 'rung-1', nodes: [node] })
+
+    expect(store.getState().ladderFlows[0].rungs[0].selectedNodes).toBeDefined()
+  })
+})

--- a/src2/store/__tests__/ladder-types.test.ts
+++ b/src2/store/__tests__/ladder-types.test.ts
@@ -1,0 +1,138 @@
+import {
+  zodLadderFlowSchema,
+  zodLadderFlowStateSchema,
+  zodLadderNodeTypesSchema,
+  zodRungLadderStateSchema,
+} from '../slices/ladder/types'
+
+describe('Ladder Zod schemas', () => {
+  const validNode = {
+    id: 'n1',
+    type: 'block',
+    position: { x: 0, y: 0 },
+    draggable: true,
+    selectable: true,
+    data: {},
+  }
+
+  const validEdge = {
+    id: 'e1',
+    source: 'n1',
+    sourceHandle: 'h1',
+    target: 'n2',
+    targetHandle: 'h2',
+  }
+
+  describe('zodRungLadderStateSchema', () => {
+    it('validates a valid rung', () => {
+      const result = zodRungLadderStateSchema.safeParse({
+        id: 'rung-1',
+        comment: 'test comment',
+        defaultBounds: [800, 200],
+        reactFlowViewport: [800, 200],
+        nodes: [validNode],
+        edges: [validEdge],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('applies default comment', () => {
+      const result = zodRungLadderStateSchema.safeParse({
+        id: 'rung-1',
+        defaultBounds: [800, 200],
+        reactFlowViewport: [800, 200],
+        nodes: [],
+        edges: [],
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.comment).toBe('')
+      }
+    })
+
+    it('rejects rung without id', () => {
+      const result = zodRungLadderStateSchema.safeParse({
+        comment: '',
+        defaultBounds: [800, 200],
+        reactFlowViewport: [800, 200],
+        nodes: [],
+        edges: [],
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects rung with invalid bounds', () => {
+      const result = zodRungLadderStateSchema.safeParse({
+        id: 'rung-1',
+        comment: '',
+        defaultBounds: 'not-an-array',
+        reactFlowViewport: [800, 200],
+        nodes: [],
+        edges: [],
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('zodLadderFlowSchema', () => {
+    it('validates a valid flow', () => {
+      const result = zodLadderFlowSchema.safeParse({
+        name: 'test-flow',
+        rungs: [
+          {
+            id: 'rung-1',
+            comment: '',
+            defaultBounds: [800, 200],
+            reactFlowViewport: [800, 200],
+            nodes: [],
+            edges: [],
+          },
+        ],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('applies default rungs', () => {
+      const result = zodLadderFlowSchema.safeParse({
+        name: 'test-flow',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.rungs).toEqual([])
+      }
+    })
+
+    it('rejects flow without name', () => {
+      const result = zodLadderFlowSchema.safeParse({ rungs: [] })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('zodLadderFlowStateSchema', () => {
+    it('validates a valid flow state', () => {
+      const result = zodLadderFlowStateSchema.safeParse({
+        ladderFlows: [{ name: 'flow-1', rungs: [] }],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('validates empty flow state', () => {
+      const result = zodLadderFlowStateSchema.safeParse({ ladderFlows: [] })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('zodLadderNodeTypesSchema', () => {
+    const validTypes = ['block', 'contact', 'coil', 'parallel', 'powerRail', 'variable']
+
+    it.each(validTypes)('accepts valid node type: %s', (type) => {
+      const result = zodLadderNodeTypesSchema.safeParse(type)
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects invalid node type', () => {
+      const result = zodLadderNodeTypesSchema.safeParse('invalid-type')
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/src2/store/__tests__/react-flow-types.test.ts
+++ b/src2/store/__tests__/react-flow-types.test.ts
@@ -1,0 +1,87 @@
+import { edgeSchema, nodeSchema } from '../slices/react-flow/types'
+
+describe('react-flow Zod schemas', () => {
+  describe('nodeSchema', () => {
+    it('validates a valid node', () => {
+      const result = nodeSchema.safeParse({
+        id: 'node-1',
+        type: 'block',
+        position: { x: 10, y: 20 },
+        draggable: true,
+        selectable: true,
+        data: { label: 'test' },
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('validates a node with optional fields', () => {
+      const result = nodeSchema.safeParse({
+        id: 'node-1',
+        type: 'block',
+        position: { x: 0, y: 0 },
+        height: 100,
+        width: 200,
+        measured: { width: 200, height: 100 },
+        draggable: false,
+        selectable: false,
+        data: {},
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.height).toBe(100)
+        expect(result.data.width).toBe(200)
+        expect(result.data.measured).toEqual({ width: 200, height: 100 })
+      }
+    })
+
+    it('rejects node missing required fields', () => {
+      const result = nodeSchema.safeParse({ id: 'node-1' })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects node with invalid position', () => {
+      const result = nodeSchema.safeParse({
+        id: 'node-1',
+        type: 'block',
+        position: { x: 'not-a-number', y: 0 },
+        draggable: true,
+        selectable: true,
+        data: {},
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('edgeSchema', () => {
+    it('validates a valid edge', () => {
+      const result = edgeSchema.safeParse({
+        id: 'edge-1',
+        source: 'node-1',
+        sourceHandle: 'h1',
+        target: 'node-2',
+        targetHandle: 'h2',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('validates an edge with optional type', () => {
+      const result = edgeSchema.safeParse({
+        id: 'edge-1',
+        source: 'node-1',
+        sourceHandle: 'h1',
+        target: 'node-2',
+        targetHandle: 'h2',
+        type: 'smoothstep',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.type).toBe('smoothstep')
+      }
+    })
+
+    it('rejects edge missing required fields', () => {
+      const result = edgeSchema.safeParse({ id: 'edge-1' })
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/src2/store/slices/fbd/index.ts
+++ b/src2/store/slices/fbd/index.ts
@@ -1,0 +1,2 @@
+export * from './slice'
+export * from './types'

--- a/src2/store/slices/fbd/slice.ts
+++ b/src2/store/slices/fbd/slice.ts
@@ -1,0 +1,345 @@
+import { addEdge, Node } from '@xyflow/react'
+import { produce } from 'immer'
+import { StateCreator } from 'zustand'
+
+import { FBDFlowSlice, FBDFlowState } from './types'
+
+export const createFBDFlowSlice: StateCreator<FBDFlowSlice, [], [], FBDFlowSlice> = (setState) => ({
+  fbdFlows: [],
+
+  fbdFlowActions: {
+    clearFBDFlows: () => {
+      setState({ fbdFlows: [] })
+    },
+    addFBDFlow: (flow) => {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flowIndex = fbdFlows.findIndex((f) => f.name === flow.name)
+          const rung = {
+            ...flow.rung,
+            selectedNodes: [],
+          }
+          const newFlow = { ...flow, rung }
+
+          if (flowIndex === -1) {
+            fbdFlows.push(newFlow)
+          } else {
+            fbdFlows[flowIndex] = newFlow
+          }
+        }),
+      )
+    },
+    removeFBDFlow: (flowId) => {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flowIndex = fbdFlows.findIndex((f) => f.name === flowId)
+          if (flowIndex === -1) return
+
+          fbdFlows.splice(flowIndex, 1)
+        }),
+      )
+    },
+
+    /**
+     * Control the rungs of the flow
+     */
+    startFBDRung: ({ editorName }) => {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          let flow = fbdFlows.find((f) => f.name === editorName)
+          if (!flow) {
+            flow = {
+              name: editorName,
+              updated: true,
+              rung: {
+                comment: '',
+                selectedNodes: [],
+                nodes: [],
+                edges: [],
+              },
+            }
+            fbdFlows.push(flow)
+          }
+
+          flow.rung = {
+            comment: '',
+            nodes: [],
+            edges: [],
+            selectedNodes: [],
+          }
+        }),
+      )
+    },
+    setRung: ({ editorName, rung }) => {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          flow.rung = rung
+          flow.updated = true
+        }),
+      )
+    },
+    addComment({ editorName, comment }) {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          flow.rung.comment = comment
+          flow.updated = true
+        }),
+      )
+    },
+
+    /**
+     * Control the rungs transactions
+     */
+    onConnect: ({ changes, editorName }) => {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          flow.rung.edges = addEdge(changes, flow.rung.edges)
+          flow.updated = true
+        }),
+      )
+    },
+
+    setNodes: ({ editorName, nodes }) => {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          flow.rung.nodes = nodes
+          flow.updated = true
+        }),
+      )
+    },
+    updateNode({ editorName, node, nodeId }) {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const nodeIndex = flow.rung.nodes.findIndex((n) => n.id === nodeId)
+          if (nodeIndex === -1) return
+
+          flow.rung.nodes[nodeIndex] = node
+          flow.updated = true
+        }),
+      )
+    },
+    addNode({ editorName, node }) {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          flow.rung.nodes.push(node)
+
+          const selectedNodes: Node[] = []
+          flow.rung.nodes = flow.rung.nodes.map((n) => {
+            if (n.id === node.id) {
+              selectedNodes.push(n)
+              return {
+                ...n,
+                selected: true,
+              }
+            }
+            return {
+              ...n,
+              selected: false,
+            }
+          })
+
+          flow.rung.selectedNodes = selectedNodes
+          flow.updated = true
+        }),
+      )
+    },
+    removeNodes({ editorName, nodes }) {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          flow.rung.nodes = flow.rung.nodes.filter((node) => !nodes.find((n) => n.id === node.id))
+          flow.rung.selectedNodes = flow.rung.selectedNodes.filter(
+            (selectedNode) => !nodes.find((n) => n.id === selectedNode.id),
+          )
+          flow.updated = true
+        }),
+      )
+    },
+
+    addSelectedNode({ editorName, node }) {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const selectedNodes = flow.rung.selectedNodes
+          if (!selectedNodes) flow.rung.selectedNodes = []
+          if (!flow.rung.selectedNodes.find((n) => n.id === node.id)) {
+            flow.rung.selectedNodes.push(node)
+            flow.updated = true
+          }
+
+          flow.rung.nodes = flow.rung.nodes.map((n) => {
+            if (n.id === node.id) {
+              return {
+                ...n,
+                selected: true,
+                draggable: (node.data as { draggable?: boolean }).draggable,
+              }
+            }
+            return n
+          })
+        }),
+      )
+    },
+    removeSelectedNode({ editorName, node }) {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const selectedNodes = flow.rung.selectedNodes.filter((n) => n.id !== node.id)
+          flow.rung.selectedNodes = selectedNodes
+
+          flow.rung.nodes = flow.rung.nodes.map((n) => {
+            if (n.id === node.id) {
+              return {
+                ...n,
+                selected: false,
+              }
+            }
+            return n
+          })
+        }),
+      )
+    },
+    setSelectedNodes({ nodes, editorName }) {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const selectedNodes = nodes
+          if (!flow.rung.selectedNodes) flow.rung.selectedNodes = []
+          flow.rung.selectedNodes = selectedNodes
+
+          flow.rung.nodes = flow.rung.nodes.map((node) => {
+            if (selectedNodes.find((n) => n.id === node.id)) {
+              return {
+                ...node,
+                selected: true,
+                draggable: (node.data as { draggable?: boolean }).draggable,
+              }
+            }
+            return {
+              ...node,
+              selected: false,
+              draggable: (node.data as { draggable?: boolean }).draggable,
+            }
+          })
+        }),
+      )
+    },
+
+    setEdges({ edges, editorName }) {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          flow.rung.edges = edges
+          flow.updated = true
+        }),
+      )
+    },
+    updateEdge({ edge, edgeId, editorName }) {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const edgeIndex = flow.rung.edges.findIndex((e) => e.id === edgeId)
+          if (edgeIndex === -1) return
+
+          flow.rung.edges[edgeIndex] = edge
+          flow.updated = true
+        }),
+      )
+    },
+    addEdge({ edge, editorName }) {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          flow.rung.edges.push(edge)
+          flow.updated = true
+        }),
+      )
+    },
+    removeEdges({ editorName, edges }) {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          flow.rung.edges = flow.rung.edges.filter((edge) => !edges.find((e) => e.id === edge.id))
+          flow.updated = true
+        }),
+      )
+    },
+
+    setFlowUpdated({ editorName, updated }) {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const flow = fbdFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          flow.updated = updated
+        }),
+      )
+    },
+
+    /**
+     * Control the undo and redo actions
+     */
+
+    applyFBDFlowSnapshot: ({ editorName, snapshot }) => {
+      setState(
+        produce(({ fbdFlows }: FBDFlowState) => {
+          const index = fbdFlows.findIndex((fbdFlow) => fbdFlow.name === editorName)
+
+          if (snapshot) {
+            const newFlow = {
+              ...snapshot,
+              name: editorName,
+              rung: {
+                ...snapshot.rung,
+                selectedNodes: [],
+              },
+              updated: true,
+            }
+
+            if (index === -1) {
+              fbdFlows.push(newFlow)
+            } else {
+              fbdFlows[index] = newFlow
+            }
+          } else {
+            if (index !== -1) fbdFlows.splice(index, 1)
+          }
+        }),
+      )
+    },
+  },
+})

--- a/src2/store/slices/fbd/types.ts
+++ b/src2/store/slices/fbd/types.ts
@@ -1,0 +1,104 @@
+import { Connection, Edge, Node } from '@xyflow/react'
+import { z } from 'zod'
+
+import { edgeSchema, nodeSchema } from '../react-flow'
+
+const zodFBDRungStateSchema = z.object({
+  comment: z.string().default(''),
+  nodes: z.array(nodeSchema),
+  edges: z.array(edgeSchema),
+})
+type ZodFBDRungType = z.infer<typeof zodFBDRungStateSchema>
+
+const zodFBDFlowSchema = z.object({
+  name: z.string(),
+  rung: zodFBDRungStateSchema,
+})
+type ZodFBDFlowType = z.infer<typeof zodFBDFlowSchema>
+
+const zodFBDFlowStateSchema = z.object({
+  fbdFlows: z.array(zodFBDFlowSchema),
+})
+type ZodFBDFlowState = z.infer<typeof zodFBDFlowStateSchema>
+
+const zodFBDNodeTypesSchema = z.enum([
+  'block',
+  'comment',
+  'connector',
+  'connection',
+  'input-variable',
+  'output-variable',
+  'inout-variable',
+])
+type ZodFBDNodeType = z.infer<typeof zodFBDNodeTypesSchema>
+
+/**
+ * Types used at the slice
+ */
+
+type FBDRungState = {
+  comment: string
+  selectedNodes: Node[]
+  nodes: Node[]
+  edges: Edge[]
+}
+
+type FBDFlowType = {
+  name: string
+  updated: boolean
+  rung: FBDRungState
+}
+
+type FBDFlowState = {
+  fbdFlows: FBDFlowType[]
+}
+
+type FBDFlowActions = {
+  clearFBDFlows: () => void
+  addFBDFlow: (flow: FBDFlowType) => void
+  removeFBDFlow: (flowId: string) => void
+
+  /**
+   * Control the rungs of the flow
+   */
+  startFBDRung: ({ editorName }: { editorName: string }) => void
+  setRung: ({ rung, editorName }: { rung: FBDRungState; editorName: string }) => void
+  addComment: ({ editorName, comment }: { editorName: string; comment: string }) => void
+
+  /**
+   * Control the rungs transactions
+   */
+  onConnect: ({ changes, editorName }: { changes: Connection; editorName: string }) => void
+
+  setNodes: ({ nodes, editorName }: { nodes: Node[]; editorName: string }) => void
+  updateNode: ({ node, nodeId, editorName }: { node: Node; nodeId: string; editorName: string }) => void
+
+  addNode: ({ node, editorName }: { node: Node; editorName: string }) => void
+  removeNodes: ({ nodes, editorName }: { nodes: Node[]; editorName: string }) => void
+
+  addSelectedNode: ({ node, editorName }: { node: Node; editorName: string }) => void
+  removeSelectedNode: ({ node, editorName }: { node: Node; editorName: string }) => void
+  setSelectedNodes: ({ nodes, editorName }: { nodes: Node[]; editorName: string }) => void
+
+  setEdges: ({ edges, editorName }: { edges: Edge[]; editorName: string }) => void
+  updateEdge: ({ edge, edgeId, editorName }: { edge: Edge; edgeId: string; editorName: string }) => void
+  addEdge: ({ edge, editorName }: { edge: Edge; editorName: string }) => void
+  removeEdges: ({ edges, editorName }: { edges: Edge[]; editorName: string }) => void
+
+  setFlowUpdated: ({ editorName, updated }: { editorName: string; updated: boolean }) => void
+  applyFBDFlowSnapshot: ({ editorName, snapshot }: { editorName: string; snapshot: FBDFlowType | null }) => void
+}
+
+/** The actions, the events that occur in the app based on user input, and trigger updates in the state - Concept based on Redux */
+type FBDFlowSlice = FBDFlowState & {
+  fbdFlowActions: FBDFlowActions
+}
+
+export type { FBDFlowActions, FBDFlowSlice, FBDFlowState, FBDFlowType, FBDRungState }
+
+/**
+ * Zod exports
+ */
+export { zodFBDFlowSchema, zodFBDFlowStateSchema, zodFBDNodeTypesSchema, zodFBDRungStateSchema }
+
+export type { ZodFBDFlowState, ZodFBDFlowType, ZodFBDNodeType, ZodFBDRungType }

--- a/src2/store/slices/index.ts
+++ b/src2/store/slices/index.ts
@@ -1,6 +1,8 @@
 export { createConsoleSlice } from './console'
 export { createEditorSlice } from './editor'
+export { createFBDFlowSlice } from './fbd'
 export { createFileSlice } from './file'
+export { createLadderFlowSlice } from './ladder'
 export { createLibrarySlice } from './library'
 export { createModalSlice } from './modal'
 export { createProjectSlice } from './project'

--- a/src2/store/slices/ladder/index.ts
+++ b/src2/store/slices/ladder/index.ts
@@ -1,0 +1,2 @@
+export * from './slice'
+export * from './types'

--- a/src2/store/slices/ladder/slice.ts
+++ b/src2/store/slices/ladder/slice.ts
@@ -1,0 +1,413 @@
+import { addEdge, applyEdgeChanges, applyNodeChanges } from '@xyflow/react'
+import { produce } from 'immer'
+import { StateCreator } from 'zustand'
+
+import { LadderFlowSlice, LadderFlowState } from './types'
+
+export const createLadderFlowSlice: StateCreator<LadderFlowSlice, [], [], LadderFlowSlice> = (setState) => ({
+  ladderFlows: [],
+
+  ladderFlowActions: {
+    clearLadderFlows: () => {
+      setState({ ladderFlows: [] })
+    },
+    addLadderFlow: (flow) => {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flowIndex = ladderFlows.findIndex((f) => f.name === flow.name)
+          const rungs = flow.rungs.map((rung) => ({
+            ...rung,
+            selectedNodes: [],
+          }))
+          const newFlow = { ...flow, rungs }
+
+          if (flowIndex === -1) {
+            ladderFlows.push(newFlow)
+          } else {
+            ladderFlows[flowIndex] = newFlow
+          }
+        }),
+      )
+    },
+    removeLadderFlow: (flowId) => {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flowIndex = ladderFlows.findIndex((f) => f.name === flowId)
+          if (flowIndex === -1) return
+
+          ladderFlows.splice(flowIndex, 1)
+        }),
+      )
+    },
+
+    /**
+     * Control the rungs of the flow
+     */
+    startLadderRung: ({ editorName, rung }) => {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          let flow = ladderFlows.find((f) => f.name === editorName)
+          if (!flow) {
+            flow = {
+              name: editorName,
+              updated: true,
+              rungs: [],
+            }
+            ladderFlows.push(flow)
+          }
+
+          flow.rungs.push(rung)
+        }),
+      )
+    },
+    setRungs: ({ editorName, rungs }) => {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          if (!Array.isArray(rungs)) return
+
+          // Validate each rung has required structure
+          if (
+            !rungs.every(
+              (rung) =>
+                rung.id &&
+                Array.isArray(rung.nodes) &&
+                Array.isArray(rung.edges) &&
+                rung.nodes.some((node) => node.id.startsWith('left-rail')) &&
+                rung.nodes.some((node) => node.id.startsWith('right-rail')),
+            )
+          )
+            return
+
+          flow.rungs = rungs
+          flow.updated = true
+        }),
+      )
+    },
+    removeRung: (editorName, rungId) => {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          flow.rungs = flow.rungs.filter((rung) => rung.id !== rungId)
+          flow.updated = true
+        }),
+      )
+    },
+    addComment({ editorName, rungId, comment }) {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rung = flow.rungs.find((rung) => rung.id === rungId)
+          if (!rung) return
+
+          rung.comment = comment
+          flow.updated = true
+        }),
+      )
+    },
+    duplicateRung({ editorName, rungId, newRung }) {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rungIndex = flow.rungs.findIndex((rung) => rung.id === rungId)
+          if (rungIndex === -1) return
+
+          flow.rungs.splice(rungIndex + 1, 0, newRung)
+          flow.updated = true
+        }),
+      )
+    },
+
+    /**
+     * Control the rungs transactions
+     */
+    onNodesChange: ({ changes, editorName, rungId }) => {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rung = flow.rungs.find((rung) => rung.id === rungId)
+          if (!rung) return
+
+          rung.nodes = applyNodeChanges(changes, rung.nodes)
+        }),
+      )
+    },
+    onEdgesChange: ({ changes, editorName, rungId }) => {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rung = flow.rungs.find((rung) => rung.id === rungId)
+          if (!rung) return
+
+          rung.edges = applyEdgeChanges(changes, rung.edges)
+        }),
+      )
+    },
+    onConnect: ({ changes, editorName, rungId }) => {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rung = flow.rungs.find((rung) => rung.id === rungId)
+          if (!rung) return
+
+          rung.edges = addEdge(changes, rung.edges)
+        }),
+      )
+    },
+
+    setNodes: ({ editorName, nodes, rungId }) => {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rung = flow.rungs.find((rung) => rung.id === rungId)
+          if (!rung) return
+
+          rung.nodes = nodes
+          flow.updated = true
+        }),
+      )
+    },
+    updateNode({ editorName, node, nodeId, rungId }) {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rung = flow.rungs.find((rung) => rung.id === rungId)
+          if (!rung) return
+
+          const nodeIndex = rung.nodes.findIndex((n) => n.id === nodeId)
+          if (nodeIndex === -1) return
+
+          rung.nodes[nodeIndex] = node
+          flow.updated = true
+        }),
+      )
+    },
+    addNode({ editorName, node, rungId }) {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rung = flow.rungs.find((rung) => rung.id === rungId)
+          if (!rung) return
+
+          rung.nodes.push(node)
+          rung.nodes = rung.nodes.map((n) => {
+            if (n.id === node.id) {
+              return {
+                ...n,
+                selected: true,
+              }
+            }
+            return {
+              ...n,
+              selected: false,
+            }
+          })
+
+          flow.updated = true
+        }),
+      )
+    },
+    removeNodes({ editorName, nodes, rungId }) {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rung = flow.rungs.find((rung) => rung.id === rungId)
+          if (!rung) return
+
+          const removedIds = new Set(nodes.map((n) => n.id))
+          rung.nodes = rung.nodes.filter((node) => !removedIds.has(node.id))
+          rung.edges = rung.edges.filter((edge) => !removedIds.has(edge.source) && !removedIds.has(edge.target))
+          rung.selectedNodes = rung.selectedNodes.filter((node) => !removedIds.has(node.id))
+          flow.updated = true
+        }),
+      )
+    },
+    setSelectedNodes({ nodes, rungId, editorName }) {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rung = flow.rungs.find((rung) => rung.id === rungId)
+          if (!rung) return
+
+          const selectedNodes = nodes
+          if (!rung.selectedNodes) rung.selectedNodes = []
+          rung.selectedNodes = selectedNodes
+
+          if (selectedNodes.length > 1) {
+            rung.nodes = rung.nodes.map((node) => {
+              if (selectedNodes.find((n) => n.id === node.id)) {
+                return {
+                  ...node,
+                  selected: true,
+                  draggable: false,
+                }
+              }
+              return {
+                ...node,
+                selected: false,
+                draggable: false,
+              }
+            })
+          } else {
+            rung.nodes = rung.nodes.map((node) => {
+              if (selectedNodes.find((n) => n.id === node.id)) {
+                return {
+                  ...node,
+                  selected: true,
+                  draggable: (node.data as { draggable?: boolean }).draggable,
+                }
+              }
+              return {
+                ...node,
+                selected: false,
+                draggable: (node.data as { draggable?: boolean }).draggable,
+              }
+            })
+          }
+
+          if (selectedNodes.length > 0) {
+            flow.rungs = flow.rungs.map((r) => {
+              const changedRung = r.id === rungId
+
+              if (changedRung) {
+                return { ...rung }
+              } else {
+                return {
+                  ...r,
+                  selectedNodes: [],
+                  nodes: r.nodes.map((node) => ({
+                    ...node,
+                    selected: false,
+                    draggable: false,
+                  })),
+                }
+              }
+            })
+          }
+        }),
+      )
+    },
+
+    setEdges({ edges, editorName, rungId }) {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rung = flow.rungs.find((rung) => rung.id === rungId)
+          if (!rung) return
+
+          rung.edges = edges
+          flow.updated = true
+        }),
+      )
+    },
+    updateEdge({ edge, edgeId, editorName, rungId }) {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rung = flow.rungs.find((rung) => rung.id === rungId)
+          if (!rung) return
+
+          const edgeIndex = rung.edges.findIndex((e) => e.id === edgeId)
+          if (edgeIndex === -1) return
+
+          rung.edges[edgeIndex] = edge
+          flow.updated = true
+        }),
+      )
+    },
+    addEdge({ edge, editorName, rungId }) {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rung = flow.rungs.find((rung) => rung.id === rungId)
+          if (!rung) return
+
+          rung.edges.push(edge)
+          flow.updated = true
+        }),
+      )
+    },
+
+    /**
+     * Control the flow viewport of the rung
+     */
+    updateReactFlowViewport({ editorName, reactFlowViewport, rungId }) {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          const rung = flow.rungs.find((rung) => rung.id === rungId)
+          if (!rung) return
+
+          rung.reactFlowViewport = reactFlowViewport
+        }),
+      )
+    },
+
+    setFlowUpdated({ editorName, updated }) {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          const flow = ladderFlows.find((flow) => flow.name === editorName)
+          if (!flow) return
+
+          flow.updated = updated
+        }),
+      )
+    },
+
+    /**
+     * Control the undo and redo actions
+     */
+    applyLadderFlowSnapshot: ({ editorName, snapshot }) => {
+      setState(
+        produce(({ ladderFlows }: LadderFlowState) => {
+          if (snapshot) {
+            const flowIndex = ladderFlows.findIndex((ladderFlow) => ladderFlow.name === editorName)
+            const rungs = snapshot.rungs.map((rung) => ({ ...rung, selectedNodes: [] }))
+            const newFlow = { ...snapshot, name: editorName, rungs }
+
+            if (flowIndex === -1) {
+              ladderFlows.push(newFlow)
+            } else {
+              ladderFlows[flowIndex] = newFlow
+            }
+          } else {
+            const flowIndex = ladderFlows.findIndex((ladderFlow) => ladderFlow.name === editorName)
+            if (flowIndex !== -1) ladderFlows.splice(flowIndex, 1)
+          }
+        }),
+      )
+    },
+  },
+})

--- a/src2/store/slices/ladder/types.ts
+++ b/src2/store/slices/ladder/types.ts
@@ -1,0 +1,162 @@
+import { Connection, Edge, EdgeChange, Node, NodeChange } from '@xyflow/react'
+import { z } from 'zod'
+
+import { edgeSchema, nodeSchema } from '../react-flow'
+
+/**
+ * Types used to save at the json
+ */
+const zodRungLadderStateSchema = z.object({
+  id: z.string(),
+  comment: z.string().default(''),
+  defaultBounds: z.array(z.number()),
+  reactFlowViewport: z.array(z.number()),
+  nodes: z.array(nodeSchema),
+  edges: z.array(edgeSchema),
+})
+type ZodLadderRungType = z.infer<typeof zodRungLadderStateSchema>
+
+const zodLadderFlowSchema = z.object({
+  name: z.string(),
+  rungs: z.array(zodRungLadderStateSchema).default([]),
+})
+type ZodLadderFlowType = z.infer<typeof zodLadderFlowSchema>
+
+const zodLadderFlowStateSchema = z.object({
+  ladderFlows: z.array(zodLadderFlowSchema),
+})
+type ZodLadderFlowState = z.infer<typeof zodLadderFlowStateSchema>
+
+const zodLadderNodeTypesSchema = z.enum(['block', 'contact', 'coil', 'parallel', 'powerRail', 'variable'])
+type ZodLadderNodeType = z.infer<typeof zodLadderNodeTypesSchema>
+
+/**
+ * Types used at the slice
+ */
+
+type RungLadderState = {
+  id: string
+  comment: string
+  defaultBounds: number[]
+  reactFlowViewport: number[]
+  selectedNodes: Node[]
+  nodes: Node[]
+  edges: Edge[]
+}
+
+type LadderFlowType = {
+  name: string
+  updated: boolean
+  rungs: RungLadderState[]
+}
+
+type LadderFlowState = {
+  ladderFlows: LadderFlowType[]
+}
+
+type LadderFlowActions = {
+  clearLadderFlows: () => void
+  addLadderFlow: (flow: LadderFlowType) => void
+  removeLadderFlow: (flowId: string) => void
+
+  /**
+   * Control the rungs of the flow
+   */
+  startLadderRung: ({ editorName, rung }: { editorName: string; rung: RungLadderState }) => void
+  setRungs: ({ rungs, editorName }: { rungs: RungLadderState[]; editorName: string }) => void
+  removeRung: (editorName: string, rungId: string) => void
+  addComment: ({ editorName, rungId, comment }: { editorName: string; rungId: string; comment: string }) => void
+  duplicateRung: ({
+    editorName,
+    rungId,
+    newRung,
+  }: {
+    editorName: string
+    rungId: string
+    newRung: RungLadderState
+  }) => void
+
+  /**
+   * Control the rungs transactions
+   */
+  onNodesChange: ({
+    changes,
+    rungId,
+    editorName,
+  }: {
+    changes: NodeChange<Node>[]
+    rungId: string
+    editorName: string
+  }) => void
+  onEdgesChange: ({
+    changes,
+    rungId,
+    editorName,
+  }: {
+    changes: EdgeChange<Edge>[]
+    rungId: string
+    editorName: string
+  }) => void
+  onConnect: ({ changes, rungId, editorName }: { changes: Connection; rungId: string; editorName: string }) => void
+
+  setNodes: ({ nodes, rungId, editorName }: { nodes: Node[]; rungId: string; editorName: string }) => void
+  updateNode: ({
+    node,
+    nodeId,
+    rungId,
+    editorName,
+  }: {
+    node: Node
+    nodeId: string
+    rungId: string
+    editorName: string
+  }) => void
+  addNode: ({ node, rungId, editorName }: { node: Node; rungId: string; editorName: string }) => void
+  removeNodes: ({ nodes, rungId, editorName }: { nodes: Node[]; rungId: string; editorName: string }) => void
+  setSelectedNodes: ({ nodes, rungId, editorName }: { nodes: Node[]; rungId: string; editorName: string }) => void
+
+  setEdges: ({ edges, rungId, editorName }: { edges: Edge[]; rungId: string; editorName: string }) => void
+  updateEdge: ({
+    edge,
+    edgeId,
+    rungId,
+    editorName,
+  }: {
+    edge: Edge
+    edgeId: string
+    rungId: string
+    editorName: string
+  }) => void
+  addEdge: ({ edge, rungId, editorName }: { edge: Edge; rungId: string; editorName: string }) => void
+
+  /**
+   * Control the flow viewport of the rung
+   */
+  updateReactFlowViewport: ({
+    reactFlowViewport,
+    rungId,
+    editorName,
+  }: {
+    reactFlowViewport: [number, number]
+    rungId: string
+    editorName: string
+  }) => void
+
+  setFlowUpdated: ({ editorName, updated }: { editorName: string; updated: boolean }) => void
+
+  applyLadderFlowSnapshot: ({ editorName, snapshot }: { editorName: string; snapshot: LadderFlowType | null }) => void
+}
+
+/** The actions, the events that occur in the app based on user input, and trigger updates in the state - Concept based on Redux */
+type LadderFlowSlice = LadderFlowState & {
+  ladderFlowActions: LadderFlowActions
+}
+
+export type { LadderFlowActions, LadderFlowSlice, LadderFlowState, LadderFlowType, RungLadderState }
+
+/**
+ * Zod exports
+ */
+export { zodLadderFlowSchema, zodLadderFlowStateSchema, zodLadderNodeTypesSchema, zodRungLadderStateSchema }
+
+export type { ZodLadderFlowState, ZodLadderFlowType, ZodLadderNodeType, ZodLadderRungType }

--- a/src2/store/slices/react-flow/index.ts
+++ b/src2/store/slices/react-flow/index.ts
@@ -1,0 +1,1 @@
+export * from './types'

--- a/src2/store/slices/react-flow/types.ts
+++ b/src2/store/slices/react-flow/types.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+
+/**
+ * Types used to save at the json
+ */
+const nodeSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  position: z.object({
+    x: z.number(),
+    y: z.number(),
+  }),
+  height: z.number().optional(),
+  width: z.number().optional(),
+  measured: z
+    .object({
+      width: z.number(),
+      height: z.number(),
+    })
+    .optional(),
+  draggable: z.boolean(),
+  selectable: z.boolean(),
+  data: z.any(),
+})
+type NodeType = z.infer<typeof nodeSchema>
+
+const edgeSchema = z.object({
+  id: z.string(),
+  source: z.string(),
+  sourceHandle: z.string(),
+  target: z.string(),
+  targetHandle: z.string(),
+  type: z.string().optional(),
+})
+type EdgeType = z.infer<typeof edgeSchema>
+
+/**
+ * Zod exports
+ */
+export { edgeSchema, nodeSchema }
+
+export type { EdgeType, NodeType }


### PR DESCRIPTION
## Summary
- Add react-flow Zod schemas (node/edge) shared by both visual editors
- Migrate FBDFlowSlice with reconciled API (includes `applyFBDFlowSnapshot` from editor)
- Migrate LadderFlowSlice with refactored API: `startLadderRung` and `duplicateRung` accept pre-built data to remove component-layer imports (`nodesBuilder`, `removeElements`)
- Replace `BasicNodeData` component import with inline cast for architecture compliance
- Ladder `removeNodes` uses simple id-based filter + edge cleanup instead of component's `removeElements`

## Key Reconciliation Decisions
- **FBD**: Editor had `applyFBDFlowSnapshot` that web lacked — included in shared slice (undo/redo support)
- **Ladder**: `startLadderRung` signature changed from `(editorName, rungId, defaultBounds, reactFlowViewport)` to `(editorName, rung)` — callers now build rail nodes (keeps store layer free of component dependencies)
- **Ladder**: `duplicateRung` signature changed to accept `newRung` parameter — node duplication logic moves to component layer
- **Ladder**: `removeNodes` simplified to filter by id + remove connected edges, replacing component-layer `removeElements` import

## Validation Gates
- [x] Architecture validation passes (`npx tsx src2/__architecture__/validate.ts`)
- [x] Unit tests pass with 100% coverage (970 tests editor, 1038 tests web)
- [x] Shared files identical between repos

## Step Progress
Step 15 of 30 — Phase: store

Generated with [Claude Code](https://claude.com/claude-code)