### PR TITLE
fix: increase Node.js heap size to prevent webpack OOM during dev build

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict = true
+node-options = --max-old-space-size=4096


### PR DESCRIPTION
This change increases the Node.js heap size during development builds to reduce webpack out-of-memory failures.

It helps make local development more reliable when the default memory limit is not enough for the current webpack build size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to increase memory allocation for Node.js processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->