### PR TITLE
migrate(step-29): templates, screens, and runtime polling hook

### DIFF
--- a/jest.config.src2.json
+++ b/jest.config.src2.json
@@ -45,6 +45,7 @@
     "!src2/frontend/assets/**",
     "!src2/frontend/data/**",
     "!src2/frontend/hooks/**",
+    "!src2/frontend/screens/**",
     "!src2/frontend/store/index.ts",
     "!src2/frontend/store/slices/project/validation/**",
     "!src2/frontend/utils/generate-uuid.ts",

--- a/src2/frontend/components/_templates/[start]/index.ts
+++ b/src2/frontend/components/_templates/[start]/index.ts
@@ -1,0 +1,2 @@
+export * from './main-content'
+export * from './side-content'

--- a/src2/frontend/components/_templates/[start]/main-content.tsx
+++ b/src2/frontend/components/_templates/[start]/main-content.tsx
@@ -1,0 +1,15 @@
+import { ComponentPropsWithoutRef } from 'react'
+
+type IStartMainContentProps = ComponentPropsWithoutRef<'div'>
+const StartMainContent = (props: IStartMainContentProps) => {
+  const { children, ...res } = props
+  return (
+    <div
+      className='my-4 mb-2 h-full w-full max-w-[778px] min-[1328px]:max-w-5xl min-[1575px]:max-w-7xl min-[1822px]:max-w-[1520px] 3xl:max-w-[1532px] 4xl:max-w-[1990px]'
+      {...res}
+    >
+      {children}
+    </div>
+  )
+}
+export { StartMainContent }

--- a/src2/frontend/components/_templates/[start]/side-content.tsx
+++ b/src2/frontend/components/_templates/[start]/side-content.tsx
@@ -1,0 +1,13 @@
+import { ComponentPropsWithoutRef } from 'react'
+
+type IStartSideContentProps = ComponentPropsWithoutRef<'div'>
+const StartSideContent = (props: IStartSideContentProps) => {
+  const { children, ...res } = props
+  return (
+    <div className='relative top-[63%] ml-16 min-w-[240px] 2xl:top-2/3' {...res}>
+      {children}
+    </div>
+  )
+}
+
+export { StartSideContent }

--- a/src2/frontend/components/_templates/[workspace]/index.ts
+++ b/src2/frontend/components/_templates/[workspace]/index.ts
@@ -1,0 +1,2 @@
+export * from './main-content'
+export * from './side-content'

--- a/src2/frontend/components/_templates/[workspace]/main-content.tsx
+++ b/src2/frontend/components/_templates/[workspace]/main-content.tsx
@@ -1,0 +1,26 @@
+import { cn } from '../../../utils'
+import { useOpenPLCStore } from '../../../store'
+import { ComponentPropsWithoutRef } from 'react'
+
+type IWorkspaceMainContentProps = ComponentPropsWithoutRef<'div'>
+const WorkspaceMainContent = (props: IWorkspaceMainContentProps) => {
+  const {
+    workspace: {
+      systemConfigs: { OS },
+    },
+  } = useOpenPLCStore()
+  const { children, ...res } = props
+
+  return (
+    <div
+      className={cn(
+        'flex h-full w-full flex-1 flex-grow gap-1 bg-neutral-100 p-2 dark:bg-neutral-900',
+        `${OS !== 'linux' && '!rounded-tl-lg'}`,
+      )}
+      {...res}
+    >
+      {children}
+    </div>
+  )
+}
+export { WorkspaceMainContent }

--- a/src2/frontend/components/_templates/[workspace]/side-content.tsx
+++ b/src2/frontend/components/_templates/[workspace]/side-content.tsx
@@ -1,0 +1,16 @@
+import { ComponentPropsWithoutRef } from 'react'
+
+type IWorkspaceSideContentProps = ComponentPropsWithoutRef<'div'>
+const WorkspaceSideContent = (props: IWorkspaceSideContentProps) => {
+  const { children, ...res } = props
+  return (
+    <div
+      className='flex h-full w-14 flex-col justify-between border-t-inherit bg-brand-dark pb-10 dark:bg-neutral-950'
+      {...res}
+    >
+      {children}
+    </div>
+  )
+}
+
+export { WorkspaceSideContent }

