### PR TITLE
migrate(step-20): extract application logic from stores into backend/shared/

### DIFF
--- a/docs/migration-state.md
+++ b/docs/migration-state.md
@@ -8,7 +8,7 @@ architecture-rework
 
 ## Current Step
 
-20
+21
 
 ## Step Log
 
@@ -34,7 +34,7 @@ architecture-rework
 | 17 | resources | Copy shared resources (styles, assets, locales, declarations) to src2/ | done | 2026-03-11 |
 | 18 | components | Atoms batch 1 — shared identical components (revised: 23 kept, 17 divergent moved to step 22) | done | 2026-03-11 |
 | 19 | architecture-rework | Restructure src2/ into frontend/middleware/backend three-layer architecture | done | 2026-03-11 |
-| 20 | architecture-rework | Extract application logic from Zustand stores into backend/shared/ | pending | |
+| 20 | architecture-rework | Extract application logic from Zustand stores into backend/shared/ | done | 2026-03-11 |
 | 21 | architecture-rework | Update comparison script to validate all byte-identical surfaces | pending | |
 | 22 | components | Atoms batch 2 — divergent components (reconcile) | pending | |
 | 23 | components | Molecules batch 1 — shared identical | pending | |

--- a/src2/backend/shared/ai/__tests__/resolve-ai-initial-state.test.ts
+++ b/src2/backend/shared/ai/__tests__/resolve-ai-initial-state.test.ts
@@ -1,0 +1,47 @@
+import { resolveAIInitialState } from '../resolve-ai-initial-state'
+
+describe('resolveAIInitialState', () => {
+  it('returns enabled and consented when config has both true', () => {
+    const result = resolveAIInitialState({
+      isFeatureEnabled: true,
+      hasUserConsented: true,
+    })
+    expect(result).toEqual({
+      isEnabled: true,
+      hasConsented: true,
+    })
+  })
+
+  it('returns disabled and not consented when config has both false', () => {
+    const result = resolveAIInitialState({
+      isFeatureEnabled: false,
+      hasUserConsented: false,
+    })
+    expect(result).toEqual({
+      isEnabled: false,
+      hasConsented: false,
+    })
+  })
+
+  it('returns enabled but not consented when only feature is enabled', () => {
+    const result = resolveAIInitialState({
+      isFeatureEnabled: true,
+      hasUserConsented: false,
+    })
+    expect(result).toEqual({
+      isEnabled: true,
+      hasConsented: false,
+    })
+  })
+
+  it('returns disabled but consented when only consent is given', () => {
+    const result = resolveAIInitialState({
+      isFeatureEnabled: false,
+      hasUserConsented: true,
+    })
+    expect(result).toEqual({
+      isEnabled: false,
+      hasConsented: true,
+    })
+  })
+})

--- a/src2/backend/shared/ai/index.ts
+++ b/src2/backend/shared/ai/index.ts
@@ -1,0 +1,2 @@
+export { resolveAIInitialState } from './resolve-ai-initial-state'
+export type { AIFeatureConfig, ConsentStorage } from './types'

--- a/src2/backend/shared/ai/resolve-ai-initial-state.ts
+++ b/src2/backend/shared/ai/resolve-ai-initial-state.ts
@@ -1,0 +1,18 @@
+import type { AIFeatureConfig } from './types'
+
+/**
+ * Derives the AI-specific initial state overrides from platform configuration.
+ *
+ * Business rules:
+ * - AI is enabled only when the platform feature flag is on
+ * - Consent status is loaded from persistent storage at startup
+ *
+ * Returns only the fields that depend on platform config. The caller merges
+ * these with the slice's hardcoded defaults.
+ */
+export function resolveAIInitialState(config: AIFeatureConfig) {
+  return {
+    isEnabled: config.isFeatureEnabled,
+    hasConsented: config.hasUserConsented,
+  }
+}

--- a/src2/backend/shared/ai/types.ts
+++ b/src2/backend/shared/ai/types.ts
@@ -1,0 +1,20 @@
+/**
+ * Platform-provided configuration for the AI feature.
+ * Resolved by the composition root from environment variables and persistent storage.
+ */
+export interface AIFeatureConfig {
+  /** Whether the AI feature is enabled on this platform */
+  isFeatureEnabled: boolean
+  /** Whether the user has previously consented to AI usage */
+  hasUserConsented: boolean
+}
+
+/**
+ * Contract for persisting AI consent decisions across sessions.
+ * Implemented by the composition root using platform-specific storage
+ * (e.g., localStorage for web, electron-store for desktop).
+ */
+export interface ConsentStorage {
+  load(): boolean
+  save(consented: boolean): void
+}

