### PR TITLE
sync(ai): mirror conversation lifecycle telemetry event names from openplc-web

### DIFF
--- a/src/middleware/shared/ports/ai-port.ts
+++ b/src/middleware/shared/ports/ai-port.ts
@@ -53,6 +53,10 @@ export type AITelemetryEventName =
   | 'completion_timeout'
   | 'chat_message'
   | 'chat_rating'
+  | 'conversation_created'
+  | 'conversation_loaded'
+  | 'conversation_renamed'
+  | 'conversation_deleted'
 
 // ---------------------------------------------------------------------------
 // Port interface


### PR DESCRIPTION
## Summary

Mirrors the `AITelemetryEventName` union extension from openplc-web's DOPE-279 (Sprint 3 of Chat History Persistence) so that `src/middleware/shared/ports/ai-port.ts` stays byte-for-byte identical between the two repos and the Shared Surface Sync CI passes.

Adds four event names to the union:
- `conversation_created`
- `conversation_loaded`
- `conversation_renamed`
- `conversation_deleted`

## Why

`Shared Surface Sync` CI (`sync / Shared Surface Sync`) cross-checks every file under `src/middleware/shared/` between openplc-web and openplc-editor. Any diff fails the check, blocking merges on the originating PR. This PR is the editor side of openplc-web PR #389.

## Editor scope

No editor-side wiring is added — the editor doesn't yet ship the conversation switcher / persistence UI that emits these events. This PR is purely a type-surface alignment so the union compiles in both repos and shared-port consumers stay in lockstep.

## Test plan

- [ ] `pnpm lint` clean
- [ ] CI's Shared Surface Sync turns green here
- [ ] After merge, openplc-web PR #389's `sync / Shared Surface Sync` re-runs green

## Companion PR

openplc-web #389 — https://github.com/Autonomy-Logic/openplc-web/pull/389 (DOPE-279)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal conversation tracking capabilities for created, loaded, renamed, and deleted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->