--- a/src2/frontend/components/_templates/accelerator-handler.tsx
+++ b/src2/frontend/components/_templates/accelerator-handler.tsx
@@ -1,0 +1,317 @@
+import { useAccelerator, useCompiler, useProject, useWindow, useCapabilities } from '../../../middleware/shared/providers'
+import { useOpenPLCStore } from '../../store'
+import type { ModalTypes } from '../../store/slices/modal'
+import { useEffect, useState } from 'react'
+
+import { toast } from '../_features/[app]/toast/use-toast'
+
+const quitAppRequest = (isUnsaved: boolean, openModal: (modal: ModalTypes, data?: unknown) => void) => {
+  if (isUnsaved) {
+    openModal('save-changes-project', {
+      validationContext: 'close-app',
+    })
+    return
+  }
+  openModal('quit-application', null)
+}
+
+const AcceleratorHandler = () => {
+  const accelerator = useAccelerator()
+  const compilerPort = useCompiler()
+  const projectPort = useProject()
+  const windowPort = useWindow()
+  const capabilities = useCapabilities()
+
+  const [requestFlag, setRequestFlag] = useState(false)
+  const [parseTo, setParseTo] = useState<'old-editor' | 'codesys' | null>(null)
+
+  const {
+    project,
+    editor: { meta },
+    deviceDefinitions,
+    workspace: { editingState, systemConfigs, close },
+    modalActions: { openModal },
+    sharedWorkspaceActions: { closeProject },
+    workspaceActions: { switchAppTheme, toggleMaximizedWindow, setCloseWindow, setCloseApp, setCloseAppDarwin },
+    tabsActions: { removeTab },
+    pouActions: { deleteRequest: deletePouRequest },
+    datatypeActions: { deleteRequest: deleteDatatypeRequest },
+    snapshotActions: { undo, redo },
+  } = useOpenPLCStore()
+  const isMonacoFocused: boolean = useOpenPLCStore((state) => state.isMonacoFocused)
+  const selectedProjectTreeLeaf = useOpenPLCStore((state) => state.workspace.selectedProjectTreeLeaf)
+
+  /**
+   * Export project accelerator
+   */
+  useEffect(() => {
+    if (!capabilities.hasProjectExport) return
+
+    const unsub = accelerator.onExportProject(() => {
+      setRequestFlag(true)
+      setParseTo('old-editor')
+    })
+
+    if (requestFlag && parseTo) {
+      compilerPort
+        .exportProjectXml({
+          projectPath: project.meta.path,
+          projectData: project.data,
+          format: parseTo,
+        })
+        .then(() => {
+          setRequestFlag(false)
+          setParseTo(null)
+        })
+        .catch(() => {
+          setRequestFlag(false)
+          setParseTo(null)
+        })
+    }
+
+    return unsub
+  }, [requestFlag, parseTo, accelerator, compilerPort, capabilities.hasProjectExport, project])
+
+  /**
+   * Create project
+   */
+  useEffect(() => {
+    const unsub = accelerator.onCreateProject(() => {
+      if (editingState !== 'unsaved') {
+        openModal('create-project', null)
+      } else {
+        openModal('save-changes-project', {
+          validationContext: 'create-project',
+        })
+      }
+    })
+    return unsub
+  }, [editingState, accelerator, openModal])
+
+  /**
+   * Open project via file picker
+   */
+  useEffect(() => {
+    const unsub = accelerator.onOpenProject(() => {
+      switch (editingState) {
+        case 'saved':
+        case 'initial-state':
+          void projectPort.openProject()
+          break
+        case 'unsaved':
+          openModal('save-changes-project', {
+            validationContext: 'open-project',
+          })
+          break
+        case 'save-request':
+          toast({
+            title: 'Save in progress',
+            description: 'Please wait for the current save operation to complete.',
+            variant: 'warn',
+          })
+          break
+        default:
+          return
+      }
+    })
+    return unsub
+  }, [editingState, accelerator, openModal, projectPort])
+
+  /**
+   * Open recent project (editor-specific — data passed via IPC accelerator)
+   */
+  useEffect(() => {
+    const unsub = accelerator.onOpenRecent(() => {
+      switch (editingState) {
+        case 'saved':
+        case 'initial-state':
+          // Recent project data is passed by the adapter via IPC callback
+          break
+        case 'unsaved':
+          openModal('save-changes-project', {
+            validationContext: 'open-recent-project',
+          })
+          break
+        case 'save-request':
+          toast({
+            title: 'Save in progress',
+            description: 'Please wait for the current save operation to complete.',
+            variant: 'warn',
+          })
+          break
+        default:
+          return
+      }
+    })
+    return unsub
+  }, [editingState, accelerator, openModal])
+
+  /**
+   * Close project
+   */
+  useEffect(() => {
+    const unsub = accelerator.onCloseProject(() => {
+      closeProject()
+    })
+    return unsub
+  }, [editingState, accelerator, closeProject])
+
+  /**
+   * Save project
+   */
+  useEffect(() => {
+    const unsub = accelerator.onSaveProject(() => {
+      void projectPort.saveProject({
+        projectPath: project.meta.path,
+        projectData: project.data,
+        deviceConfiguration: deviceDefinitions.configuration,
+        devicePinMapping: deviceDefinitions.pinMapping.pins,
+      })
+    })
+    return unsub
+  }, [project, deviceDefinitions, accelerator, projectPort])
+
+  /**
+   * Delete file
+   */
+  useEffect(() => {
+    const handleDelete = () => {
+      const { label, type } = selectedProjectTreeLeaf
+      if (!type || !label) {
+        toast({
+          title: 'Error',
+          description: 'No file selected to delete.',
+          variant: 'fail',
+        })
+        return
+      }
+
+      const isPou = ['function', 'function-block', 'program'].includes(type)
+      const isDatatype = type === 'data-type'
+
+      if (isPou) {
+        deletePouRequest(label)
+      } else if (isDatatype) {
+        deleteDatatypeRequest(label)
+      } else {
+        toast({
+          title: 'Error',
+          description: 'This element cannot be deleted.',
+          variant: 'fail',
+        })
+        return
+      }
+    }
+
+    const unsub = accelerator.onDeleteFile(() => {
+      handleDelete()
+    })
+    return unsub
+  }, [selectedProjectTreeLeaf, accelerator, deletePouRequest, deleteDatatypeRequest])
+
+  /**
+   * Close tab
+   */
+  useEffect(() => {
+    const unsub = accelerator.onCloseTab(() => removeTab(selectedProjectTreeLeaf.label))
+    return unsub
+  }, [selectedProjectTreeLeaf, accelerator, removeTab])
+
+  /**
+   * Save file (saves entire project since files are part of project XML)
+   */
+  useEffect(() => {
+    const unsub = accelerator.onSaveFile(() => {
+      void projectPort.saveProject({
+        projectPath: project.meta.path,
+        projectData: project.data,
+        deviceConfiguration: deviceDefinitions.configuration,
+        devicePinMapping: deviceDefinitions.pinMapping.pins,
+      })
+    })
+    return unsub
+  }, [selectedProjectTreeLeaf, accelerator, projectPort, project, deviceDefinitions])
+
+  /**
+   * Undo / Redo
+   */
+  useEffect(() => {
+    const unsub = accelerator.onUndo(() => {
+      if (!meta?.name) return
+      undo(meta.name)
+    })
+    return unsub
+  }, [meta.name, isMonacoFocused, accelerator, undo])
+
+  useEffect(() => {
+    const unsub = accelerator.onRedo(() => {
+      if (!meta?.name) return
+      redo(meta.name)
+    })
+    return unsub
+  }, [meta.name, isMonacoFocused, accelerator, redo])
+
+  /**
+   * Window lifecycle events (editor-only, gated by capabilities)
+   */
+  useEffect(() => {
+    if (!capabilities.hasNativeWindowControls) return
+
+    const unsub = windowPort.onCloseRequested(() => {
+      setCloseWindow(true)
+    })
+    return unsub
+  }, [capabilities.hasNativeWindowControls, windowPort, setCloseWindow])
+
+  useEffect(() => {
+    if (!capabilities.hasNativeWindowControls) return
+
+    const unsub = windowPort.onMaximizedChanged?.(() => {
+      toggleMaximizedWindow()
+    })
+    return unsub
+  }, [capabilities.hasNativeWindowControls, windowPort, toggleMaximizedWindow])
+
+  /**
+   * beforeunload event (editor-only)
+   */
+  useEffect(() => {
+    if (!capabilities.hasNativeWindowControls) return
+
+    const handler = (e: BeforeUnloadEvent) => {
+      if (process.env.NODE_ENV !== 'production') return
+
+      if (!close.window) {
+        e.returnValue = false
+        return
+      }
+
+      if (close.app) return
+
+      if (systemConfigs.OS === 'darwin' && !close.appDarwin) {
+        windowPort.hide()
+        e.returnValue = false
+        return
+      }
+
+      quitAppRequest(editingState === 'unsaved', openModal)
+      e.returnValue = false
+    }
+
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [
+    capabilities.hasNativeWindowControls,
+    close.window,
+    close.app,
+    close.appDarwin,
+    systemConfigs.OS,
+    editingState,
+    openModal,
+    windowPort,
+  ])
+
+  return <></>
+}
+
+export { AcceleratorHandler }

--- a/src2/frontend/components/_templates/app-layout.tsx
+++ b/src2/frontend/components/_templates/app-layout.tsx
@@ -1,0 +1,117 @@
+import { useOpenPLCStore } from '../../store'
+import { useSystem, useProject, useCapabilities } from '../../../middleware/shared/providers'
+import { cn } from '../../utils'
+import { ComponentPropsWithoutRef, ReactNode, useEffect, useState } from 'react'
+
+import Toaster from '../_features/[app]/toast/toaster'
+import { ProjectModal } from '../_features/[start]/new-project/project-modal'
+import { ConfirmDeleteElementModal } from '../_organisms/modals/delete-confirmation-modal'
+import { DebuggerMessageModal } from '../_organisms/modals/debugger-message-modal'
+import { QuitApplicationModal } from '../_organisms/modals/quit-application-modal'
+import { RuntimeConnectionLostModal } from '../_organisms/modals/runtime-connection-lost-modal'
+import { SaveChangesFileModal } from '../_organisms/modals/save-changes-file-modal'
+import { SaveChangesModal } from '../_organisms/modals/save-changes-modal'
+import { ServerIpMismatchModal } from '../_organisms/modals/server-ip-mismatch-modal'
+import type { SaveChangeModalProps } from '../_organisms/modals/save-changes-modal'
+import type { SaveChangesFileModalData } from '../_organisms/modals/save-changes-file-modal'
+import type { RungLadderState } from '../../store/slices'
+import { TitleBar } from '../_organisms/title-bar'
+import { ResolutionWarning } from '../_atoms/resolution-warning-message'
+import { AcceleratorHandler } from './accelerator-handler'
+
+type AppLayoutProps = ComponentPropsWithoutRef<'main'>
+const AppLayout = ({ children, ...rest }: AppLayoutProps): ReactNode => {
+  const capabilities = useCapabilities()
+  const system = useSystem()
+  const projectPort = useProject()
+  const [showComponent, setShowComponent] = useState(true)
+  const {
+    modals,
+    workspace: {
+      systemConfigs: { OS },
+    },
+    workspaceActions: { setSystemConfigs, setRecent },
+  } = useOpenPLCStore()
+
+  // System initialization
+  useEffect(() => {
+    const initSystem = async () => {
+      const sysInfo = await system.getSystemInfo()
+      setSystemConfigs({
+        OS: sysInfo.OS,
+        arch: sysInfo.architecture,
+        shouldUseDarkMode: sysInfo.prefersDarkMode,
+        isWindowMaximized: sysInfo.isWindowMaximized,
+      })
+      const recent = await projectPort.getRecentProjects()
+      setRecent(recent)
+    }
+    void initSystem()
+  }, [system, projectPort, setSystemConfigs, setRecent])
+
+  // Resolution check (web: hides UI below minimum size; harmless on editor)
+  useEffect(() => {
+    const handleResize = () => {
+      const { innerWidth: width, innerHeight: height } = window
+      setShowComponent(width >= 1024 && height >= 300)
+    }
+    window.addEventListener('resize', handleResize)
+    handleResize()
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  const showTitleBar = OS !== 'linux'
+
+  return (
+    <>
+      <div
+        className={`h-full bg-neutral-50 text-gray-500 dark:bg-neutral-950 dark:text-gray-400 ${showComponent ? 'block' : 'hidden'}`}
+      >
+        {showTitleBar && <TitleBar />}
+        <main
+          className={cn(
+            'absolute bottom-0 left-0 right-0 flex overflow-hidden',
+            showTitleBar ? 'top-[--oplc-title-bar-height]' : 'top-0',
+          )}
+          {...rest}
+        >
+          {children}
+          <Toaster />
+          {modals?.['create-project']?.open === true && <ProjectModal isOpen={modals['create-project'].open} />}
+          {modals?.['save-changes-project']?.open === true && (
+            <SaveChangesModal
+              isOpen={modals['save-changes-project'].open}
+              validationContext={
+                (modals['save-changes-project'].data as SaveChangeModalProps)?.validationContext ?? 'close-project'
+              }
+            />
+          )}
+          {modals?.['save-changes-file']?.open === true && (
+            <SaveChangesFileModal
+              isOpen={modals['save-changes-file'].open}
+              data={modals['save-changes-file'].data as SaveChangesFileModalData}
+            />
+          )}
+          {modals?.['confirm-delete-element']?.open === true && (
+            <ConfirmDeleteElementModal
+              isOpen={modals['confirm-delete-element'].open}
+              rung={modals['confirm-delete-element'].data as RungLadderState}
+            />
+          )}
+          {modals?.['quit-application']?.open === true && (
+            <QuitApplicationModal isOpen={modals['quit-application'].open} />
+          )}
+          {modals?.['server-ip-mismatch']?.open === true && (
+            <ServerIpMismatchModal isOpen={modals['server-ip-mismatch'].open} />
+          )}
+          {modals?.['runtime-connection-lost']?.open === true && <RuntimeConnectionLostModal />}
+          {modals?.['debugger-message']?.open === true && <DebuggerMessageModal />}
+          {capabilities.hasNativeMenu && <AcceleratorHandler />}
+        </main>
+      </div>
+      <ResolutionWarning />
+    </>
+  )
+}
+
+export { AppLayout }

--- a/src2/frontend/components/_templates/index.ts
+++ b/src2/frontend/components/_templates/index.ts
@@ -1,0 +1,5 @@
+export * from './[editors]'
+export * from './[start]'
+export * from './[workspace]'
+export * from './accelerator-handler'
+export * from './app-layout'

--- a/src2/frontend/hooks/index.ts
+++ b/src2/frontend/hooks/index.ts
@@ -1,0 +1,4 @@
+export { useRuntimePolling } from './use-runtime-polling'
+export * from './use-debug-composite-key'
+export * from './use-pou-snapshot'
+export * from './use-store-selectors'

--- a/src2/frontend/hooks/use-runtime-polling.ts
+++ b/src2/frontend/hooks/use-runtime-polling.ts
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+import { useRuntime } from '../../middleware/shared/providers'
+import { useOpenPLCStore } from '../store'
+import type { PlcStatus } from '../../middleware/shared/ports/types'
+
+// Unified polling interval for both status and logs (in milliseconds).
+const POLL_INTERVAL_MS = 2000
+
+// Number of consecutive poll failures before showing connection lost modal
+const MAX_CONSECUTIVE_FAILURES = 5
+
+/**
+ * Custom hook that handles runtime status and logs polling.
+ * Uses the RuntimePort abstraction so the same hook works on both
+ * the Electron editor (IPC) and the web app (HTTP/WebRTC).
+ *
+ * Should be called once at the workspace level to ensure global polling.
+ */
+export const useRuntimePolling = () => {
+  const runtime = useRuntime()
+  const connectionStatus = useOpenPLCStore((state) => state.runtimeConnection.connectionStatus)
+  const jwtToken = useOpenPLCStore((state) => state.runtimeConnection.jwtToken)
+  const setPlcRuntimeStatus = useOpenPLCStore((state) => state.deviceActions.setPlcRuntimeStatus)
+  const setTimingStats = useOpenPLCStore((state) => state.deviceActions.setTimingStats)
+  const openModal = useOpenPLCStore((state) => state.modalActions.openModal)
+
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const consecutiveFailuresRef = useRef<number>(0)
+  const isPollingRef = useRef(false)
+
+  const clearConnectionState = useCallback(() => {
+    const { deviceActions } = useOpenPLCStore.getState()
+    consecutiveFailuresRef.current = 0
+    deviceActions.setRuntimeJwtToken(null)
+    deviceActions.setRuntimeConnectionStatus('disconnected')
+    deviceActions.setPlcRuntimeStatus(null)
+    deviceActions.setTimingStats(null)
+  }, [])
+
+  const handleConnectionLost = useCallback(() => {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current)
+      pollIntervalRef.current = null
+    }
+    clearConnectionState()
+    const { workspaceActions } = useOpenPLCStore.getState()
+    workspaceActions.setPlcLogsVisible(false)
+    workspaceActions.clearPlcLogs()
+    openModal('runtime-connection-lost', null)
+  }, [clearConnectionState, openModal])
+
+  const poll = useCallback(async () => {
+    if (isPollingRef.current) return
+
+    const currentState = useOpenPLCStore.getState()
+    const {
+      runtimeConnection: { connectionStatus: curStatus, jwtToken: curToken, includeTimingStatsInPolling },
+      workspace: { plcLogsLastId, plcLogs },
+      workspaceActions,
+    } = currentState
+
+    if (curStatus !== 'connected' || !curToken) return
+
+    isPollingRef.current = true
+
+    const handlePollFailure = () => {
+      consecutiveFailuresRef.current += 1
+      if (consecutiveFailuresRef.current >= MAX_CONSECUTIVE_FAILURES) {
+        handleConnectionLost()
+      } else {
+        setPlcRuntimeStatus('UNKNOWN')
+      }
+    }
+
+    try {
+      // Determine if we need incremental log fetching (v4 runtime)
+      const isV4 = Array.isArray(plcLogs) || plcLogs === ''
+      const minId = isV4 && plcLogsLastId !== null ? plcLogsLastId + 1 : undefined
+
+      const [statusResult, logsResult] = await Promise.all([
+        runtime.getStatus(includeTimingStatsInPolling),
+        runtime.getLogs(minId),
+      ])
+
+      // Process status
+      if (statusResult.success && statusResult.status) {
+        consecutiveFailuresRef.current = 0
+        const rawStatus =
+          typeof statusResult.status === 'string'
+            ? statusResult.status.replace('STATUS:', '').replace('\n', '').trim()
+            : statusResult.status
+        const validStatuses: PlcStatus[] = ['INIT', 'RUNNING', 'STOPPED', 'ERROR', 'EMPTY', 'UNKNOWN']
+        const plcStatus: PlcStatus = validStatuses.includes(rawStatus as PlcStatus)
+          ? (rawStatus as PlcStatus)
+          : 'UNKNOWN'
+        setPlcRuntimeStatus(plcStatus)
+
+        if (includeTimingStatsInPolling && statusResult.timingStats) {
+          setTimingStats(statusResult.timingStats)
+        } else if (!includeTimingStatsInPolling) {
+          setTimingStats(null)
+        }
+      } else {
+        handlePollFailure()
+        return
+      }
+
+      // Process logs
+      if (logsResult.success && logsResult.logs !== undefined) {
+        const newLogs = logsResult.logs
+        if (Array.isArray(newLogs)) {
+          if (newLogs.length > 0) {
+            const hasRestarted =
+              plcLogsLastId !== null && newLogs.some((log) => log.id !== null && log.id < plcLogsLastId)
+
+            if (hasRestarted) {
+              const capped = newLogs.length > 1000 ? newLogs.slice(-1000) : newLogs
+              workspaceActions.setPlcLogs(capped)
+            } else {
+              workspaceActions.appendPlcLogs(newLogs)
+            }
+
+            const maxId = newLogs.reduce(
+              (max, log) => (log.id !== null && log.id > max ? log.id : max),
+              plcLogsLastId ?? -1,
+            )
+            if (maxId >= 0) {
+              workspaceActions.setPlcLogsLastId(maxId)
+            }
+          }
+        } else {
+          workspaceActions.setPlcLogs(newLogs)
+        }
+      }
+    } catch {
+      handlePollFailure()
+    } finally {
+      isPollingRef.current = false
+    }
+  }, [runtime, handleConnectionLost, setPlcRuntimeStatus, setTimingStats])
+
+  useEffect(() => {
+    const { workspaceActions } = useOpenPLCStore.getState()
+
+    if (connectionStatus === 'connected' && jwtToken) {
+      consecutiveFailuresRef.current = 0
+      void poll()
+
+      pollIntervalRef.current = setInterval(() => {
+        void poll()
+      }, POLL_INTERVAL_MS)
+
+      workspaceActions.setPlcLogsVisible(true)
+    } else {
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current)
+        pollIntervalRef.current = null
+      }
+      workspaceActions.setPlcLogsVisible(false)
+      workspaceActions.clearPlcLogs()
+    }
+
+    return () => {
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current)
+        pollIntervalRef.current = null
+      }
+    }
+  }, [connectionStatus, jwtToken, poll])
+
+  return {
+    isConnected: connectionStatus === 'connected',
+    plcStatus: useOpenPLCStore((state) => state.runtimeConnection.plcStatus),
+  }
+}

