### PR TITLE
fix: recompute debug inline positions when editor mounts during active debug

### DIFF
--- a/src/renderer/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/renderer/components/_features/[workspace]/editor/monaco/index.tsx
@@ -114,6 +114,7 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
   const editorRef = useRef<null | monaco.editor.IStandaloneCodeEditor>(null)
   const monacoRef = useRef<null | typeof monaco>(null)
   const focusDisposables = useRef<{ onFocus?: monaco.IDisposable; onBlur?: monaco.IDisposable }>({})
+  const [editorMounted, setEditorMounted] = useState(false)
 
   const {
     editor,
@@ -356,7 +357,7 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
     }
 
     return { prefix, positions }
-  }, [isDebuggerVisible, debugVarKeySet, language, name, fbInstanceContext])
+  }, [isDebuggerVisible, debugVarKeySet, language, name, fbInstanceContext, editorMounted])
 
   // Phase 2: stamp current values onto cached positions (runs on each poll, O(positions) map lookups only)
   useEffect(() => {
@@ -724,6 +725,7 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
   ) {
     editorRef.current = editorInstance
     monacoRef.current = monacoInstance
+    setEditorMounted(true)
 
     if (!editorInstance || !monacoInstance) return
 


### PR DESCRIPTION
## Summary
- When an ST tab is opened after the debugger is already running, `editorRef` is null during the initial `debugVarPositions` memo computation
- Since ref changes don't trigger re-renders, the memo never recomputes and no inline value badges appear
- Adds an `editorMounted` state flag set in `handleEditorDidMount` so the position-scanning memo re-runs when the editor becomes available

## Test plan
- [ ] Start debugger, then open an ST/IL tab — verify green inline value badges appear
- [ ] Verify badges still work when ST tab is already open before debugger starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Monaco editor initialization handling to ensure proper state synchronization during component mounting, enhancing editor stability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->