### PR TITLE
migrate(step-31): app shell and routing

### DIFF
--- a/docs/migration-state.md
+++ b/docs/migration-state.md
@@ -4,11 +4,11 @@ Tracks progress of the shared UI migration. Updated by the `/migrate` skill afte
 
 ## Current Phase
 
-components
+integration
 
 ## Current Step
 
-30
+31
 
 ## Step Log
 
@@ -47,6 +47,6 @@ components
 | 28 | components | Features — platform-specific (97 files: divergent reconciliation of search, create-element, device/board, monaco editor, data-type editor; web-only AI chat, debug-manager, loading-overlay, orchestrators, device elements; editor-only device-aware gating; new utils device.ts, formatters/POU.ts, data sources data-type.tsx) | done | 2026-03-13 |
 | 29 | components | Templates, screens, and shared hooks | done | 2026-03-13 |
 | 30 | components | Hooks migration — debug/AI/WebRTC hooks, services, utilities, simulator facade, architecture validator updates (637 byte-identical files) | done | 2026-03-13 |
-| 31 | integration | App shell and routing | pending | |
+| 31 | integration | App shell and routing — editor store-based routing, web TanStack Router with project loading | done | 2026-03-13 |
 | 32 | integration | Production build configs | pending | |
 | 33 | integration | Switchover and cleanup — remove src/ | pending | |

--- a/src2/App.tsx
+++ b/src2/App.tsx
@@ -2,42 +2,22 @@ import '@xyflow/react/dist/style.css'
 import 'tailwindcss/tailwind.css'
 import './backend/styles/globals.css'
 
-import { PlatformProvider } from './middleware/shared/providers'
+import { AppLayout } from './frontend/components/_templates'
+import { StartScreen, WorkspaceScreen } from './frontend/screens'
+import { useOpenPLCStore } from './frontend/store'
 import { editorPorts } from './middleware/editor-platform'
+import { PlatformProvider } from './middleware/shared/providers'
 
-/**
- * src2 App root — wires PlatformProvider with editor adapter ports.
- *
- * During migration, components are progressively moved from src/ to src2/.
- * Unmigrated ports will throw descriptive errors when called — this is
- * intentional so you know exactly what still needs implementation.
- *
- * As components are migrated, replace the placeholder below with real screens:
- *
- *   import { AppLayout } from '../frontend/components/_templates'
- *   import { StartScreen, WorkspaceScreen } from '../frontend/components/screens'
- *   import { useOpenPLCStore } from '../store'
- *
- *   const { project: { meta: { path } } } = useOpenPLCStore()
- *   return (
- *     <PlatformProvider ports={editorPorts}>
- *       <AppLayout>
- *         {path === '' ? <StartScreen /> : <WorkspaceScreen />}
- *       </AppLayout>
- *     </PlatformProvider>
- *   )
- */
 export default function App() {
+  const {
+    project: {
+      meta: { path },
+    },
+  } = useOpenPLCStore()
+
   return (
     <PlatformProvider ports={editorPorts}>
-      <div className="flex h-full items-center justify-center bg-neutral-950 text-white">
-        <div className="text-center">
-          <h1 className="text-2xl font-semibold">OpenPLC Editor (src2)</h1>
-          <p className="mt-2 text-neutral-400">
-            Migration in progress. Replace this placeholder as components are migrated.
-          </p>
-        </div>
-      </div>
+      <AppLayout>{path === '' ? <StartScreen /> : <WorkspaceScreen />}</AppLayout>
     </PlatformProvider>
   )
 }

--- a/src2/main.tsx
+++ b/src2/main.tsx
@@ -1,3 +1,5 @@
+import './frontend/locales/i18n'
+
 import { createRoot } from 'react-dom/client'
 
 import App from './App'


### PR DESCRIPTION
## Summary
- Replace App.tsx placeholder with real store-based screen routing (StartScreen/WorkspaceScreen)
- Wire AppLayout template around screens for modals, title bar, system init
- Add i18n initialization to main.tsx entry point

## Validation Gates
- [x] Architecture validation passes (`npx tsx src2/__architecture__/validate.ts`)
- [x] Unit tests pass with 100% coverage
- [x] Byte-identical surfaces pass (`python3 ~/compare_repos.py`) — 637 files

## Step Progress
Step 31 of 33 — Phase: integration

Generated with [Claude Code](https://claude.com/claude-code)