### PR TITLE
fix(explorer): show Servers branch on platforms without local serial ports

### DIFF
--- a/src/frontend/components/_organisms/explorer/project.tsx
+++ b/src/frontend/components/_organisms/explorer/project.tsx
@@ -278,27 +278,25 @@ const Project = () => {
           </ProjectTreeBranch>
 
           {/* Project Servers tree branch */}
-          {capabilities.hasLocalSerialPorts && (
-            <ProjectTreeBranch branchTarget='server'>
-              {[...(servers || [])]
-                .sort((a, b) => a.name.localeCompare(b.name))
-                .map((server) => (
-                  <ProjectTreeLeaf
-                    key={server.name}
-                    leafLang='server'
-                    leafType='server'
-                    label={searchQuery ? extractSearchQuery(server.name, searchQuery) : server.name}
-                    onClick={() =>
-                      handleCreateTab({
-                        name: server.name,
-                        path: `/servers/${server.name}`,
-                        elementType: { type: 'server', protocol: server.protocol },
-                      })
-                    }
-                  />
-                ))}
-            </ProjectTreeBranch>
-          )}
+          <ProjectTreeBranch branchTarget='server'>
+            {[...(servers || [])]
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((server) => (
+                <ProjectTreeLeaf
+                  key={server.name}
+                  leafLang='server'
+                  leafType='server'
+                  label={searchQuery ? extractSearchQuery(server.name, searchQuery) : server.name}
+                  onClick={() =>
+                    handleCreateTab({
+                      name: server.name,
+                      path: `/servers/${server.name}`,
+                      elementType: { type: 'server', protocol: server.protocol },
+                    })
+                  }
+                />
+              ))}
+          </ProjectTreeBranch>
 
           {/* Project Remote Devices tree branch */}
           <ProjectTreeBranch branchTarget='remote-device'>


### PR DESCRIPTION
## Summary
- Removes the `capabilities.hasLocalSerialPorts` gate around the Servers branch in the project tree explorer (`src/frontend/components/_organisms/explorer/project.tsx`).
- Functionally a no-op on this repo (editor's `hasLocalSerialPorts` is `true`), but required to keep the shared surface byte-identical with openplc-web.

## Context
Mirror of openplc-web's `fix/server-tree-visibility` (commit `db830fa0`). Servers (OPC UA, Modbus, S7Comm) are project-level entities persisted in the project file and have no dependency on the host's ability to access serial ports — gating their visibility by serial-port capability hides them on the web platform.

This PR is paired with the openplc-web PR; both must merge so `ci-sync` stays green.

## Test plan
- [ ] Open the editor with a project that has at least one server configured; confirm the Servers branch shows in the file tree (regression check on the no-op path).
- [ ] Run `python3 scripts/compare-surfaces.py --web-root <web>/src --editor-root src` after both PRs are checked out → expect `match: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The Project Servers section in the explorer now displays unconditionally for all user configurations, ensuring server options remain consistently accessible. Server entries maintain their organized appearance with automatic name-based sorting, integrated search functionality, and tab management features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->