### PR TITLE
fix: increase Node.js heap size to prevent webpack OOM during dev build

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict = true
+node-options = --max-old-space-size=4096


### PR DESCRIPTION
## Summary
- Adds `node-options = --max-old-space-size=4096` to `.npmrc` to prevent webpack from crashing with out-of-memory during development builds
- The renderer webpack process was hitting the default Node.js heap limit (~2GB) and crashing with `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`

## Test plan
- [ ] Run `npm run start:dev` and verify the app starts without OOM crash
- [ ] Confirm webpack renderer bundle completes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Node.js memory configuration for npm operations to enhance build stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->