### PR TITLE
ci: add cross-repo surface sync check

### DIFF
--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -1,0 +1,177 @@
+name: CI - Surface Sync
+
+on:
+  pull_request:
+    branches:
+      - main
+      - development
+    paths:
+      - 'src/frontend/**'
+      - 'src/middleware/shared/**'
+      - 'src/backend/shared/**'
+      - 'src/__architecture__/**'
+      - 'scripts/compare-surfaces.py'
+      - '.github/workflows/ci-sync.yml'
+
+jobs:
+  surface-sync:
+    name: Shared Surface Sync Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout editor repo
+        uses: actions/checkout@v4
+        with:
+          path: editor
+
+      - name: Checkout web repo (target branch)
+        uses: actions/checkout@v4
+        with:
+          repository: Autonomy-Logic/openplc-web
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: web
+        continue-on-error: true
+        id: checkout-web-target
+
+      - name: Checkout web repo (main fallback)
+        if: steps.checkout-web-target.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          repository: Autonomy-Logic/openplc-web
+          ref: main
+          path: web
+
+      - name: Warn about branch fallback
+        if: steps.checkout-web-target.outcome == 'failure'
+        run: |
+          echo "::warning::Web repo does not have branch '${{ github.event.pull_request.base.ref }}'. Fell back to 'main'."
+
+      - name: Compare surfaces against target branch
+        id: compare-target
+        run: |
+          set +e
+          RESULT=$(python3 editor/scripts/compare-surfaces.py \
+            --web-root web/src \
+            --editor-root editor/src \
+            --github-annotations 2>&1 1>/tmp/compare-result.json)
+          EXIT_CODE=$?
+          set -e
+
+          # Forward annotations to stderr
+          if [ -n "$RESULT" ]; then
+            echo "$RESULT" >&2
+          fi
+
+          MATCH=$(python3 -c "import json; print(json.load(open('/tmp/compare-result.json'))['match'])")
+          echo "match=$MATCH" >> "$GITHUB_OUTPUT"
+
+          if [ "$MATCH" = "True" ]; then
+            echo "All shared surfaces match the web's ${{ github.event.pull_request.base.ref }} branch."
+          else
+            DIFF_COUNT=$(python3 -c "import json; print(json.load(open('/tmp/compare-result.json'))['total_diffs'])")
+            echo "Found $DIFF_COUNT difference(s) against web's ${{ github.event.pull_request.base.ref }} branch."
+            echo "Checking open web PRs for a matching sync..."
+          fi
+
+      - name: Find matching web PRs
+        if: steps.compare-target.outputs.match == 'False'
+        id: find-prs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+
+          PR_JSON=$(gh pr list \
+            --repo Autonomy-Logic/openplc-web \
+            --base "$BASE_BRANCH" \
+            --state open \
+            --limit 10 \
+            --json number,headRefName,title)
+
+          PR_COUNT=$(echo "$PR_JSON" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+          echo "pr_count=$PR_COUNT" >> "$GITHUB_OUTPUT"
+
+          # Save PR list for next step
+          echo "$PR_JSON" > /tmp/web-prs.json
+
+          if [ "$PR_COUNT" = "0" ]; then
+            echo "No open web PRs targeting '$BASE_BRANCH'."
+          else
+            echo "Found $PR_COUNT open web PR(s) targeting '$BASE_BRANCH'."
+          fi
+
+      - name: Check web PRs for sync
+        if: steps.compare-target.outputs.match == 'False' && steps.find-prs.outputs.pr_count != '0'
+        id: check-prs
+        run: |
+          PR_JSON=$(cat /tmp/web-prs.json)
+          MATCHED_PR=""
+
+          for PR_NUMBER in $(echo "$PR_JSON" | python3 -c "import json,sys; [print(p['number']) for p in json.load(sys.stdin)]"); do
+            TITLE=$(echo "$PR_JSON" | python3 -c "import json,sys; prs=json.load(sys.stdin); [print(p['title']) for p in prs if p['number']==$PR_NUMBER]")
+            BRANCH=$(echo "$PR_JSON" | python3 -c "import json,sys; prs=json.load(sys.stdin); [print(p['headRefName']) for p in prs if p['number']==$PR_NUMBER]")
+
+            echo "::group::Checking web PR #$PR_NUMBER: $TITLE ($BRANCH)"
+
+            # Fetch the PR head using refs/pull/N/head (works for forks too)
+            if ! git -C web fetch origin "refs/pull/$PR_NUMBER/head" 2>/dev/null; then
+              echo "::warning::Could not fetch PR #$PR_NUMBER head"
+              echo "::endgroup::"
+              continue
+            fi
+
+            git -C web checkout FETCH_HEAD --quiet
+
+            # Run comparison (suppress annotations, just check match)
+            set +e
+            RESULT=$(python3 editor/scripts/compare-surfaces.py \
+              --web-root web/src \
+              --editor-root editor/src \
+              2>/dev/null)
+            set -e
+
+            IS_MATCH=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['match'])")
+
+            if [ "$IS_MATCH" = "True" ]; then
+              echo "Surfaces MATCH with web PR #$PR_NUMBER ($BRANCH)"
+              echo "matched_pr=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+              echo "matched_title=$TITLE" >> "$GITHUB_OUTPUT"
+              echo "::endgroup::"
+              exit 0
+            else
+              DIFF_COUNT=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['total_diffs'])")
+              echo "Still $DIFF_COUNT difference(s) with PR #$PR_NUMBER"
+            fi
+
+            echo "::endgroup::"
+          done
+
+      - name: Report result
+        if: always()
+        run: |
+          MATCH="${{ steps.compare-target.outputs.match }}"
+          MATCHED_PR="${{ steps.check-prs.outputs.matched_pr }}"
+          MATCHED_TITLE="${{ steps.check-prs.outputs.matched_title }}"
+
+          if [ "$MATCH" = "True" ]; then
+            echo "Shared surfaces are in sync with web's ${{ github.event.pull_request.base.ref }} branch."
+            exit 0
+          elif [ -n "$MATCHED_PR" ]; then
+            echo "::warning::Surfaces will be in sync once web PR #${MATCHED_PR} is merged: ${MATCHED_TITLE}"
+            echo "Shared surfaces match web PR #${MATCHED_PR}."
+            exit 0
+          else
+            echo "::error::Shared surfaces are NOT in sync with openplc-web."
+            echo ""
+            echo "Differing files:"
+            python3 -c "
+          import json
+          with open('/tmp/compare-result.json') as f:
+              data = json.load(f)
+          for surface, info in data['surfaces'].items():
+              if not info['match']:
+                  for d in info['diffs']:
+                      print(f\"  {d['reason']}: src/{d['file']}\")
+          "
+            exit 1
+          fi

--- a/scripts/compare-surfaces.py
+++ b/scripts/compare-surfaces.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Compare byte-identical surfaces between openplc-editor and openplc-web.
+
+Surfaces checked:
+  - frontend/          (UI layer)
+  - middleware/shared/  (ports + providers)
+  - backend/shared/    (application logic, use cases)
+  - __architecture__/  (validation scripts)
+
+Every file in these directories must be byte-identical across both repos.
+Exit code 0 = all identical, 1 = differences found.
+"""
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+SURFACES = [
+    "frontend",
+    "middleware/shared",
+    "backend/shared",
+    "__architecture__",
+]
+
+
+def hash_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def collect_hashes(root: Path, surface: str) -> dict[str, str]:
+    base = root / surface
+    if not base.exists():
+        return {}
+    result = {}
+    for path in sorted(base.rglob("*")):
+        if path.is_file():
+            rel = str(path.relative_to(root))
+            result[rel] = hash_file(path)
+    return result
+
+
+def compare_surface(
+    web_root: Path, editor_root: Path, surface: str
+) -> dict:
+    web_hashes = collect_hashes(web_root, surface)
+    editor_hashes = collect_hashes(editor_root, surface)
+    all_files = sorted(set(web_hashes) | set(editor_hashes))
+
+    diffs = []
+    for f in all_files:
+        in_web = f in web_hashes
+        in_editor = f in editor_hashes
+        if in_web and not in_editor:
+            diffs.append({"file": f, "reason": "only_in_web"})
+        elif in_editor and not in_web:
+            diffs.append({"file": f, "reason": "only_in_editor"})
+        elif web_hashes[f] != editor_hashes[f]:
+            diffs.append({"file": f, "reason": "hash_mismatch"})
+
+    return {
+        "match": len(diffs) == 0,
+        "files_checked": len(all_files),
+        "diffs": diffs,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare byte-identical surfaces between web and editor repos."
+    )
+    parser.add_argument(
+        "--web-root",
+        required=True,
+        type=Path,
+        help="Path to the web repo's src/ directory",
+    )
+    parser.add_argument(
+        "--editor-root",
+        required=True,
+        type=Path,
+        help="Path to the editor repo's src/ directory",
+    )
+    parser.add_argument(
+        "--github-annotations",
+        action="store_true",
+        help="Emit GitHub Actions annotations to stderr",
+    )
+    args = parser.parse_args()
+
+    surfaces = {}
+    total_diffs = 0
+
+    for surface in SURFACES:
+        result = compare_surface(args.web_root, args.editor_root, surface)
+        surfaces[surface] = result
+        total_diffs += len(result["diffs"])
+
+    total_files = sum(s["files_checked"] for s in surfaces.values())
+    overall_match = all(s["match"] for s in surfaces.values())
+
+    output = {
+        "match": overall_match,
+        "surfaces": surfaces,
+        "total_files": total_files,
+        "total_diffs": total_diffs,
+    }
+
+    # JSON to stdout (machine-readable)
+    print(json.dumps(output))
+
+    # GitHub annotations to stderr
+    if args.github_annotations:
+        for surface, result in surfaces.items():
+            if result["match"]:
+                continue
+            for diff in result["diffs"]:
+                reason = diff["reason"]
+                filepath = diff["file"]
+                if reason == "only_in_web":
+                    msg = f"File exists only in web repo: src/{filepath}"
+                elif reason == "only_in_editor":
+                    msg = f"File exists only in editor repo: src/{filepath}"
+                else:
+                    msg = f"File differs between repos: src/{filepath}"
+                print(f"::error file=src/{filepath}::{msg}", file=sys.stderr)
+
+    return 0 if overall_match else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/compare-surfaces.py
+++ b/scripts/compare-surfaces.py
@@ -124,11 +124,11 @@ def main() -> int:
                 reason = diff["reason"]
                 filepath = diff["file"]
                 if reason == "only_in_web":
-                    msg = f"File exists only in web repo: src/{filepath}"
+                    msg = f"[{surface}] File exists only in web repo: src/{filepath}"
                 elif reason == "only_in_editor":
-                    msg = f"File exists only in editor repo: src/{filepath}"
+                    msg = f"[{surface}] File exists only in editor repo: src/{filepath}"
                 else:
-                    msg = f"File differs between repos: src/{filepath}"
+                    msg = f"[{surface}] File differs between repos: src/{filepath}"
                 print(f"::error file=src/{filepath}::{msg}", file=sys.stderr)
 
     return 0 if overall_match else 1


### PR DESCRIPTION
## Summary
- Adds a CI workflow (`ci-sync.yml`) that verifies byte-identical shared surfaces stay in sync between openplc-editor and openplc-web
- Adds a parameterized comparison script (`scripts/compare-surfaces.py`) that compares SHA256 hashes of all files in 4 shared surfaces
- When surfaces differ from the target branch, the workflow checks open PRs in the web repo targeting the same branch for a matching sync

## Test plan
- [ ] Verify workflow triggers on PRs targeting `main` or `development` that touch shared surface paths
- [ ] Verify workflow passes when surfaces are already in sync
- [ ] Verify workflow detects differences and checks web PRs for matching sync
- [ ] Run comparison script locally: `python3 scripts/compare-surfaces.py --web-root ../openplc-web/src --editor-root ./src`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated pull request validation that compares shared code surfaces across components, emits review annotations for any mismatches, searches for matching candidate PRs in the companion repository, and reports results as success, warning (when a matching PR exists), or failure during CI. This runs on PRs targeting main/development and helps ensure surface parity before merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->