--- a/src2/frontend/screens/index.ts
+++ b/src2/frontend/screens/index.ts
@@ -1,0 +1,2 @@
+export { StartScreen } from './start-screen'
+export { WorkspaceScreen } from './workspace-screen'

--- a/src2/frontend/screens/start-screen.tsx
+++ b/src2/frontend/screens/start-screen.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react'
+
+import { FolderIcon, PlusIcon, StickArrowIcon, VideoIcon } from '../assets'
+import { MenuDivider, MenuItem, MenuRoot, MenuSection } from '../components/_features/[start]/menu'
+import DisplayRecentProjects from '../components/_organisms/display-recent-projects'
+import { ProjectFilterBar } from '../components/_organisms/project-filter-bar'
+import { StartMainContent, StartSideContent } from '../components/_templates'
+import { useOpenPLCStore } from '../store'
+import { useCapabilities, useDevice, useProject, useSystem, useWindow } from '../../middleware/shared/providers'
+
+const StartScreen = () => {
+  const [searchFilterValue, setSearchFilterProps] = useState<string>('')
+  const capabilities = useCapabilities()
+  const system = useSystem()
+  const projectPort = useProject()
+  const device = useDevice()
+  const windowPort = useWindow()
+
+  const {
+    workspaceActions: { setRecent },
+    modalActions: { openModal },
+    deviceActions: { setAvailableOptions },
+  } = useOpenPLCStore()
+
+  const handleCreateProject = () => {
+    openModal('create-project', null)
+  }
+
+  const handleOpenProject = () => {
+    void projectPort.openProject()
+  }
+
+  const searchFilter = (value: string) => {
+    setSearchFilterProps(value)
+  }
+
+  const handleExitAppRequest = () => {
+    windowPort.close()
+  }
+
+  // Load recent projects
+  useEffect(() => {
+    const loadRecent = async () => {
+      const recentProjects = await projectPort.getRecentProjects()
+      setRecent(recentProjects)
+    }
+    void loadRecent()
+  }, [projectPort, setRecent])
+
+  // Load available communication ports (editor-only, harmless no-op on web)
+  useEffect(() => {
+    let isMounted = true
+
+    const loadPorts = async () => {
+      const ports = await device.getCommunicationPorts()
+      if (isMounted) {
+        setAvailableOptions({ availableCommunicationPorts: ports })
+      }
+    }
+    void loadPorts()
+
+    return () => {
+      isMounted = false
+    }
+  }, [device, setAvailableOptions])
+
+  // Web: show welcome message when no local filesystem
+  if (!capabilities.hasLocalFilesystem) {
+    return (
+      <div className='flex h-full w-full items-center justify-center bg-neutral-950'>
+        <div className='flex flex-col items-center gap-6 text-center'>
+          <div className='flex flex-col items-center gap-2'>
+            <h1 className='text-2xl font-semibold text-neutral-100'>Welcome to OpenPLC Editor</h1>
+            <p className='max-w-md text-neutral-400'>
+              No project is currently loaded. Please provide a project ID in the URL to load a project.
+            </p>
+          </div>
+          <div className='rounded-lg border border-neutral-800 bg-neutral-900 p-4'>
+            <p className='text-sm text-neutral-500'>
+              Example: <code className='text-brand'>?project_id=your-project-id</code>
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Editor: show menu + recent projects
+  return (
+    <>
+      <StartSideContent>
+        <MenuRoot>
+          <MenuSection id='1'>
+            <MenuItem onClick={() => handleCreateProject()}>
+              <PlusIcon className='stroke-white' /> New Project
+            </MenuItem>
+            <MenuItem ghosted onClick={handleOpenProject}>
+              <FolderIcon /> Open
+            </MenuItem>
+            <MenuItem ghosted>
+              <VideoIcon /> Tutorials
+            </MenuItem>
+          </MenuSection>
+          <MenuDivider />
+          <MenuSection id='2'>
+            <MenuItem onClick={handleExitAppRequest} ghosted>
+              <StickArrowIcon className='rotate-180 stroke-brand' /> Exit
+            </MenuItem>
+          </MenuSection>
+        </MenuRoot>
+      </StartSideContent>
+      <StartMainContent>
+        <ProjectFilterBar setSearchFilterValue={searchFilter} />
+        <DisplayRecentProjects searchNameFilterValue={searchFilterValue} />
+      </StartMainContent>
+    </>
+  )
+}
+
+export { StartScreen }

--- a/src2/frontend/screens/workspace-screen.tsx
+++ b/src2/frontend/screens/workspace-screen.tsx
@@ -1,0 +1,571 @@
+import { AIChatPanel } from '../components/_features/[workspace]/ai-chat'
+import { ClearConsoleButton } from '../components/_atoms/buttons/console/clear-console'
+import { ConsoleFilters } from '../components/_organisms/console/filters'
+import { DataTypeEditor } from '../components/_features/[workspace]/data-type'
+import { DeviceEditor } from '../components/_features/[workspace]/editor/device'
+import { RemoteDeviceEditor } from '../components/_features/[workspace]/editor/device/remote-device'
+import {
+  ModbusServerEditor,
+  OpcUaServerEditor,
+  S7CommServerEditor,
+} from '../components/_features/[workspace]/editor/server'
+import { MonacoEditor } from '../components/_features/[workspace]/editor'
+import { GraphicalEditor } from '../components/_features/[workspace]/editor/graphical'
+import { ResourcesEditor } from '../components/_features/[workspace]/editor/resource-editor'
+import { Search } from '../components/_features/[workspace]/search'
+import { VariablesPanel } from '../components/_molecules/variables-panel'
+import { Console as ConsoleComponent } from '../components/_organisms/console'
+import { Debugger } from '../components/_organisms/debugger'
+import { Explorer } from '../components/_organisms/explorer'
+import { Navigation } from '../components/_organisms/navigation'
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '../components/_organisms/panel'
+import { PlcLogs } from '../components/_organisms/plc-logs'
+import { PlcLogsFilters } from '../components/_organisms/plc-logs/filters'
+import { VariablesEditor } from '../components/_organisms/variables-editor'
+import { WorkspaceActivityBar } from '../components/_organisms/workspace-activity-bar'
+import { WorkspaceMainContent, WorkspaceSideContent } from '../components/_templates'
+import { ExitIcon } from '../assets'
+import { useRuntimePolling } from '../hooks/use-runtime-polling'
+import { useCapabilities, useDebugger, useDevice } from '../../middleware/shared/providers'
+import * as Tabs from '@radix-ui/react-tabs'
+import { useOpenPLCStore } from '../store'
+import { cn } from '../utils'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ImperativePanelHandle } from 'react-resizable-panels'
+
+const SIMULATOR_BOARD_NAME = 'OpenPLC Simulator'
+
+const WorkspaceScreen = () => {
+  const capabilities = useCapabilities()
+  const debuggerPort = useDebugger()
+  const device = useDevice()
+
+  const {
+    tabs,
+    workspace: {
+      isCollapsed,
+      isPlcLogsVisible,
+      plcLogs,
+      isDebuggerVisible,
+      debugVariableValues,
+      debugVariableTree,
+      debugVariableIndexes,
+      debugForcedVariables,
+      debugExpandedNodes,
+      fbSelectedInstance,
+      fbDebugInstances,
+    },
+    editor,
+    workspaceActions: {
+      toggleCollapse,
+      clearPlcLogs,
+      setDebugForcedVariables,
+      toggleDebugExpandedNode,
+      setDebugGraphList,
+    },
+    deviceActions: { setAvailableOptions, setDeviceBoard },
+    searchResults,
+    ai: { isChatOpen, isEnabled: isAIEnabled, hasConsented: hasAIConsented },
+    project: {
+      data: { pous },
+    },
+  } = useOpenPLCStore()
+
+  // Start global runtime polling for status and logs
+  useRuntimePolling()
+
+  // Build debug variables from POUs with debug=true
+  const allDebugVariables = useMemo(
+    () =>
+      pous.flatMap((pou) => {
+        const variables = pou.interface?.variables ?? []
+        return variables
+          .filter((v) => v.debug === true)
+          .map((v) => {
+            let typeValue = ''
+            if (v.type.definition === 'base-type') {
+              typeValue = v.type.value
+            } else if (v.type.definition === 'user-data-type') {
+              typeValue = v.type.value
+            } else if (v.type.definition === 'array') {
+              typeValue = v.type.value
+            } else if (v.type.definition === 'derived') {
+              typeValue = v.type.value
+            }
+
+            // For function block POUs, transform the key to use instance context
+            let compositeKey: string
+            let displayName: string
+            if (pou.pouType === 'function-block') {
+              const fbTypeKey = pou.name.toUpperCase()
+              const selectedKey = fbSelectedInstance.get(fbTypeKey)
+              const instances = fbDebugInstances.get(fbTypeKey) ?? []
+              const selectedInstance = instances.find((inst) => inst.key === selectedKey)
+
+              if (selectedInstance) {
+                compositeKey = `${selectedInstance.programName}:${selectedInstance.fbVariableName}.${v.name}`
+                displayName = `${selectedInstance.programName}.${selectedInstance.fbVariableName}.${v.name}`
+              } else {
+                compositeKey = `${pou.name}:${v.name}`
+                displayName = v.name
+              }
+            } else {
+              compositeKey = `${pou.name}:${v.name}`
+              displayName = v.name
+            }
+
+            const variableValue = debugVariableValues.get(compositeKey)
+            const displayValue = variableValue !== undefined ? variableValue : '-'
+
+            return {
+              pouName: pou.name,
+              name: displayName,
+              type: typeValue,
+              value: displayValue,
+              compositeKey,
+            }
+          })
+      }),
+    [pous, debugVariableValues, fbSelectedInstance, fbDebugInstances],
+  )
+
+  // Deduplicate names with POU prefix when conflicts exist
+  const debugVariables = useMemo(() => {
+    const nameOccurrences = new Map<string, number>()
+    allDebugVariables.forEach((v) => {
+      nameOccurrences.set(v.name, (nameOccurrences.get(v.name) || 0) + 1)
+    })
+
+    return allDebugVariables.map((v) => {
+      const hasConflict = nameOccurrences.get(v.name)! > 1
+      return {
+        name: hasConflict ? `[${v.pouName}] ${v.name}` : v.name,
+        type: v.type,
+        value: v.value,
+        compositeKey: v.compositeKey,
+      }
+    })
+  }, [allDebugVariables])
+
+  // Filter debug variable tree to only include watched or forced keys
+  const filteredDebugVariableTree = useMemo(() => {
+    const watchedCompositeKeys = new Set<string>(allDebugVariables.map((v) => v.compositeKey))
+    const forcedKeys = Array.from(debugForcedVariables.keys())
+    const allKeys = new Set([...watchedCompositeKeys, ...forcedKeys])
+    return new Map(Array.from(debugVariableTree.entries()).filter(([key]) => allKeys.has(key)))
+  }, [allDebugVariables, debugForcedVariables, debugVariableTree])
+
+  // Force variable handler via DebuggerPort
+  const handleForceVariable = useCallback(
+    async (
+      compositeKey: string,
+      _variableType: string,
+      value?: boolean,
+      valueBuffer?: Uint8Array,
+      lookupKey?: string,
+    ): Promise<void> => {
+      const keyForIndexLookup = lookupKey ?? compositeKey
+      const variableIndex = debugVariableIndexes.get(keyForIndexLookup)
+      if (variableIndex === undefined) return
+
+      if (!debuggerPort.isConnected()) return
+
+      if (value === undefined && valueBuffer === undefined) {
+        // Release force
+        const result = await debuggerPort.setVariable(variableIndex, false)
+        if (result.success) {
+          const newForced = new Map(debugForcedVariables)
+          newForced.delete(compositeKey)
+          setDebugForcedVariables(newForced)
+        }
+      } else {
+        // Set force
+        const buffer = valueBuffer ?? new Uint8Array([value ? 1 : 0])
+        const result = await debuggerPort.setVariable(variableIndex, true, buffer)
+        if (result.success) {
+          const newForced = new Map(debugForcedVariables)
+          newForced.set(compositeKey, value ?? true)
+          setDebugForcedVariables(newForced)
+        }
+      }
+    },
+    [debugVariableIndexes, debugForcedVariables, setDebugForcedVariables, debuggerPort],
+  )
+
+  const [graphList, _setGraphList] = useState<string[]>([])
+  const setGraphList = useCallback(
+    (update: string[] | ((prev: string[]) => string[])) => {
+      _setGraphList((prev) => {
+        const next = typeof update === 'function' ? update(prev) : update
+        setDebugGraphList(next)
+        return next
+      })
+    },
+    [setDebugGraphList],
+  )
+  const [isVariablesPanelCollapsed, setIsVariablesPanelCollapsed] = useState(false)
+
+  type PanelMethods = {
+    collapse: () => void
+    expand: () => void
+  } & ImperativePanelHandle
+
+  const panelRef = useRef<ImperativePanelHandle | null>(null)
+  const explorerPanelRef = useRef<PanelMethods | null>(null)
+  const workspacePanelRef = useRef<PanelMethods | null>(null)
+  const consolePanelRef = useRef<PanelMethods | null>(null)
+  const [activeTab, setActiveTab] = useState('console')
+  const hasSearchResults = searchResults.length > 0
+
+  const togglePanel = () => {
+    if (panelRef.current) {
+      panelRef.current.resize(25)
+    }
+  }
+
+  useEffect(() => {
+    if (hasSearchResults) {
+      setActiveTab('search')
+    } else {
+      setActiveTab((prev) => (prev === 'search' ? 'console' : prev))
+    }
+  }, [hasSearchResults])
+
+  useEffect(() => {
+    if (!isPlcLogsVisible) {
+      setActiveTab((prev) => (prev === 'plc-logs' ? 'console' : prev))
+    }
+  }, [isPlcLogsVisible])
+
+  useEffect(() => {
+    if (isDebuggerVisible) {
+      setActiveTab('debug')
+    } else {
+      setActiveTab((prev) => (prev === 'debug' ? 'console' : prev))
+    }
+  }, [isDebuggerVisible])
+
+  useEffect(() => {
+    const action = isCollapsed ? 'collapse' : 'expand'
+    ;[explorerPanelRef, workspacePanelRef, consolePanelRef].forEach((ref) => {
+      if (ref.current && typeof ref.current[action] === 'function') {
+        ref.current[action]()
+      }
+    })
+  }, [isCollapsed])
+
+  // Load available boards via device port
+  useEffect(() => {
+    const loadAvailableBoards = async () => {
+      try {
+        const boardsMap = await device.getAvailableBoards()
+        setAvailableOptions({ availableBoards: boardsMap })
+
+        // Default to simulator board if no orchestrator device is connected
+        const { runtimeConnection, deviceDefinitions } = useOpenPLCStore.getState()
+        const currentBoard = deviceDefinitions.configuration.deviceBoard
+        const currentBoardInfo = boardsMap.get(currentBoard)
+        if (runtimeConnection.connectionStatus !== 'connected' && currentBoardInfo?.compiler !== 'simulator') {
+          setDeviceBoard(SIMULATOR_BOARD_NAME)
+        }
+      } catch (error) {
+        console.error('Failed to load boards data:', error)
+      }
+    }
+
+    void loadAvailableBoards()
+  }, [device, setAvailableOptions, setDeviceBoard])
+
+  return (
+    <div className='flex h-full w-full bg-brand-dark dark:bg-neutral-950 overflow-hidden'>
+      <WorkspaceSideContent>
+        <WorkspaceActivityBar
+          defaultActivityBar={{
+            zoom: {
+              onClick: () => void toggleCollapse(),
+            },
+          }}
+        />
+      </WorkspaceSideContent>
+      <WorkspaceMainContent>
+        <ResizablePanelGroup
+          id='mainContentPanelGroup'
+          direction='horizontal'
+          className='relative flex h-full w-full gap-2'
+        >
+          <Explorer collapse={explorerPanelRef} />
+          <ResizablePanel
+            id='workspacePanel'
+            order={2}
+            defaultSize={87}
+            className='relative flex h-full min-h-0 w-[400px]'
+          >
+            <ResizableHandle
+              id='workspaceHandle'
+              hitAreaMargins={{ coarse: 12, fine: 3 }}
+              className='absolute bottom-0 top-0 z-[99] my-[2px] w-[4px] py-2 transition-colors duration-200 data-[resize-handle-active="pointer"]:bg-brand-light data-[resize-handle-state="hover"]:bg-brand-light data-[resize-handle-active="pointer"]:dark:bg-neutral-700  data-[resize-handle-state="hover"]:dark:bg-neutral-700'
+            />
+
+            <div id='workspaceContentPanel' className='flex h-full min-h-0 flex-1 grow flex-col gap-2'>
+              {tabs.length > 0 && <Navigation />}
+              <ResizablePanelGroup id='editorPanelGroup' className={`flex h-full gap-2`} direction='vertical'>
+                <ResizablePanel
+                  id='editorPanel'
+                  order={1}
+                  minSize={15}
+                  defaultSize={75}
+                  className={cn(
+                    'relative  flex flex-1 grow flex-col overflow-hidden rounded-lg border-2 border-neutral-200 bg-white px-4 py-4 dark:border-neutral-800 dark:bg-neutral-950',
+                    {
+                      'py-0 pb-4': isVariablesPanelCollapsed,
+                    },
+                  )}
+                >
+                  {isVariablesPanelCollapsed && (
+                    <div className='flex w-full justify-center'>
+                      <button
+                        className='flex w-auto items-center rounded-b-lg border-brand bg-neutral-50 px-2 py-1 dark:bg-neutral-900'
+                        onClick={togglePanel}
+                      >
+                        <p className='text-xs font-medium text-brand-medium dark:text-brand-light'>Expand Table</p>
+                        <ExitIcon
+                          size='sm'
+                          className='-rotate-90 select-none fill-brand-medium  stroke-brand dark:fill-brand-light dark:stroke-brand-light'
+                        />
+                      </button>
+                    </div>
+                  )}
+
+                  {tabs.length > 0 ? (
+                    <>
+                      {editor['type'] === 'plc-resource' && <ResourcesEditor />}
+                      {editor['type'] === 'plc-device' && <DeviceEditor />}
+                      {editor['type'] === 'plc-remote-device' && <RemoteDeviceEditor />}
+                      {editor['type'] === 'plc-server' && editor.meta.protocol === 'modbus-tcp' && (
+                        <ModbusServerEditor />
+                      )}
+                      {editor['type'] === 'plc-server' && editor.meta.protocol === 's7comm' && <S7CommServerEditor />}
+                      {editor['type'] === 'plc-server' && editor.meta.protocol === 'opcua' && <OpcUaServerEditor />}
+                      {editor['type'] === 'plc-datatype' && (
+                        <div aria-label='Datatypes editor container' className='flex h-full w-full flex-1 gap-2'>
+                          <DataTypeEditor dataTypeName={editor.meta.name} />{' '}
+                        </div>
+                      )}
+                      {(editor['type'] === 'plc-textual' || editor['type'] === 'plc-graphical') && (
+                        <ResizablePanelGroup
+                          id='editorContentPanelGroup'
+                          direction='vertical'
+                          className='flex flex-1 flex-col gap-1'
+                        >
+                          <ResizablePanel
+                            ref={panelRef}
+                            id='variableTablePanel'
+                            order={1}
+                            collapsible
+                            onCollapse={() => {
+                              setIsVariablesPanelCollapsed(true)
+                            }}
+                            onExpand={() => setIsVariablesPanelCollapsed(false)}
+                            collapsedSize={0}
+                            defaultSize={25}
+                            minSize={20}
+                            className={`relative flex h-full w-full flex-1 flex-col gap-4 overflow-auto`}
+                          >
+                            <VariablesEditor />
+                          </ResizablePanel>
+
+                          <ResizableHandle
+                            style={{ height: '1px' }}
+                            className={`${isVariablesPanelCollapsed && ' !hidden '}  flex  w-full bg-brand-light `}
+                          />
+
+                          <ResizablePanel
+                            defaultSize={75}
+                            id='textualEditorPanel'
+                            order={2}
+                            className='mt-4 flex-1 flex-grow rounded-md'
+                          >
+                            {editor['type'] === 'plc-textual' ? (
+                              <MonacoEditor
+                                name={editor.meta.name}
+                                language={editor.meta.language}
+                                path={editor.meta.path}
+                              />
+                            ) : (
+                              <GraphicalEditor
+                                name={editor.meta.name}
+                                language={editor.meta.language}
+                                path={editor.meta.path}
+                              />
+                            )}
+                          </ResizablePanel>
+                        </ResizablePanelGroup>
+                      )}
+                      <ResizableHandle
+                        id='consoleResizeHandle'
+                        hitAreaMargins={{ coarse: 12, fine: 3 }}
+                        style={{ height: '2px', width: 'calc(100% - 16px)' }}
+                        className={`absolute bottom-0 left-0 mx-2 transition-colors duration-200 data-[resize-handle-active="pointer"]:bg-brand-light data-[resize-handle-state="hover"]:bg-brand-light data-[resize-handle-active="pointer"]:dark:bg-neutral-700 data-[resize-handle-state="hover"]:dark:bg-neutral-700`}
+                      />
+                    </>
+                  ) : (
+                    <p className='mx-auto my-auto flex cursor-default select-none flex-col items-center gap-2 font-display text-xl font-medium'>
+                      No tabs open
+                    </p>
+                  )}
+                  <ResizableHandle
+                    id='consoleResizeHandle'
+                    hitAreaMargins={{ coarse: 12, fine: 3 }}
+                    style={{ height: '2px', width: 'calc(100% - 16px)' }}
+                    className={`absolute bottom-0 left-0 mx-2 transition-colors duration-200 data-[resize-handle-active="pointer"]:bg-brand-light data-[resize-handle-state="hover"]:bg-brand-light data-[resize-handle-active="pointer"]:dark:bg-neutral-700 data-[resize-handle-state="hover"]:dark:bg-neutral-700`}
+                  />
+                </ResizablePanel>
+
+                <ResizablePanel
+                  ref={consolePanelRef}
+                  id='consolePanel'
+                  order={2}
+                  collapsible
+                  defaultSize={31}
+                  minSize={22}
+                  className='flex-1 grow min-h-0 rounded-lg border-2 border-neutral-200 bg-white p-4 data-[panel-size="0.0"]:hidden dark:border-neutral-800 dark:bg-neutral-950'
+                >
+                  <Tabs.Root
+                    value={activeTab}
+                    onValueChange={setActiveTab}
+                    className='relative flex h-full min-h-0 w-full flex-col gap-2'
+                  >
+                    <Tabs.List className='flex h-7 w-64 select-none gap-4'>
+                      <Tabs.Trigger
+                        value='console'
+                        className='h-7 w-16 rounded-md bg-neutral-100 text-xs font-medium text-brand-light data-[state=active]:bg-blue-500 data-[state=active]:text-white dark:bg-neutral-900 dark:text-neutral-700 dark:data-[state=active]:bg-blue-500 dark:data-[state=active]:text-white'
+                      >
+                        Console
+                      </Tabs.Trigger>
+                      {isDebuggerVisible && (
+                        <Tabs.Trigger
+                          value='debug'
+                          className='h-7 w-20 rounded-md bg-neutral-100 text-xs font-medium text-brand-light data-[state=active]:bg-blue-500 data-[state=active]:text-white dark:bg-neutral-900 dark:text-neutral-700 dark:data-[state=active]:bg-blue-500 dark:data-[state=active]:text-white'
+                        >
+                          Debugger
+                        </Tabs.Trigger>
+                      )}
+                      {hasSearchResults && (
+                        <Tabs.Trigger
+                          value='search'
+                          className='h-7 w-16 rounded-md bg-neutral-100 text-xs font-medium text-brand-light data-[state=active]:bg-blue-500 data-[state=active]:text-white dark:bg-neutral-900 dark:text-neutral-700 dark:data-[state=active]:bg-blue-500 dark:data-[state=active]:text-white'
+                        >
+                          Search
+                        </Tabs.Trigger>
+                      )}
+                      {isPlcLogsVisible && (
+                        <Tabs.Trigger
+                          value='plc-logs'
+                          className='h-7 w-20 rounded-md bg-neutral-100 text-xs font-medium text-brand-light data-[state=active]:bg-blue-500 data-[state=active]:text-white dark:bg-neutral-900 dark:text-neutral-700 dark:data-[state=active]:bg-blue-500 dark:data-[state=active]:text-white'
+                        >
+                          PLC Logs
+                        </Tabs.Trigger>
+                      )}
+                    </Tabs.List>
+                    <Tabs.Content
+                      aria-label='Console panel content'
+                      value='console'
+                      className='flex flex-col h-full min-h-0 w-full overflow-hidden p-2 data-[state=inactive]:hidden'
+                    >
+                      <ConsoleComponent />
+                    </Tabs.Content>
+                    {isDebuggerVisible && (
+                      <Tabs.Content
+                        value='debug'
+                        className='debug-panel flex h-full w-full overflow-hidden data-[state=inactive]:hidden'
+                      >
+                        <ResizablePanelGroup direction='horizontal' className='flex h-full w-full'>
+                          <ResizablePanel minSize={15} defaultSize={20} className='h-full w-full'>
+                            <VariablesPanel
+                              variables={debugVariables}
+                              variableTree={filteredDebugVariableTree}
+                              graphList={graphList}
+                              setGraphList={setGraphList}
+                              debugVariableValues={debugVariableValues}
+                              debugVariableIndexes={debugVariableIndexes}
+                              debugForcedVariables={debugForcedVariables}
+                              debugExpandedNodes={debugExpandedNodes}
+                              onToggleExpandedNode={toggleDebugExpandedNode}
+                              isDebuggerVisible={isDebuggerVisible}
+                              onForceVariable={handleForceVariable}
+                            />
+                          </ResizablePanel>
+                          <ResizableHandle className='w-2 bg-transparent' />
+                          <ResizablePanel minSize={20} defaultSize={80} className='h-full w-full'>
+                            <Debugger graphList={graphList} />
+                          </ResizablePanel>
+                        </ResizablePanelGroup>
+                      </Tabs.Content>
+                    )}
+                    {hasSearchResults && (
+                      <Tabs.Content
+                        value='search'
+                        className='debug-panel flex  h-full w-full overflow-hidden  data-[state=inactive]:hidden'
+                      >
+                        <ResizablePanelGroup direction='horizontal' className='flex h-full w-full'>
+                          <ResizablePanel minSize={20} defaultSize={100} className='h-full w-full'>
+                            <Search items={searchResults} />
+                          </ResizablePanel>
+                        </ResizablePanelGroup>
+                      </Tabs.Content>
+                    )}
+                    {isPlcLogsVisible && (
+                      <Tabs.Content
+                        aria-label='PLC Logs panel content'
+                        value='plc-logs'
+                        className='flex flex-col h-full min-h-0 w-full overflow-hidden p-2 data-[state=inactive]:hidden'
+                      >
+                        <PlcLogs />
+                      </Tabs.Content>
+                    )}
+                    {activeTab === 'console' && (
+                      <div className='absolute right-2 top-1 flex items-center gap-2'>
+                        <ConsoleFilters />
+                        <ClearConsoleButton />
+                      </div>
+                    )}
+                    {activeTab === 'plc-logs' && (
+                      <div className='absolute right-2 top-1 flex items-center gap-2'>
+                        <PlcLogsFilters />
+                        <ClearConsoleButton
+                          onClear={clearPlcLogs}
+                          isEmpty={typeof plcLogs === 'string' ? plcLogs.length === 0 : plcLogs.length === 0}
+                          label='Clear logs'
+                        />
+                      </div>
+                    )}
+                  </Tabs.Root>
+                </ResizablePanel>
+              </ResizablePanelGroup>
+            </div>
+          </ResizablePanel>
+          {capabilities.hasAIAssistant && isChatOpen && isAIEnabled && hasAIConsented && (
+            <>
+              <ResizableHandle
+                id='chatHandle'
+                hitAreaMargins={{ coarse: 12, fine: 3 }}
+                className='z-[99] my-[2px] w-[4px] py-2 transition-colors duration-200 data-[resize-handle-active="pointer"]:bg-brand-light data-[resize-handle-state="hover"]:bg-brand-light data-[resize-handle-active="pointer"]:dark:bg-neutral-700 data-[resize-handle-state="hover"]:dark:bg-neutral-700'
+              />
+              <ResizablePanel
+                id='chatPanel'
+                order={3}
+                defaultSize={16}
+                maxSize={25}
+                className='relative flex h-full min-h-0 w-full min-w-xs'
+              >
+                <AIChatPanel />
+              </ResizablePanel>
+            </>
+          )}
+        </ResizablePanelGroup>
+      </WorkspaceMainContent>
+    </div>
+  )
+}
+
+export { WorkspaceScreen }


### PR DESCRIPTION
## Summary
- Migrate template layout components (`[start]`, `[workspace]`, `app-layout`, `accelerator-handler`) to `src2/frontend/components/_templates/`
- Migrate screen components (`start-screen`, `workspace-screen`) to `src2/frontend/screens/`
- Add unified `useRuntimePolling` hook using `RuntimePort` abstraction
- All code is capability-aware and byte-identical between editor and web repos

## Key decisions
- `app-layout.tsx`: merged both repo versions — uses `useSystem()` for init, `useCapabilities()` for platform gating, superset of all modals
- `accelerator-handler.tsx`: converted all `window.bridge.*Accelerator` calls to `useAccelerator()` port methods
- `workspace-screen.tsx`: uses flat `PLCPou` type, `useDebugger().setVariable()` for force, `useDevice().getAvailableBoards()` for boards
- `start-screen.tsx`: gates editor menu+recent projects vs web welcome via `hasLocalFilesystem`
- `useRuntimePolling`: unified hook using `runtime.getStatus()` / `runtime.getLogs()` port methods

## Test plan
- [ ] `npx tsx src2/__architecture__/validate.ts` passes
- [ ] `python3 ~/compare_repos.py` shows byte-identical shared surfaces
- [ ] Editor dev build compiles without errors
- [ ] Web dev build compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)