### PR TITLE
fix: compilation, debugger, resource editor, and lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "build:main": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./configs/webpack/webpack.config.main.prod.ts",
     "build:renderer": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./configs/webpack/webpack.config.renderer.prod.ts",
     "lint": "cross-env NODE_ENV=development eslint ./src/**/*.{ts,tsx}",
-    "lint:fix": "cross-env NODE_ENV=development eslint ./src/**/*.{ts,tsx} --debug --fix",
+    "lint:fix": "cross-env NODE_ENV=development eslint ./src/**/*.{ts,tsx} --fix",
     "lint:old": "cross-env NODE_ENV=development eslint ./src_old/**/*.{ts,tsx}",
-    "lint:old:fix": "cross-env NODE_ENV=development eslint ./src_old/**/*.{ts,tsx} --debug --fix",
+    "lint:old:fix": "cross-env NODE_ENV=development eslint ./src_old/**/*.{ts,tsx} --fix",
     "format": "cross-env NODE_ENV=development prettier --write \"./src/**/*.{ts,tsx}\"",
     "format:old": "cross-env NODE_ENV=development prettier --write \"./src_old/**/*.{ts,tsx}\"",
     "postinstall": "ts-node scripts/download-binaries.ts && ts-node scripts/check-native-dep.js && electron-builder install-app-deps && npm run build:dll",
