### PR TITLE
Preserve deleted POUs across project reloads

### DIFF
--- a/src/main/services/project-service/utils/read-project.ts
+++ b/src/main/services/project-service/utils/read-project.ts
@@ -589,6 +589,14 @@ export async function readProjectFiles(basePath: string): Promise<IProjectServic
     remoteDevices: remoteDeviceFiles,
   }
 
+  const deletedPouKeys = new Set(
+    (returnData.project.data.deletedPous ?? []).map((deletedPou) => `${deletedPou.type}:${deletedPou.name}`),
+  )
+
+  if (deletedPouKeys.size > 0) {
+    returnData.pous = returnData.pous.filter((pou) => !deletedPouKeys.has(`${pou.type}:${pou.data.name}`))
+  }
+
   // Check if project needs migration from ID-based to name+type-based system
   if (needsMigration(returnData.project.data)) {
     console.log('Project needs migration from ID-based to name+type-based system')

--- a/src/renderer/store/slices/shared/index.ts
+++ b/src/renderer/store/slices/shared/index.ts
@@ -363,8 +363,25 @@ export const createSharedSlice: StateCreator<
       getState().modalActions.openModal('confirm-delete-element', modalData)
     },
 
-    delete: (data) => {
+    delete: async (data) => {
       const { file: targetLabel } = data
+      const projectPath = getState().project.meta.path
+      const extension = getExtensionFromLanguage(data.pou.data.body.language)
+      const typeDir = getFolderFromPouType(data.pou.type)
+      const actualFilePath = `${projectPath}/pous/${typeDir}/${targetLabel}${extension}`
+      const legacyJsonFilePath = `${projectPath}/pous/${typeDir}/${targetLabel}.json`
+
+      try {
+        await window.bridge.deletePouFile(actualFilePath)
+      } catch (error) {
+        console.error(`Error deleting POU file ${actualFilePath}:`, error)
+      }
+
+      try {
+        await window.bridge.deletePouFile(legacyJsonFilePath)
+      } catch {
+        // Legacy JSON files are optional; ignore if missing.
+      }
 
       getState().projectActions.deletePou(targetLabel)
       getState().ladderFlowActions.removeLadderFlow(targetLabel)
@@ -2034,6 +2051,13 @@ export const createSharedSlice: StateCreator<
 
     saveFile: async (name) => {
       const { file } = getState().fileActions.getFile({ name: name })
+      const currentProject = getState().project
+      const deviceDefinitions = getState().deviceDefinitions
+      const hasPendingProjectStructureDeletes =
+        (currentProject.data.deletedPous?.length ?? 0) > 0 ||
+        (currentProject.data.deletedServers?.length ?? 0) > 0 ||
+        (currentProject.data.deletedRemoteDevices?.length ?? 0) > 0
+
       if (!file) {
         const editor = getState().editor
         if (editor.type === 'available') {
@@ -2055,6 +2079,10 @@ export const createSharedSlice: StateCreator<
           success: false,
           error: { title: 'Error saving file', description: `File with name ${name} does not exist.` },
         }
+      }
+
+      if (hasPendingProjectStructureDeletes) {
+        return await getState().sharedWorkspaceActions.saveProject(currentProject, deviceDefinitions)
       }
 
       const projectFilePath = getState().project.meta.path


### PR DESCRIPTION
## Summary
Prevent deleted POUs from reappearing after reopening a project.

## Problem
POUs marked in `deletedPous` were still rebuilt into the in-memory project on load, so removed function blocks could reappear after reopening.

## Fix
- Filter loaded POUs against `deletedPous` during project load
- Promote file saves to full project saves when structural deletions are pending

## Validation
- Reproduced with a deleted function block named `can`
- Confirmed the deleted POU no longer reappears after reopening


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deletion handling to properly remove files from the filesystem when POUs are deleted.
  * Enhanced save functionality to correctly process pending deletions before saving project changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->