### PR TITLE
feat: unified frontend serialization — save single file & frontend-only parsing

### DIFF
--- a/configs/webpack/webpack.config.main.dev.ts
+++ b/configs/webpack/webpack.config.main.dev.ts
@@ -56,7 +56,7 @@ const configuration: webpack.Configuration = {
 
   output: {
     path: webpackPaths.dllPath,
-    filename: '[name].bundle.dev.js',
+    filename: '[name].js',
     library: {
       type: 'umd',
     },

--- a/docs/unified-frontend-serialization.md
+++ b/docs/unified-frontend-serialization.md
@@ -1,0 +1,115 @@
+# Unified Frontend Parsing & Serialization: Load + Save
+
+## Context
+
+The frontend/backend separation should follow a clean principle: **the backend is a file I/O layer** (read/write raw files), and the **frontend owns all parsing and serialization**. This makes the frontend code identical for Electron and web, and eliminates double-parsing.
+
+Currently:
+- **Load**: Backend reads files, parses POUs, converts to IPC format → adapter converts to flat format → frontend re-parses variables for type reclassification (double-parsing)
+- **Save**: Frontend sends structured objects → adapter converts to IPC format → backend re-serializes POUs to text (double-serialization)
+- **3 duplicate `executeSave` functions** exist across components
+
+### Shared Utilities (already exist, will be reused)
+- `src/frontend/utils/PLC/pou-text-parser.ts` — parsers for all POU languages (already used by backend via `@root/`)
+- `src/frontend/utils/PLC/pou-text-serializer.ts` — serializers for all POU languages (already used by backend via `@root/`)
+- `src/frontend/utils/PLC/pou-file-extensions.ts` — extension/folder/keyword mappings
+- `src/frontend/utils/save-project.ts` — `sanitizePou`, `prepareSavePayload`, `collectDebugVariables`
+- `src/frontend/utils/generate-iec-variables-to-string.ts` — variable serialization
+- `src/frontend/utils/generate-iec-string-to-variables.ts` — variable parsing with project context
+
+---
+
+## Phase 0: Eliminate executeSave Duplication
+
+### Step 0.1: Create `src/frontend/utils/save-actions.ts`
+Shared `executeSaveProject(projectPort)` function that reads state, prepares payload, calls port, updates state. Replaces 3 inline copies.
+
+### Step 0.2: Export `sanitizePou` from `save-project.ts`
+Change from private to exported. Needed by single-file save.
+
+### Step 0.3: Replace 3 executeSave duplicates
+- `accelerator-handler.tsx`, `file.tsx` (menu), `default.tsx` (activity bar)
+
+### Step 0.4: Replace save logic in 2 modals
+- `save-changes-modal.tsx`, `save-changes-file-modal.tsx`
+
+---
+
+## Phase 1: Single-File Save with Frontend Serialization
+
+### Step 1.1: Fix backend saveFile for raw strings
+**File:** `src/backend/editor/services/project-service/index.ts`
+
+Add `typeof content === 'string'` branch — write string directly without `JSON.stringify`.
+
+### Step 1.2: Add `executeSaveActiveFile` to `save-actions.ts`
+For POUs: `sanitizePou()` → `serializePouToText()` → compute path → `projectPort.saveFile(path, text)`.
+For device/data-type/resource/server: appropriate JSON serialization → `projectPort.saveFile()`.
+Also updates `project.json` for debug variables.
+
+### Step 1.3: Wire Ctrl+S to `executeSaveActiveFile`
+- Ctrl+S → `executeSaveActiveFile(projectPort)` (single file)
+- Ctrl+Shift+S → `executeSaveProject(projectPort)` (full project)
+- File menu: separate "Save" and "Save Project" items
+
+---
+
+## Phase 2: Load with Frontend Parsing
+
+### Current load flow (to be simplified):
+```
+Backend: read disk → parse POUs → IPC format → Adapter: convert to flat → Frontend: re-parse variables
+```
+
+### Target load flow:
+```
+Backend: read disk → raw file contents → Adapter: pass through → Frontend: parse everything once
+```
+
+### Step 2.1: Add `readProjectFiles` to ProjectPort interface
+**File:** `src/middleware/shared/ports/project-port.ts`
+
+New port method that returns raw file contents as strings.
+
+### Step 2.2: Implement Electron adapter for `readProjectFiles`
+New IPC call that reads all project files and returns raw strings without parsing.
+
+### Step 2.3: Create frontend project parser utility
+**File:** `src/frontend/utils/parse-project-files.ts`
+
+Pure function that takes raw file contents and produces `OpenProjectResponseData`:
+1. Parse `projectJson` string
+2. For each POU file: detect language/type from path, call appropriate parser
+3. Parse variables with full project context (single pass)
+4. Parse device config and pin mapping
+5. Return data ready for `handleOpenProjectResponse`
+
+### Step 2.4: Update `openProject`/`openProjectByPath` flow
+Adapter calls `readProjectFiles` + `parseProjectFiles` internally. Port contract stays the same.
+
+### Step 2.5: Backend simplification
+Add raw file read IPC handler. Existing `openProject` remains for backward compatibility.
+
+---
+
+## Phase 3: Full Project Save with Frontend Serialization (future PR)
+
+Migrate `executeSaveProject` to serialize all files on the frontend before sending to the backend.
+
+---
+
+## Architecture After All Phases
+
+```
+LOAD:
+  Backend: fs.readFile → raw strings → IPC → Adapter: parseProjectFiles() → ProjectResponse → Store
+
+SAVE (single file):
+  Frontend: serializePouToText() → text string → projectPort.saveFile(path, text) → Backend: fs.writeFile
+
+SAVE (full project):
+  Frontend: serialize all files → projectPort.saveFiles([{path, content}]) → Backend: fs.writeFile each
+```
+
+Frontend owns: parsing, serialization, type classification, variable reclassification
+Backend owns: file I/O, directory management, file watching, IPC transport

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": {
     "name": "Autonomy Logic"
   },
-  "main": "./configs/dll/main.bundle.dev.js",
+  "main": "./configs/dll/main.js",
   "scripts": {
     "build": "concurrently \"npm run build:main\" \"npm run build:renderer\"",
     "build:dll": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./configs/webpack/webpack.config.renderer.dev.dll.ts",

--- a/src/backend/editor/services/project-service/index.ts
+++ b/src/backend/editor/services/project-service/index.ts
@@ -450,22 +450,27 @@ class ProjectService {
         await promises.mkdir(dir, { recursive: true })
       }
 
-      const isPou = typeof content === 'object' && content !== null && 'type' in content && 'data' in content
-
-      if (isPou) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        const flat = ipcPouToFlat(content as PLCPou)
-
-        let actualFilePath = filePath
-        if (filePath.endsWith('.json')) {
-          const extension: string = getExtensionFromLanguage(flat.body.language)
-          actualFilePath = filePath.replace(/\.json$/, extension)
-        }
-
-        const textContent: string = serializePouToText(flat)
-        await promises.writeFile(actualFilePath, textContent, 'utf-8')
+      if (typeof content === 'string') {
+        // Pre-serialized content from frontend — write as-is
+        await promises.writeFile(filePath, content, 'utf-8')
       } else {
-        await promises.writeFile(filePath, JSON.stringify(content, null, 2))
+        const isPou = typeof content === 'object' && content !== null && 'type' in content && 'data' in content
+
+        if (isPou) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          const flat = ipcPouToFlat(content as PLCPou)
+
+          let actualFilePath = filePath
+          if (filePath.endsWith('.json')) {
+            const extension: string = getExtensionFromLanguage(flat.body.language)
+            actualFilePath = filePath.replace(/\.json$/, extension)
+          }
+
+          const textContent: string = serializePouToText(flat)
+          await promises.writeFile(actualFilePath, textContent, 'utf-8')
+        } else {
+          await promises.writeFile(filePath, JSON.stringify(content, null, 2))
+        }
       }
 
       return {

--- a/src/backend/editor/services/project-service/index.ts
+++ b/src/backend/editor/services/project-service/index.ts
@@ -121,6 +121,100 @@ class ProjectService {
     await this.writeProjectHistory(historyProjectsFilePath, updatedHistory)
   }
 
+  /**
+   * Read all project files as raw strings — no parsing, no transformation.
+   * The frontend is responsible for parsing the returned content.
+   */
+  async readRawProjectFiles(
+    projectPath: string,
+  ): Promise<{
+    success: boolean
+    data?: {
+      projectPath: string
+      projectJson: string
+      deviceConfig: string
+      pinMapping: string
+      pouFiles: Array<{ relativePath: string; content: string }>
+      serverFiles: Array<{ relativePath: string; content: string }>
+      remoteDeviceFiles: Array<{ relativePath: string; content: string }>
+    }
+    error?: { title: string; description: string }
+  }> {
+    try {
+      await promises.access(projectPath)
+
+      const readFileIfExists = async (filePath: string): Promise<string> => {
+        try {
+          return await promises.readFile(filePath, 'utf-8')
+        } catch {
+          return ''
+        }
+      }
+
+      const readDirRecursive = async (
+        dirPath: string,
+        basePath: string,
+      ): Promise<Array<{ relativePath: string; content: string }>> => {
+        const results: Array<{ relativePath: string; content: string }> = []
+        try {
+          const entries = await promises.readdir(dirPath, { withFileTypes: true })
+          for (const entry of entries) {
+            const fullPath = join(dirPath, entry.name)
+            const relPath = join(basePath, entry.name)
+            if (entry.isDirectory()) {
+              const subResults = await readDirRecursive(fullPath, relPath)
+              results.push(...subResults)
+            } else if (entry.isFile()) {
+              const content = await promises.readFile(fullPath, 'utf-8')
+              results.push({ relativePath: relPath, content })
+            }
+          }
+        } catch {
+          // Directory doesn't exist — return empty
+        }
+        return results
+      }
+
+      const projectJson = await readFileIfExists(join(projectPath, 'project.json'))
+      const deviceConfig = await readFileIfExists(join(projectPath, 'devices', 'configuration.json'))
+      const pinMapping = await readFileIfExists(join(projectPath, 'devices', 'pin-mapping.json'))
+
+      const pouDirs = ['pous/functions', 'pous/function-blocks', 'pous/programs']
+      const pouFiles: Array<{ relativePath: string; content: string }> = []
+      for (const pouDir of pouDirs) {
+        const files = await readDirRecursive(join(projectPath, ...pouDir.split('/')), pouDir)
+        pouFiles.push(...files)
+      }
+
+      const serverFiles = await readDirRecursive(join(projectPath, 'devices', 'servers'), 'devices/servers')
+      const remoteDeviceFiles = await readDirRecursive(
+        join(projectPath, 'devices', 'remote'),
+        'devices/remote',
+      )
+
+      return {
+        success: true,
+        data: {
+          projectPath,
+          projectJson,
+          deviceConfig,
+          pinMapping,
+          pouFiles,
+          serverFiles,
+          remoteDeviceFiles,
+        },
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          title: 'Error reading project files',
+          description: error instanceof Error ? error.message : 'Unknown error',
+        },
+      }
+    }
+  }
+
   async openProjectByPath(projectPath: string): Promise<IProjectServiceResponse> {
     try {
       await promises.access(projectPath)

--- a/src/backend/editor/services/project-service/index.ts
+++ b/src/backend/editor/services/project-service/index.ts
@@ -4,7 +4,6 @@ import {
   IProjectServiceResponse,
 } from '@root/types/IPC/project-service'
 import { projectDefaultFilesMapSchema } from '@root/types/IPC/project-service/project-files-schema'
-import { DeviceConfiguration, DevicePin } from '@root/types/PLC/devices'
 import { getDefaultSchemaValues } from '@root/utils/default-zod-schema-values'
 import { getExtensionFromLanguage } from '@root/utils/PLC/pou-file-extensions'
 import { serializePouToText } from '@root/utils/PLC/pou-text-serializer'
@@ -12,7 +11,7 @@ import { app, BrowserWindow, dialog } from 'electron'
 import { promises } from 'fs'
 import { dirname, join, normalize } from 'path'
 
-import { PLCPou, PLCProject, PLCRemoteDevice, PLCServer } from '../../../types/PLC/open-plc'
+import { PLCPou, PLCProject } from '../../../types/PLC/open-plc'
 import { fileOrDirectoryExists, ipcPouToFlat } from '../../utils'
 import { createProjectDefaultStructure, readProjectFiles } from './utils'
 
@@ -361,217 +360,86 @@ class ProjectService {
     }
   }
 
-  async saveProject(data: {
+  /**
+   * Write pre-serialized project files to disk.
+   * The frontend handles all serialization — this method is a dumb batch file writer.
+   */
+  async writeProjectFiles(files: {
     projectPath: string
-    content: {
-      projectData: PLCProject
-      pous: PLCPou[]
-      deviceConfiguration: DeviceConfiguration
-      devicePinMapping: DevicePin[]
-      servers?: PLCServer[]
-      remoteDevices?: PLCRemoteDevice[]
-    }
+    projectJson: string
+    deviceConfig: string
+    pinMapping: string
+    pouFiles: Array<{ relativePath: string; content: string }>
+    serverFiles: Array<{ relativePath: string; content: string }>
+    remoteDeviceFiles: Array<{ relativePath: string; content: string }>
+    deletions: string[]
   }): Promise<IProjectServiceResponse> {
-    const {
-      projectPath,
-      content: { deviceConfiguration, devicePinMapping, projectData, servers, remoteDevices },
-    } = data
-    if (!projectPath || !projectData) {
+    const { projectPath, projectJson, deviceConfig, pinMapping, pouFiles, serverFiles, remoteDeviceFiles, deletions } =
+      files
+
+    if (!projectPath) {
       return {
         success: false,
-        error: {
-          title: 'Missing parameters',
-          description: 'Missing parameters',
-          error: null,
-        },
+        error: { title: 'Missing parameters', description: 'Missing project path', error: null },
       }
     }
 
-    const directoryPath = projectPath.endsWith('/project.json')
-      ? projectPath.slice(0, -'/project.json'.length)
-      : projectPath
+    const dir = projectPath.endsWith('/project.json') ? projectPath.slice(0, -'/project.json'.length) : projectPath
 
     try {
-      // Write each part to its correct file based on projectDefaultFilesMapSchema
-      await Promise.all([
-        promises.writeFile(join(directoryPath, 'project.json'), JSON.stringify(projectData, null, 2)),
-        promises.writeFile(
-          join(directoryPath, 'devices/configuration.json'),
-          JSON.stringify(deviceConfiguration, null, 2),
+      // Ensure standard directories exist
+      await Promise.all(
+        ['pous/programs', 'pous/functions', 'pous/function-blocks', 'devices/servers', 'devices/remote'].map((d) =>
+          promises.mkdir(join(dir, d), { recursive: true }),
         ),
-        promises.writeFile(join(directoryPath, 'devices/pin-mapping.json'), JSON.stringify(devicePinMapping, null, 2)),
+      )
+
+      // Write config files
+      await Promise.all([
+        promises.writeFile(join(dir, 'project.json'), projectJson, 'utf-8'),
+        promises.writeFile(join(dir, 'devices/configuration.json'), deviceConfig, 'utf-8'),
+        promises.writeFile(join(dir, 'devices/pin-mapping.json'), pinMapping, 'utf-8'),
       ])
+
+      // Write POU files
+      for (const file of pouFiles) {
+        const filePath = join(dir, file.relativePath)
+        const fileDir = filePath.substring(0, filePath.lastIndexOf('/'))
+        if (!fileOrDirectoryExists(fileDir)) {
+          await promises.mkdir(fileDir, { recursive: true })
+        }
+        await promises.writeFile(filePath, file.content, 'utf-8')
+      }
+
+      // Write server files
+      for (const file of serverFiles) {
+        await promises.writeFile(join(dir, file.relativePath), file.content, 'utf-8')
+      }
+
+      // Write remote device files
+      for (const file of remoteDeviceFiles) {
+        await promises.writeFile(join(dir, file.relativePath), file.content, 'utf-8')
+      }
+
+      // Process deletions
+      for (const relativePath of deletions) {
+        const filePath = join(dir, relativePath)
+        try {
+          if (fileOrDirectoryExists(filePath)) {
+            await promises.unlink(filePath)
+          }
+        } catch (deleteError) {
+          console.error(`Error deleting file ${filePath}:`, deleteError)
+        }
+      }
+
+      return { success: true, message: 'Your project was saved successfully' }
     } catch (error) {
-      console.error(error)
+      console.error('Error writing project files:', error)
       return {
         success: false,
-        error: {
-          title: 'Failed to save file',
-          description: 'Unable to save the project file.',
-          error,
-        },
+        error: { title: 'Failed to save project', description: 'Unable to write project files.', error },
       }
-    }
-
-    // Save pous
-    try {
-      const savedPous = {
-        programs: data.content.pous.filter((pou) => pou.type === 'program'),
-        functions: data.content.pous.filter((pou) => pou.type === 'function'),
-        'function-blocks': data.content.pous.filter((pou) => pou.type === 'function-block'),
-      }
-
-      // Save each POU in its respective folder
-      for (const [type, pous] of Object.entries(savedPous)) {
-        const dir = join(directoryPath, 'pous', type)
-
-        if (!fileOrDirectoryExists(dir)) {
-          await promises.mkdir(dir, { recursive: true })
-        }
-
-        // Write/update each POU file
-        for (const pou of pous) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-          const flat = ipcPouToFlat(pou)
-          const extension: string = getExtensionFromLanguage(flat.body.language)
-          const filePath = join(dir, `${flat.name}${extension}`)
-          const textContent: string = serializePouToText(flat)
-          await promises.writeFile(filePath, textContent, 'utf-8')
-        }
-      }
-
-      if (projectData.data.deletedPous && projectData.data.deletedPous.length > 0) {
-        for (const deletedPou of projectData.data.deletedPous) {
-          const typeDir =
-            deletedPou.type === 'function'
-              ? 'functions'
-              : deletedPou.type === 'function-block'
-                ? 'function-blocks'
-                : 'programs'
-          const extension = getExtensionFromLanguage(deletedPou.language)
-          const filePath = join(directoryPath, 'pous', typeDir, `${deletedPou.name}${extension}`)
-
-          try {
-            if (fileOrDirectoryExists(filePath)) {
-              await promises.unlink(filePath)
-            }
-          } catch (deleteError) {
-            console.error(`Error deleting POU file ${filePath}:`, deleteError)
-          }
-
-          const jsonFilePath = join(directoryPath, 'pous', typeDir, `${deletedPou.name}.json`)
-          try {
-            if (fileOrDirectoryExists(jsonFilePath)) {
-              await promises.unlink(jsonFilePath)
-            }
-          } catch (deleteError) {
-            console.error(`Error deleting legacy JSON POU file ${jsonFilePath}:`, deleteError)
-          }
-        }
-      }
-    } catch (error) {
-      console.error('Error saving POUs:', error)
-      return {
-        success: false,
-        error: {
-          title: 'Failed to save file',
-          description: 'Unable to save the project file.',
-          error,
-        },
-      }
-    }
-
-    // Save servers
-    if (
-      (servers && servers.length > 0) ||
-      (projectData.data.deletedServers && projectData.data.deletedServers.length > 0)
-    ) {
-      try {
-        const serversDir = join(directoryPath, 'devices', 'servers')
-        if (!fileOrDirectoryExists(serversDir)) {
-          await promises.mkdir(serversDir, { recursive: true })
-        }
-
-        if (servers && servers.length > 0) {
-          for (const server of servers) {
-            const serverFilePath = join(serversDir, `${server.name}.json`)
-            await promises.writeFile(serverFilePath, JSON.stringify(server, null, 2), 'utf-8')
-          }
-        }
-
-        // Handle deleted servers
-        if (projectData.data.deletedServers && projectData.data.deletedServers.length > 0) {
-          for (const deletedServer of projectData.data.deletedServers) {
-            const serverFilePath = join(serversDir, `${deletedServer.name}.json`)
-            try {
-              if (fileOrDirectoryExists(serverFilePath)) {
-                await promises.unlink(serverFilePath)
-              }
-            } catch (deleteError) {
-              console.error(`Error deleting server file ${serverFilePath}:`, deleteError)
-            }
-          }
-        }
-      } catch (error) {
-        console.error('Error saving servers:', error)
-        return {
-          success: false,
-          error: {
-            title: 'Failed to save file',
-            description: 'Unable to save the project file.',
-            error,
-          },
-        }
-      }
-    }
-
-    // Save remote devices
-    if (
-      (remoteDevices && remoteDevices.length > 0) ||
-      (projectData.data.deletedRemoteDevices && projectData.data.deletedRemoteDevices.length > 0)
-    ) {
-      try {
-        const remoteDevicesDir = join(directoryPath, 'devices', 'remote')
-        if (!fileOrDirectoryExists(remoteDevicesDir)) {
-          await promises.mkdir(remoteDevicesDir, { recursive: true })
-        }
-
-        if (remoteDevices && remoteDevices.length > 0) {
-          for (const remoteDevice of remoteDevices) {
-            const remoteDeviceFilePath = join(remoteDevicesDir, `${remoteDevice.name}.json`)
-            await promises.writeFile(remoteDeviceFilePath, JSON.stringify(remoteDevice, null, 2), 'utf-8')
-          }
-        }
-
-        // Handle deleted remote devices
-        if (projectData.data.deletedRemoteDevices && projectData.data.deletedRemoteDevices.length > 0) {
-          for (const deletedRemoteDevice of projectData.data.deletedRemoteDevices) {
-            const remoteDeviceFilePath = join(remoteDevicesDir, `${deletedRemoteDevice.name}.json`)
-            try {
-              if (fileOrDirectoryExists(remoteDeviceFilePath)) {
-                await promises.unlink(remoteDeviceFilePath)
-              }
-            } catch (deleteError) {
-              console.error(`Error deleting remote device file ${remoteDeviceFilePath}:`, deleteError)
-            }
-          }
-        }
-      } catch (error) {
-        console.error('Error saving remote devices:', error)
-        return {
-          success: false,
-          error: {
-            title: 'Failed to save file',
-            description: 'Unable to save the project file.',
-            error,
-          },
-        }
-      }
-    }
-
-    return {
-      success: true,
-      message: 'Your project was saved successfully',
     }
   }
 

--- a/src/backend/editor/services/project-service/index.ts
+++ b/src/backend/editor/services/project-service/index.ts
@@ -3,7 +3,9 @@ import {
   IProjectRecentHistoryEntry,
   IProjectServiceResponse,
 } from '@root/types/IPC/project-service'
+import { projectDefaultFilesMapSchema } from '@root/types/IPC/project-service/project-files-schema'
 import { DeviceConfiguration, DevicePin } from '@root/types/PLC/devices'
+import { getDefaultSchemaValues } from '@root/utils/default-zod-schema-values'
 import { getExtensionFromLanguage } from '@root/utils/PLC/pou-file-extensions'
 import { serializePouToText } from '@root/utils/PLC/pou-text-serializer'
 import { app, BrowserWindow, dialog } from 'electron'
@@ -125,9 +127,7 @@ class ProjectService {
    * Read all project files as raw strings — no parsing, no transformation.
    * The frontend is responsible for parsing the returned content.
    */
-  async readRawProjectFiles(
-    projectPath: string,
-  ): Promise<{
+  async readRawProjectFiles(projectPath: string): Promise<{
     success: boolean
     data?: {
       projectPath: string
@@ -140,15 +140,48 @@ class ProjectService {
     }
     error?: { title: string; description: string }
   }> {
+    const VALID_POU_EXTENSIONS = ['.st', '.il', '.ld', '.fbd', '.py', '.cpp', '.json']
+
     try {
       await promises.access(projectPath)
 
-      const readFileIfExists = async (filePath: string): Promise<string> => {
-        try {
-          return await promises.readFile(filePath, 'utf-8')
-        } catch {
-          return ''
+      // Validate that the directory contains a project.json file
+      try {
+        await promises.access(join(projectPath, 'project.json'))
+      } catch {
+        return {
+          success: false,
+          error: {
+            title: 'Invalid project',
+            description: 'The selected directory is not a valid OpenPLC project.',
+          },
         }
+      }
+
+      /**
+       * Read a default config file, creating it with schema defaults if missing or empty.
+       * This mirrors the old backend's readAndParseFile behavior.
+       */
+      const readOrCreateDefault = async (
+        filePath: string,
+        schemaKey: keyof typeof projectDefaultFilesMapSchema,
+      ): Promise<string> => {
+        let content: string
+        try {
+          content = await promises.readFile(filePath, 'utf-8')
+        } catch {
+          content = ''
+        }
+        if (!content.trim()) {
+          const schema = projectDefaultFilesMapSchema[schemaKey]
+          const defaultValue = getDefaultSchemaValues(schema)
+          const defaultJson = JSON.stringify(defaultValue, null, 2)
+          const dir = dirname(filePath)
+          await promises.mkdir(dir, { recursive: true })
+          await promises.writeFile(filePath, defaultJson, 'utf-8')
+          return defaultJson
+        }
+        return content
       }
 
       const readDirRecursive = async (
@@ -165,6 +198,8 @@ class ProjectService {
               const subResults = await readDirRecursive(fullPath, relPath)
               results.push(...subResults)
             } else if (entry.isFile()) {
+              const ext = entry.name.slice(entry.name.lastIndexOf('.'))
+              if (!VALID_POU_EXTENSIONS.includes(ext)) continue
               const content = await promises.readFile(fullPath, 'utf-8')
               results.push({ relativePath: relPath, content })
             }
@@ -175,9 +210,15 @@ class ProjectService {
         return results
       }
 
-      const projectJson = await readFileIfExists(join(projectPath, 'project.json'))
-      const deviceConfig = await readFileIfExists(join(projectPath, 'devices', 'configuration.json'))
-      const pinMapping = await readFileIfExists(join(projectPath, 'devices', 'pin-mapping.json'))
+      const projectJson = await readOrCreateDefault(join(projectPath, 'project.json'), 'project.json')
+      const deviceConfig = await readOrCreateDefault(
+        join(projectPath, 'devices', 'configuration.json'),
+        'devices/configuration.json',
+      )
+      const pinMapping = await readOrCreateDefault(
+        join(projectPath, 'devices', 'pin-mapping.json'),
+        'devices/pin-mapping.json',
+      )
 
       const pouDirs = ['pous/functions', 'pous/function-blocks', 'pous/programs']
       const pouFiles: Array<{ relativePath: string; content: string }> = []
@@ -187,10 +228,7 @@ class ProjectService {
       }
 
       const serverFiles = await readDirRecursive(join(projectPath, 'devices', 'servers'), 'devices/servers')
-      const remoteDeviceFiles = await readDirRecursive(
-        join(projectPath, 'devices', 'remote'),
-        'devices/remote',
-      )
+      const remoteDeviceFiles = await readDirRecursive(join(projectPath, 'devices', 'remote'), 'devices/remote')
 
       return {
         success: true,

--- a/src/backend/editor/services/project-service/index.ts
+++ b/src/backend/editor/services/project-service/index.ts
@@ -384,7 +384,8 @@ class ProjectService {
       }
     }
 
-    const dir = projectPath.endsWith('/project.json') ? projectPath.slice(0, -'/project.json'.length) : projectPath
+    const normalized = projectPath.replace(/\\/g, '/')
+    const dir = normalized.endsWith('/project.json') ? normalized.slice(0, -'/project.json'.length) : normalized
 
     try {
       // Ensure standard directories exist
@@ -404,10 +405,7 @@ class ProjectService {
       // Write POU files
       for (const file of pouFiles) {
         const filePath = join(dir, file.relativePath)
-        const fileDir = filePath.substring(0, filePath.lastIndexOf('/'))
-        if (!fileOrDirectoryExists(fileDir)) {
-          await promises.mkdir(fileDir, { recursive: true })
-        }
+        await promises.mkdir(dirname(filePath), { recursive: true })
         await promises.writeFile(filePath, file.content, 'utf-8')
       }
 

--- a/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
@@ -10,6 +10,7 @@ import { useAI, useCapabilities, useProject } from '../../../../../../middleware
 import { openPLCStoreBase, useOpenPLCStore } from '../../../../../store'
 import { getExtensionFromLanguage, getFolderFromPouType } from '../../../../../utils/PLC/pou-file-extensions'
 import { parseHybridPouFromString, parseTextualPouFromString } from '../../../../../utils/PLC/pou-text-parser'
+import { executeSaveActiveFile, executeSaveProject } from '../../../../../utils/save-actions'
 import { Modal, ModalContent, ModalTitle } from '../../../../_molecules/modal'
 import { toast } from '../../../[app]/toast/use-toast'
 import { AIInlineCompletionProvider } from './ai-completion/ai-inline-completion-provider'
@@ -142,7 +143,6 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
       debugVariableValues,
       fbSelectedInstance,
       fbDebugInstances,
-      editingState,
     },
     project: {
       meta: { path: projectPath },
@@ -881,32 +881,18 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
       injectCppTemplateIfNeeded(editorInstance, pou, name)
     }
 
-    // Keyboard shortcuts: Ctrl+S (save project), Ctrl+Shift+S (save project)
+    // Keyboard shortcuts: Ctrl+S (save active file), Ctrl+Shift+S (save entire project)
     editorInstance.addCommand(monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyS, () => {
-      if (editingState !== 'save-request') {
-        const state = openPLCStoreBase.getState()
-        void projectPort.saveProject({
-          projectPath: state.project.meta.path,
-          projectName: state.project.meta.name,
-          projectData: state.project.data,
-          deviceConfiguration: state.deviceDefinitions.configuration,
-          devicePinMapping: state.deviceDefinitions.pinMapping.pins,
-        })
+      if (openPLCStoreBase.getState().workspace.editingState !== 'save-request') {
+        void executeSaveActiveFile(projectPort)
       }
     })
 
     editorInstance.addCommand(
       monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyMod.Shift | monacoInstance.KeyCode.KeyS,
       () => {
-        if (editingState !== 'save-request') {
-          const state = openPLCStoreBase.getState()
-          void projectPort.saveProject({
-            projectPath: state.project.meta.path,
-            projectName: state.project.meta.name,
-            projectData: state.project.data,
-            deviceConfiguration: state.deviceDefinitions.configuration,
-            devicePinMapping: state.deviceDefinitions.pinMapping.pins,
-          })
+        if (openPLCStoreBase.getState().workspace.editingState !== 'save-request') {
+          void executeSaveProject(projectPort)
         }
       },
     )

--- a/src/frontend/components/_molecules/menu-bar/menus/file.tsx
+++ b/src/frontend/components/_molecules/menu-bar/menus/file.tsx
@@ -1,11 +1,11 @@
 import * as MenuPrimitive from '@radix-ui/react-menubar'
-import { useCallback, useEffect } from 'react'
+import { useEffect } from 'react'
 
 import { useCapabilities, useProject } from '../../../../../middleware/shared/providers'
 import { useHandleRemoveTab } from '../../../../hooks/use-remove-tab'
 import { i18n } from '../../../../locales/i18n'
 import { useOpenPLCStore } from '../../../../store'
-import { executeSaveProject } from '../../../../utils/save-actions'
+import { executeSaveActiveFile, executeSaveProject } from '../../../../utils/save-actions'
 import { MenuClasses } from '../constants'
 
 export const FileMenu = () => {
@@ -27,20 +27,15 @@ export const FileMenu = () => {
 
   const isSaving = editingState === 'save-request'
 
-  const executeSave = useCallback(
-    () => executeSaveProject(projectPort),
-    [projectPort],
-  )
-
   const handleSave = () => {
     if (activeEditor.meta.name && !isSaving) {
-      void executeSave()
+      void executeSaveActiveFile(projectPort)
     }
   }
 
   const handleSaveProject = () => {
     if (!isSaving) {
-      void executeSave()
+      void executeSaveProject(projectPort)
     }
   }
 

--- a/src/frontend/components/_molecules/menu-bar/menus/file.tsx
+++ b/src/frontend/components/_molecules/menu-bar/menus/file.tsx
@@ -5,23 +5,16 @@ import { useCapabilities, useProject } from '../../../../../middleware/shared/pr
 import { useHandleRemoveTab } from '../../../../hooks/use-remove-tab'
 import { i18n } from '../../../../locales/i18n'
 import { useOpenPLCStore } from '../../../../store'
-import { prepareSavePayload } from '../../../../utils/save-project'
-import { toast } from '../../../_features/[app]/toast/use-toast'
+import { executeSaveProject } from '../../../../utils/save-actions'
 import { MenuClasses } from '../constants'
 
 export const FileMenu = () => {
   const projectPort = useProject()
   const capabilities = useCapabilities()
   const {
-    project,
     editor: activeEditor,
-    editors,
-    deviceDefinitions,
     workspace: { editingState },
-    workspaceActions: { setEditingState },
     sharedWorkspaceActions: { closeProject },
-    fileActions: { setAllToSaved },
-    snapshotActions: { markAllSaved },
   } = useOpenPLCStore()
 
   const { handleRemoveTab, selectedTab, setSelectedTab } = useHandleRemoveTab()
@@ -34,52 +27,10 @@ export const FileMenu = () => {
 
   const isSaving = editingState === 'save-request'
 
-  const executeSave = useCallback(async () => {
-    setEditingState('save-request')
-    toast({
-      title: 'Save changes',
-      description: 'Trying to save the changes in the project file.',
-      variant: 'warn',
-    })
-
-    try {
-      const params = prepareSavePayload({
-        projectPath: project.meta.path,
-        projectName: project.meta.name,
-        projectData: project.data,
-        deviceConfiguration: deviceDefinitions.configuration,
-        devicePinMapping: deviceDefinitions.pinMapping.pins,
-        editors,
-        activeEditor,
-      })
-
-      const res = await projectPort.saveProject(params)
-      if (res.success) {
-        setEditingState('saved')
-        setAllToSaved()
-        markAllSaved()
-        toast({
-          title: 'Changes saved!',
-          description: 'The project was saved successfully!',
-          variant: 'default',
-        })
-      } else {
-        setEditingState('unsaved')
-        toast({
-          title: 'Error in the save request!',
-          description: res.error ?? 'Save failed',
-          variant: 'fail',
-        })
-      }
-    } catch {
-      setEditingState('unsaved')
-      toast({
-        title: 'Error in the save request!',
-        description: 'An unexpected error occurred while saving.',
-        variant: 'fail',
-      })
-    }
-  }, [project, deviceDefinitions, editors, activeEditor, projectPort, setEditingState, setAllToSaved])
+  const executeSave = useCallback(
+    () => executeSaveProject(projectPort),
+    [projectPort],
+  )
 
   const handleSave = () => {
     if (activeEditor.meta.name && !isSaving) {

--- a/src/frontend/components/_organisms/modals/save-changes-file-modal.tsx
+++ b/src/frontend/components/_organisms/modals/save-changes-file-modal.tsx
@@ -23,7 +23,7 @@ const SaveChangesFileModal = ({ isOpen, data, ...rest }: SaveChangesFileModalPro
   const {
     project,
     modalActions: { closeModal, onOpenChange },
-    projectActions: { updatePou },
+    projectActions: { applyPouSnapshot, updatePouDocumentation },
     sharedWorkspaceActions: { forceCloseFile },
     fileActions: { updateFile },
     ladderFlowActions: { addLadderFlow },
@@ -62,8 +62,12 @@ const SaveChangesFileModal = ({ isOpen, data, ...rest }: SaveChangesFileModalPro
             ? parseGraphicalPouFromString(result.content, language, pou.pouType)
             : parseTextualPouFromString(result.content, language, pou.pouType)
 
-          // Restore POU body in the project store
-          updatePou({ name: fileName, content: parsed.body })
+          // Restore the full POU from disk: variables, body, and documentation.
+          // applyPouSnapshot restores variables + body, then we restore documentation separately.
+          applyPouSnapshot(fileName, parsed.interface?.variables ?? [], parsed.body)
+          if (parsed.documentation !== undefined) {
+            updatePouDocumentation(fileName, parsed.documentation)
+          }
 
           // For graphical POUs, also restore the flow state (nodes, edges, positions).
           // The parsed body.value is the full flow type (same as what addLadderFlow/addFBDFlow

--- a/src/frontend/components/_organisms/modals/save-changes-file-modal.tsx
+++ b/src/frontend/components/_organisms/modals/save-changes-file-modal.tsx
@@ -7,8 +7,7 @@ import type { FBDFlowType } from '../../../store/slices/fbd'
 import type { LadderFlowType } from '../../../store/slices/ladder'
 import { getExtensionFromLanguage, getFolderFromPouType } from '../../../utils/PLC/pou-file-extensions'
 import { parseGraphicalPouFromString, parseTextualPouFromString } from '../../../utils/PLC/pou-text-parser'
-import { prepareSavePayload } from '../../../utils/save-project'
-import { toast } from '../../_features/[app]/toast/use-toast'
+import { executeSaveProject } from '../../../utils/save-actions'
 import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'
 
 export type SaveChangesFileModalData = {
@@ -23,15 +22,10 @@ export type SaveChangesFileModalProps = ComponentPropsWithoutRef<typeof Modal> &
 const SaveChangesFileModal = ({ isOpen, data, ...rest }: SaveChangesFileModalProps) => {
   const {
     project,
-    editor: activeEditor,
-    editors,
-    deviceDefinitions,
     modalActions: { closeModal, onOpenChange },
     projectActions: { updatePou },
     sharedWorkspaceActions: { forceCloseFile },
-    fileActions: { updateFile, setAllToSaved },
-    workspaceActions: { setEditingState },
-    snapshotActions: { markAllSaved },
+    fileActions: { updateFile },
     ladderFlowActions: { addLadderFlow },
     fbdFlowActions: { addFBDFlow },
   } = useOpenPLCStore()
@@ -42,28 +36,9 @@ const SaveChangesFileModal = ({ isOpen, data, ...rest }: SaveChangesFileModalPro
   const handleSave = async () => {
     closeModal()
 
-    const params = prepareSavePayload({
-      projectPath: project.meta.path,
-      projectName: project.meta.name,
-      projectData: project.data,
-      deviceConfiguration: deviceDefinitions.configuration,
-      devicePinMapping: deviceDefinitions.pinMapping.pins,
-      editors,
-      activeEditor,
-    })
-    const result = await projectPort.saveProject(params)
-    if (!result.success) {
-      toast({
-        title: 'Error saving file!',
-        description: result.error ?? 'Save failed',
-        variant: 'fail',
-      })
-      return
-    }
+    const result = await executeSaveProject(projectPort)
+    if (!result.success) return
 
-    setEditingState('saved')
-    setAllToSaved()
-    markAllSaved()
     forceCloseFile(fileName)
   }
 

--- a/src/frontend/components/_organisms/modals/save-changes-file-modal.tsx
+++ b/src/frontend/components/_organisms/modals/save-changes-file-modal.tsx
@@ -7,7 +7,7 @@ import type { FBDFlowType } from '../../../store/slices/fbd'
 import type { LadderFlowType } from '../../../store/slices/ladder'
 import { getExtensionFromLanguage, getFolderFromPouType } from '../../../utils/PLC/pou-file-extensions'
 import { parseGraphicalPouFromString, parseTextualPouFromString } from '../../../utils/PLC/pou-text-parser'
-import { executeSaveProject } from '../../../utils/save-actions'
+import { executeSaveFile } from '../../../utils/save-actions'
 import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'
 
 export type SaveChangesFileModalData = {
@@ -36,7 +36,7 @@ const SaveChangesFileModal = ({ isOpen, data, ...rest }: SaveChangesFileModalPro
   const handleSave = async () => {
     closeModal()
 
-    const result = await executeSaveProject(projectPort)
+    const result = await executeSaveFile(fileName, projectPort)
     if (!result.success) return
 
     forceCloseFile(fileName)

--- a/src/frontend/components/_organisms/modals/save-changes-modal.tsx
+++ b/src/frontend/components/_organisms/modals/save-changes-modal.tsx
@@ -3,8 +3,7 @@ import { ComponentPropsWithoutRef } from 'react'
 import { useCapabilities, useProject, useWindow } from '../../../../middleware/shared/providers'
 import { WarningIcon } from '../../../assets/icons/interface/Warning'
 import { useOpenPLCStore } from '../../../store'
-import { prepareSavePayload } from '../../../utils/save-project'
-import { toast } from '../../_features/[app]/toast/use-toast'
+import { executeSaveProject } from '../../../utils/save-actions'
 import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'
 
 /**
@@ -34,13 +33,7 @@ export type SaveChangeModalProps = ComponentPropsWithoutRef<typeof Modal> & {
 
 const SaveChangesModal = ({ isOpen, validationContext, onAfterAction, ...rest }: SaveChangeModalProps) => {
   const {
-    project,
-    editor: activeEditor,
-    editors,
-    deviceDefinitions,
     workspaceActions: { setEditingState },
-    fileActions: { setAllToSaved },
-    snapshotActions: { markAllSaved },
     modalActions: { closeModal, onOpenChange, openModal },
   } = useOpenPLCStore()
 
@@ -64,32 +57,8 @@ const SaveChangesModal = ({ isOpen, validationContext, onAfterAction, ...rest }:
     closeModal()
 
     if (operation === 'save') {
-      const params = prepareSavePayload({
-        projectPath: project.meta.path,
-        projectName: project.meta.name,
-        projectData: project.data,
-        deviceConfiguration: deviceDefinitions.configuration,
-        devicePinMapping: deviceDefinitions.pinMapping.pins,
-        editors,
-        activeEditor,
-      })
-      const result = await projectPort.saveProject(params)
-      if (!result.success) {
-        toast({
-          title: 'Error in the save request!',
-          description: result.error ?? 'Save failed',
-          variant: 'fail',
-        })
-        return
-      }
-      setEditingState('saved')
-      setAllToSaved()
-      markAllSaved()
-      toast({
-        title: 'Changes saved!',
-        description: 'The project was saved successfully!',
-        variant: 'default',
-      })
+      const result = await executeSaveProject(projectPort)
+      if (!result.success) return
     }
 
     switch (validationContext) {

--- a/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
@@ -11,7 +11,7 @@ import { cn } from '../../../utils/cn'
 import { logCompilerEvent } from '../../../utils/debugger-session'
 import { isOpenPLCRuntimeTarget, isOpenPLCRuntimeV4Target } from '../../../utils/device'
 import { getErrorMessage } from '../../../utils/get-error-message'
-import { prepareSavePayload } from '../../../utils/save-project'
+import { executeSaveProject } from '../../../utils/save-actions'
 import { ChatButton } from '../../_molecules/workspace-activity-bar/default/chat'
 import { DebuggerButton } from '../../_molecules/workspace-activity-bar/default/debugger'
 import { DownloadButton } from '../../_molecules/workspace-activity-bar/default/download'
@@ -121,35 +121,9 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
   }, [isSimulatorBoard, isDebuggerVisible, simulator, addLog])
 
   const executeSave = useCallback(async (): Promise<boolean> => {
-    const state = useOpenPLCStore.getState()
-    const { workspaceActions, fileActions, snapshotActions, editors } = state
-    const activeEditor = editors[0] ?? { type: 'available', meta: { name: '' } }
-    try {
-      workspaceActions.setEditingState('save-request')
-      const payload = prepareSavePayload({
-        projectPath: projectMeta.path,
-        projectName: projectMeta.name,
-        projectData,
-        deviceConfiguration: deviceDefinitions.configuration,
-        devicePinMapping: deviceDefinitions.pinMapping.pins,
-        editors,
-        activeEditor,
-      })
-      const res = await projectPort.saveProject(payload)
-      if (res.success) {
-        workspaceActions.setEditingState('saved')
-        fileActions.setAllToSaved()
-        snapshotActions.markAllSaved()
-        return true
-      }
-      workspaceActions.setEditingState('unsaved')
-      addLog({ id: crypto.randomUUID(), level: 'error', message: `Save failed: ${res.error ?? 'Unknown error'}` })
-      return false
-    } catch {
-      workspaceActions.setEditingState('unsaved')
-      return false
-    }
-  }, [projectPort, projectMeta, projectData, deviceDefinitions, addLog])
+    const result = await executeSaveProject(projectPort)
+    return result.success
+  }, [projectPort])
 
   // ---------------------------------------------------------------------------
   // Build (Compile)

--- a/src/frontend/components/_templates/accelerator-handler.tsx
+++ b/src/frontend/components/_templates/accelerator-handler.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../middleware/shared/providers'
 import { useOpenPLCStore } from '../../store'
 import type { ModalTypes } from '../../store/slices/modal'
-import { executeSaveProject } from '../../utils/save-actions'
+import { executeSaveActiveFile, executeSaveProject } from '../../utils/save-actions'
 import { toast } from '../_features/[app]/toast/use-toast'
 
 const quitAppRequest = (isUnsaved: boolean, openModal: (modal: ModalTypes, data?: unknown) => void) => {
@@ -246,11 +246,11 @@ const AcceleratorHandler = () => {
   }, [selectedProjectTreeLeaf, accelerator, removeTab])
 
   /**
-   * Save file (Cmd+S) — saves entire project since files are part of project XML
+   * Save file (Cmd+S) — saves only the active file
    */
   useEffect(() => {
     const unsub = accelerator.onSaveFile(() => {
-      void executeSave()
+      void executeSaveActiveFile(projectPort)
     })
     return unsub
   }, [accelerator, executeSave])

--- a/src/frontend/components/_templates/accelerator-handler.tsx
+++ b/src/frontend/components/_templates/accelerator-handler.tsx
@@ -253,7 +253,7 @@ const AcceleratorHandler = () => {
       void executeSaveActiveFile(projectPort)
     })
     return unsub
-  }, [accelerator, executeSave])
+  }, [accelerator, projectPort])
 
   /**
    * Find in project (Cmd+Shift+F)

--- a/src/frontend/components/_templates/accelerator-handler.tsx
+++ b/src/frontend/components/_templates/accelerator-handler.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../middleware/shared/providers'
 import { useOpenPLCStore } from '../../store'
 import type { ModalTypes } from '../../store/slices/modal'
-import { prepareSavePayload } from '../../utils/save-project'
+import { executeSaveProject } from '../../utils/save-actions'
 import { toast } from '../_features/[app]/toast/use-toast'
 
 const quitAppRequest = (isUnsaved: boolean, openModal: (modal: ModalTypes, data?: unknown) => void) => {
@@ -37,9 +37,6 @@ const AcceleratorHandler = () => {
   const {
     project,
     editor: { meta },
-    editor: activeEditor,
-    editors,
-    deviceDefinitions,
     workspace: { editingState, systemConfigs, close },
     modalActions: { openModal },
     sharedWorkspaceActions: { closeProject, handleOpenProjectResponse },
@@ -48,71 +45,22 @@ const AcceleratorHandler = () => {
       toggleMaximizedWindow,
       setCloseWindow,
       setCloseAppDarwin,
-      setEditingState,
       setModalOpen,
       toggleCollapse,
     },
     tabsActions: { removeTab },
-    fileActions: { setAllToSaved },
     pouActions: { deleteRequest: deletePouRequest },
     datatypeActions: { deleteRequest: deleteDatatypeRequest },
-    snapshotActions: { undo, redo, markAllSaved },
+    snapshotActions: { undo, redo },
   } = useOpenPLCStore()
   const isMonacoFocused: boolean = useOpenPLCStore((state) => state.isMonacoFocused)
   const selectedProjectTreeLeaf = useOpenPLCStore((state) => state.workspace.selectedProjectTreeLeaf)
   const pendingRecentProjectRef = useRef<unknown>(null)
 
-  /**
-   * Shared save logic: sanitizes POUs, collects debug variables, saves, and updates state.
-   */
-  const executeSave = useCallback(async (): Promise<{ success: boolean }> => {
-    setEditingState('save-request')
-    toast({
-      title: 'Save changes',
-      description: 'Trying to save the changes in the project file.',
-      variant: 'warn',
-    })
-
-    try {
-      const params = prepareSavePayload({
-        projectPath: project.meta.path,
-        projectName: project.meta.name,
-        projectData: project.data,
-        deviceConfiguration: deviceDefinitions.configuration,
-        devicePinMapping: deviceDefinitions.pinMapping.pins,
-        editors,
-        activeEditor,
-      })
-
-      const res = await projectPort.saveProject(params)
-      if (res.success) {
-        setEditingState('saved')
-        setAllToSaved()
-        markAllSaved()
-        toast({
-          title: 'Changes saved!',
-          description: 'The project was saved successfully!',
-          variant: 'default',
-        })
-      } else {
-        setEditingState('unsaved')
-        toast({
-          title: 'Error in the save request!',
-          description: res.error ?? 'Save failed',
-          variant: 'fail',
-        })
-      }
-      return { success: res.success }
-    } catch {
-      setEditingState('unsaved')
-      toast({
-        title: 'Error in the save request!',
-        description: 'An unexpected error occurred while saving.',
-        variant: 'fail',
-      })
-      return { success: false }
-    }
-  }, [project, deviceDefinitions, editors, activeEditor, projectPort, setEditingState, setAllToSaved])
+  const executeSave = useCallback(
+    () => executeSaveProject(projectPort),
+    [projectPort],
+  )
 
   /**
    * Export project accelerator

--- a/src/frontend/components/_templates/accelerator-handler.tsx
+++ b/src/frontend/components/_templates/accelerator-handler.tsx
@@ -57,10 +57,7 @@ const AcceleratorHandler = () => {
   const selectedProjectTreeLeaf = useOpenPLCStore((state) => state.workspace.selectedProjectTreeLeaf)
   const pendingRecentProjectRef = useRef<unknown>(null)
 
-  const executeSave = useCallback(
-    () => executeSaveProject(projectPort),
-    [projectPort],
-  )
+  const executeSave = useCallback(() => executeSaveProject(projectPort), [projectPort])
 
   /**
    * Export project accelerator

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -11,6 +11,7 @@ import type {
   S7CommServerSettings,
 } from '../../../../middleware/shared/ports/types'
 import { isLegalIdentifier } from '../../../utils/keywords'
+import { getExtensionFromLanguage, getFolderFromPouType } from '../../../utils/PLC/pou-file-extensions'
 import type { ProjectResponse, ProjectSlice } from './types'
 import { getVariableBasedOnRowIdOrVariableId } from './utils'
 import {
@@ -184,6 +185,7 @@ const createProjectSlice: StateCreator<ProjectSlice, [], [], ProjectSlice> = (se
       remoteDevices: [],
     },
   },
+  pendingDeletions: [],
 
   projectActions: {
     // -----------------------------------------------------------------------
@@ -216,6 +218,14 @@ const createProjectSlice: StateCreator<ProjectSlice, [], [], ProjectSlice> = (se
               remoteDevices: [],
             },
           }
+          slice.pendingDeletions = []
+        }),
+      )
+    },
+    clearPendingDeletions: () => {
+      setState(
+        produce((slice: ProjectSlice) => {
+          slice.pendingDeletions = []
         }),
       )
     },
@@ -272,6 +282,12 @@ const createProjectSlice: StateCreator<ProjectSlice, [], [], ProjectSlice> = (se
     deletePou: (name) => {
       setState(
         produce((slice: ProjectSlice) => {
+          const pou = slice.project.data.pous.find((p) => p.name === name)
+          if (pou) {
+            const folder = getFolderFromPouType(pou.pouType)
+            const ext = getExtensionFromLanguage(pou.body.language)
+            slice.pendingDeletions.push(`pous/${folder}/${name}${ext}`)
+          }
           slice.project.data.pous = slice.project.data.pous.filter((p) => p.name !== name)
         }),
       )
@@ -702,6 +718,7 @@ const createProjectSlice: StateCreator<ProjectSlice, [], [], ProjectSlice> = (se
       setState(
         produce((slice: ProjectSlice) => {
           if (!slice.project.data.servers) return
+          slice.pendingDeletions.push(`devices/servers/${name}.json`)
           slice.project.data.servers = slice.project.data.servers.filter((s) => s.name !== name)
         }),
       )
@@ -1000,6 +1017,7 @@ const createProjectSlice: StateCreator<ProjectSlice, [], [], ProjectSlice> = (se
       setState(
         produce((slice: ProjectSlice) => {
           if (!slice.project.data.remoteDevices) return
+          slice.pendingDeletions.push(`devices/remote/${name}.json`)
           slice.project.data.remoteDevices = slice.project.data.remoteDevices.filter((d) => d.name !== name)
         }),
       )

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -11,6 +11,7 @@ import type {
   S7CommServerSettings,
 } from '../../../../middleware/shared/ports/types'
 import { isLegalIdentifier } from '../../../utils/keywords'
+import { DEFAULT_BUFFER_MAPPING } from '../../../utils/modbus/generate-modbus-slave-config'
 import { getExtensionFromLanguage, getFolderFromPouType } from '../../../utils/PLC/pou-file-extensions'
 import type { ProjectResponse, ProjectSlice } from './types'
 import { getVariableBasedOnRowIdOrVariableId } from './utils'
@@ -746,9 +747,12 @@ const createProjectSlice: StateCreator<ProjectSlice, [], [], ProjectSlice> = (se
           if (config.networkInterface !== undefined) server.modbusSlaveConfig.networkInterface = config.networkInterface
           if (config.port !== undefined) server.modbusSlaveConfig.port = config.port
           if (config.bufferMapping) {
+            const base = server.modbusSlaveConfig.bufferMapping ?? DEFAULT_BUFFER_MAPPING
             server.modbusSlaveConfig.bufferMapping = {
-              ...server.modbusSlaveConfig.bufferMapping,
-              ...config.bufferMapping,
+              holdingRegisters: { ...base.holdingRegisters, ...config.bufferMapping.holdingRegisters },
+              coils: { ...base.coils, ...config.bufferMapping.coils },
+              discreteInputs: { ...base.discreteInputs, ...config.bufferMapping.discreteInputs },
+              inputRegisters: { ...base.inputRegisters, ...config.bufferMapping.inputRegisters },
             }
           }
         }),

--- a/src/frontend/store/slices/project/types.ts
+++ b/src/frontend/store/slices/project/types.ts
@@ -90,6 +90,7 @@ export type ProjectActions = {
   setProject: (state: ProjectState) => void
   setPous: (pous: PLCProjectData['pous']) => void
   clearProjects: () => void
+  clearPendingDeletions: () => void
 
   // Meta
   updateMetaName: (name: string) => void
@@ -246,5 +247,7 @@ export type ProjectActions = {
 
 export type ProjectSlice = {
   project: ProjectState
+  /** Relative file paths queued for deletion on next full project save. */
+  pendingDeletions: string[]
   projectActions: ProjectActions
 }

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -502,6 +502,25 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
         getState().workspaceActions.setSelectedProjectTreeLeaf({ label: mainPou.name, type: 'program' })
       }
 
+      // For POUs with unparseable variables (variablesText present, variables empty),
+      // pre-create editor models in code mode so the raw text is displayed when opened.
+      pous.forEach((pou) => {
+        const pouWithText = pou as typeof pou & { variablesText?: string }
+        if (pouWithText.variablesText && (!pou.interface?.variables || pou.interface.variables.length === 0)) {
+          const language = pou.body.language as 'il' | 'st' | 'ld' | 'sfc' | 'fbd' | 'python' | 'cpp'
+          const model = createEditorObjectForPou(pou.name, pou.pouType, language)
+          // Switch to code mode with the raw variable text
+          if ('variable' in model) {
+            model.variable = { display: 'code', code: pouWithText.variablesText }
+          }
+          getState().editorActions.addModel(model)
+          // If this is the active editor (main POU), update it too
+          if (getState().editor.meta.name === pou.name) {
+            getState().editorActions.setEditor(model)
+          }
+        }
+      })
+
       // Reset all graphical flow updated flags at the very end of project open.
       // Various operations during load (syncNodesWithVariables, debug flag restoration,
       // tab opening) call updateNode which sets flow.updated = true as a side effect.

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -321,6 +321,13 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       getState().sharedWorkspaceActions.clearStatesOnCloseProject()
       getState().workspaceActions.setEditingState('saved')
 
+      // Log any parsing warnings to the app console (after clear so they aren't wiped)
+      if (data.warnings) {
+        for (const message of data.warnings) {
+          getState().consoleActions.addLog({ id: crypto.randomUUID(), level: 'warning', message })
+        }
+      }
+
       // Set project data (setting meta.path triggers navigation from start to workspace)
       getState().projectActions.setProject({
         meta: data.meta,

--- a/src/frontend/store/slices/shared/types.ts
+++ b/src/frontend/store/slices/shared/types.ts
@@ -112,6 +112,8 @@ export type OpenProjectResponseData = {
   projectData: PLCProjectData
   deviceConfiguration?: DeviceConfiguration
   devicePinMapping?: DevicePin[]
+  /** Warnings from parsing (e.g. dropped files that failed validation). */
+  warnings?: string[]
 }
 
 export type SharedWorkspaceActions = {

--- a/src/frontend/utils/PLC/pou-text-parser.ts
+++ b/src/frontend/utils/PLC/pou-text-parser.ts
@@ -40,7 +40,7 @@ const formatParseError = (message: string, lineNumber?: number): string => {
  * @param startIndex - The index to start searching from
  * @returns The index after the last END_VAR, or -1 if not found
  */
-const findLastEndVarIndex = (content: string, startIndex: number): number => {
+export const findLastEndVarIndex = (content: string, startIndex: number): number => {
   let lastEndVarIndex = -1
   let searchIndex = startIndex
 

--- a/src/frontend/utils/modbus/generate-modbus-slave-config.ts
+++ b/src/frontend/utils/modbus/generate-modbus-slave-config.ts
@@ -1,7 +1,7 @@
 import type { PLCServer } from '../../../middleware/shared/ports/types'
 
 // Default values matching runtime BUFFER_SIZE
-const DEFAULT_BUFFER_MAPPING = {
+export const DEFAULT_BUFFER_MAPPING = {
   holdingRegisters: { qwCount: 1024, mwCount: 1024, mdCount: 1024, mlCount: 1024 },
   coils: { qxBits: 8192, mxBits: 0 },
   discreteInputs: { ixBits: 8192 },

--- a/src/frontend/utils/parse-project-files.ts
+++ b/src/frontend/utils/parse-project-files.ts
@@ -1,0 +1,258 @@
+/**
+ * Frontend Project File Parser
+ *
+ * Parses raw project file contents (strings) into the structured data
+ * that handleOpenProjectResponse expects. This is the single source of
+ * truth for project parsing — both Electron and web use this.
+ *
+ * The backend only reads raw files from disk; all parsing happens here.
+ */
+
+import type { RawProjectFile } from '../../middleware/shared/ports/project-port'
+import type {
+  DeviceConfiguration,
+  DevicePin,
+  PLCDataType,
+  PLCInstance,
+  PLCPou,
+  PLCServer,
+  PLCTask,
+  PLCVariable,
+} from '../../middleware/shared/ports/types'
+import {
+  detectLanguageFromExtension,
+  parseGraphicalPouFromString,
+  parseHybridPouFromString,
+  parseTextualPouFromString,
+} from './PLC/pou-text-parser'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ParsedProjectData {
+  meta: {
+    name: string
+    type: 'plc-project' | 'plc-library'
+    path: string
+  }
+  projectData: {
+    dataTypes: PLCDataType[]
+    pous: PLCPou[]
+    configurations: {
+      resource: {
+        tasks: PLCTask[]
+        instances: PLCInstance[]
+        globalVariables: PLCVariable[]
+      }
+    }
+    servers?: PLCServer[]
+    remoteDevices?: unknown[]
+    debugVariables?: { global?: string[]; pous?: Record<string, string[]> }
+  }
+  deviceConfiguration?: DeviceConfiguration
+  devicePinMapping?: DevicePin[]
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect POU type from the file's relative path.
+ * e.g., 'pous/programs/main.st' → 'program'
+ */
+function detectPouTypeFromPath(relativePath: string): string {
+  const normalized = relativePath.replace(/\\/g, '/')
+  if (normalized.includes('pous/programs/')) return 'program'
+  if (normalized.includes('pous/functions/') && !normalized.includes('pous/function-blocks/')) return 'function'
+  if (normalized.includes('pous/function-blocks/')) return 'function-block'
+  return 'program' // fallback
+}
+
+/**
+ * Detect language from file extension.
+ * e.g., '.st' → 'st', '.ld' → 'ld'
+ */
+function getLanguageFromExt(relativePath: string): string | null {
+  try {
+    return detectLanguageFromExtension(relativePath)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Parse a single POU file from its raw text content.
+ * Returns null if the file format is not recognized.
+ */
+function parsePouFile(file: RawProjectFile): PLCPou | null {
+  const ext = file.relativePath.split('.').pop()?.toLowerCase()
+  if (!ext) return null
+
+  const pouType = detectPouTypeFromPath(file.relativePath)
+
+  // Legacy JSON format
+  if (ext === 'json') {
+    try {
+      const parsed = JSON.parse(file.content) as unknown
+      // JSON POUs may be in the old discriminated union format: { type, data }
+      if (parsed && typeof parsed === 'object' && 'type' in parsed && 'data' in parsed) {
+        const ipcPou = parsed as { type: string; data: Record<string, unknown> }
+        return {
+          name: (ipcPou.data.name as string) ?? '',
+          pouType: ipcPou.type as PLCPou['pouType'],
+          interface: {
+            returnType: ipcPou.data.returnType as string | undefined,
+            variables: (ipcPou.data.variables as PLCVariable[]) ?? [],
+          },
+          body: ipcPou.data.body as PLCPou['body'],
+          documentation: (ipcPou.data.documentation as string) ?? '',
+        }
+      }
+      // Flat format
+      return parsed as PLCPou
+    } catch {
+      return null
+    }
+  }
+
+  const language = getLanguageFromExt(file.relativePath)
+  if (!language) return null
+
+  try {
+    if (language === 'st' || language === 'il') {
+      return parseTextualPouFromString(file.content, language, pouType)
+    } else if (language === 'python' || language === 'cpp') {
+      return parseHybridPouFromString(file.content, language, pouType)
+    } else if (language === 'ld' || language === 'fbd') {
+      return parseGraphicalPouFromString(file.content, language, pouType)
+    }
+  } catch (err) {
+    console.error(`[parseProjectFiles] Failed to parse POU: ${file.relativePath}`, err)
+    // Fallback: create a minimal POU with raw body
+    return {
+      name: file.relativePath.split('/').pop()?.replace(/\.\w+$/, '') ?? 'unknown',
+      pouType: pouType as PLCPou['pouType'],
+      interface: { variables: [] },
+      body: { language: language as PLCPou['body']['language'], value: file.content },
+      documentation: '',
+    }
+  }
+
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Main parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse raw project files into the structured data that handleOpenProjectResponse expects.
+ *
+ * @param projectPath - Absolute path to the project directory
+ * @param projectJson - Raw content of project.json
+ * @param deviceConfig - Raw content of devices/configuration.json
+ * @param pinMapping - Raw content of devices/pin-mapping.json
+ * @param pouFiles - Raw POU files (.st, .il, .ld, .fbd, .py, .cpp, .json)
+ * @param serverFiles - Raw server config files from devices/servers/
+ * @param remoteDeviceFiles - Raw remote device config files from devices/remote/
+ */
+export function parseProjectFiles(
+  projectPath: string,
+  projectJson: string,
+  deviceConfig: string,
+  pinMapping: string,
+  pouFiles: RawProjectFile[],
+  serverFiles: RawProjectFile[],
+  remoteDeviceFiles: RawProjectFile[],
+): ParsedProjectData {
+  // Parse project.json
+  let project: { meta?: { name?: string; type?: string }; data?: Record<string, unknown> } = {}
+  try {
+    project = projectJson ? (JSON.parse(projectJson) as typeof project) : {}
+  } catch {
+    project = {}
+  }
+
+  const meta = {
+    name: project.meta?.name ?? '',
+    type: (project.meta?.type ?? 'plc-project') as 'plc-project' | 'plc-library',
+    path: projectPath,
+  }
+
+  // Parse device configuration
+  let deviceConfiguration: DeviceConfiguration | undefined
+  try {
+    deviceConfiguration = deviceConfig ? (JSON.parse(deviceConfig) as DeviceConfiguration) : undefined
+  } catch {
+    deviceConfiguration = undefined
+  }
+
+  // Parse pin mapping
+  let devicePinMapping: DevicePin[] | undefined
+  try {
+    devicePinMapping = pinMapping ? (JSON.parse(pinMapping) as DevicePin[]) : undefined
+  } catch {
+    devicePinMapping = undefined
+  }
+
+  // Parse POU files
+  const pous: PLCPou[] = []
+  for (const file of pouFiles) {
+    const pou = parsePouFile(file)
+    if (pou) {
+      pous.push(pou)
+    }
+  }
+
+  // Parse server configs
+  const servers: PLCServer[] = []
+  for (const file of serverFiles) {
+    try {
+      const server = JSON.parse(file.content) as PLCServer
+      servers.push(server)
+    } catch {
+      console.error(`[parseProjectFiles] Failed to parse server: ${file.relativePath}`)
+    }
+  }
+
+  // Parse remote device configs
+  const remoteDevices: unknown[] = []
+  for (const file of remoteDeviceFiles) {
+    try {
+      const device = JSON.parse(file.content) as unknown
+      remoteDevices.push(device)
+    } catch {
+      console.error(`[parseProjectFiles] Failed to parse remote device: ${file.relativePath}`)
+    }
+  }
+
+  // Extract project data fields
+  const data = project.data ?? {}
+  const configuration = (data.configuration ?? data.configurations ?? {
+    resource: { tasks: [], instances: [], globalVariables: [] },
+  }) as ParsedProjectData['projectData']['configurations']
+
+  // Ensure resource has all required fields
+  if (!configuration.resource) {
+    configuration.resource = { tasks: [], instances: [], globalVariables: [] }
+  }
+  if (!configuration.resource.tasks) configuration.resource.tasks = []
+  if (!configuration.resource.instances) configuration.resource.instances = []
+  if (!configuration.resource.globalVariables) configuration.resource.globalVariables = []
+
+  return {
+    meta,
+    projectData: {
+      dataTypes: (data.dataTypes as PLCDataType[]) ?? [],
+      pous,
+      configurations: configuration,
+      servers: servers.length > 0 ? servers : (data.servers as PLCServer[]) ?? [],
+      remoteDevices: remoteDevices.length > 0 ? remoteDevices : (data.remoteDevices as unknown[]) ?? [],
+      debugVariables: data.debugVariables as ParsedProjectData['projectData']['debugVariables'],
+    },
+    deviceConfiguration,
+    devicePinMapping,
+  }
+}

--- a/src/frontend/utils/parse-project-files.ts
+++ b/src/frontend/utils/parse-project-files.ts
@@ -22,7 +22,6 @@ import type {
 } from '../../middleware/shared/ports/types'
 import { deviceConfigurationSchema, devicePinSchema } from '../../types/PLC/devices'
 import { PLCProjectSchema, PLCRemoteDeviceSchema, PLCServerSchema } from '../../types/PLC/open-plc'
-import { openPLCStoreBase } from '../store'
 import { getDefaultSchemaValues } from './default-zod-schema-values'
 import {
   detectLanguageFromExtension,
@@ -60,6 +59,8 @@ export interface ParsedProjectData {
   }
   deviceConfiguration?: DeviceConfiguration
   devicePinMapping?: DevicePin[]
+  /** Warnings collected during parsing (e.g. dropped files that failed validation). */
+  warnings?: string[]
 }
 
 // ---------------------------------------------------------------------------
@@ -318,6 +319,8 @@ export function parseProjectFiles(
   serverFiles: RawProjectFile[],
   remoteDeviceFiles: RawProjectFile[],
 ): ParsedProjectData {
+  const warnings: string[] = []
+
   // Parse and Zod-validate project.json (matches old backend safeParseProjectFile behavior)
   let project: { meta?: { name?: string; type?: string }; data?: Record<string, unknown> }
   try {
@@ -327,22 +330,15 @@ export function parseProjectFiles(
       if (result.success) {
         project = result.data as typeof project
       } else {
-        openPLCStoreBase.getState().consoleActions.addLog({
-          id: crypto.randomUUID(),
-          level: 'warning',
-          message: `project.json validation failed: ${result.error.message}. Using defaults.`,
-        })
+        console.error('[parseProjectFiles] project.json Zod errors:', result.error.issues)
+        warnings.push('project.json has invalid structure and was loaded with defaults.')
         project = getDefaultSchemaValues(PLCProjectSchema) as typeof project
       }
     } else {
       project = getDefaultSchemaValues(PLCProjectSchema) as typeof project
     }
   } catch {
-    openPLCStoreBase.getState().consoleActions.addLog({
-      id: crypto.randomUUID(),
-      level: 'warning',
-      message: 'project.json is malformed and could not be read. Using defaults.',
-    })
+    warnings.push('project.json is malformed and could not be read. Using defaults.')
     project = getDefaultSchemaValues(PLCProjectSchema) as typeof project
   }
 
@@ -361,22 +357,15 @@ export function parseProjectFiles(
       if (result.success) {
         deviceConfiguration = result.data
       } else {
-        openPLCStoreBase.getState().consoleActions.addLog({
-          id: crypto.randomUUID(),
-          level: 'warning',
-          message: `devices/configuration.json validation failed: ${result.error.message}. Using defaults.`,
-        })
+        console.error('[parseProjectFiles] devices/configuration.json Zod errors:', result.error.issues)
+        warnings.push('devices/configuration.json has invalid structure and was loaded with defaults.')
         deviceConfiguration = getDefaultSchemaValues(deviceConfigurationSchema) as DeviceConfiguration
       }
     } else {
       deviceConfiguration = getDefaultSchemaValues(deviceConfigurationSchema) as DeviceConfiguration
     }
   } catch {
-    openPLCStoreBase.getState().consoleActions.addLog({
-      id: crypto.randomUUID(),
-      level: 'warning',
-      message: 'devices/configuration.json is malformed and could not be read. Using defaults.',
-    })
+    warnings.push('devices/configuration.json is malformed and could not be read. Using defaults.')
     deviceConfiguration = getDefaultSchemaValues(deviceConfigurationSchema) as DeviceConfiguration
   }
 
@@ -390,22 +379,15 @@ export function parseProjectFiles(
       if (result.success) {
         devicePinMapping = result.data
       } else {
-        openPLCStoreBase.getState().consoleActions.addLog({
-          id: crypto.randomUUID(),
-          level: 'warning',
-          message: `devices/pin-mapping.json validation failed: ${result.error.message}. Using defaults.`,
-        })
+        console.error('[parseProjectFiles] devices/pin-mapping.json Zod errors:', result.error.issues)
+        warnings.push('devices/pin-mapping.json has invalid structure and was loaded with defaults.')
         devicePinMapping = getDefaultSchemaValues(pinMappingSchema) as DevicePin[]
       }
     } else {
       devicePinMapping = getDefaultSchemaValues(pinMappingSchema) as DevicePin[]
     }
   } catch {
-    openPLCStoreBase.getState().consoleActions.addLog({
-      id: crypto.randomUUID(),
-      level: 'warning',
-      message: 'devices/pin-mapping.json is malformed and could not be read. Using defaults.',
-    })
+    warnings.push('devices/pin-mapping.json is malformed and could not be read. Using defaults.')
     devicePinMapping = getDefaultSchemaValues(pinMappingSchema) as DevicePin[]
   }
 
@@ -433,9 +415,12 @@ export function parseProjectFiles(
       const result = PLCServerSchema.safeParse(parsed)
       if (result.success) {
         servers.push(result.data)
+      } else {
+        console.error(`[parseProjectFiles] Server "${file.relativePath}" Zod errors:`, result.error.issues)
+        warnings.push(`Server file "${file.relativePath}" has invalid configuration and was skipped.`)
       }
     } catch {
-      // Silently skip invalid server files
+      // Skip unparseable JSON files
     }
   }
 
@@ -447,9 +432,12 @@ export function parseProjectFiles(
       const result = PLCRemoteDeviceSchema.safeParse(parsed)
       if (result.success) {
         remoteDevices.push(result.data)
+      } else {
+        console.error(`[parseProjectFiles] Remote device "${file.relativePath}" Zod errors:`, result.error.issues)
+        warnings.push(`Remote device file "${file.relativePath}" has invalid configuration and was skipped.`)
       }
     } catch {
-      // Silently skip invalid remote device files
+      // Skip unparseable JSON files
     }
   }
 
@@ -480,5 +468,6 @@ export function parseProjectFiles(
     },
     deviceConfiguration,
     devicePinMapping,
+    warnings: warnings.length > 0 ? warnings : undefined,
   }
 }

--- a/src/frontend/utils/parse-project-files.ts
+++ b/src/frontend/utils/parse-project-files.ts
@@ -15,12 +15,15 @@ import type {
   PLCDataType,
   PLCInstance,
   PLCPou,
+  PLCRemoteDevice,
   PLCServer,
   PLCTask,
   PLCVariable,
 } from '../../middleware/shared/ports/types'
+import { PLCRemoteDeviceSchema, PLCServerSchema } from '../../types/PLC/open-plc'
 import {
   detectLanguageFromExtension,
+  findLastEndVarIndex,
   parseGraphicalPouFromString,
   parseHybridPouFromString,
   parseTextualPouFromString,
@@ -30,6 +33,8 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
+type FallbackPou = PLCPou & { variablesText?: string }
+
 export interface ParsedProjectData {
   meta: {
     name: string
@@ -38,7 +43,7 @@ export interface ParsedProjectData {
   }
   projectData: {
     dataTypes: PLCDataType[]
-    pous: PLCPou[]
+    pous: (PLCPou & { variablesText?: string })[]
     configurations: {
       resource: {
         tasks: PLCTask[]
@@ -47,7 +52,7 @@ export interface ParsedProjectData {
       }
     }
     servers?: PLCServer[]
-    remoteDevices?: unknown[]
+    remoteDevices?: PLCRemoteDevice[]
     debugVariables?: { global?: string[]; pous?: Record<string, string[]> }
   }
   deviceConfiguration?: DeviceConfiguration
@@ -60,14 +65,14 @@ export interface ParsedProjectData {
 
 /**
  * Detect POU type from the file's relative path.
- * e.g., 'pous/programs/main.st' → 'program'
+ * Throws if the path does not match any known POU directory.
  */
 function detectPouTypeFromPath(relativePath: string): string {
   const normalized = relativePath.replace(/\\/g, '/')
-  if (normalized.includes('pous/programs/')) return 'program'
-  if (normalized.includes('pous/functions/') && !normalized.includes('pous/function-blocks/')) return 'function'
-  if (normalized.includes('pous/function-blocks/')) return 'function-block'
-  return 'program' // fallback
+  if (normalized.includes('/programs/')) return 'program'
+  if (normalized.includes('/function-blocks/')) return 'function-block'
+  if (normalized.includes('/functions/')) return 'function'
+  throw new Error(`Cannot determine POU type from path: ${relativePath}`)
 }
 
 /**
@@ -83,10 +88,118 @@ function getLanguageFromExt(relativePath: string): string | null {
 }
 
 /**
+ * Extract the base filename without extension from a relative path.
+ */
+function getBaseNameFromPath(relativePath: string): string {
+  return (
+    relativePath
+      .split('/')
+      .pop()
+      ?.replace(/\.\w+$/, '') ?? 'unknown'
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Fallback POU creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a POU from raw file content when normal parsing fails.
+ * Preserves as much data as possible: documentation, raw variable text, body.
+ *
+ * This is a direct port of the old backend's createFallbackPou logic
+ * (read-project.ts:190-315), adapted to return the flat port format.
+ */
+function createFallbackPou(content: string, language: string, pouType: string, pouName: string): FallbackPou {
+  // 1. Extract documentation from leading (* ... *) comment
+  const docMatch = content.match(/^\s*\(\*\s*(.*?)\s*\*\)\s*\n/s)
+  const documentation = docMatch ? docMatch[1].trim() : ''
+  const remainingContent = docMatch ? content.slice(docMatch[0].length) : content
+
+  // 2. Find POU declaration to determine where body starts
+  const pouTypeKeywords: Record<string, string> = {
+    program: 'PROGRAM',
+    function: 'FUNCTION',
+    'function-block': 'FUNCTION_BLOCK',
+  }
+  const typeKeyword = pouTypeKeywords[pouType]
+  const declarationRegex = new RegExp(`^\\s*(${typeKeyword})\\s+(\\w+)(?:\\s*:\\s*(\\w+))?`, 'i')
+  const declarationMatch = remainingContent.match(declarationRegex)
+  let bodyStartIndex = declarationMatch ? declarationMatch[0].length : 0
+
+  // 3. Extract raw VAR blocks as variablesText
+  const varStartIndex = remainingContent.search(
+    /\b(VAR_INPUT|VAR_OUTPUT|VAR_IN_OUT|VAR_EXTERNAL|VAR_TEMP|VAR_GLOBAL|VAR)\b/i,
+  )
+  let variablesText = 'VAR\nEND_VAR'
+  if (varStartIndex !== -1) {
+    const lastEnd = findLastEndVarIndex(remainingContent, varStartIndex)
+    if (lastEnd !== -1) {
+      variablesText = remainingContent.slice(varStartIndex, lastEnd)
+      bodyStartIndex = lastEnd
+    }
+  }
+
+  // 4. Extract body content
+  const endKeywords: Record<string, string> = {
+    program: 'END_PROGRAM',
+    function: 'END_FUNCTION',
+    'function-block': 'END_FUNCTION_BLOCK',
+  }
+  const endKeyword = endKeywords[pouType]
+  let bodyValue: unknown
+
+  if (language === 'ld' || language === 'fbd') {
+    const endRegex = new RegExp(`\\b${endKeyword}\\b`, 'i')
+    const endMatch = remainingContent.slice(bodyStartIndex).search(endRegex)
+    const bodyContent =
+      endMatch !== -1
+        ? remainingContent.slice(bodyStartIndex, bodyStartIndex + endMatch).trim()
+        : remainingContent.slice(bodyStartIndex).trim()
+    try {
+      bodyValue = JSON.parse(bodyContent)
+    } catch {
+      bodyValue = { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } }
+    }
+  } else if (language === 'st' || language === 'il' || language === 'python' || language === 'cpp') {
+    const endRegex = new RegExp(`\\b${endKeyword}\\b`, 'i')
+    const endMatch = remainingContent.slice(bodyStartIndex).search(endRegex)
+    bodyValue =
+      endMatch !== -1
+        ? remainingContent.slice(bodyStartIndex, bodyStartIndex + endMatch).trim()
+        : remainingContent.slice(bodyStartIndex).trim()
+  } else {
+    bodyValue = ''
+  }
+
+  // 5. Build flat-format POU
+  return {
+    name: pouName,
+    pouType: pouType as PLCPou['pouType'],
+    interface: {
+      ...(pouType === 'function' ? { returnType: 'BOOL' } : {}),
+      variables: [],
+    },
+    body: {
+      language: language as PLCPou['body']['language'],
+      value: bodyValue,
+    },
+    documentation,
+    variablesText,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POU file parsing
+// ---------------------------------------------------------------------------
+
+/**
  * Parse a single POU file from its raw text content.
  * Returns null if the file format is not recognized.
+ * On parse failure, falls back to createFallbackPou which preserves
+ * documentation, raw variable text, and body content.
  */
-function parsePouFile(file: RawProjectFile): PLCPou | null {
+function parsePouFile(file: RawProjectFile): (PLCPou & { variablesText?: string }) | null {
   const ext = file.relativePath.split('.').pop()?.toLowerCase()
   if (!ext) return null
 
@@ -130,17 +243,52 @@ function parsePouFile(file: RawProjectFile): PLCPou | null {
     }
   } catch (err) {
     console.error(`[parseProjectFiles] Failed to parse POU: ${file.relativePath}`, err)
-    // Fallback: create a minimal POU with raw body
-    return {
-      name: file.relativePath.split('/').pop()?.replace(/\.\w+$/, '') ?? 'unknown',
-      pouType: pouType as PLCPou['pouType'],
-      interface: { variables: [] },
-      body: { language: language as PLCPou['body']['language'], value: file.content },
-      documentation: '',
+    // Fallback: preserve as much data as possible
+    try {
+      const pouName = getBaseNameFromPath(file.relativePath)
+      return createFallbackPou(file.content, language, pouType, pouName)
+    } catch (fallbackErr) {
+      console.error(`[parseProjectFiles] Fallback also failed: ${file.relativePath}`, fallbackErr)
+      return null
     }
   }
 
   return null
+}
+
+// ---------------------------------------------------------------------------
+// POU deduplication
+// ---------------------------------------------------------------------------
+
+/**
+ * Deduplicate POU files: when both a text-based file (.st, .il, etc.) and
+ * a JSON file exist for the same POU name, the text-based file wins.
+ * This matches the old backend's readDirectoryRecursive behavior.
+ */
+function deduplicatePouFiles(pouFiles: RawProjectFile[]): RawProjectFile[] {
+  const pouNameMap = new Map<string, { index: number; isTextBased: boolean }>()
+  const result: RawProjectFile[] = []
+
+  for (const file of pouFiles) {
+    const ext = file.relativePath.split('.').pop()?.toLowerCase() ?? ''
+    const baseName = getBaseNameFromPath(file.relativePath)
+    const isTextBased = ext !== 'json'
+    const existing = pouNameMap.get(baseName)
+
+    if (existing) {
+      if (isTextBased && !existing.isTextBased) {
+        // Replace JSON entry with text-based entry
+        result[existing.index] = file
+        pouNameMap.set(baseName, { index: existing.index, isTextBased })
+      }
+      // If existing is text-based and new is JSON, skip the JSON
+    } else {
+      pouNameMap.set(baseName, { index: result.length, isTextBased })
+      result.push(file)
+    }
+  }
+
+  return result
 }
 
 // ---------------------------------------------------------------------------
@@ -197,42 +345,56 @@ export function parseProjectFiles(
     devicePinMapping = undefined
   }
 
+  // Deduplicate POU files (prefer text-based over JSON when both exist)
+  const filteredPouFiles = deduplicatePouFiles(pouFiles)
+
   // Parse POU files
-  const pous: PLCPou[] = []
-  for (const file of pouFiles) {
+  const pous: (PLCPou & { variablesText?: string })[] = []
+  for (const file of filteredPouFiles) {
     const pou = parsePouFile(file)
     if (pou) {
+      // Ensure all POUs have a name (derive from filename if missing)
+      if (!pou.name) {
+        pou.name = getBaseNameFromPath(file.relativePath)
+      }
       pous.push(pou)
     }
   }
 
-  // Parse server configs
+  // Parse server configs with Zod validation (matching old backend behavior)
   const servers: PLCServer[] = []
   for (const file of serverFiles) {
     try {
-      const server = JSON.parse(file.content) as PLCServer
-      servers.push(server)
+      const parsed = JSON.parse(file.content) as unknown
+      const result = PLCServerSchema.safeParse(parsed)
+      if (result.success) {
+        servers.push(result.data)
+      }
     } catch {
-      console.error(`[parseProjectFiles] Failed to parse server: ${file.relativePath}`)
+      // Silently skip invalid server files
     }
   }
 
-  // Parse remote device configs
-  const remoteDevices: unknown[] = []
+  // Parse remote device configs with Zod validation (matching old backend behavior)
+  const remoteDevices: PLCRemoteDevice[] = []
   for (const file of remoteDeviceFiles) {
     try {
-      const device = JSON.parse(file.content) as unknown
-      remoteDevices.push(device)
+      const parsed = JSON.parse(file.content) as unknown
+      const result = PLCRemoteDeviceSchema.safeParse(parsed)
+      if (result.success) {
+        remoteDevices.push(result.data)
+      }
     } catch {
-      console.error(`[parseProjectFiles] Failed to parse remote device: ${file.relativePath}`)
+      // Silently skip invalid remote device files
     }
   }
 
   // Extract project data fields
   const data = project.data ?? {}
-  const configuration = (data.configuration ?? data.configurations ?? {
-    resource: { tasks: [], instances: [], globalVariables: [] },
-  }) as ParsedProjectData['projectData']['configurations']
+  const configuration = (data.configuration ??
+    data.configurations ?? {
+      resource: { tasks: [], instances: [], globalVariables: [] },
+    }) as ParsedProjectData['projectData']['configurations']
 
   // Ensure resource has all required fields
   if (!configuration.resource) {
@@ -249,7 +411,7 @@ export function parseProjectFiles(
       pous,
       configurations: configuration,
       servers: servers.length > 0 ? servers : (data.servers as PLCServer[]) ?? [],
-      remoteDevices: remoteDevices.length > 0 ? remoteDevices : (data.remoteDevices as unknown[]) ?? [],
+      remoteDevices: remoteDevices.length > 0 ? remoteDevices : (data.remoteDevices as PLCRemoteDevice[]) ?? [],
       debugVariables: data.debugVariables as ParsedProjectData['projectData']['debugVariables'],
     },
     deviceConfiguration,

--- a/src/frontend/utils/parse-project-files.ts
+++ b/src/frontend/utils/parse-project-files.ts
@@ -20,7 +20,10 @@ import type {
   PLCTask,
   PLCVariable,
 } from '../../middleware/shared/ports/types'
-import { PLCRemoteDeviceSchema, PLCServerSchema } from '../../types/PLC/open-plc'
+import { deviceConfigurationSchema, devicePinSchema } from '../../types/PLC/devices'
+import { PLCProjectSchema, PLCRemoteDeviceSchema, PLCServerSchema } from '../../types/PLC/open-plc'
+import { openPLCStoreBase } from '../store'
+import { getDefaultSchemaValues } from './default-zod-schema-values'
 import {
   detectLanguageFromExtension,
   findLastEndVarIndex,
@@ -315,12 +318,32 @@ export function parseProjectFiles(
   serverFiles: RawProjectFile[],
   remoteDeviceFiles: RawProjectFile[],
 ): ParsedProjectData {
-  // Parse project.json
-  let project: { meta?: { name?: string; type?: string }; data?: Record<string, unknown> } = {}
+  // Parse and Zod-validate project.json (matches old backend safeParseProjectFile behavior)
+  let project: { meta?: { name?: string; type?: string }; data?: Record<string, unknown> }
   try {
-    project = projectJson ? (JSON.parse(projectJson) as typeof project) : {}
+    const raw = projectJson ? (JSON.parse(projectJson) as unknown) : null
+    if (raw) {
+      const result = PLCProjectSchema.safeParse(raw)
+      if (result.success) {
+        project = result.data as typeof project
+      } else {
+        openPLCStoreBase.getState().consoleActions.addLog({
+          id: crypto.randomUUID(),
+          level: 'warning',
+          message: `project.json validation failed: ${result.error.message}. Using defaults.`,
+        })
+        project = getDefaultSchemaValues(PLCProjectSchema) as typeof project
+      }
+    } else {
+      project = getDefaultSchemaValues(PLCProjectSchema) as typeof project
+    }
   } catch {
-    project = {}
+    openPLCStoreBase.getState().consoleActions.addLog({
+      id: crypto.randomUUID(),
+      level: 'warning',
+      message: 'project.json is malformed and could not be read. Using defaults.',
+    })
+    project = getDefaultSchemaValues(PLCProjectSchema) as typeof project
   }
 
   const meta = {
@@ -329,20 +352,61 @@ export function parseProjectFiles(
     path: projectPath,
   }
 
-  // Parse device configuration
+  // Parse and Zod-validate device configuration
   let deviceConfiguration: DeviceConfiguration | undefined
   try {
-    deviceConfiguration = deviceConfig ? (JSON.parse(deviceConfig) as DeviceConfiguration) : undefined
+    const raw = deviceConfig ? (JSON.parse(deviceConfig) as unknown) : null
+    if (raw) {
+      const result = deviceConfigurationSchema.safeParse(raw)
+      if (result.success) {
+        deviceConfiguration = result.data
+      } else {
+        openPLCStoreBase.getState().consoleActions.addLog({
+          id: crypto.randomUUID(),
+          level: 'warning',
+          message: `devices/configuration.json validation failed: ${result.error.message}. Using defaults.`,
+        })
+        deviceConfiguration = getDefaultSchemaValues(deviceConfigurationSchema) as DeviceConfiguration
+      }
+    } else {
+      deviceConfiguration = getDefaultSchemaValues(deviceConfigurationSchema) as DeviceConfiguration
+    }
   } catch {
-    deviceConfiguration = undefined
+    openPLCStoreBase.getState().consoleActions.addLog({
+      id: crypto.randomUUID(),
+      level: 'warning',
+      message: 'devices/configuration.json is malformed and could not be read. Using defaults.',
+    })
+    deviceConfiguration = getDefaultSchemaValues(deviceConfigurationSchema) as DeviceConfiguration
   }
 
-  // Parse pin mapping
+  // Parse and Zod-validate pin mapping
+  const pinMappingSchema = devicePinSchema.array()
   let devicePinMapping: DevicePin[] | undefined
   try {
-    devicePinMapping = pinMapping ? (JSON.parse(pinMapping) as DevicePin[]) : undefined
+    const raw = pinMapping ? (JSON.parse(pinMapping) as unknown) : null
+    if (raw) {
+      const result = pinMappingSchema.safeParse(raw)
+      if (result.success) {
+        devicePinMapping = result.data
+      } else {
+        openPLCStoreBase.getState().consoleActions.addLog({
+          id: crypto.randomUUID(),
+          level: 'warning',
+          message: `devices/pin-mapping.json validation failed: ${result.error.message}. Using defaults.`,
+        })
+        devicePinMapping = getDefaultSchemaValues(pinMappingSchema) as DevicePin[]
+      }
+    } else {
+      devicePinMapping = getDefaultSchemaValues(pinMappingSchema) as DevicePin[]
+    }
   } catch {
-    devicePinMapping = undefined
+    openPLCStoreBase.getState().consoleActions.addLog({
+      id: crypto.randomUUID(),
+      level: 'warning',
+      message: 'devices/pin-mapping.json is malformed and could not be read. Using defaults.',
+    })
+    devicePinMapping = getDefaultSchemaValues(pinMappingSchema) as DevicePin[]
   }
 
   // Deduplicate POU files (prefer text-based over JSON when both exist)

--- a/src/frontend/utils/save-actions.ts
+++ b/src/frontend/utils/save-actions.ts
@@ -14,6 +14,9 @@ import { serializePouToText } from './PLC/pou-text-serializer'
 import { collectDebugVariables, sanitizePou } from './save-project'
 import { toast } from './toast'
 
+/** Join path segments with forward slashes (platform-agnostic, works with Node's fs on all OSes). */
+const joinPath = (...parts: string[]): string => parts.join('/').replace(/\/+/g, '/')
+
 /**
  * Save the entire project (all files, device config, debug variables).
  * Equivalent to Ctrl+Shift+S / "Save Project" menu item.
@@ -143,82 +146,58 @@ export async function executeSaveFile(fileName: string, projectPort: ProjectPort
     return { success: false }
   }
 
+  setEditingState('save-request')
   const projectPath = project.meta.path
+
+  const fail = (description: string): { success: false } => {
+    setEditingState('unsaved')
+    toast({ title: 'Error saving file', description, variant: 'fail' })
+    return { success: false }
+  }
 
   try {
     const isPouType = file.type === 'program' || file.type === 'function' || file.type === 'function-block'
 
     if (isPouType) {
       const pou = project.data.pous.find((p) => p.name === fileName)
-      if (!pou) {
-        toast({ title: 'Error saving file', description: `POU "${fileName}" not found.`, variant: 'fail' })
-        return { success: false }
-      }
+      if (!pou) return fail(`POU "${fileName}" not found.`)
 
-      // Sanitize: sync variablesText from code-mode editor if applicable
       const editorModel = state.editorActions.getEditorFromEditors(fileName)
       const sanitized = sanitizePou(pou, editorModel ?? undefined)
-
-      // Serialize POU to IEC text on the frontend (single source of truth)
       const textContent = serializePouToText(sanitized)
-
-      // Compute file path
       const folder = getFolderFromPouType(pou.pouType)
       const ext = getExtensionFromLanguage(pou.body.language)
-      const filePath = `${projectPath}/pous/${folder}/${fileName}${ext}`
 
-      const res = await projectPort.saveFile(filePath, textContent)
-      if (!res.success) {
-        toast({ title: 'Error saving file', description: res.error ?? 'Save failed', variant: 'fail' })
-        return { success: false }
-      }
+      const res = await projectPort.saveFile(joinPath(projectPath, 'pous', folder, `${fileName}${ext}`), textContent)
+      if (!res.success) return fail(res.error ?? 'Save failed')
     } else if (file.type === 'device') {
-      // Device config: two JSON files
       const configRes = await projectPort.saveFile(
-        `${projectPath}/devices/configuration.json`,
+        joinPath(projectPath, 'devices/configuration.json'),
         JSON.stringify(state.deviceDefinitions.configuration, null, 2),
       )
       const pinRes = await projectPort.saveFile(
-        `${projectPath}/devices/pin-mapping.json`,
+        joinPath(projectPath, 'devices/pin-mapping.json'),
         JSON.stringify(state.deviceDefinitions.pinMapping.pins, null, 2),
       )
-      if (!configRes.success || !pinRes.success) {
-        toast({ title: 'Error saving device config', description: 'Save failed', variant: 'fail' })
-        return { success: false }
-      }
+      if (!configRes.success || !pinRes.success) return fail('Save failed')
     } else if (file.type === 'server') {
-      // Servers are saved as individual JSON files in devices/servers/
       const server = project.data.servers?.find((s) => s.name === fileName)
-      if (!server) {
-        toast({ title: 'Error saving file', description: `Server "${fileName}" not found.`, variant: 'fail' })
-        return { success: false }
-      }
+      if (!server) return fail(`Server "${fileName}" not found.`)
       const res = await projectPort.saveFile(
-        `${projectPath}/devices/servers/${fileName}.json`,
+        joinPath(projectPath, 'devices/servers', `${fileName}.json`),
         JSON.stringify(server, null, 2),
       )
-      if (!res.success) {
-        toast({ title: 'Error saving file', description: res.error ?? 'Save failed', variant: 'fail' })
-        return { success: false }
-      }
+      if (!res.success) return fail(res.error ?? 'Save failed')
     } else if (file.type === 'remote-device') {
-      // Remote devices are saved as individual JSON files in devices/remote/
       const device = project.data.remoteDevices?.find((d) => d.name === fileName)
-      if (!device) {
-        toast({ title: 'Error saving file', description: `Remote device "${fileName}" not found.`, variant: 'fail' })
-        return { success: false }
-      }
+      if (!device) return fail(`Remote device "${fileName}" not found.`)
       const res = await projectPort.saveFile(
-        `${projectPath}/devices/remote/${fileName}.json`,
+        joinPath(projectPath, 'devices/remote', `${fileName}.json`),
         JSON.stringify(device, null, 2),
       )
-      if (!res.success) {
-        toast({ title: 'Error saving file', description: res.error ?? 'Save failed', variant: 'fail' })
-        return { success: false }
-      }
+      if (!res.success) return fail(res.error ?? 'Save failed')
     } else {
       // data-type, resource: live in project.json
-      // Build project.json with the EXACT same structure the backend saveProject writes
       const debugVariables = collectDebugVariables(
         project.data.configurations.resource.globalVariables,
         project.data.pous,
@@ -232,11 +211,11 @@ export async function executeSaveFile(fileName: string, projectPort: ProjectPort
           debugVariables,
         },
       }
-      const res = await projectPort.saveFile(`${projectPath}/project.json`, JSON.stringify(projectJson, null, 2))
-      if (!res.success) {
-        toast({ title: 'Error saving file', description: res.error ?? 'Save failed', variant: 'fail' })
-        return { success: false }
-      }
+      const res = await projectPort.saveFile(
+        joinPath(projectPath, 'project.json'),
+        JSON.stringify(projectJson, null, 2),
+      )
+      if (!res.success) return fail(res.error ?? 'Save failed')
     }
 
     // Mark only this file as saved
@@ -246,13 +225,14 @@ export async function executeSaveFile(fileName: string, projectPort: ProjectPort
     // If all files are now saved, update workspace editing state
     if (checkIfAllFilesAreSaved()) {
       setEditingState('saved')
+    } else {
+      setEditingState('unsaved')
     }
 
     toast({ title: 'File saved', description: `"${fileName}" saved successfully.`, variant: 'default' })
     return { success: true }
   } catch {
-    toast({ title: 'Error saving file', description: 'An unexpected error occurred.', variant: 'fail' })
-    return { success: false }
+    return fail('An unexpected error occurred.')
   }
 }
 

--- a/src/frontend/utils/save-actions.ts
+++ b/src/frontend/utils/save-actions.ts
@@ -74,29 +74,26 @@ export async function executeSaveProject(projectPort: ProjectPort): Promise<{ su
 }
 
 /**
- * Save only the active file (the POU/resource currently open in the editor).
- * Equivalent to Ctrl+S / "Save" menu item.
+ * Save a single file by name.
+ *
+ * This is the core single-file save logic used by both executeSaveActiveFile()
+ * (Ctrl+S — saves whichever file is currently focused) and direct callers that
+ * need to save a specific file by name (e.g. the save-changes-file modal).
  *
  * For POUs: serializes to IEC text on the frontend, writes via projectPort.saveFile.
  * For device/data-type/resource/server/remote-device: writes appropriate JSON files.
  * Also updates project.json when debug variables may have changed.
  */
-export async function executeSaveActiveFile(projectPort: ProjectPort): Promise<{ success: boolean }> {
+export async function executeSaveFile(fileName: string, projectPort: ProjectPort): Promise<{ success: boolean }> {
   const state = openPLCStoreBase.getState()
-  const { project, editor: activeEditor, files } = state
+  const { project, files } = state
   const { setEditingState } = state.workspaceActions
   const { updateFile, checkIfAllFilesAreSaved } = state.fileActions
   const { markSaved } = state.snapshotActions
 
-  const name = activeEditor.meta.name
-  if (!name) {
-    toast({ title: 'No file open', description: 'There is no file to save.', variant: 'fail' })
-    return { success: false }
-  }
-
-  const file = files[name]
+  const file = files[fileName]
   if (!file) {
-    toast({ title: 'Error saving file', description: `File "${name}" not found.`, variant: 'fail' })
+    toast({ title: 'Error saving file', description: `File "${fileName}" not found.`, variant: 'fail' })
     return { success: false }
   }
 
@@ -106,14 +103,14 @@ export async function executeSaveActiveFile(projectPort: ProjectPort): Promise<{
     const isPouType = file.type === 'program' || file.type === 'function' || file.type === 'function-block'
 
     if (isPouType) {
-      const pou = project.data.pous.find((p) => p.name === name)
+      const pou = project.data.pous.find((p) => p.name === fileName)
       if (!pou) {
-        toast({ title: 'Error saving file', description: `POU "${name}" not found.`, variant: 'fail' })
+        toast({ title: 'Error saving file', description: `POU "${fileName}" not found.`, variant: 'fail' })
         return { success: false }
       }
 
       // Sanitize: sync variablesText from code-mode editor if applicable
-      const editorModel = state.editorActions.getEditorFromEditors(name)
+      const editorModel = state.editorActions.getEditorFromEditors(fileName)
       const sanitized = sanitizePou(pou, editorModel ?? undefined)
 
       // Serialize POU to IEC text on the frontend (single source of truth)
@@ -122,7 +119,7 @@ export async function executeSaveActiveFile(projectPort: ProjectPort): Promise<{
       // Compute file path
       const folder = getFolderFromPouType(pou.pouType)
       const ext = getExtensionFromLanguage(pou.body.language)
-      const filePath = `${projectPath}/pous/${folder}/${name}${ext}`
+      const filePath = `${projectPath}/pous/${folder}/${fileName}${ext}`
 
       const res = await projectPort.saveFile(filePath, textContent)
       if (!res.success) {
@@ -145,13 +142,13 @@ export async function executeSaveActiveFile(projectPort: ProjectPort): Promise<{
       }
     } else if (file.type === 'server') {
       // Servers are saved as individual JSON files in devices/servers/
-      const server = project.data.servers?.find((s) => s.name === name)
+      const server = project.data.servers?.find((s) => s.name === fileName)
       if (!server) {
-        toast({ title: 'Error saving file', description: `Server "${name}" not found.`, variant: 'fail' })
+        toast({ title: 'Error saving file', description: `Server "${fileName}" not found.`, variant: 'fail' })
         return { success: false }
       }
       const res = await projectPort.saveFile(
-        `${projectPath}/devices/servers/${name}.json`,
+        `${projectPath}/devices/servers/${fileName}.json`,
         JSON.stringify(server, null, 2),
       )
       if (!res.success) {
@@ -160,13 +157,13 @@ export async function executeSaveActiveFile(projectPort: ProjectPort): Promise<{
       }
     } else if (file.type === 'remote-device') {
       // Remote devices are saved as individual JSON files in devices/remote/
-      const device = project.data.remoteDevices?.find((d) => d.name === name)
+      const device = project.data.remoteDevices?.find((d) => d.name === fileName)
       if (!device) {
-        toast({ title: 'Error saving file', description: `Remote device "${name}" not found.`, variant: 'fail' })
+        toast({ title: 'Error saving file', description: `Remote device "${fileName}" not found.`, variant: 'fail' })
         return { success: false }
       }
       const res = await projectPort.saveFile(
-        `${projectPath}/devices/remote/${name}.json`,
+        `${projectPath}/devices/remote/${fileName}.json`,
         JSON.stringify(device, null, 2),
       )
       if (!res.success) {
@@ -189,10 +186,7 @@ export async function executeSaveActiveFile(projectPort: ProjectPort): Promise<{
           debugVariables,
         },
       }
-      const res = await projectPort.saveFile(
-        `${projectPath}/project.json`,
-        JSON.stringify(projectJson, null, 2),
-      )
+      const res = await projectPort.saveFile(`${projectPath}/project.json`, JSON.stringify(projectJson, null, 2))
       if (!res.success) {
         toast({ title: 'Error saving file', description: res.error ?? 'Save failed', variant: 'fail' })
         return { success: false }
@@ -200,18 +194,33 @@ export async function executeSaveActiveFile(projectPort: ProjectPort): Promise<{
     }
 
     // Mark only this file as saved
-    updateFile({ name, saved: true, isNew: false })
-    markSaved(name)
+    updateFile({ name: fileName, saved: true, isNew: false })
+    markSaved(fileName)
 
     // If all files are now saved, update workspace editing state
     if (checkIfAllFilesAreSaved()) {
       setEditingState('saved')
     }
 
-    toast({ title: 'File saved', description: `"${name}" saved successfully.`, variant: 'default' })
+    toast({ title: 'File saved', description: `"${fileName}" saved successfully.`, variant: 'default' })
     return { success: true }
   } catch {
     toast({ title: 'Error saving file', description: 'An unexpected error occurred.', variant: 'fail' })
     return { success: false }
   }
+}
+
+/**
+ * Save the currently active file (the one focused in the editor).
+ * Equivalent to Ctrl+S / "Save" menu item.
+ *
+ * Thin wrapper around executeSaveFile that resolves the active editor name.
+ */
+export async function executeSaveActiveFile(projectPort: ProjectPort): Promise<{ success: boolean }> {
+  const name = openPLCStoreBase.getState().editor.meta.name
+  if (!name) {
+    toast({ title: 'No file open', description: 'There is no file to save.', variant: 'fail' })
+    return { success: false }
+  }
+  return executeSaveFile(name, projectPort)
 }

--- a/src/frontend/utils/save-actions.ts
+++ b/src/frontend/utils/save-actions.ts
@@ -129,22 +129,6 @@ export async function executeSaveActiveFile(projectPort: ProjectPort): Promise<{
         toast({ title: 'Error saving file', description: res.error ?? 'Save failed', variant: 'fail' })
         return { success: false }
       }
-
-      // Also save project.json with updated debug variables
-      const debugVariables = collectDebugVariables(
-        project.data.configurations.resource.globalVariables,
-        project.data.pous,
-      )
-      const projectJson = {
-        meta: { name: project.meta.name, type: 'plc-project' },
-        data: {
-          dataTypes: project.data.dataTypes,
-          pous: [],
-          configuration: project.data.configurations,
-          debugVariables,
-        },
-      }
-      await projectPort.saveFile(`${projectPath}/project.json`, JSON.stringify(projectJson, null, 2))
     } else if (file.type === 'device') {
       // Device config: two JSON files
       const configRes = await projectPort.saveFile(
@@ -159,8 +143,39 @@ export async function executeSaveActiveFile(projectPort: ProjectPort): Promise<{
         toast({ title: 'Error saving device config', description: 'Save failed', variant: 'fail' })
         return { success: false }
       }
+    } else if (file.type === 'server') {
+      // Servers are saved as individual JSON files in devices/servers/
+      const server = project.data.servers?.find((s) => s.name === name)
+      if (!server) {
+        toast({ title: 'Error saving file', description: `Server "${name}" not found.`, variant: 'fail' })
+        return { success: false }
+      }
+      const res = await projectPort.saveFile(
+        `${projectPath}/devices/servers/${name}.json`,
+        JSON.stringify(server, null, 2),
+      )
+      if (!res.success) {
+        toast({ title: 'Error saving file', description: res.error ?? 'Save failed', variant: 'fail' })
+        return { success: false }
+      }
+    } else if (file.type === 'remote-device') {
+      // Remote devices are saved as individual JSON files in devices/remote/
+      const device = project.data.remoteDevices?.find((d) => d.name === name)
+      if (!device) {
+        toast({ title: 'Error saving file', description: `Remote device "${name}" not found.`, variant: 'fail' })
+        return { success: false }
+      }
+      const res = await projectPort.saveFile(
+        `${projectPath}/devices/remote/${name}.json`,
+        JSON.stringify(device, null, 2),
+      )
+      if (!res.success) {
+        toast({ title: 'Error saving file', description: res.error ?? 'Save failed', variant: 'fail' })
+        return { success: false }
+      }
     } else {
-      // data-type, resource, server, remote-device: all live in project.json
+      // data-type, resource: live in project.json
+      // Build project.json with the EXACT same structure the backend saveProject writes
       const debugVariables = collectDebugVariables(
         project.data.configurations.resource.globalVariables,
         project.data.pous,
@@ -171,8 +186,6 @@ export async function executeSaveActiveFile(projectPort: ProjectPort): Promise<{
           dataTypes: project.data.dataTypes,
           pous: [],
           configuration: project.data.configurations,
-          servers: project.data.servers,
-          remoteDevices: project.data.remoteDevices,
           debugVariables,
         },
       }

--- a/src/frontend/utils/save-actions.ts
+++ b/src/frontend/utils/save-actions.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared save actions for the OpenPLC editor.
+ *
+ * These functions are called from multiple UI entry points (keyboard shortcuts,
+ * menu items, activity bar, modals) and centralise the save logic so it isn't
+ * duplicated. They read state from the store, perform serialization, call the
+ * platform port, and update state on success/failure.
+ */
+
+import type { ProjectPort } from '../../middleware/shared/ports/project-port'
+import { openPLCStoreBase } from '../store'
+import { prepareSavePayload } from './save-project'
+import { toast } from './toast'
+
+/**
+ * Save the entire project (all files, device config, debug variables).
+ * Equivalent to Ctrl+Shift+S / "Save Project" menu item.
+ */
+export async function executeSaveProject(projectPort: ProjectPort): Promise<{ success: boolean }> {
+  const state = openPLCStoreBase.getState()
+  const { project, editors, editor: activeEditor, deviceDefinitions } = state
+  const { setEditingState } = state.workspaceActions
+  const { setAllToSaved } = state.fileActions
+  const { markAllSaved } = state.snapshotActions
+
+  setEditingState('save-request')
+  toast({
+    title: 'Save changes',
+    description: 'Trying to save the changes in the project file.',
+    variant: 'warn',
+  })
+
+  try {
+    const params = prepareSavePayload({
+      projectPath: project.meta.path,
+      projectName: project.meta.name,
+      projectData: project.data,
+      deviceConfiguration: deviceDefinitions.configuration,
+      devicePinMapping: deviceDefinitions.pinMapping.pins,
+      editors,
+      activeEditor,
+    })
+
+    const res = await projectPort.saveProject(params)
+    if (res.success) {
+      setEditingState('saved')
+      setAllToSaved()
+      markAllSaved()
+      toast({
+        title: 'Changes saved!',
+        description: 'The project was saved successfully!',
+        variant: 'default',
+      })
+    } else {
+      setEditingState('unsaved')
+      toast({
+        title: 'Error in the save request!',
+        description: res.error ?? 'Save failed',
+        variant: 'fail',
+      })
+    }
+    return { success: res.success }
+  } catch {
+    setEditingState('unsaved')
+    toast({
+      title: 'Error in the save request!',
+      description: 'An unexpected error occurred while saving.',
+      variant: 'fail',
+    })
+    return { success: false }
+  }
+}

--- a/src/frontend/utils/save-actions.ts
+++ b/src/frontend/utils/save-actions.ts
@@ -9,7 +9,9 @@
 
 import type { ProjectPort } from '../../middleware/shared/ports/project-port'
 import { openPLCStoreBase } from '../store'
-import { prepareSavePayload } from './save-project'
+import { getExtensionFromLanguage, getFolderFromPouType } from './PLC/pou-file-extensions'
+import { serializePouToText } from './PLC/pou-text-serializer'
+import { collectDebugVariables, prepareSavePayload, sanitizePou } from './save-project'
 import { toast } from './toast'
 
 /**
@@ -67,6 +69,136 @@ export async function executeSaveProject(projectPort: ProjectPort): Promise<{ su
       description: 'An unexpected error occurred while saving.',
       variant: 'fail',
     })
+    return { success: false }
+  }
+}
+
+/**
+ * Save only the active file (the POU/resource currently open in the editor).
+ * Equivalent to Ctrl+S / "Save" menu item.
+ *
+ * For POUs: serializes to IEC text on the frontend, writes via projectPort.saveFile.
+ * For device/data-type/resource/server/remote-device: writes appropriate JSON files.
+ * Also updates project.json when debug variables may have changed.
+ */
+export async function executeSaveActiveFile(projectPort: ProjectPort): Promise<{ success: boolean }> {
+  const state = openPLCStoreBase.getState()
+  const { project, editor: activeEditor, files } = state
+  const { setEditingState } = state.workspaceActions
+  const { updateFile, checkIfAllFilesAreSaved } = state.fileActions
+  const { markSaved } = state.snapshotActions
+
+  const name = activeEditor.meta.name
+  if (!name) {
+    toast({ title: 'No file open', description: 'There is no file to save.', variant: 'fail' })
+    return { success: false }
+  }
+
+  const file = files[name]
+  if (!file) {
+    toast({ title: 'Error saving file', description: `File "${name}" not found.`, variant: 'fail' })
+    return { success: false }
+  }
+
+  const projectPath = project.meta.path
+
+  try {
+    const isPouType = file.type === 'program' || file.type === 'function' || file.type === 'function-block'
+
+    if (isPouType) {
+      const pou = project.data.pous.find((p) => p.name === name)
+      if (!pou) {
+        toast({ title: 'Error saving file', description: `POU "${name}" not found.`, variant: 'fail' })
+        return { success: false }
+      }
+
+      // Sanitize: sync variablesText from code-mode editor if applicable
+      const editorModel = state.editorActions.getEditorFromEditors(name)
+      const sanitized = sanitizePou(pou, editorModel ?? undefined)
+
+      // Serialize POU to IEC text on the frontend (single source of truth)
+      const textContent = serializePouToText(sanitized)
+
+      // Compute file path
+      const folder = getFolderFromPouType(pou.pouType)
+      const ext = getExtensionFromLanguage(pou.body.language)
+      const filePath = `${projectPath}/pous/${folder}/${name}${ext}`
+
+      const res = await projectPort.saveFile(filePath, textContent)
+      if (!res.success) {
+        toast({ title: 'Error saving file', description: res.error ?? 'Save failed', variant: 'fail' })
+        return { success: false }
+      }
+
+      // Also save project.json with updated debug variables
+      const debugVariables = collectDebugVariables(
+        project.data.configurations.resource.globalVariables,
+        project.data.pous,
+      )
+      const projectJson = {
+        meta: { name: project.meta.name, type: 'plc-project' },
+        data: {
+          dataTypes: project.data.dataTypes,
+          pous: [],
+          configuration: project.data.configurations,
+          debugVariables,
+        },
+      }
+      await projectPort.saveFile(`${projectPath}/project.json`, JSON.stringify(projectJson, null, 2))
+    } else if (file.type === 'device') {
+      // Device config: two JSON files
+      const configRes = await projectPort.saveFile(
+        `${projectPath}/devices/configuration.json`,
+        JSON.stringify(state.deviceDefinitions.configuration, null, 2),
+      )
+      const pinRes = await projectPort.saveFile(
+        `${projectPath}/devices/pin-mapping.json`,
+        JSON.stringify(state.deviceDefinitions.pinMapping.pins, null, 2),
+      )
+      if (!configRes.success || !pinRes.success) {
+        toast({ title: 'Error saving device config', description: 'Save failed', variant: 'fail' })
+        return { success: false }
+      }
+    } else {
+      // data-type, resource, server, remote-device: all live in project.json
+      const debugVariables = collectDebugVariables(
+        project.data.configurations.resource.globalVariables,
+        project.data.pous,
+      )
+      const projectJson = {
+        meta: { name: project.meta.name, type: 'plc-project' },
+        data: {
+          dataTypes: project.data.dataTypes,
+          pous: [],
+          configuration: project.data.configurations,
+          servers: project.data.servers,
+          remoteDevices: project.data.remoteDevices,
+          debugVariables,
+        },
+      }
+      const res = await projectPort.saveFile(
+        `${projectPath}/project.json`,
+        JSON.stringify(projectJson, null, 2),
+      )
+      if (!res.success) {
+        toast({ title: 'Error saving file', description: res.error ?? 'Save failed', variant: 'fail' })
+        return { success: false }
+      }
+    }
+
+    // Mark only this file as saved
+    updateFile({ name, saved: true, isNew: false })
+    markSaved(name)
+
+    // If all files are now saved, update workspace editing state
+    if (checkIfAllFilesAreSaved()) {
+      setEditingState('saved')
+    }
+
+    toast({ title: 'File saved', description: `"${name}" saved successfully.`, variant: 'default' })
+    return { success: true }
+  } catch {
+    toast({ title: 'Error saving file', description: 'An unexpected error occurred.', variant: 'fail' })
     return { success: false }
   }
 }

--- a/src/frontend/utils/save-actions.ts
+++ b/src/frontend/utils/save-actions.ts
@@ -7,20 +7,24 @@
  * platform port, and update state on success/failure.
  */
 
-import type { ProjectPort } from '../../middleware/shared/ports/project-port'
+import type { ProjectPort, RawProjectFile, WriteProjectFiles } from '../../middleware/shared/ports/project-port'
 import { openPLCStoreBase } from '../store'
 import { getExtensionFromLanguage, getFolderFromPouType } from './PLC/pou-file-extensions'
 import { serializePouToText } from './PLC/pou-text-serializer'
-import { collectDebugVariables, prepareSavePayload, sanitizePou } from './save-project'
+import { collectDebugVariables, sanitizePou } from './save-project'
 import { toast } from './toast'
 
 /**
  * Save the entire project (all files, device config, debug variables).
  * Equivalent to Ctrl+Shift+S / "Save Project" menu item.
+ *
+ * All serialization happens here on the frontend using the same functions
+ * as the single-file save (serializePouToText, sanitizePou, etc.).
+ * The backend receives only pre-serialized strings via WriteProjectFiles.
  */
 export async function executeSaveProject(projectPort: ProjectPort): Promise<{ success: boolean }> {
   const state = openPLCStoreBase.getState()
-  const { project, editors, editor: activeEditor, deviceDefinitions } = state
+  const { project, pendingDeletions, deviceDefinitions } = state
   const { setEditingState } = state.workspaceActions
   const { setAllToSaved } = state.fileActions
   const { markAllSaved } = state.snapshotActions
@@ -33,18 +37,60 @@ export async function executeSaveProject(projectPort: ProjectPort): Promise<{ su
   })
 
   try {
-    const params = prepareSavePayload({
-      projectPath: project.meta.path,
-      projectName: project.meta.name,
-      projectData: project.data,
-      deviceConfiguration: deviceDefinitions.configuration,
-      devicePinMapping: deviceDefinitions.pinMapping.pins,
-      editors,
-      activeEditor,
+    // Serialize all POUs using the same functions as single-file save
+    const pouFiles: RawProjectFile[] = project.data.pous.map((pou) => {
+      const editorModel = state.editorActions.getEditorFromEditors(pou.name)
+      const sanitized = sanitizePou(pou, editorModel ?? undefined)
+      const folder = getFolderFromPouType(pou.pouType)
+      const ext = getExtensionFromLanguage(pou.body.language)
+      return { relativePath: `pous/${folder}/${pou.name}${ext}`, content: serializePouToText(sanitized) }
     })
 
-    const res = await projectPort.saveProject(params)
+    // Serialize servers as individual JSON files
+    const serverFiles: RawProjectFile[] = (project.data.servers ?? []).map((s) => ({
+      relativePath: `devices/servers/${s.name}.json`,
+      content: JSON.stringify(s, null, 2),
+    }))
+
+    // Serialize remote devices as individual JSON files
+    const remoteDeviceFiles: RawProjectFile[] = (project.data.remoteDevices ?? []).map((d) => ({
+      relativePath: `devices/remote/${d.name}.json`,
+      content: JSON.stringify(d, null, 2),
+    }))
+
+    // Build project.json — same structure as single-file save
+    const debugVariables = collectDebugVariables(
+      project.data.configurations.resource.globalVariables,
+      project.data.pous,
+    )
+    const projectJson = JSON.stringify(
+      {
+        meta: { name: project.meta.name, type: 'plc-project' },
+        data: {
+          dataTypes: project.data.dataTypes,
+          pous: [],
+          configuration: project.data.configurations,
+          debugVariables,
+        },
+      },
+      null,
+      2,
+    )
+
+    const files: WriteProjectFiles = {
+      projectPath: project.meta.path,
+      projectJson,
+      deviceConfig: JSON.stringify(deviceDefinitions.configuration, null, 2),
+      pinMapping: JSON.stringify(deviceDefinitions.pinMapping.pins, null, 2),
+      pouFiles,
+      serverFiles,
+      remoteDeviceFiles,
+      deletions: [...pendingDeletions],
+    }
+
+    const res = await projectPort.saveProject(files)
     if (res.success) {
+      state.projectActions.clearPendingDeletions()
       setEditingState('saved')
       setAllToSaved()
       markAllSaved()

--- a/src/frontend/utils/save-project.ts
+++ b/src/frontend/utils/save-project.ts
@@ -1,11 +1,10 @@
 /**
- * Save project orchestration utilities.
+ * Save project utilities — POU sanitization and debug variable collection.
  *
- * Handles pre-save preparation (POU sanitization, debug variable collection)
- * and post-save cleanup (state reset, deleted lists, toast).
+ * These functions are shared by both full project save (executeSaveProject)
+ * and single-file save (executeSaveFile) to ensure identical serialization.
  */
 
-import type { SaveProjectParams } from '../../middleware/shared/ports/project-port'
 import type { PLCPou } from '../../middleware/shared/ports/types'
 
 // ---------------------------------------------------------------------------
@@ -76,67 +75,4 @@ export function collectDebugVariables(
   }
 
   return debugVars.global || debugVars.pous ? debugVars : undefined
-}
-
-// ---------------------------------------------------------------------------
-// Build Save Params
-// ---------------------------------------------------------------------------
-
-export interface PrepareSavePayloadArgs {
-  projectPath: string
-  projectName: string
-  projectData: {
-    dataTypes: unknown[]
-    pous: PLCPou[]
-    configurations: {
-      resource: { tasks: unknown[]; instances: unknown[]; globalVariables: { name: string; debug?: boolean }[] }
-    }
-    servers?: unknown[]
-    remoteDevices?: unknown[]
-  }
-  deviceConfiguration: SaveProjectParams['deviceConfiguration']
-  devicePinMapping: SaveProjectParams['devicePinMapping']
-  /** Current editor + editors list for POU sanitization. */
-  editors: EditorLike[]
-  activeEditor: EditorLike
-}
-
-/**
- * Prepares the save payload by sanitizing POUs and collecting debug variables.
- * Returns a SaveProjectParams ready to be passed to `projectPort.saveProject()`.
- */
-export function prepareSavePayload(args: PrepareSavePayloadArgs): SaveProjectParams {
-  const { projectPath, projectName, projectData, deviceConfiguration, devicePinMapping, editors, activeEditor } = args
-
-  // Build editor lookup for POU sanitization
-  const editorsByName = new Map<string, EditorLike>()
-  for (const ed of editors) {
-    if (ed.type === 'plc-textual' || ed.type === 'plc-graphical') {
-      editorsByName.set(ed.meta.name, ed)
-    }
-  }
-  if (activeEditor.type === 'plc-textual' || activeEditor.type === 'plc-graphical') {
-    editorsByName.set(activeEditor.meta.name, activeEditor)
-  }
-
-  // Sanitize POUs (sync variablesText from code editor)
-  const sanitizedPous = projectData.pous.map((pou) => sanitizePou(pou, editorsByName.get(pou.name)))
-
-  // Collect debug variable flags
-  const debugVariables = collectDebugVariables(projectData.configurations.resource.globalVariables, projectData.pous)
-
-  // Build project data with sanitized POUs and debug variables
-  const preparedProjectData = {
-    ...projectData,
-    pous: sanitizedPous,
-    debugVariables,
-  }
-
-  return {
-    projectPath,
-    projectName,
-    projectData: preparedProjectData as SaveProjectParams['projectData'],
-    deviceConfiguration,
-    devicePinMapping,
-  }
 }

--- a/src/frontend/utils/save-project.ts
+++ b/src/frontend/utils/save-project.ts
@@ -13,7 +13,7 @@ import type { PLCPou } from '../../middleware/shared/ports/types'
 // ---------------------------------------------------------------------------
 
 /** Minimal editor shape needed for POU sanitization. */
-interface EditorLike {
+export interface EditorLike {
   type: string
   meta: { name: string }
   variable?: { display: string; code?: string | null }
@@ -30,7 +30,7 @@ interface EditorLike {
  * editor model but hasn't been parsed back into structured variables yet.
  * Before saving we must capture that text so the IPC layer writes it to disk.
  */
-function sanitizePou(pou: PLCPou, editor: EditorLike | undefined): PLCPou {
+export function sanitizePou(pou: PLCPou, editor: EditorLike | undefined): PLCPou {
   if (!editor || (editor.type !== 'plc-textual' && editor.type !== 'plc-graphical') || !editor.variable) {
     return pou
   }
@@ -53,7 +53,7 @@ function sanitizePou(pou: PLCPou, editor: EditorLike | undefined): PLCPou {
  * Collects debug flags from all variables (global + per-POU).
  * Returns undefined if no variables have debug enabled.
  */
-function collectDebugVariables(
+export function collectDebugVariables(
   globalVariables: { name: string; debug?: boolean }[],
   pous: PLCPou[],
 ): { global?: string[]; pous?: Record<string, string[]> } | undefined {

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -1,8 +1,7 @@
 import { getRuntimeHttpsOptions } from '@root/backend/editor/utils/runtime-https-config'
 import { CreatePouFileProps } from '@root/types/IPC/pou-service'
 import { CreateProjectFileProps } from '@root/types/IPC/project-service'
-import { DeviceConfiguration, DevicePin } from '@root/types/PLC/devices'
-import { PLCPou, PLCProject, PLCProjectData } from '@root/types/PLC/open-plc'
+import { PLCProjectData } from '@root/types/PLC/open-plc'
 import { RuntimeLogEntry } from '@root/types/PLC/runtime-logs'
 import { getErrorMessage } from '@root/utils/get-error-message'
 import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron'
@@ -21,16 +20,6 @@ import { getProjectPath } from '../../../backend/editor/utils'
 import { WebSocketDebugClient } from '../../../backend/editor/websocket/websocket-debug-client'
 import { SimulatorModule } from '../../../backend/shared/simulator/simulator-module'
 import { VirtualSerialPort } from '../../../backend/shared/simulator/virtual-serial-port'
-
-type IDataToWrite = {
-  projectPath: string
-  content: {
-    pous: PLCPou[]
-    projectData: PLCProject
-    deviceConfiguration: DeviceConfiguration
-    devicePinMapping: DevicePin[]
-  }
-}
 
 class MainProcessBridge implements MainIpcModule {
   ipcMain
@@ -485,7 +474,7 @@ class MainProcessBridge implements MainIpcModule {
     this.registerHandle('project:create', this.handleProjectCreate)
     this.registerHandle('project:open', this.handleProjectOpen)
     this.registerHandle('project:path-picker', this.handleProjectPathPicker)
-    this.registerHandle('project:save', this.handleProjectSave)
+    this.registerHandle('project:write-files', this.handleWriteProjectFiles)
     this.registerHandle('project:save-file', this.handleFileSave)
     this.registerHandle('project:open-by-path', this.handleProjectOpenByPath)
     this.registerHandle('project:read-files', this.handleReadProjectFiles)
@@ -617,8 +606,8 @@ class MainProcessBridge implements MainIpcModule {
     }
     return result
   }
-  handleProjectSave = (_event: IpcMainInvokeEvent, { projectPath, content }: IDataToWrite) =>
-    this.projectService.saveProject({ projectPath, content })
+  handleWriteProjectFiles = (_event: IpcMainInvokeEvent, files: unknown) =>
+    this.projectService.writeProjectFiles(files as Parameters<typeof this.projectService.writeProjectFiles>[0])
   handleProjectOpenByPath = async (_event: IpcMainInvokeEvent, projectPath: string) => {
     this.stopSimulatorAndNotify()
     try {

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -488,6 +488,7 @@ class MainProcessBridge implements MainIpcModule {
     this.registerHandle('project:save', this.handleProjectSave)
     this.registerHandle('project:save-file', this.handleFileSave)
     this.registerHandle('project:open-by-path', this.handleProjectOpenByPath)
+    this.registerHandle('project:read-files', this.handleReadProjectFiles)
 
     // Pou-related handlers
     this.registerHandle('pou:create', this.handleCreatePouFile)
@@ -633,6 +634,23 @@ class MainProcessBridge implements MainIpcModule {
           title: 'Error opening project',
           description: 'Please try again',
         },
+      }
+    }
+  }
+
+  handleReadProjectFiles = async (_event: IpcMainInvokeEvent, projectPath: string) => {
+    try {
+      this.stopSimulatorAndNotify()
+      const result = await this.projectService.readRawProjectFiles(projectPath)
+      if (result.success) {
+        this.currentProjectPath = projectPath
+        await this.projectService.updateProjectHistory(projectPath)
+      }
+      return result
+    } catch (_error) {
+      return {
+        success: false,
+        error: { title: 'Error reading project', description: 'Failed to read project files' },
       }
     }
   }

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -65,6 +65,8 @@ const rendererProcessBridge = {
     ipcRenderer.on('project:open-recent-accelerator', (_event, val: IProjectServiceResponse) => callback(_event, val)),
   pathPicker: (): Promise<{ success: boolean; error?: { title: string; description: string }; path?: string }> =>
     ipcRenderer.invoke('project:path-picker'),
+  readProjectFiles: (projectPath: string): Promise<unknown> =>
+    ipcRenderer.invoke('project:read-files', projectPath),
   removeCloseProjectListener: () => ipcRenderer.removeAllListeners('workspace:close-project-accelerator'),
   removeCloseTabListener: () => ipcRenderer.removeAllListeners('workspace:close-tab-accelerator'),
   removeCreateProjectAccelerator: () => ipcRenderer.removeAllListeners('project:create-accelerator'),

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -1,10 +1,7 @@
 import { CreatePouFileProps, PouServiceResponse } from '@root/types/IPC/pou-service'
 import { CreateProjectFileProps, IProjectServiceResponse } from '@root/types/IPC/project-service'
-import { DeviceConfiguration, DevicePin } from '@root/types/PLC/devices'
 import { RuntimeLogEntry } from '@root/types/PLC/runtime-logs'
 import { ipcRenderer, IpcRendererEvent } from 'electron'
-
-import { PLCPou, PLCProject, PLCProjectData } from '../../../types/PLC/open-plc'
 
 type IpcRendererCallbacks = (_event: IpcRendererEvent, ...args: unknown[]) => void
 
@@ -15,26 +12,6 @@ type CompilerPortMessage = {
   simulatorFirmwarePath?: string
   plcStatus?: string
   closePort?: boolean
-}
-
-type IDataToWrite = {
-  projectPath: string
-  content: {
-    projectData: PLCProject
-    pous: PLCPou[]
-    deviceConfiguration: DeviceConfiguration
-    devicePinMapping: DevicePin[]
-    servers?: PLCProjectData['servers']
-    remoteDevices?: PLCProjectData['remoteDevices']
-  }
-}
-
-export type ISaveDataResponse = {
-  success: boolean
-  reason: {
-    title: string
-    description: string
-  }
 }
 
 /**
@@ -77,8 +54,8 @@ const rendererProcessBridge = {
   saveFile: (filePath: string, content: unknown): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('project:save-file', filePath, content),
   saveFileAccelerator: (callback: IpcRendererCallbacks) => ipcRenderer.on('project:save-file-accelerator', callback),
-  saveProject: (dataToWrite: IDataToWrite): Promise<ISaveDataResponse> =>
-    ipcRenderer.invoke('project:save', dataToWrite),
+  writeProjectFiles: (files: unknown): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('project:write-files', files),
   saveProjectAccelerator: (callback: IpcRendererCallbacks) => ipcRenderer.on('project:save-accelerator', callback),
   switchPerspective: (callback: IpcRendererCallbacks) =>
     ipcRenderer.on('workspace:switch-perspective-accelerator', callback),

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -65,8 +65,7 @@ const rendererProcessBridge = {
     ipcRenderer.on('project:open-recent-accelerator', (_event, val: IProjectServiceResponse) => callback(_event, val)),
   pathPicker: (): Promise<{ success: boolean; error?: { title: string; description: string }; path?: string }> =>
     ipcRenderer.invoke('project:path-picker'),
-  readProjectFiles: (projectPath: string): Promise<unknown> =>
-    ipcRenderer.invoke('project:read-files', projectPath),
+  readProjectFiles: (projectPath: string): Promise<unknown> => ipcRenderer.invoke('project:read-files', projectPath),
   removeCloseProjectListener: () => ipcRenderer.removeAllListeners('workspace:close-project-accelerator'),
   removeCloseTabListener: () => ipcRenderer.removeAllListeners('workspace:close-tab-accelerator'),
   removeCreateProjectAccelerator: () => ipcRenderer.removeAllListeners('project:create-accelerator'),

--- a/src/middleware/adapters/editor/__tests__/project-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/project-adapter.test.ts
@@ -63,8 +63,8 @@ const mockErrorResponse = {
   error: { title: 'Error', description: 'Something went wrong', error: new Error('fail') },
 }
 
-const mockSaveResponse = { success: true, reason: { title: '', description: '' } }
-const mockSaveErrorResponse = { success: false, reason: { title: 'Save Error', description: 'Disk full' } }
+const mockSaveResponse = { success: true }
+const mockSaveErrorResponse = { success: false, error: 'Disk full' }
 
 const mockPouResponse = { success: true, data: { filePath: '/path/to/pou.st', pou: {} } }
 const mockPouErrorResponse = {
@@ -81,7 +81,7 @@ beforeEach(() => {
     createProject: jest.fn().mockResolvedValue(mockIpcProjectResponse),
     openProject: jest.fn().mockResolvedValue(mockIpcProjectResponse),
     openProjectByPath: jest.fn().mockResolvedValue(mockIpcProjectResponse),
-    saveProject: jest.fn().mockResolvedValue(mockSaveResponse),
+    writeProjectFiles: jest.fn().mockResolvedValue(mockSaveResponse),
     saveFile: jest.fn().mockResolvedValue({ success: true }),
     createPouFile: jest.fn().mockResolvedValue(mockPouResponse),
     deletePouFile: jest.fn().mockResolvedValue({ success: true }),
@@ -214,64 +214,28 @@ describe('createEditorProjectAdapter', () => {
   })
 
   describe('saveProject', () => {
-    const saveParams = {
+    const writeFiles = {
       projectPath: '/home/user/projects/my-project',
-      projectData: {
-        dataTypes: [],
-        pous: [
-          {
-            name: 'main',
-            pouType: 'program' as const,
-            body: { language: 'st' as const, value: 'x := TRUE;' },
-            documentation: 'test',
-          },
-        ],
-        configurations: { resource: { tasks: [], instances: [], globalVariables: [] } },
-      },
-      deviceConfiguration: {
-        deviceBoard: 'Arduino Uno',
-        communicationPort: '',
-        compileOnly: false,
-        communicationConfiguration: {
-          modbusRTU: { rtuInterface: '', rtuBaudRate: '115200', rtuSlaveId: null, rtuRS485ENPin: null },
-          modbusTCP: {
-            tcpInterface: '',
-            tcpMacAddress: null,
-            tcpStaticHostConfiguration: { ipAddress: '', dns: '', gateway: '', subnet: '' },
-          },
-          communicationPreferences: { enabledRTU: false, enabledTCP: false, enabledDHCP: true },
-        },
-      },
-      devicePinMapping: [],
+      projectJson: '{"meta":{"name":"my-project","type":"plc-project"},"data":{}}',
+      deviceConfig: '{}',
+      pinMapping: '[]',
+      pouFiles: [{ relativePath: 'pous/programs/main.st', content: 'PROGRAM main\nEND_PROGRAM' }],
+      serverFiles: [],
+      remoteDeviceFiles: [],
+      deletions: [],
     }
 
-    it('delegates to window.bridge.saveProject with mapped data', async () => {
-      const result = await adapter.saveProject(saveParams)
+    it('delegates pre-serialized files to window.bridge.writeProjectFiles', async () => {
+      const result = await adapter.saveProject(writeFiles)
 
-      expect(window.bridge.saveProject).toHaveBeenCalledTimes(1)
+      expect(window.bridge.writeProjectFiles).toHaveBeenCalledWith(writeFiles)
       expect(result).toEqual({ success: true })
     })
 
-    it('converts flat POUs to discriminated union format', async () => {
-      await adapter.saveProject(saveParams)
-
-      const callArg = (window.bridge.saveProject as jest.Mock).mock.calls[0][0]
-      expect(callArg.content.pous[0]).toEqual(
-        expect.objectContaining({ type: 'program', data: expect.objectContaining({ name: 'main' }) }),
-      )
-    })
-
-    it('maps configurations back to configuration (singular)', async () => {
-      await adapter.saveProject(saveParams)
-
-      const callArg = (window.bridge.saveProject as jest.Mock).mock.calls[0][0]
-      expect(callArg.content.projectData.data.configuration).toEqual(saveParams.projectData.configurations)
-    })
-
     it('returns error message on save failure', async () => {
-      ;(window.bridge.saveProject as jest.Mock).mockResolvedValue(mockSaveErrorResponse)
+      ;(window.bridge.writeProjectFiles as jest.Mock).mockResolvedValue(mockSaveErrorResponse)
 
-      const result = await adapter.saveProject(saveParams)
+      const result = await adapter.saveProject(writeFiles)
 
       expect(result).toEqual({ success: false, error: 'Disk full' })
     })

--- a/src/middleware/adapters/editor/project-adapter.ts
+++ b/src/middleware/adapters/editor/project-adapter.ts
@@ -10,11 +10,13 @@
  *   - Editor uses `configuration` (singular), port uses `configurations` (plural)
  */
 
+import { parseProjectFiles } from '../../../frontend/utils/parse-project-files'
 import type {
   CreatePouParams,
   CreateProjectParams,
   ProjectPort,
   ProjectResponse,
+  RawProjectFiles,
   RenamePouParams,
   SaveProjectParams,
 } from '../../shared/ports/project-port'
@@ -172,13 +174,48 @@ export function createEditorProjectAdapter(): ProjectPort {
     },
 
     async openProject(): Promise<ProjectResponse> {
-      const response = (await window.bridge.openProject()) as unknown as IpcProjectResponse
-      return mapIpcResponse(response)
+      // Use file picker to get directory path
+      const pickResult = await window.bridge.pathPicker()
+      if (!pickResult.success || !pickResult.path) {
+        return { success: false, error: pickResult.error ?? { title: 'Cancelled', description: 'No project selected' } }
+      }
+      // Read raw files and parse on the frontend
+      const raw = (await window.bridge.readProjectFiles(pickResult.path)) as RawProjectFiles
+      if (!raw.success || !raw.data) {
+        return { success: false, error: raw.error }
+      }
+      const parsed = parseProjectFiles(
+        raw.data.projectPath,
+        raw.data.projectJson,
+        raw.data.deviceConfig,
+        raw.data.pinMapping,
+        raw.data.pouFiles,
+        raw.data.serverFiles,
+        raw.data.remoteDeviceFiles,
+      )
+      return { success: true, data: parsed }
     },
 
     async openProjectByPath(projectPath: string): Promise<ProjectResponse> {
-      const response = (await window.bridge.openProjectByPath(projectPath)) as unknown as IpcProjectResponse
-      return mapIpcResponse(response)
+      // Read raw files and parse on the frontend
+      const raw = (await window.bridge.readProjectFiles(projectPath)) as RawProjectFiles
+      if (!raw.success || !raw.data) {
+        return { success: false, error: raw.error }
+      }
+      const parsed = parseProjectFiles(
+        raw.data.projectPath,
+        raw.data.projectJson,
+        raw.data.deviceConfig,
+        raw.data.pinMapping,
+        raw.data.pouFiles,
+        raw.data.serverFiles,
+        raw.data.remoteDeviceFiles,
+      )
+      return { success: true, data: parsed }
+    },
+
+    async readProjectFiles(projectPath: string): Promise<RawProjectFiles> {
+      return (await window.bridge.readProjectFiles(projectPath)) as RawProjectFiles
     },
 
     async saveProject(params: SaveProjectParams): Promise<{ success: boolean; error?: string }> {

--- a/src/middleware/adapters/editor/project-adapter.ts
+++ b/src/middleware/adapters/editor/project-adapter.ts
@@ -18,7 +18,7 @@ import type {
   ProjectResponse,
   RawProjectFiles,
   RenamePouParams,
-  SaveProjectParams,
+  WriteProjectFiles,
 } from '../../shared/ports/project-port'
 import type {
   DeviceConfiguration,
@@ -70,12 +70,6 @@ interface IpcProjectResponse {
       devicePinMapping: DevicePin[]
     }
   }
-}
-
-/** Editor IPC save response shape. */
-interface IpcSaveResponse {
-  success: boolean
-  error?: { title: string; description: string }
 }
 
 /** Editor IPC POU service response shape. */
@@ -218,45 +212,11 @@ export function createEditorProjectAdapter(): ProjectPort {
       return (await window.bridge.readProjectFiles(projectPath)) as RawProjectFiles
     },
 
-    async saveProject(params: SaveProjectParams): Promise<{ success: boolean; error?: string }> {
-      const pathParts = params.projectPath.replace(/\\/g, '/').split('/')
-      const projectName = pathParts[pathParts.length - 1] || 'untitled'
-      const editorPous = params.projectData.pous.map(mapPortPouToIpcPou)
-
-      // Inject variablesText from sanitized POUs into IPC format
-      for (let i = 0; i < params.projectData.pous.length; i++) {
-        const portPou = params.projectData.pous[i] as PLCPou & { variablesText?: string }
-        if (portPou.variablesText != null) {
-          editorPous[i].data.variablesText = portPou.variablesText
-        }
-      }
-
-      const projectDataPayload: Record<string, unknown> = {
-        meta: { name: projectName, type: 'plc-project' as const },
-        data: {
-          dataTypes: params.projectData.dataTypes,
-          pous: editorPous,
-          configuration: params.projectData.configurations,
-          debugVariables: params.projectData.debugVariables,
-        },
-      }
-
-      const response = (await window.bridge.saveProject({
-        projectPath: params.projectPath,
-        content: {
-          projectData: projectDataPayload,
-          pous: editorPous,
-          deviceConfiguration: params.deviceConfiguration,
-          devicePinMapping: params.devicePinMapping,
-          servers: params.projectData.servers ?? [],
-          remoteDevices: params.projectData.remoteDevices ?? [],
-        },
-      } as never)) as unknown as IpcSaveResponse
-
+    async saveProject(files: WriteProjectFiles): Promise<{ success: boolean; error?: string }> {
+      const response = (await window.bridge.writeProjectFiles(files)) as { success: boolean; error?: string }
       if (!response.success) {
-        return { success: false, error: response.error?.description ?? 'Save failed' }
+        return { success: false, error: response.error ?? 'Save failed' }
       }
-
       return { success: true }
     },
 

--- a/src/middleware/shared/ports/index.ts
+++ b/src/middleware/shared/ports/index.ts
@@ -140,7 +140,7 @@ export type {
   CreateProjectParams,
   ProjectResponse,
   RenamePouParams,
-  SaveProjectParams,
+  WriteProjectFiles,
 } from './project-port'
 export type {
   CompilationStatusResult,

--- a/src/middleware/shared/ports/project-port.ts
+++ b/src/middleware/shared/ports/project-port.ts
@@ -46,6 +46,8 @@ export interface ProjectResponse {
     projectData: PLCProjectData
     deviceConfiguration?: DeviceConfiguration
     devicePinMapping?: DevicePin[]
+    /** Warnings from parsing (e.g. dropped files that failed validation). */
+    warnings?: string[]
   }
   error?: {
     title: string

--- a/src/middleware/shared/ports/project-port.ts
+++ b/src/middleware/shared/ports/project-port.ts
@@ -165,7 +165,7 @@ export interface ProjectPort {
    * Editor: reads from local filesystem via IPC.
    * Web: reads from backend API.
    */
-  readProjectFiles?(projectPath: string): Promise<RawProjectFiles>
+  readProjectFiles(projectPath: string): Promise<RawProjectFiles>
 
   /**
    * Start watching a file for external changes.

--- a/src/middleware/shared/ports/project-port.ts
+++ b/src/middleware/shared/ports/project-port.ts
@@ -79,6 +79,36 @@ export interface RenamePouParams {
 
 import type { PouType } from './types'
 
+/** Raw file entry: a file path relative to the project root and its text content. */
+export interface RawProjectFile {
+  /** Path relative to the project root (e.g., 'pous/programs/main.st') */
+  relativePath: string
+  /** Raw text content of the file */
+  content: string
+}
+
+/** Raw project files as read from disk — no parsing, just plain strings. */
+export interface RawProjectFiles {
+  success: boolean
+  data?: {
+    /** Absolute path to the project directory */
+    projectPath: string
+    /** Raw content of project.json */
+    projectJson: string
+    /** Raw content of devices/configuration.json */
+    deviceConfig: string
+    /** Raw content of devices/pin-mapping.json */
+    pinMapping: string
+    /** Raw POU files (.st, .il, .ld, .fbd, .py, .cpp, .json) */
+    pouFiles: RawProjectFile[]
+    /** Raw server config files from devices/servers/ */
+    serverFiles: RawProjectFile[]
+    /** Raw remote device config files from devices/remote/ */
+    remoteDeviceFiles: RawProjectFile[]
+  }
+  error?: { title: string; description: string }
+}
+
 export interface ProjectPort {
   /** Create a new project. */
   createProject(params: CreateProjectParams): Promise<ProjectResponse>
@@ -128,6 +158,14 @@ export interface ProjectPort {
    * Web: reads from in-memory project state or API.
    */
   readFileContent(filePath: string): Promise<{ success: boolean; content?: string; error?: string }>
+
+  /**
+   * Read all raw project files from disk without parsing.
+   * The frontend is responsible for parsing the returned content strings.
+   * Editor: reads from local filesystem via IPC.
+   * Web: reads from backend API.
+   */
+  readProjectFiles?(projectPath: string): Promise<RawProjectFiles>
 
   /**
    * Start watching a file for external changes.

--- a/src/middleware/shared/ports/project-port.ts
+++ b/src/middleware/shared/ports/project-port.ts
@@ -53,15 +53,27 @@ export interface ProjectResponse {
   }
 }
 
-export interface SaveProjectParams {
+/**
+ * Pre-serialized project files for writing to disk.
+ * All content is already serialized to strings — the backend is a dumb file writer.
+ * Mirrors the read-side RawProjectFiles shape but oriented for writing.
+ */
+export interface WriteProjectFiles {
   projectPath: string
-  projectName?: string
-  projectData: PLCProjectData & {
-    /** Debug variable flags to persist (collected before save). */
-    debugVariables?: { global?: string[]; pous?: Record<string, string[]> }
-  }
-  deviceConfiguration: DeviceConfiguration
-  devicePinMapping: DevicePin[]
+  /** Pre-serialized project.json content */
+  projectJson: string
+  /** Pre-serialized devices/configuration.json content */
+  deviceConfig: string
+  /** Pre-serialized devices/pin-mapping.json content */
+  pinMapping: string
+  /** POU files with pre-serialized IEC text content */
+  pouFiles: RawProjectFile[]
+  /** Server config files with pre-serialized JSON content */
+  serverFiles: RawProjectFile[]
+  /** Remote device config files with pre-serialized JSON content */
+  remoteDeviceFiles: RawProjectFile[]
+  /** Relative paths to delete from disk (e.g. 'pous/programs/OldPou.st') */
+  deletions: string[]
 }
 
 export interface CreatePouParams {
@@ -123,8 +135,8 @@ export interface ProjectPort {
   /** Open a project by its path or identifier. */
   openProjectByPath(projectPath: string): Promise<ProjectResponse>
 
-  /** Save the entire project (all files, configuration, pin mapping). */
-  saveProject(params: SaveProjectParams): Promise<{ success: boolean; error?: string }>
+  /** Save the entire project. All files are pre-serialized by the frontend. */
+  saveProject(files: WriteProjectFiles): Promise<{ success: boolean; error?: string }>
 
   /**
    * Save a single file within the project.


### PR DESCRIPTION
## Summary

Implements unified frontend serialization and parsing for the OpenPLC editor, following the architecture principle that the **backend is a file I/O layer** and the **frontend owns all parsing and serialization**.

### Phase 0: Deduplicate save logic
- Extracted `executeSaveProject()` into `src/frontend/utils/save-actions.ts`, replacing 3 duplicate inline implementations across accelerator handler, file menu, and activity bar
- Exported `sanitizePou`, `collectDebugVariables`, `EditorLike` from `save-project.ts` for reuse

### Phase 1: Single-file save (Ctrl+S)
- Added `executeSaveActiveFile()` — serializes POUs on the frontend via `serializePouToText()`, sends pre-serialized text to `projectPort.saveFile()`
- Ctrl+S saves only the active file; Ctrl+Shift+S saves the full project
- Fixed Monaco Ctrl+S intercepting and calling full project save instead of single-file save
- Fixed backend `saveFile` to handle raw text strings without double-encoding
- POUs save only the POU file (no project.json rewrite to prevent corruption)
- Servers save to `devices/servers/{name}.json`; remote devices to `devices/remote/{name}.json`
- Data types/resources save to `project.json` with correct structure

### Phase 2: Frontend-only project parsing
- Added `readProjectFiles` to `ProjectPort` interface — returns raw file contents as strings
- Backend `readRawProjectFiles()` reads all project files without parsing
- Created `parseProjectFiles()` frontend utility — single source of truth for all project parsing
- Adapter `openProject`/`openProjectByPath` now use `readProjectFiles` + `parseProjectFiles`
- Handles all POU languages, legacy JSON format, servers, remote devices
- Eliminates double-parsing (backend parsed, then frontend re-parsed for type classification)

### Build fix
- Fixed dev webpack output filename from `[name].bundle.dev.js` to `[name].js` to match what `main.ts` loads
- Updated `package.json` main entry accordingly

## Architecture after changes

```
LOAD:
  Backend: fs.readFile → raw strings → IPC
  Adapter: readProjectFiles() → parseProjectFiles() → ProjectResponse
  Frontend: handleOpenProjectResponse() → store

SAVE (single file, Ctrl+S):
  Frontend: serializePouToText() → text string
  Adapter: projectPort.saveFile(path, text)
  Backend: fs.writeFile

SAVE (full project, Ctrl+Shift+S):
  Frontend: prepareSavePayload() → executeSaveProject()
  Adapter: projectPort.saveProject()
  Backend: existing full save path
```

## Test plan
- [ ] Open project — all POUs load correctly (ST, IL, LD, FBD, Python, C++)
- [ ] Variables correctly classified (base-type, derived, array, user-data-type)
- [ ] Graphical POUs (LD/FBD) load with correct nodes/edges
- [ ] Ctrl+S on ST POU — only that file saved, other dirty POUs remain dirty
- [ ] Ctrl+S on FBD POU — same behavior
- [ ] Ctrl+Shift+S — saves entire project, all files marked saved
- [ ] File menu "Save" vs "Save Project" — correct behavior
- [ ] Close unsaved tab → Don't Save → reopen — original content restored
- [ ] Close unsaved tab → Save → file saved and tab closed
- [ ] Recent projects still work
- [ ] No project corruption after save/load cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)