@@ -194,13 +194,13 @@
     "logLevel": "quiet"
   },
   "lint-staged": {
-    "./src/**/*": [
-      "npm run lint:fix",
-      "npm run format"
+    "./src/**/*.{ts,tsx}": [
+      "cross-env NODE_ENV=development eslint --fix",
+      "prettier --write"
     ],
-    "./src_old/**/*": [
-      "npm run lint:old:fix",
-      "npm run format:old"
+    "./src_old/**/*.{ts,tsx}": [
+      "cross-env NODE_ENV=development eslint --fix",
+      "prettier --write"
     ]
   }
 }

--- a/src/frontend/components/_organisms/global-variables-editor/index.tsx
+++ b/src/frontend/components/_organisms/global-variables-editor/index.tsx
@@ -235,8 +235,10 @@ const GlobalVariablesEditor = () => {
       selectedRow === ROWS_NOT_SELECTED ? variables[variables.length - 1] : variables[selectedRow]
     ) as PLCGlobalVariable
 
+    const newVarData = { ...variable, documentation: '' }
+
     if (selectedRow === ROWS_NOT_SELECTED) {
-      createVariable({ scope: 'global', data: { ...variable } })
+      createVariable({ scope: 'global', data: newVarData })
       updateModelVariables({
         display: 'table',
         selectedRow: variables.length,
@@ -247,7 +249,7 @@ const GlobalVariablesEditor = () => {
 
     createVariable({
       scope: 'global',
-      data: { ...variable },
+      data: newVarData,
       rowToInsert: selectedRow + 1,
     })
     updateModelVariables({

--- a/src/frontend/components/_organisms/instances-editor/index.tsx
+++ b/src/frontend/components/_organisms/instances-editor/index.tsx
@@ -133,16 +133,17 @@ const InstancesEditor = () => {
     handleFileAndWorkspaceSavedState('Resource')
   }
 
-  const getNextInstanceName = (existingInstances: PLCInstance[]) => {
-    const baseName = 'instance'
-    const numbers = existingInstances
-      .map((inst) => {
-        const match = inst.name.match(/^instance(\d+)$/i)
-        return match ? parseInt(match[1], 10) : -1
+  const getNextName = (baseName: string, existingNames: string[]) => {
+    const baseWithoutNumber = baseName.replace(/\d+$/, '')
+    const numbers = existingNames
+      .filter((n) => n.toLowerCase().startsWith(baseWithoutNumber.toLowerCase()))
+      .map((n) => {
+        const suffix = n.slice(baseWithoutNumber.length)
+        return /^\d+$/.test(suffix) ? parseInt(suffix, 10) : -1
       })
-      .filter((num) => num >= 0)
+      .filter((n) => n >= 0)
     const maxNumber = numbers.length === 0 ? -1 : Math.max(...numbers)
-    return `${baseName}${maxNumber + 1}`
+    return `${baseWithoutNumber}${maxNumber + 1}`
   }
 
   const handleCreateInstance = () => {
@@ -177,8 +178,10 @@ const InstancesEditor = () => {
       return
     }
 
+    const instanceNames = instances.map((i) => i.name)
+
     if (selectedRow === ROWS_NOT_SELECTED) {
-      createInstance({ data: { ...instance, name: getNextInstanceName(instances) } })
+      createInstance({ data: { ...instance, name: getNextName(instance.name, instanceNames) } })
       updateModelInstances({
         display: 'table',
         selectedRow: instances.length,
@@ -187,7 +190,10 @@ const InstancesEditor = () => {
       return
     }
 
-    createInstance({ data: { ...instance, name: getNextInstanceName(instances) }, rowToInsert: selectedRow + 1 })
+    createInstance({
+      data: { ...instance, name: getNextName(instance.name, instanceNames) },
+      rowToInsert: selectedRow + 1,
+    })
     updateModelInstances({
       display: 'table',
       selectedRow: selectedRow + 1,

--- a/src/frontend/components/_organisms/instances-editor/index.tsx
+++ b/src/frontend/components/_organisms/instances-editor/index.tsx
@@ -9,6 +9,7 @@ import { TableIcon } from '../../../assets/icons/interface/TableIcon'
 import { useOpenPLCStore } from '../../../store'
 import type { InstanceType } from '../../../store/slices/editor'
 import { cn } from '../../../utils/cn'
+import { getNextName } from '../../../utils/next-name'
 import { parseResourceConfigurationToString } from '../../../utils/parse-resource-configuration-to-string'
 import { parseResourceStringToConfiguration } from '../../../utils/parse-resource-string-to-configuration'
 import TableActions from '../../_atoms/table-actions'
@@ -131,19 +132,6 @@ const InstancesEditor = () => {
       selectedRow: parseInt(editorInstances.selectedRow) + index,
     })
     handleFileAndWorkspaceSavedState('Resource')
-  }
-
-  const getNextName = (baseName: string, existingNames: string[]) => {
-    const baseWithoutNumber = baseName.replace(/\d+$/, '')
-    const numbers = existingNames
-      .filter((n) => n.toLowerCase().startsWith(baseWithoutNumber.toLowerCase()))
-      .map((n) => {
-        const suffix = n.slice(baseWithoutNumber.length)
-        return /^\d+$/.test(suffix) ? parseInt(suffix, 10) : -1
-      })
-      .filter((n) => n >= 0)
-    const maxNumber = numbers.length === 0 ? -1 : Math.max(...numbers)
-    return `${baseWithoutNumber}${maxNumber + 1}`
   }
 
   const handleCreateInstance = () => {

--- a/src/frontend/components/_organisms/instances-editor/index.tsx
+++ b/src/frontend/components/_organisms/instances-editor/index.tsx
@@ -133,6 +133,18 @@ const InstancesEditor = () => {
     handleFileAndWorkspaceSavedState('Resource')
   }
 
+  const getNextInstanceName = (existingInstances: PLCInstance[]) => {
+    const baseName = 'instance'
+    const numbers = existingInstances
+      .map((inst) => {
+        const match = inst.name.match(/^instance(\d+)$/i)
+        return match ? parseInt(match[1], 10) : -1
+      })
+      .filter((num) => num >= 0)
+    const maxNumber = numbers.length === 0 ? -1 : Math.max(...numbers)
+    return `${baseName}${maxNumber + 1}`
+  }
+
   const handleCreateInstance = () => {
     if (editorInstances.display === 'code') return
 
@@ -166,7 +178,7 @@ const InstancesEditor = () => {
     }
 
     if (selectedRow === ROWS_NOT_SELECTED) {
-      createInstance({ data: { ...instance } })
+      createInstance({ data: { ...instance, name: getNextInstanceName(instances) } })
       updateModelInstances({
         display: 'table',
         selectedRow: instances.length,
@@ -175,7 +187,7 @@ const InstancesEditor = () => {
       return
     }
 
-    createInstance({ data: { ...instance }, rowToInsert: selectedRow + 1 })
+    createInstance({ data: { ...instance, name: getNextInstanceName(instances) }, rowToInsert: selectedRow + 1 })
     updateModelInstances({
       display: 'table',
       selectedRow: selectedRow + 1,

--- a/src/frontend/components/_organisms/task-editor/index.tsx
+++ b/src/frontend/components/_organisms/task-editor/index.tsx
@@ -198,7 +198,7 @@ const TaskEditor = () => {
       return
     }
 
-    createTask({ data: { ...task }, rowToInsert: selectedRow + 1 })
+    createTask({ data: { ...task, name: getNextTaskName(filteredTasks) }, rowToInsert: selectedRow + 1 })
     updateModelTasks({
       display: 'table',
       selectedRow: selectedRow + 1,

--- a/src/frontend/components/_organisms/task-editor/index.tsx
+++ b/src/frontend/components/_organisms/task-editor/index.tsx
@@ -9,6 +9,7 @@ import { TableIcon } from '../../../assets/icons/interface/TableIcon'
 import { useOpenPLCStore } from '../../../store'
 import type { TaskType } from '../../../store/slices/editor'
 import { cn } from '../../../utils/cn'
+import { getNextName } from '../../../utils/next-name'
 import { parseResourceConfigurationToString } from '../../../utils/parse-resource-configuration-to-string'
 import { parseResourceStringToConfiguration } from '../../../utils/parse-resource-string-to-configuration'
 import TableActions from '../../_atoms/table-actions'
@@ -127,19 +128,6 @@ const TaskEditor = () => {
       selectedRow: parseInt(editorTasks.selectedRow) + index,
     })
     handleFileAndWorkspaceSavedState('Resource')
-  }
-
-  const getNextName = (baseName: string, existingNames: string[]) => {
-    const baseWithoutNumber = baseName.replace(/\d+$/, '')
-    const numbers = existingNames
-      .filter((n) => n.toLowerCase().startsWith(baseWithoutNumber.toLowerCase()))
-      .map((n) => {
-        const suffix = n.slice(baseWithoutNumber.length)
-        return /^\d+$/.test(suffix) ? parseInt(suffix, 10) : -1
-      })
-      .filter((n) => n >= 0)
-    const maxNumber = numbers.length === 0 ? -1 : Math.max(...numbers)
-    return `${baseWithoutNumber}${maxNumber + 1}`
   }
 
   const handleCreateTask = () => {

--- a/src/frontend/components/_organisms/task-editor/index.tsx
+++ b/src/frontend/components/_organisms/task-editor/index.tsx
@@ -129,23 +129,17 @@ const TaskEditor = () => {
     handleFileAndWorkspaceSavedState('Resource')
   }
 
-  const getNextTaskName = (existingTasks: PLCTask[]) => {
-    const baseName = 'Task'
-    // Find all tasks that match the pattern "Task" followed by a number
-    const taskNumbers = existingTasks
-      .map((task) => {
-        const match = task.name.match(/^Task(\d+)$/i)
-        return match ? parseInt(match[1], 10) : -1
+  const getNextName = (baseName: string, existingNames: string[]) => {
+    const baseWithoutNumber = baseName.replace(/\d+$/, '')
+    const numbers = existingNames
+      .filter((n) => n.toLowerCase().startsWith(baseWithoutNumber.toLowerCase()))
+      .map((n) => {
+        const suffix = n.slice(baseWithoutNumber.length)
+        return /^\d+$/.test(suffix) ? parseInt(suffix, 10) : -1
       })
-      .filter((num) => num >= 0)
-
-    if (taskNumbers.length === 0) {
-      return 'Task0'
-    }
-
-    // Get the highest number and increment
-    const maxNumber = Math.max(...taskNumbers)
-    return `${baseName}${maxNumber + 1}`
+      .filter((n) => n >= 0)
+    const maxNumber = numbers.length === 0 ? -1 : Math.max(...numbers)
+    return `${baseWithoutNumber}${maxNumber + 1}`
   }
 
   const handleCreateTask = () => {
@@ -181,13 +175,13 @@ const TaskEditor = () => {
       return
     }
 
+    const taskNames = filteredTasks.map((t) => t.name)
+
     if (selectedRow === ROWS_NOT_SELECTED) {
       createTask({
         data: {
-          name: getNextTaskName(filteredTasks),
-          triggering: 'Cyclic',
-          interval: 'T#20ms',
-          priority: 0,
+          ...task,
+          name: getNextName(task.name, taskNames),
         },
       })
       updateModelTasks({
@@ -198,7 +192,7 @@ const TaskEditor = () => {
       return
     }
 
-    createTask({ data: { ...task, name: getNextTaskName(filteredTasks) }, rowToInsert: selectedRow + 1 })
+    createTask({ data: { ...task, name: getNextName(task.name, taskNames) }, rowToInsert: selectedRow + 1 })
     updateModelTasks({
       display: 'table',
       selectedRow: selectedRow + 1,

--- a/src/frontend/components/_organisms/variables-editor/index.tsx
+++ b/src/frontend/components/_organisms/variables-editor/index.tsx
@@ -348,15 +348,18 @@ const VariablesEditor = () => {
     const variable: PLCVariable =
       selectedRow === ROWS_NOT_SELECTED ? variables[variables.length - 1] : variables[selectedRow]
 
+    const newVarData = {
+      ...variable,
+      class: defaultClass,
+      type: variable.type.definition === 'derived' ? { definition: 'base-type', value: 'DINT' } : variable.type,
+      documentation: '',
+    }
+
     if (selectedRow === ROWS_NOT_SELECTED) {
       createVariable({
         scope: 'local',
         associatedPou: editor.meta.name,
-        data: {
-          ...variable,
-          class: defaultClass,
-          type: variable.type.definition === 'derived' ? { definition: 'base-type', value: 'DINT' } : variable.type,
-        },
+        data: newVarData,
       })
       updateModelVariables({
         display: 'table',
@@ -368,11 +371,7 @@ const VariablesEditor = () => {
     createVariable({
       scope: 'local',
       associatedPou: editor.meta.name,
-      data: {
-        ...variable,
-        class: defaultClass,
-        type: variable.type.definition === 'derived' ? { definition: 'base-type', value: 'DINT' } : variable.type,
-      },
+      data: newVarData,
       rowToInsert: selectedRow + 1,
     })
     updateModelVariables({

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -16,7 +16,6 @@ import { getExtensionFromLanguage, getFolderFromPouType } from '../../../utils/P
 import type { ProjectResponse, ProjectSlice } from './types'
 import { getVariableBasedOnRowIdOrVariableId } from './utils'
 import {
-  createGlobalVariableValidation,
   createVariableValidation,
   updateGlobalVariableValidation,
   updateVariableValidation,
@@ -368,7 +367,8 @@ const createProjectSlice: StateCreator<ProjectSlice, [], [], ProjectSlice> = (se
             response.data = data
           } else {
             const vars = slice.project.data.configurations.resource.globalVariables
-            data.name = createGlobalVariableValidation(vars, data.name)
+            const validated = createVariableValidation(vars, data)
+            data = { ...data, name: validated.name, location: validated.location }
             if (rowToInsert !== undefined) {
               vars.splice(rowToInsert, 0, data)
             } else {

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -618,7 +618,7 @@ const createProjectSlice: StateCreator<ProjectSlice, [], [], ProjectSlice> = (se
         produce((slice: ProjectSlice) => {
           const tasks = slice.project.data.configurations.resource.tasks
           if (dto.rowId >= 0 && dto.rowId < tasks.length) {
-            tasks[dto.rowId] = dto.data
+            tasks[dto.rowId] = { ...tasks[dto.rowId], ...dto.data }
           }
         }),
       )
@@ -675,7 +675,7 @@ const createProjectSlice: StateCreator<ProjectSlice, [], [], ProjectSlice> = (se
         produce((slice: ProjectSlice) => {
           const instances = slice.project.data.configurations.resource.instances
           if (dto.rowId >= 0 && dto.rowId < instances.length) {
-            instances[dto.rowId] = dto.data
+            instances[dto.rowId] = { ...instances[dto.rowId], ...dto.data }
           }
         }),
       )

--- a/src/frontend/store/slices/project/validation/variables.ts
+++ b/src/frontend/store/slices/project/validation/variables.ts
@@ -283,14 +283,6 @@ const createVariableValidation = (
   return response
 }
 
-const createGlobalVariableValidation = (variables: PLCVariable[], variableName: string) => {
-  if (checkIfGlobalVariableExists(variables, variableName)) {
-    const { name: variableNameWithoutNumber, number } = checkVariableName(variables, variableName)
-    return `${variableNameWithoutNumber}${number}`
-  }
-  return variableName
-}
-
 /**
  * This is a validation to check the name of the variable at update.
  * If the variable name is invalid, create a response.
@@ -398,7 +390,6 @@ const updateGlobalVariableValidation = (variables: PLCVariable[], dataToBeUpdate
 export {
   arrayValidation,
   checkVariableName,
-  createGlobalVariableValidation,
   createVariableValidation,
   enumeratedValidation,
   updateGlobalVariableValidation,

--- a/src/frontend/utils/next-name.ts
+++ b/src/frontend/utils/next-name.ts
@@ -1,0 +1,21 @@
+/**
+ * Generate the next unique name by incrementing a trailing number.
+ *
+ * Given a base name like "Task0" and existing names ["Task0", "Task1"],
+ * strips the trailing digits ("Task"), finds the highest existing number
+ * with that prefix (1), and returns "Task2".
+ *
+ * Used by task, instance, and other list editors that create items by copy.
+ */
+export const getNextName = (baseName: string, existingNames: string[]): string => {
+  const baseWithoutNumber = baseName.replace(/\d+$/, '')
+  const numbers = existingNames
+    .filter((n) => n.toLowerCase().startsWith(baseWithoutNumber.toLowerCase()))
+    .map((n) => {
+      const suffix = n.slice(baseWithoutNumber.length)
+      return /^\d+$/.test(suffix) ? parseInt(suffix, 10) : -1
+    })
+    .filter((n) => n >= 0)
+  const maxNumber = numbers.length === 0 ? -1 : Math.max(...numbers)
+  return `${baseWithoutNumber}${maxNumber + 1}`
+}

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -917,6 +917,18 @@ class MainProcessBridge implements MainIpcModule {
         if (!connectionParams.port || !connectionParams.baudRate || connectionParams.slaveId === undefined) {
           return { success: false, error: 'Port, baud rate, and slave ID are required for RTU connection' }
         }
+
+        // Reuse existing RTU client if already connected to the same port
+        if (
+          this.debuggerModbusClient &&
+          this.debuggerConnectionType === 'rtu' &&
+          this.debuggerRtuPort === connectionParams.port
+        ) {
+          const targetMd5 = await this.debuggerModbusClient.getMd5Hash()
+          const match = targetMd5.toLowerCase() === expectedMd5.toLowerCase()
+          return { success: true, match, targetMd5 }
+        }
+
         client = new ModbusRtuClient({
           port: connectionParams.port,
           baudRate: connectionParams.baudRate,


### PR DESCRIPTION
## Summary

- **Compiler plugin configs**: `toIpcProjectData()` was dropping `servers` and `remoteDevices`, causing all plugin config generators to skip
- **Device board persistence**: workspace-screen `useEffect` was forcing board back to Simulator on every project open; fixed `mergeDeviceConfigWithDefaults` to use `||` so empty string falls back to default
- **Debugger RTU**: `handleDebuggerVerifyMd5` was opening a duplicate serial port instead of reusing the existing client from `handleDebuggerConnect`
- **Task/instance update**: `updateTask`/`updateInstance` replaced entire object instead of merging, causing items to disappear when changing one field
- **Task/instance creation**: duplicate name check silently rejected copies; naming now derives from copied item's base name
- **Variable creation**: documentation was copied to new variables (should be empty); global variables now get location auto-increment like local variables
- **lint-staged**: removed `--debug` flag causing buffer overflow; lint-staged now runs eslint/prettier directly on staged files instead of linting entire codebase

## Test plan
- [ ] Compile project with servers/remote devices — plugin configs generated
- [ ] Open existing project — device board selection preserved
- [ ] Create new project — defaults to OpenPLC Simulator
- [ ] Start debugger on Arduino with Modbus RTU — no "Cannot lock port" error
- [ ] Resource → Tasks: change interval — task stays in list
- [ ] Resource → Tasks: click + — new task created with incremented name
- [ ] Resource → Instances: same tests
- [ ] Variables: create by copy — documentation empty, location auto-incremented
- [ ] Global variables: same behavior
- [ ] Commit with 3+ staged TS files — lint-staged completes without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)