--- a/src2/frontend/store/__tests__/ai-slice.test.ts
+++ b/src2/frontend/store/__tests__/ai-slice.test.ts
@@ -1,6 +1,6 @@
 import { createStore, StoreApi } from 'zustand/vanilla'
 
-import { createAISlice } from '../slices/ai/slice'
+import { createAISlice, createAISliceFactory } from '../slices/ai/slice'
 import type { AISlice, ChatMessage } from '../slices/ai/types'
 import { MAX_CONVERSATION_MESSAGES } from '../slices/ai/types'
 
@@ -352,5 +352,51 @@ describe('createAISlice', () => {
       store.getState().aiActions.setChatOpen(false)
       expect(store.getState().ai.isChatOpen).toBe(false)
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Factory pattern (createAISliceFactory)
+// ---------------------------------------------------------------------------
+
+describe('createAISliceFactory', () => {
+  it('uses default state when called without config', () => {
+    const store = createStore<AISlice>()(createAISliceFactory())
+    const { ai } = store.getState()
+    expect(ai.isEnabled).toBe(false)
+    expect(ai.hasConsented).toBe(false)
+  })
+
+  it('overrides isEnabled and hasConsented from config', () => {
+    const store = createStore<AISlice>()(
+      createAISliceFactory({ isFeatureEnabled: true, hasUserConsented: true }),
+    )
+    const { ai } = store.getState()
+    expect(ai.isEnabled).toBe(true)
+    expect(ai.hasConsented).toBe(true)
+  })
+
+  it('preserves other default values when config is provided', () => {
+    const store = createStore<AISlice>()(
+      createAISliceFactory({ isFeatureEnabled: true, hasUserConsented: false }),
+    )
+    const { ai } = store.getState()
+    expect(ai.model).toBe('haiku')
+    expect(ai.creditsUsed).toBe(0)
+    expect(ai.creditsTotal).toBe(500)
+    expect(ai.tier).toBe('free')
+    expect(ai.currentPeriodEnd).toBeNull()
+    expect(ai.conversations).toEqual([])
+    expect(ai.activeConversationPou).toBeNull()
+    expect(ai.isChatOpen).toBe(false)
+    expect(ai.error).toBeNull()
+  })
+
+  it('creates functional actions when config is provided', () => {
+    const store = createStore<AISlice>()(
+      createAISliceFactory({ isFeatureEnabled: true, hasUserConsented: true }),
+    )
+    store.getState().aiActions.setAIEnabled(false)
+    expect(store.getState().ai.isEnabled).toBe(false)
   })
 })

--- a/src2/frontend/store/index.ts
+++ b/src2/frontend/store/index.ts
@@ -6,6 +6,8 @@ import { subscribeWithSelector } from 'zustand/middleware'
 // Enable Immer's MapSet plugin for Map/Set support in store state
 enableMapSet()
 
+import type { AIFeatureConfig } from '../../backend/shared/ai'
+
 import type {
   AISlice,
   ConsoleSlice,
@@ -25,7 +27,7 @@ import type {
   WorkspaceSlice,
 } from './slices'
 import {
-  createAISlice,
+  createAISliceFactory,
   createConsoleSlice,
   createDeviceSlice,
   createEditorSlice,
@@ -60,25 +62,37 @@ export type RootState = AISlice &
   WebRTCSlice &
   WorkspaceSlice
 
-export const openPLCStoreBase = create(
-  subscribeWithSelector<RootState>((...a) => ({
-    ...createAISlice(...a),
-    ...createConsoleSlice(...a),
-    ...createDeviceSlice(...a),
-    ...createEditorSlice(...a),
-    ...createFBDFlowSlice(...a),
-    ...createFileSlice(...a),
-    ...createHistorySlice(...a),
-    ...createLadderFlowSlice(...a),
-    ...createLibrarySlice(...a),
-    ...createModalSlice(...a),
-    ...createProjectSlice(...a),
-    ...createSearchSlice(...a),
-    ...createSharedSlice(...a),
-    ...createTabsSlice(...a),
-    ...createWebRTCSlice(...a),
-    ...createWorkspaceSlice(...a),
-  })),
-)
+/**
+ * Configuration for store initialization.
+ * Allows the composition root to inject platform-specific initial state.
+ */
+export interface StoreConfig {
+  /** AI feature configuration from platform environment */
+  ai?: AIFeatureConfig
+}
 
+export function createOpenPLCStore(config: StoreConfig = {}) {
+  return create(
+    subscribeWithSelector<RootState>((...a) => ({
+      ...createAISliceFactory(config.ai)(...a),
+      ...createConsoleSlice(...a),
+      ...createDeviceSlice(...a),
+      ...createEditorSlice(...a),
+      ...createFBDFlowSlice(...a),
+      ...createFileSlice(...a),
+      ...createHistorySlice(...a),
+      ...createLadderFlowSlice(...a),
+      ...createLibrarySlice(...a),
+      ...createModalSlice(...a),
+      ...createProjectSlice(...a),
+      ...createSearchSlice(...a),
+      ...createSharedSlice(...a),
+      ...createTabsSlice(...a),
+      ...createWebRTCSlice(...a),
+      ...createWorkspaceSlice(...a),
+    })),
+  )
+}
+
+export const openPLCStoreBase = createOpenPLCStore()
 export const useOpenPLCStore = createSelectorHooks(openPLCStoreBase)

--- a/src2/frontend/store/slices/ai/index.ts
+++ b/src2/frontend/store/slices/ai/index.ts
@@ -1,4 +1,4 @@
-export { createAISlice } from './slice'
+export { createAISlice, createAISliceFactory } from './slice'
 export type {
   AIActions,
   AIModel,

--- a/src2/frontend/store/slices/ai/slice.ts
+++ b/src2/frontend/store/slices/ai/slice.ts
@@ -1,155 +1,164 @@
 import { produce } from 'immer'
 import { StateCreator } from 'zustand'
 
+import { resolveAIInitialState } from '../../../../backend/shared/ai'
+import type { AIFeatureConfig } from '../../../../backend/shared/ai'
+
 import type { AISlice } from './types'
 import { MAX_CONVERSATION_MESSAGES } from './types'
 
-const createAISlice: StateCreator<AISlice, [], [], AISlice> = (setState) => ({
-  ai: {
-    isEnabled: false,
-    isLoading: false,
-    hasConsented: false,
-    model: 'haiku',
-    creditsUsed: 0,
-    creditsTotal: 500,
-    tier: 'free',
-    currentPeriodEnd: null,
-    conversations: [],
-    activeConversationPou: null,
-    isChatOpen: false,
-    error: null,
-  },
+const DEFAULT_AI_STATE: AISlice['ai'] = {
+  isEnabled: false,
+  isLoading: false,
+  hasConsented: false,
+  model: 'haiku',
+  creditsUsed: 0,
+  creditsTotal: 500,
+  tier: 'free',
+  currentPeriodEnd: null,
+  conversations: [],
+  activeConversationPou: null,
+  isChatOpen: false,
+  error: null,
+}
 
-  aiActions: {
-    setAIEnabled: (enabled) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          ai.isEnabled = enabled
-        }),
-      )
-    },
-    setAILoading: (loading) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          ai.isLoading = loading
-        }),
-      )
-    },
-    setAIConsented: (consented) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          ai.hasConsented = consented
-        }),
-      )
-    },
-    setAIModel: (model) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          ai.model = model
-        }),
-      )
-    },
-    setCredits: (used, total) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          ai.creditsUsed = used
-          ai.creditsTotal = total
-        }),
-      )
-    },
-    setTier: (tier) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          ai.tier = tier
-        }),
-      )
-    },
-    setCurrentPeriodEnd: (date) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          ai.currentPeriodEnd = date
-        }),
-      )
-    },
-    setAIError: (error) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          ai.error = error
-        }),
-      )
-    },
-    setActiveConversationPou: (pouName) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          ai.activeConversationPou = pouName
-        }),
-      )
-    },
-    addMessage: (pouName, message) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          let conversation = ai.conversations.find((c) => c.pouName === pouName)
-          if (!conversation) {
-            conversation = { pouName, messages: [] }
-            ai.conversations.push(conversation)
-          }
-          conversation.messages.push(message)
-          if (conversation.messages.length > MAX_CONVERSATION_MESSAGES) {
-            conversation.messages = conversation.messages.slice(-MAX_CONVERSATION_MESSAGES)
-          }
-        }),
-      )
-    },
-    updateMessageContent: (pouName, messageId, content) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          const conversation = ai.conversations.find((c) => c.pouName === pouName)
-          if (!conversation) return
-          const msg = conversation.messages.find((m) => m.id === messageId)
-          if (msg) {
-            msg.content = content
-          }
-        }),
-      )
-    },
-    rateMessage: (pouName, messageId, rating) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          const conversation = ai.conversations.find((c) => c.pouName === pouName)
-          if (!conversation) return
-          const msg = conversation.messages.find((m) => m.id === messageId)
-          if (msg) {
-            msg.rating = rating
-          }
-        }),
-      )
-    },
-    clearConversation: (pouName) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          ai.conversations = ai.conversations.filter((c) => c.pouName !== pouName)
-          if (ai.activeConversationPou === pouName) {
-            ai.activeConversationPou = null
-            ai.error = null
-          }
-        }),
-      )
-    },
-    toggleChat: () => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          ai.isChatOpen = !ai.isChatOpen
-        }),
-      )
-    },
-    setChatOpen: (open) => {
-      setState(
-        produce(({ ai }: AISlice) => {
-          ai.isChatOpen = open
-        }),
-      )
-    },
-  },
-})
+export function createAISliceFactory(config?: AIFeatureConfig): StateCreator<AISlice, [], [], AISlice> {
+  const overrides = config ? resolveAIInitialState(config) : {}
+  return (setState) => ({
+    ai: { ...DEFAULT_AI_STATE, ...overrides },
 
+    aiActions: {
+      setAIEnabled: (enabled) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.isEnabled = enabled
+          }),
+        )
+      },
+      setAILoading: (loading) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.isLoading = loading
+          }),
+        )
+      },
+      setAIConsented: (consented) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.hasConsented = consented
+          }),
+        )
+      },
+      setAIModel: (model) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.model = model
+          }),
+        )
+      },
+      setCredits: (used, total) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.creditsUsed = used
+            ai.creditsTotal = total
+          }),
+        )
+      },
+      setTier: (tier) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.tier = tier
+          }),
+        )
+      },
+      setCurrentPeriodEnd: (date) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.currentPeriodEnd = date
+          }),
+        )
+      },
+      setAIError: (error) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.error = error
+          }),
+        )
+      },
+      setActiveConversationPou: (pouName) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.activeConversationPou = pouName
+          }),
+        )
+      },
+      addMessage: (pouName, message) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            let conversation = ai.conversations.find((c) => c.pouName === pouName)
+            if (!conversation) {
+              conversation = { pouName, messages: [] }
+              ai.conversations.push(conversation)
+            }
+            conversation.messages.push(message)
+            if (conversation.messages.length > MAX_CONVERSATION_MESSAGES) {
+              conversation.messages = conversation.messages.slice(-MAX_CONVERSATION_MESSAGES)
+            }
+          }),
+        )
+      },
+      updateMessageContent: (pouName, messageId, content) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            const conversation = ai.conversations.find((c) => c.pouName === pouName)
+            if (!conversation) return
+            const msg = conversation.messages.find((m) => m.id === messageId)
+            if (msg) {
+              msg.content = content
+            }
+          }),
+        )
+      },
+      rateMessage: (pouName, messageId, rating) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            const conversation = ai.conversations.find((c) => c.pouName === pouName)
+            if (!conversation) return
+            const msg = conversation.messages.find((m) => m.id === messageId)
+            if (msg) {
+              msg.rating = rating
+            }
+          }),
+        )
+      },
+      clearConversation: (pouName) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.conversations = ai.conversations.filter((c) => c.pouName !== pouName)
+            if (ai.activeConversationPou === pouName) {
+              ai.activeConversationPou = null
+              ai.error = null
+            }
+          }),
+        )
+      },
+      toggleChat: () => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.isChatOpen = !ai.isChatOpen
+          }),
+        )
+      },
+      setChatOpen: (open) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.isChatOpen = open
+          }),
+        )
+      },
+    },
+  })
+}
+
+const createAISlice: StateCreator<AISlice, [], [], AISlice> = createAISliceFactory()
 export { createAISlice }

--- a/src2/frontend/store/slices/index.ts
+++ b/src2/frontend/store/slices/index.ts
@@ -1,4 +1,4 @@
-export { createAISlice } from './ai'
+export { createAISlice, createAISliceFactory } from './ai'
 export type { AISlice } from './ai'
 export { MAX_CONVERSATION_MESSAGES } from './ai'
 export { createConsoleSlice } from './console'


### PR DESCRIPTION
## Summary
- Audited all 16 Zustand store slices — all already side-effect free (cleaned in step 19)
- Created `backend/shared/ai/` module with `AIFeatureConfig`, `ConsentStorage` types and `resolveAIInitialState` use case
- Added `createAISliceFactory` to AI slice for configurable initialization from platform config
- Added `StoreConfig` type and `createOpenPLCStore` factory to store composition layer

## Validation Gates
- [x] Architecture validation passes (`npx tsx src2/__architecture__/validate.ts`)
- [x] Unit tests pass with 100% coverage (38 suites, 1300 tests)
- [x] Shared files identical between repos

## Step Progress
Step 20 of 33 — Phase: architecture-rework

Generated with [Claude Code](https://claude.com/claude-code)