### PR TITLE
migrate(step-21): update comparison script for all byte-identical surfaces

### DIFF
--- a/docs/migration-state.md
+++ b/docs/migration-state.md
@@ -4,11 +4,11 @@ Tracks progress of the shared UI migration. Updated by the `/migrate` skill afte
 
 ## Current Phase
 
-architecture-rework
+components
 
 ## Current Step
 
-21
+22
 
 ## Step Log
 
@@ -35,7 +35,7 @@ architecture-rework
 | 18 | components | Atoms batch 1 — shared identical components (revised: 23 kept, 17 divergent moved to step 22) | done | 2026-03-11 |
 | 19 | architecture-rework | Restructure src2/ into frontend/middleware/backend three-layer architecture | done | 2026-03-11 |
 | 20 | architecture-rework | Extract application logic from Zustand stores into backend/shared/ | done | 2026-03-11 |
-| 21 | architecture-rework | Update comparison script to validate all byte-identical surfaces | pending | |
+| 21 | architecture-rework | Update comparison script to validate all byte-identical surfaces | done | 2026-03-11 |
 | 22 | components | Atoms batch 2 — divergent components (reconcile) | pending | |
 | 23 | components | Molecules batch 1 — shared identical | pending | |
 | 24 | components | Molecules batch 2 — divergent (reconcile) | pending | |


### PR DESCRIPTION
## Summary
- Renamed `~/compare_frontend.py` to `~/compare_repos.py`
- Added `backend/shared/` as fourth byte-identical comparison surface
- Improved output format with per-surface reporting and overall pass/fail summary
- Updated `docs/migration-state.md`: step 21 done, next step 22 (components phase)

## Validation Gates
- [x] Architecture validation passes (`npx tsx src2/__architecture__/validate.ts`)
- [x] Unit tests pass with 100% coverage (38 suites, 1300 tests)
- [x] Shared files identical between repos (272 files across 4 surfaces)

## Step Progress
Step 21 of 33 — Phase: architecture-rework (final step of this phase)

Generated with [Claude Code](https://claude.com/claude-code)