### PR TITLE
fix(workspace): prevent AI chat panel from overflowing viewport

### DIFF
--- a/src/backend/shared/styles/globals.css
+++ b/src/backend/shared/styles/globals.css
@@ -27,6 +27,33 @@
   background-color: transparent;
 }
 
+@keyframes ai-chat-pulse {
+  0%,
+  80%,
+  100% {
+    opacity: 0.25;
+  }
+  40% {
+    opacity: 1;
+  }
+}
+
+.ai-chat-typing-dot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  margin: 0 2px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: ai-chat-pulse 1.2s infinite;
+}
+.ai-chat-typing-dot:nth-child(2) {
+  animation-delay: 0.18s;
+}
+.ai-chat-typing-dot:nth-child(3) {
+  animation-delay: 0.36s;
+}
+
 @layer base {
   :root {
     --primary-default: #0464fb;

--- a/src/frontend/components/_templates/[workspace]/main-content.tsx
+++ b/src/frontend/components/_templates/[workspace]/main-content.tsx
@@ -11,7 +11,7 @@ const WorkspaceMainContent = (props: IWorkspaceMainContentProps) => {
   return (
     <div
       className={cn(
-        'flex h-full w-full flex-1 flex-grow gap-1 bg-neutral-100 p-2 dark:bg-neutral-900',
+        'flex h-full w-full min-w-0 flex-1 flex-grow gap-1 overflow-hidden bg-neutral-100 p-2 dark:bg-neutral-900',
         `${OS !== 'linux' && '!rounded-tl-lg'}`,
       )}
       {...res}

--- a/src/frontend/components/_templates/[workspace]/side-content.tsx
+++ b/src/frontend/components/_templates/[workspace]/side-content.tsx
@@ -5,7 +5,7 @@ const WorkspaceSideContent = (props: IWorkspaceSideContentProps) => {
   const { children, ...res } = props
   return (
     <div
-      className='flex h-full w-14 flex-col justify-between border-t-inherit bg-brand-dark pb-10 dark:bg-neutral-950'
+      className='flex h-full w-14 shrink-0 flex-col justify-between border-t-inherit bg-brand-dark pb-10 dark:bg-neutral-950'
       {...res}
     >
       {children}

--- a/src/frontend/screens/workspace-screen.tsx
+++ b/src/frontend/screens/workspace-screen.tsx
@@ -402,7 +402,7 @@ const WorkspaceScreen = () => {
               hitAreaMargins={{ coarse: 12, fine: 3 }}
               className='z-[99] my-[2px] w-[4px] py-2 transition-colors duration-200 data-[resize-handle-active="pointer"]:bg-brand-light data-[resize-handle-state="hover"]:bg-brand-light data-[resize-handle-active="pointer"]:dark:bg-neutral-700 data-[resize-handle-state="hover"]:dark:bg-neutral-700'
             />
-            <ResizablePanel id='workspacePanel' order={2} defaultSize={84} className='flex h-full min-h-0 w-[400px]'>
+            <ResizablePanel id='workspacePanel' order={2} defaultSize={68} minSize={50} className='flex h-full min-h-0 overflow-hidden'>
               <div
                 id='workspaceContentPanel'
                 className='flex h-full min-h-0 flex-1 grow flex-col gap-2 overflow-hidden'
@@ -658,8 +658,9 @@ const WorkspaceScreen = () => {
                   id='chatPanel'
                   order={3}
                   defaultSize={16}
+                  minSize={16}
                   maxSize={25}
-                  className='min-w-xs relative flex h-full min-h-0 w-full'
+                  className='relative flex h-full min-h-0 w-full'
                 >
                   <ChatPanel />
                 </ResizablePanel>

--- a/src/frontend/screens/workspace-screen.tsx
+++ b/src/frontend/screens/workspace-screen.tsx
@@ -402,7 +402,13 @@ const WorkspaceScreen = () => {
               hitAreaMargins={{ coarse: 12, fine: 3 }}
               className='z-[99] my-[2px] w-[4px] py-2 transition-colors duration-200 data-[resize-handle-active="pointer"]:bg-brand-light data-[resize-handle-state="hover"]:bg-brand-light data-[resize-handle-active="pointer"]:dark:bg-neutral-700 data-[resize-handle-state="hover"]:dark:bg-neutral-700'
             />
-            <ResizablePanel id='workspacePanel' order={2} defaultSize={68} minSize={50} className='flex h-full min-h-0 overflow-hidden'>
+            <ResizablePanel
+              id='workspacePanel'
+              order={2}
+              defaultSize={68}
+              minSize={50}
+              className='flex h-full min-h-0 overflow-hidden'
+            >
               <div
                 id='workspaceContentPanel'
                 className='flex h-full min-h-0 flex-1 grow flex-col gap-2 overflow-hidden'


### PR DESCRIPTION
## Summary

Mirrors the workspace-layout portion of [openplc-web#380](https://github.com/Autonomy-Logic/openplc-web/pull/380). The AI chat panel itself isn't rendered in the editor build, but the workspace layout is shared between the two repos and was carrying the same flex-shrink bug that lets internal content force the activity bar to shrink and push neighbouring panels past the viewport.

This PR only touches shared layout files. The web-only chat-component changes from #380 do not apply here (the editor's chat slot is null by design).

## What changes

- `WorkspaceMainContent` now has `min-w-0 overflow-hidden` so it cannot be pushed past its flex share by intrinsic min-content of children
- `WorkspaceSideContent` gets `shrink-0` so the activity bar can never shrink below its 56 px width
- Resizable panel sizes now sum to 100 (Explorer 16 / Workspace 68 / Chat 16), replacing the prior 16+84+16=116 layout that triggered react-resizable-panels' "Invalid layout total size" warning and forced normalization against CSS `min-width`
- Chat panel container switched from CSS `min-w-xs` to library-aware `minSize={16}` so the constraint is respected during normalization
- Adds the `ai-chat-pulse` keyframe and `.ai-chat-typing-dot` class to globals.css (consumed by the web ChatPanel; harmless in editor where no chat panel renders)

## Test plan

- [ ] Resize the workspace explorer / editor split — no visible jumps in panel widths
- [ ] On a build with the chat panel enabled, confirm no console warning "Invalid layout total size: 16%, 84%, 16%"
- [ ] Verify activity bar icons remain fully visible under all panel-resize states

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an animated typing indicator for AI chat responses.

* **UI/Layout Improvements**
  * Improved workspace layout to prevent content overflow and preserve visibility.
  * Adjusted side and chat panel sizing and constraints for more stable, flexible resizing and consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->