### PR TITLE
fix: compilation plugin configs + device board persistence

### DIFF
--- a/src/frontend/screens/workspace-screen.tsx
+++ b/src/frontend/screens/workspace-screen.tsx
@@ -32,8 +32,6 @@ import { useRuntimePolling } from '../hooks/use-runtime-polling'
 import { useOpenPLCStore } from '../store'
 import { cn } from '../utils/cn'
 
-const SIMULATOR_BOARD_NAME = 'OpenPLC Simulator'
-
 const WorkspaceScreen = () => {
   const capabilities = useCapabilities()
   const ChatPanel = useChatPanel()
@@ -63,7 +61,7 @@ const WorkspaceScreen = () => {
       toggleDebugExpandedNode,
       setDebugGraphList,
     },
-    deviceActions: { setAvailableOptions, setDeviceBoard },
+    deviceActions: { setAvailableOptions },
     searchResults,
     ai: { isChatOpen, isEnabled: isAIEnabled, hasConsented: hasAIConsented },
     project: {
@@ -261,20 +259,16 @@ const WorkspaceScreen = () => {
         const boardsMap = await device.getAvailableBoards()
         setAvailableOptions({ availableBoards: boardsMap })
 
-        // Default to simulator board if no orchestrator device is connected
-        const { runtimeConnection, deviceDefinitions } = useOpenPLCStore.getState()
-        const currentBoard = deviceDefinitions.configuration.deviceBoard
-        const currentBoardInfo = boardsMap.get(currentBoard)
-        if (runtimeConnection.connectionStatus !== 'connected' && currentBoardInfo?.compiler !== 'simulator') {
-          setDeviceBoard(SIMULATOR_BOARD_NAME)
-        }
+        // Respect the board saved in the project — do not override on load.
+        // The user explicitly chose a target board; resetting it would discard
+        // their selection every time the project reopens.
       } catch (error) {
         console.error('Failed to load boards data:', error)
       }
     }
 
     void loadAvailableBoards()
-  }, [device, setAvailableOptions, setDeviceBoard])
+  }, [device, setAvailableOptions])
 
   return (
     <div className='flex h-full w-full overflow-hidden bg-brand-dark dark:bg-neutral-950'>

--- a/src/frontend/store/slices/device/slice.ts
+++ b/src/frontend/store/slices/device/slice.ts
@@ -502,7 +502,7 @@ function mergeDeviceConfigWithDefaults(
   defaults: DeviceConfiguration,
 ): DeviceConfiguration {
   return {
-    deviceBoard: provided.deviceBoard ?? defaults.deviceBoard,
+    deviceBoard: provided.deviceBoard || defaults.deviceBoard,
     communicationPort: provided.communicationPort ?? defaults.communicationPort,
     runtimeIpAddress: provided.runtimeIpAddress ?? defaults.runtimeIpAddress,
     compileOnly: provided.compileOnly ?? defaults.compileOnly,

--- a/src/middleware/adapters/editor/compiler-adapter.ts
+++ b/src/middleware/adapters/editor/compiler-adapter.ts
@@ -41,6 +41,8 @@ interface IpcProjectData {
     }
   }>
   configuration: PLCProjectData['configurations']
+  servers?: PLCProjectData['servers']
+  remoteDevices?: PLCProjectData['remoteDevices']
   originalCppPous?: Array<{ name: string; code: string; variables: unknown[] }>
 }
 
@@ -64,6 +66,8 @@ function toIpcProjectData(data: PLCProjectData & { originalCppPous?: unknown[] }
     dataTypes: data.dataTypes,
     pous: data.pous.map(portPouToIpcPou),
     configuration: data.configurations,
+    servers: data.servers,
+    remoteDevices: data.remoteDevices,
     ...(data.originalCppPous ? { originalCppPous: data.originalCppPous as IpcProjectData['originalCppPous'] } : {}),
   }
 }


### PR DESCRIPTION
## Summary

- Fix plugin config generation: `toIpcProjectData()` in the compiler adapter was silently dropping `servers` and `remoteDevices`, causing all plugin config generators (modbus_slave, modbus_master, s7comm, opcua) to skip generation
- Fix device board persistence: workspace-screen `useEffect` was forcing the board back to 'OpenPLC Simulator' on every project open when runtime wasn't connected, discarding the user's saved selection

## Test plan
- [ ] Open project with servers/remote devices, compile — plugin configs are generated (check logs for modbus_slave.json, s7comm.json, etc.)
- [ ] Open existing project with non-simulator board — board selection is preserved
- [ ] Create new project — board defaults to OpenPLC Simulator
- [ ] Change board, save, close, reopen — board selection persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)