### PR TITLE
feat(vpp): backplane editor + per-slot module config

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.4.9",
+    "version": "v0.4.10",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -21,6 +21,10 @@
       {
         "from": "./resources/sources",
         "to": "./sources"
+      },
+      {
+        "from": "./resources/strucpp",
+        "to": "./strucpp"
       }
     ],
     "target": {
@@ -64,6 +68,10 @@
       {
         "from": "./resources/sources",
         "to": "./sources"
+      },
+      {
+        "from": "./resources/strucpp",
+        "to": "./strucpp"
       }
     ],
     "target": [
@@ -83,6 +91,10 @@
       {
         "from": "./resources/sources",
         "to": "./sources"
+      },
+      {
+        "from": "./resources/strucpp",
+        "to": "./strucpp"
       }
     ],
     "target": [

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -1871,6 +1871,17 @@ class CompilerModule {
           assertPathContained(confFolderPath, configFilePath, 'plugin config path')
           await writeFile(configFilePath, JSON.stringify(finalConfig, null, 2), 'utf-8')
           handleOutputData(`Generated conf/${pluginName}.json for VPP plugin`, 'info')
+
+          // Generate vpp_plugins.conf so the runtime knows exactly which
+          // VPP plugin to load and where its compiled .so and config live.
+          // Format matches plugins.conf: name,path,enabled,type,config_path,venv_path
+          // The paths are the deterministic locations that compile.sh and the
+          // runtime's apply_vpp_plugin_conf() agree on.
+          const vppPluginsConfContent =
+            `${pluginName},./build/vpp/lib${pluginName}_plugin.so,1,1,./build/vpp/${pluginName}.json,\n`
+          const vppPluginsConfPath = join(sourceTargetFolderPath, 'vpp_plugins.conf')
+          await writeFile(vppPluginsConfPath, vppPluginsConfContent, 'utf-8')
+          handleOutputData('Generated vpp_plugins.conf', 'info')
         }
       } else {
         handleOutputData('VPP board has no HAL configTemplate, skipping plugin config generation', 'info')

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -1832,7 +1832,29 @@ class CompilerModule {
             // Device configuration may not exist yet — use empty vendor data
           }
 
-          const modules = matchingDevice.moduleSystem?.modules ?? []
+          // Pre-load each module's configScreen JSON so the (pure)
+          // generator can encode per-slot configuration bytes without
+          // touching the filesystem.
+          const rawModules = matchingDevice.moduleSystem?.modules ?? []
+          const modules = await Promise.all(
+            rawModules.map(async (m) => {
+              let configScreenDefinition: unknown
+              const rel = (m as { configScreen?: string }).configScreen
+              if (rel) {
+                try {
+                  const screenPath = join(matchingPackagePath, rel)
+                  const raw = await readFile(screenPath, 'utf-8')
+                  configScreenDefinition = JSON.parse(raw)
+                } catch (err) {
+                  handleOutputData(
+                    `Failed to load configScreen ${rel} for module ${m.id}: ${getErrorMessage(err)}`,
+                    'error',
+                  )
+                }
+              }
+              return { ...m, configScreenDefinition }
+            }),
+          )
           const finalConfig = generateVendorPluginConfig(configTemplate, vendorScreenData, modules)
 
           // configTemplate is supplied by the package author through

--- a/src/backend/editor/hardware/hardware-module.ts
+++ b/src/backend/editor/hardware/hardware-module.ts
@@ -222,6 +222,38 @@ class HardwareModule {
           // Map target type to compiler
           const compiler = device.target.type === 'runtime-v4' ? 'openplc-compiler' : 'arduino-cli'
 
+          // Per-module configuration screens live alongside top-level
+          // screens; load them eagerly so the renderer can present the
+          // full per-slot detail pane without an extra IPC round trip.
+          const loadModuleConfigScreen = async (relPath: string | undefined) => {
+            if (!relPath) return undefined
+            const fullPath = join(pkg.path, relPath)
+            if (!existsSync(fullPath)) return undefined
+            try {
+              return await HardwareModule.readJSONFile(fullPath)
+            } catch {
+              return undefined
+            }
+          }
+
+          const modules = device.moduleSystem
+            ? await Promise.all(
+                device.moduleSystem.modules.map(async (m) => ({
+                  id: m.id,
+                  name: m.name,
+                  hwId: m.hwId,
+                  image: m.image,
+                  description: m.description,
+                  specs: m.specs,
+                  configScreen: m.configScreen,
+                  configScreenDefinition: await loadModuleConfigScreen(m.configScreen),
+                  io: m.io,
+                  parameters: m.parameters,
+                  addressMapping: m.addressMapping,
+                })),
+              )
+            : []
+
           boards.set(device.name, {
             compiler,
             core: device.target.core ?? '',
@@ -242,14 +274,7 @@ class HardwareModule {
                 ? {
                     enabled: device.moduleSystem.enabled,
                     maxSlots: device.moduleSystem.maxSlots,
-                    modules: device.moduleSystem.modules.map((m) => ({
-                      id: m.id,
-                      name: m.name,
-                      image: m.image,
-                      io: m.io,
-                      parameters: m.parameters,
-                      addressMapping: m.addressMapping,
-                    })),
+                    modules,
                   }
                 : null,
             },

--- a/src/backend/editor/package-manager/package-manager-module.ts
+++ b/src/backend/editor/package-manager/package-manager-module.ts
@@ -52,7 +52,7 @@ class PackageManagerModule {
           error: `Invalid manifest schema: ${parsed.error.issues.map((i) => i.path.join('.') + ': ' + i.message).join('; ')}`,
         }
       }
-      const manifest: PackageManifest = parsed.data as PackageManifest
+      const manifest: PackageManifest = parsed.data as unknown as PackageManifest
 
       // Validate package.id BEFORE using it as a path component. Without
       // this, a malicious .vpp with `"id": "../../something"` would have
@@ -177,7 +177,7 @@ class PackageManagerModule {
       return null
     }
     const parsed = PackageManifestSchema.safeParse(raw)
-    return parsed.success ? (parsed.data as PackageManifest) : null
+    return parsed.success ? (parsed.data as unknown as PackageManifest) : null
   }
 
   getPackagePath(packageId: string): string | null {

--- a/src/backend/shared/utils/vpp/__tests__/byte-encoder.test.ts
+++ b/src/backend/shared/utils/vpp/__tests__/byte-encoder.test.ts
@@ -1,0 +1,225 @@
+import { bytesToHexString, encodeConfigBytes } from '../byte-encoder'
+
+describe('encodeConfigBytes', () => {
+  it('returns an empty array when no fields and no totalBytes are supplied', () => {
+    expect(encodeConfigBytes([], {})).toEqual([])
+  })
+
+  it('pads to totalBytes when explicit', () => {
+    expect(encodeConfigBytes([], {}, 4)).toEqual([0, 0, 0, 0])
+  })
+
+  it('writes a size-2 big-endian value verbatim', () => {
+    const fields = [{ id: 'channels', encoding: { byteOffset: 0, size: 2 as const, endian: 'big' as const } }]
+    expect(encodeConfigBytes(fields, { channels: '0x4003' })).toEqual([0x40, 0x03])
+  })
+
+  it('writes a size-2 little-endian value', () => {
+    const fields = [{ id: 'x', encoding: { byteOffset: 0, size: 2 as const, endian: 'little' as const } }]
+    expect(encodeConfigBytes(fields, { x: '0x1234' })).toEqual([0x34, 0x12])
+  })
+
+  it('defaults endian to big', () => {
+    const fields = [{ id: 'x', encoding: { byteOffset: 0, size: 2 as const } }]
+    expect(encodeConfigBytes(fields, { x: '0xABCD' })).toEqual([0xab, 0xcd])
+  })
+
+  it('writes a size-1 value at the requested offset', () => {
+    const fields = [{ id: 'b', encoding: { byteOffset: 3, size: 1 as const } }]
+    expect(encodeConfigBytes(fields, { b: 0x07 }, 5)).toEqual([0, 0, 0, 0x07, 0])
+  })
+
+  it('combines mask+base correctly (low nibble from value, upper bits from base)', () => {
+    // base 0x2100, mask 0x000F. Value 0x5 -> (0x2100 & 0xFFF0) | (0x5 & 0xF) = 0x2105
+    const fields = [
+      {
+        id: 'ch1_type',
+        encoding: { byteOffset: 4, size: 2 as const, base: '0x2100', mask: '0x000F' },
+      },
+    ]
+    expect(encodeConfigBytes(fields, { ch1_type: '0x5' }, 6)).toEqual([0, 0, 0, 0, 0x21, 0x05])
+  })
+
+  it('treats only-mask-or-only-base as no mask/base (and warns)', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const fields = [{ id: 'x', encoding: { byteOffset: 0, size: 2 as const, mask: '0x000F' } }]
+    expect(encodeConfigBytes(fields, { x: '0xABCD' })).toEqual([0xab, 0xcd])
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('parses decimal strings as decimal', () => {
+    const fields = [{ id: 'n', encoding: { byteOffset: 0, size: 1 as const } }]
+    expect(encodeConfigBytes(fields, { n: '15' }, 1)).toEqual([15])
+  })
+
+  it('coerces booleans to 0/1', () => {
+    const fields = [
+      { id: 't', encoding: { byteOffset: 0, size: 1 as const } },
+      { id: 'f', encoding: { byteOffset: 1, size: 1 as const } },
+    ]
+    expect(encodeConfigBytes(fields, { t: true, f: false }, 2)).toEqual([1, 0])
+  })
+
+  it('skips fields with undefined / null / empty-string values', () => {
+    const fields = [
+      { id: 'a', encoding: { byteOffset: 0, size: 1 as const } },
+      { id: 'b', encoding: { byteOffset: 1, size: 1 as const } },
+      { id: 'c', encoding: { byteOffset: 2, size: 1 as const } },
+    ]
+    expect(encodeConfigBytes(fields, { a: undefined, b: null as unknown as undefined, c: '' }, 3)).toEqual([0, 0, 0])
+  })
+
+  it('skips non-finite numeric values', () => {
+    const fields = [{ id: 'x', encoding: { byteOffset: 0, size: 1 as const } }]
+    expect(encodeConfigBytes(fields, { x: Number.NaN }, 1)).toEqual([0])
+    expect(encodeConfigBytes(fields, { x: Number.POSITIVE_INFINITY }, 1)).toEqual([0])
+  })
+
+  it('skips fields that fail numeric parsing', () => {
+    const fields = [{ id: 'x', encoding: { byteOffset: 0, size: 1 as const } }]
+    expect(encodeConfigBytes(fields, { x: 'not-a-number' }, 1)).toEqual([0])
+  })
+
+  it('handles whitespace-only strings as missing', () => {
+    const fields = [{ id: 'x', encoding: { byteOffset: 0, size: 1 as const } }]
+    expect(encodeConfigBytes(fields, { x: '   ' }, 1)).toEqual([0])
+  })
+
+  it('ignores fields whose encoding is missing or malformed', () => {
+    const fields = [
+      { id: 'a' },
+      { id: 'b', encoding: null as unknown as undefined },
+      { id: 'c', encoding: { byteOffset: 0 } as unknown },
+      { id: 'd', encoding: { size: 1 } as unknown },
+      { id: 'e', encoding: { byteOffset: 0, size: 3 } as unknown },
+    ]
+    expect(encodeConfigBytes(fields, { a: '1', b: '2', c: '3', d: '4', e: '5' })).toEqual([])
+  })
+
+  it('clips writes that fall outside totalBytes (size 1 and size 2)', () => {
+    const fields = [
+      { id: 'b1', encoding: { byteOffset: 5, size: 1 as const } },
+      { id: 'b2', encoding: { byteOffset: 3, size: 2 as const, endian: 'big' as const } },
+      { id: 'b3', encoding: { byteOffset: 3, size: 2 as const, endian: 'little' as const } },
+    ]
+    // totalBytes = 4: byte at offset 5 is clipped. offset 3..4 partially clipped (only [3] written).
+    expect(encodeConfigBytes(fields, { b1: 0xff, b2: '0xAABB', b3: '0xAABB' }, 4)).toEqual([0, 0, 0, 0xbb])
+  })
+
+  it('handles negative byte offsets by ignoring them', () => {
+    const fields = [
+      { id: 'a', encoding: { byteOffset: -1, size: 1 as const } },
+      { id: 'b', encoding: { byteOffset: -2, size: 2 as const } },
+    ]
+    expect(encodeConfigBytes(fields, { a: 0xff, b: 0xffff }, 2)).toEqual([0, 0])
+  })
+
+  it('truncates oversized values to the field size', () => {
+    const fields = [
+      { id: 'big', encoding: { byteOffset: 0, size: 1 as const } },
+      { id: 'huge', encoding: { byteOffset: 1, size: 2 as const, endian: 'big' as const } },
+    ]
+    expect(encodeConfigBytes(fields, { big: 0xabcd, huge: 0xfeedface }, 3)).toEqual([0xcd, 0xfa, 0xce])
+  })
+
+  it('computes totalBytes from field offsets when omitted', () => {
+    const fields = [
+      { id: 'a', encoding: { byteOffset: 0, size: 2 as const } },
+      { id: 'b', encoding: { byteOffset: 5, size: 1 as const } },
+    ]
+    expect(encodeConfigBytes(fields, { a: '0x1234', b: '0xFF' })).toEqual([0x12, 0x34, 0, 0, 0, 0xff])
+  })
+
+  it('does not shrink computed totalBytes when a later field ends earlier', () => {
+    // Field "big" pushes max to 8. Field "small" ends at 2 — must NOT
+    // overwrite max. Exercises the false branch of `end > max`.
+    const fields = [
+      { id: 'big', encoding: { byteOffset: 6, size: 2 as const } },
+      { id: 'small', encoding: { byteOffset: 0, size: 2 as const } },
+    ]
+    expect(encodeConfigBytes(fields, { big: '0xAABB', small: '0x1234' })).toEqual([
+      0x12, 0x34, 0, 0, 0, 0, 0xaa, 0xbb,
+    ])
+  })
+
+  it('skips malformed-encoding fields while still encoding valid ones in the same call', () => {
+    // Mixes a valid field (so length > 0) with two malformed ones — the
+    // malformed ones must be silently skipped without affecting the output.
+    const fields = [
+      { id: 'good', encoding: { byteOffset: 0, size: 2 as const } },
+      { id: 'no_size', encoding: { byteOffset: 0 } as unknown },
+      { id: 'no_offset', encoding: { size: 1 } as unknown },
+    ]
+    expect(encodeConfigBytes(fields, { good: '0x4003', no_size: '0xFF', no_offset: '0xFF' })).toEqual([0x40, 0x03])
+  })
+
+  it('falls back to 0 when mask or base is not a valid number', () => {
+    // mask "garbage" -> 0; base "garbage" -> 0. Result: (0 & ~0) | (raw & 0) = 0.
+    const fields = [
+      {
+        id: 'x',
+        encoding: { byteOffset: 0, size: 2 as const, mask: 'garbage', base: 'garbage' },
+      },
+    ]
+    expect(encodeConfigBytes(fields, { x: '0x1234' }, 2)).toEqual([0, 0])
+  })
+
+  it('clips a little-endian write whose first byte is past the end', () => {
+    // off0 = 4 (>= totalBytes), off1 = 5 (>= totalBytes). Nothing written.
+    const fields = [{ id: 'b', encoding: { byteOffset: 4, size: 2 as const, endian: 'little' as const } }]
+    expect(encodeConfigBytes(fields, { b: '0xAABB' }, 4)).toEqual([0, 0, 0, 0])
+  })
+
+  it('matches the SLM-THM-4 factory default (all 4 channels, low burnout/F, type J everywhere)', () => {
+    const fields = [
+      { id: 'channels_enabled', encoding: { byteOffset: 0, size: 2 as const, endian: 'big' as const } },
+      { id: 'burnout_units', encoding: { byteOffset: 2, size: 2 as const, endian: 'big' as const } },
+      {
+        id: 'ch1_type',
+        encoding: { byteOffset: 4, size: 2 as const, endian: 'big' as const, base: '0x2100', mask: '0x000F' },
+      },
+      {
+        id: 'ch2_type',
+        encoding: { byteOffset: 6, size: 2 as const, endian: 'big' as const, base: '0x2200', mask: '0x000F' },
+      },
+      {
+        id: 'ch3_type',
+        encoding: { byteOffset: 8, size: 2 as const, endian: 'big' as const, base: '0x2300', mask: '0x000F' },
+      },
+      {
+        id: 'ch4_type',
+        encoding: { byteOffset: 10, size: 2 as const, endian: 'big' as const, base: '0x2400', mask: '0x000F' },
+      },
+    ]
+    const values = {
+      channels_enabled: '0x4003',
+      burnout_units: '0x6005',
+      ch1_type: '0x0',
+      ch2_type: '0x0',
+      ch3_type: '0x0',
+      ch4_type: '0x0',
+    }
+    expect(encodeConfigBytes(fields, values, 20)).toEqual([
+      0x40, 0x03, 0x60, 0x05, 0x21, 0x00, 0x22, 0x00, 0x23, 0x00, 0x24, 0x00, 0, 0, 0, 0, 0, 0, 0, 0,
+    ])
+  })
+})
+
+describe('bytesToHexString', () => {
+  it('formats bytes as space-separated upper-case hex', () => {
+    expect(bytesToHexString([0x40, 0x03, 0x60, 0x05])).toBe('40 03 60 05')
+  })
+
+  it('zero-pads each byte to two characters', () => {
+    expect(bytesToHexString([0, 1, 0xff])).toBe('00 01 FF')
+  })
+
+  it('masks values to a single byte', () => {
+    expect(bytesToHexString([0x1ff, 0x200])).toBe('FF 00')
+  })
+
+  it('returns an empty string for an empty array', () => {
+    expect(bytesToHexString([])).toBe('')
+  })
+})

--- a/src/backend/shared/utils/vpp/__tests__/generate-vendor-plugin-config.test.ts
+++ b/src/backend/shared/utils/vpp/__tests__/generate-vendor-plugin-config.test.ts
@@ -28,6 +28,48 @@ const moduleAi4 = {
   },
 } satisfies VppModuleDefinition
 
+// A module with a configScreen — used for module_config encoding tests.
+const moduleThm4 = {
+  id: 'thm-4',
+  name: 'THM-4',
+  hwId: '0x34608CE1',
+  addressMapping: {
+    channels: [{ name: 'TC1', type: 'analogInput', dataType: 'INT', addressPrefix: '%IW' }],
+  },
+  configScreenDefinition: {
+    sections: [
+      {
+        id: 'config',
+        layout: 'form',
+        totalBytes: 20,
+        fields: [
+          {
+            id: 'channels_enabled',
+            label: 'Channels',
+            type: 'select',
+            default: '0x4003',
+            encoding: { byteOffset: 0, size: 2, endian: 'big' },
+          },
+          {
+            id: 'burnout_units',
+            label: 'Burnout / Units',
+            type: 'select',
+            default: '0x6005',
+            encoding: { byteOffset: 2, size: 2, endian: 'big' },
+          },
+          {
+            id: 'ch1_type',
+            label: 'CH1 Type',
+            type: 'select',
+            default: '0x0',
+            encoding: { byteOffset: 4, size: 2, endian: 'big', base: '0x2100', mask: '0x000F' },
+          },
+        ],
+      },
+    ],
+  },
+} satisfies VppModuleDefinition
+
 describe('generateVendorPluginConfig', () => {
   it('preserves all fields from the config template', () => {
     const template = { plugin_name: 'acme', baud_rate: 115200, nested: { x: 1 } }
@@ -315,5 +357,142 @@ describe('generateVendorPluginConfig', () => {
       'digital_inputs',
       'digital_outputs',
     ])
+  })
+
+  /* ------------------------------------------------------------ */
+  /* module_config (per-slot configuration bytes)                  */
+  /* ------------------------------------------------------------ */
+
+  it('emits module_config built from field defaults when the user has not set values', () => {
+    const data: VendorScreenData = {
+      'module-configuration': { slots: ['thm-4'] },
+      'io-mapping': { entries: [] },
+    }
+    const result = generateVendorPluginConfig({}, data, [moduleThm4])
+    const slot = (result.slots as Array<{ module_config?: string }>)[0]
+    // defaults: channels=0x4003, burnout/units=0x6005, ch1=type J (0x2100|0=0x2100)
+    // padded to totalBytes=20
+    expect(slot.module_config).toBe('40 03 60 05 21 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00')
+  })
+
+  it('lets per-slot user values override field defaults', () => {
+    const data: VendorScreenData = {
+      'module-configuration': {
+        slots: ['thm-4'],
+        slotsConfig: {
+          '1': { channels_enabled: '0x4001', burnout_units: '0x6001', ch1_type: '0x1' },
+        },
+      },
+    }
+    const result = generateVendorPluginConfig({}, data, [moduleThm4])
+    const slot = (result.slots as Array<{ module_config?: string }>)[0]
+    // 0x4001 / 0x6001 / 0x2101 (CH1 type K)
+    expect(slot.module_config?.startsWith('40 01 60 01 21 01')).toBe(true)
+  })
+
+  it('omits module_config when the module has no configScreenDefinition', () => {
+    const data: VendorScreenData = {
+      'module-configuration': { slots: ['di-8'] },
+      'io-mapping': { entries: [] },
+    }
+    const result = generateVendorPluginConfig({}, data, [moduleDi8])
+    const slot = (result.slots as Array<{ module_config?: string }>)[0]
+    expect(slot.module_config).toBeUndefined()
+  })
+
+  it('omits module_config when the configScreen declares no encodable fields', () => {
+    const moduleEmpty: VppModuleDefinition = {
+      id: 'empty-screen',
+      name: 'Empty',
+      hwId: '0xAA',
+      addressMapping: { channels: [] },
+      configScreenDefinition: { sections: [{ id: 'x', fields: [] }] },
+    }
+    const data: VendorScreenData = {
+      'module-configuration': { slots: ['empty-screen'] },
+    }
+    const result = generateVendorPluginConfig({}, data, [moduleEmpty])
+    const slot = (result.slots as Array<{ module_config?: string }>)[0]
+    expect(slot.module_config).toBeUndefined()
+  })
+
+  it('handles malformed configScreenDefinitions gracefully', () => {
+    // sections is not an array, fields is not an array, items have no id —
+    // collectConfigFormFields must silently skip and return no fields.
+    const moduleBad: VppModuleDefinition = {
+      id: 'bad-screen',
+      name: 'Bad',
+      hwId: '0xBB',
+      addressMapping: { channels: [] },
+      configScreenDefinition: {
+        sections: [
+          null,
+          'not-an-object',
+          { fields: 'not-an-array' },
+          { fields: [null, 'string-field', { /* no id */ encoding: { byteOffset: 0, size: 1 } }] },
+        ],
+      },
+    }
+    const data: VendorScreenData = { 'module-configuration': { slots: ['bad-screen'] } }
+    const result = generateVendorPluginConfig({}, data, [moduleBad])
+    const slot = (result.slots as Array<{ module_config?: string }>)[0]
+    expect(slot.module_config).toBeUndefined()
+  })
+
+  it('omits module_config when configScreenDefinition is explicitly null', () => {
+    const moduleNullDef: VppModuleDefinition = {
+      id: 'null-def',
+      name: 'Null',
+      hwId: '0xCC',
+      addressMapping: { channels: [] },
+      configScreenDefinition: null,
+    }
+    const data: VendorScreenData = { 'module-configuration': { slots: ['null-def'] } }
+    const result = generateVendorPluginConfig({}, data, [moduleNullDef])
+    const slot = (result.slots as Array<{ module_config?: string }>)[0]
+    expect(slot.module_config).toBeUndefined()
+  })
+
+  it('falls back to encoder-computed length when totalBytes is absent', () => {
+    const moduleShort: VppModuleDefinition = {
+      id: 'short',
+      name: 'Short',
+      hwId: '0xDD',
+      addressMapping: { channels: [] },
+      configScreenDefinition: {
+        sections: [
+          {
+            id: 'cfg',
+            layout: 'form',
+            fields: [
+              {
+                id: 'channels_enabled',
+                label: 'Channels',
+                type: 'select',
+                default: '0x4007',
+                encoding: { byteOffset: 0, size: 2, endian: 'big' },
+              },
+            ],
+          },
+        ],
+      },
+    }
+    const data: VendorScreenData = { 'module-configuration': { slots: ['short'] } }
+    const result = generateVendorPluginConfig({}, data, [moduleShort])
+    const slot = (result.slots as Array<{ module_config?: string }>)[0]
+    expect(slot.module_config).toBe('40 07')
+  })
+
+  it('treats empty-string user values as "use the default"', () => {
+    const data: VendorScreenData = {
+      'module-configuration': {
+        slots: ['thm-4'],
+        slotsConfig: { '1': { channels_enabled: '' } },
+      },
+    }
+    const result = generateVendorPluginConfig({}, data, [moduleThm4])
+    const slot = (result.slots as Array<{ module_config?: string }>)[0]
+    // empty -> use default 0x4003
+    expect(slot.module_config?.startsWith('40 03')).toBe(true)
   })
 })

--- a/src/backend/shared/utils/vpp/byte-encoder.ts
+++ b/src/backend/shared/utils/vpp/byte-encoder.ts
@@ -1,0 +1,159 @@
+/**
+ * Encodes form-field values into a configuration byte array.
+ *
+ * VPP module configuration screens declare an `encoding` block per
+ * field that describes how the field's value contributes to the raw
+ * SPI configuration payload the runtime plugin pushes to each slot
+ * (see synergy_spi_send_config). This module converts the {fieldId
+ * -> value} bag the editor stores into the byte array the runtime
+ * expects.
+ *
+ * Per-field semantics:
+ *
+ *   - The value is parsed as a number. Strings prefixed with "0x" or
+ *     "0X" are parsed as hex; everything else as decimal. Booleans
+ *     become 1/0; missing values are skipped (the byte stays zero).
+ *   - When `mask` and `base` are both provided, the bits selected by
+ *     `mask` come from the value and the rest come from `base`. This
+ *     is how a "low nibble selects type, upper 12 bits identify the
+ *     channel" layout (e.g. P1/SLM thermocouple `0x2100 | type`) is
+ *     expressed without duplicating the channel constant on every
+ *     option.
+ *   - When `mask` and `base` are both omitted, the value is written
+ *     verbatim. Specifying only one is a screen-author error: we
+ *     emit a console warning and treat it as "no mask/base."
+ *   - Bytes are written in `endian` order at `byteOffset`. Default
+ *     endian is `big`. Field overlap (two fields writing to the same
+ *     offset) is permitted; later fields overwrite earlier ones —
+ *     screen authors should avoid this.
+ *   - Writes that fall outside the configured `totalBytes` are
+ *     clipped. The output array is always exactly `totalBytes` long
+ *     when that value is provided, otherwise it is sized to the
+ *     largest declared (byteOffset + size).
+ */
+
+type FieldValue = string | number | boolean | undefined | null
+
+export type ByteEncoding = {
+  byteOffset: number
+  size: 1 | 2
+  endian?: 'big' | 'little'
+  mask?: string
+  base?: string
+}
+
+export type EncoderFieldDef = {
+  id: string
+  /** May arrive shaped as `ByteEncoding` or as something else
+   *  entirely (vendor-supplied JSON). `isEncoding()` narrows it
+   *  internally. */
+  encoding?: unknown
+}
+
+/** Parse a hex (`0x...`) or decimal string into an integer. Returns
+ *  null on parse failure or unsupported input. */
+function parseNumberLike(v: FieldValue): number | null {
+  if (v === undefined || v === null || v === '') return null
+  if (typeof v === 'boolean') return v ? 1 : 0
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null
+  const s = String(v).trim()
+  if (s === '') return null
+  const isHex = s.startsWith('0x') || s.startsWith('0X')
+  const parsed = isHex ? Number.parseInt(s.slice(2), 16) : Number.parseInt(s, 10)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function isEncoding(e: unknown): e is ByteEncoding {
+  if (!e || typeof e !== 'object') return false
+  const r = e as Record<string, unknown>
+  return typeof r.byteOffset === 'number' && (r.size === 1 || r.size === 2)
+}
+
+function computeTotalBytes(fields: EncoderFieldDef[], explicit: number | undefined): number {
+  if (typeof explicit === 'number' && explicit >= 0) return explicit
+  let max = 0
+  for (const f of fields) {
+    if (!isEncoding(f.encoding)) continue
+    const end = f.encoding.byteOffset + f.encoding.size
+    if (end > max) max = end
+  }
+  return max
+}
+
+/**
+ * Encode field values into a configuration byte array.
+ *
+ * @param fields    Form-layout fields (with optional `encoding`)
+ * @param values    Bag of field-id -> current value, as stored in the
+ *                  Zustand vendor-screen state
+ * @param totalBytes Optional fixed output size. When supplied, the
+ *                  output is zero-padded or clipped to exactly this
+ *                  length. When omitted, the output covers exactly
+ *                  what the fields declare.
+ */
+export function encodeConfigBytes(
+  fields: EncoderFieldDef[],
+  values: Record<string, FieldValue>,
+  totalBytes?: number,
+): number[] {
+  const length = computeTotalBytes(fields, totalBytes)
+  const bytes = new Array<number>(length).fill(0)
+  if (length === 0) return bytes
+
+  for (const field of fields) {
+    if (!isEncoding(field.encoding)) continue
+    const enc = field.encoding
+    const raw = parseNumberLike(values[field.id])
+    if (raw === null) continue
+
+    let composed = raw
+    const hasMask = typeof enc.mask === 'string'
+    const hasBase = typeof enc.base === 'string'
+    if (hasMask !== hasBase) {
+      // Inconsistent — treat as no mask/base. Surfaced as a warning
+      // because it's almost certainly a screen-author mistake.
+      console.warn(
+        `[vpp byte-encoder] field "${field.id}" defines only one of mask/base; both are required to merge with the value`,
+      )
+    } else if (hasMask && hasBase) {
+      const mask = parseNumberLike(enc.mask) ?? 0
+      const base = parseNumberLike(enc.base) ?? 0
+      composed = (base & ~mask) | (raw & mask)
+    }
+
+    const endian = enc.endian ?? 'big'
+    const size = enc.size
+
+    // Mask to size to avoid leaking high bits the screen author
+    // didn't anticipate (e.g. a 32-bit option value into a size-2
+    // field).
+    const widthMask = size === 1 ? 0xff : 0xffff
+    const bounded = composed & widthMask
+
+    if (size === 1) {
+      const off = enc.byteOffset
+      if (off >= 0 && off < length) bytes[off] = bounded
+    } else {
+      const hi = (bounded >> 8) & 0xff
+      const lo = bounded & 0xff
+      const off0 = enc.byteOffset
+      const off1 = enc.byteOffset + 1
+      if (endian === 'big') {
+        if (off0 >= 0 && off0 < length) bytes[off0] = hi
+        if (off1 >= 0 && off1 < length) bytes[off1] = lo
+      } else {
+        if (off0 >= 0 && off0 < length) bytes[off0] = lo
+        if (off1 >= 0 && off1 < length) bytes[off1] = hi
+      }
+    }
+  }
+
+  return bytes
+}
+
+/** Format bytes as a space-separated hex string, e.g. "40 03 60 05". */
+export function bytesToHexString(bytes: number[]): string {
+  return bytes
+    .map((b) => (b & 0xff).toString(16).padStart(2, '0').toUpperCase())
+    .join(' ')
+}

--- a/src/backend/shared/utils/vpp/generate-vendor-plugin-config.ts
+++ b/src/backend/shared/utils/vpp/generate-vendor-plugin-config.ts
@@ -22,6 +22,8 @@
  *   }
  */
 
+import { bytesToHexString, encodeConfigBytes } from './byte-encoder'
+
 type ModuleChannel = {
   name: string
   type: string
@@ -34,10 +36,19 @@ type VppModuleDefinition = {
   name: string
   hwId?: string
   addressMapping?: unknown
+  /** Optional per-module config-screen JSON. Pre-loaded by the caller
+   *  (compiler-module) so this pure-function generator never touches
+   *  the filesystem. */
+  configScreenDefinition?: unknown
 }
 
 type ModuleConfiguration = {
   slots?: (string | null)[]
+  /** Per-slot bag of form-field values, keyed by 1-based slot number
+   *  (stored as a string for JSON safety). Populated by the master-
+   *  detail backplane editor when the user fills in a module's
+   *  configuration form. */
+  slotsConfig?: Record<string, Record<string, string | number | boolean>>
 }
 
 type IoMappingEntry = {
@@ -74,6 +85,11 @@ type PluginSlotIoMapping = {
 type PluginSlot = {
   slot: number
   module_hw_id?: string
+  /** Module configuration bytes for the runtime to push over SPI
+   *  immediately after sign-on. Hex-encoded space-separated string,
+   *  e.g. "40 03 60 05 21 00 22 00 ...". Absent when the module has
+   *  no configuration screen or the user left every field empty. */
+  module_config?: string
   io_mapping: PluginSlotIoMapping
 }
 
@@ -150,6 +166,7 @@ function buildSlots(vendorScreenData: VendorScreenData, modules: VppModuleDefini
   const moduleConfig = (vendorScreenData['module-configuration'] as ModuleConfiguration | undefined) ?? {}
   const ioMapping = (vendorScreenData['io-mapping'] as IoMapping | undefined) ?? {}
   const slotAssignments = moduleConfig.slots ?? []
+  const slotsConfigBag = moduleConfig.slotsConfig ?? {}
   const ioEntries = ioMapping.entries ?? []
 
   const slots: PluginSlot[] = []
@@ -163,6 +180,8 @@ function buildSlots(vendorScreenData: VendorScreenData, modules: VppModuleDefini
 
     const slotNumber = slotIndex + 1
     const channels = (moduleDef.addressMapping as { channels?: ModuleChannel[] } | undefined)?.channels ?? []
+    const configScreenDef = moduleDef.configScreenDefinition
+    const slotConfigValues = slotsConfigBag[String(slotNumber)] ?? {}
 
     // Group channels by type and resolve each channel's assigned IEC address
     const di: { name: string; address: string }[] = []
@@ -195,10 +214,90 @@ function buildSlots(vendorScreenData: VendorScreenData, modules: VppModuleDefini
       io_mapping: ioMappingBlock,
     }
     if (moduleDef.hwId) slot.module_hw_id = moduleDef.hwId
+
+    // Module configuration bytes — only when the manifest declared a
+    // configScreen for this SKU and the editor has either user input
+    // or schema defaults to feed the encoder.
+    const moduleConfigBytes = encodeModuleConfig(configScreenDef, slotConfigValues)
+    if (moduleConfigBytes !== null) slot.module_config = bytesToHexString(moduleConfigBytes)
+
     slots.push(slot)
   }
 
   return slots
+}
+
+/* ------------------------------------------------------------------ */
+/* Module configuration encoding                                      */
+/* ------------------------------------------------------------------ */
+
+type FormField = {
+  id: string
+  default?: unknown
+  encoding?: unknown
+}
+
+type ConfigSection = {
+  layout?: string
+  fields?: unknown
+  totalBytes?: number
+}
+
+type ConfigScreenDef = {
+  sections?: ConfigSection[]
+}
+
+/** Walk a module's configScreenDefinition and produce (fields, total). */
+function collectConfigFormFields(def: unknown): { fields: FormField[]; totalBytes?: number } {
+  const screen = (def ?? {}) as ConfigScreenDef
+  const sections = Array.isArray(screen.sections) ? screen.sections : []
+  const fields: FormField[] = []
+  let totalBytes: number | undefined
+  for (const section of sections) {
+    if (!section || typeof section !== 'object') continue
+    if (typeof section.totalBytes === 'number' && totalBytes === undefined) {
+      totalBytes = section.totalBytes
+    }
+    const sectionFields = Array.isArray(section.fields) ? section.fields : []
+    for (const f of sectionFields) {
+      if (f && typeof f === 'object' && typeof (f as { id?: unknown }).id === 'string') {
+        fields.push(f as FormField)
+      }
+    }
+  }
+  return { fields, totalBytes }
+}
+
+/**
+ * Encode the configuration bytes for a single slot.
+ *
+ * Returns `null` when the module has no config screen (and therefore
+ * no module_config in the emitted slot), or when the screen declares
+ * no encodable fields.
+ *
+ * Field values come from the user's stored input where present and
+ * from the field's `default` otherwise — mirroring what the editor's
+ * UI shows so the runtime gets what the user sees.
+ */
+function encodeModuleConfig(
+  configScreenDef: unknown,
+  storedValues: Record<string, string | number | boolean>,
+): number[] | null {
+  if (!configScreenDef) return null
+  const { fields, totalBytes } = collectConfigFormFields(configScreenDef)
+  if (fields.length === 0) return null
+
+  const merged: Record<string, string | number | boolean> = {}
+  for (const f of fields) {
+    const v = storedValues[f.id]
+    if (v !== undefined && v !== null && v !== '') {
+      merged[f.id] = v
+    } else if (f.default !== undefined && f.default !== null && f.default !== '') {
+      merged[f.id] = f.default as string | number | boolean
+    }
+  }
+
+  return encodeConfigBytes(fields, merged, totalBytes)
 }
 
 /**

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/index.tsx
@@ -22,6 +22,15 @@ type ScreenDefinition = {
 type ModuleDefinition = {
   id: string
   name: string
+  hwId?: string
+  image?: string
+  description?: string
+  specs?: Record<string, string>
+  configScreen?: string
+  /** Parsed per-module config-screen JSON, loaded by the backend
+   *  alongside top-level screens. Renderers read fields from here to
+   *  produce the slot-detail config form. */
+  configScreenDefinition?: unknown
   io: { digitalInputs: number; digitalOutputs: number; analogInputs: number; analogOutputs: number }
   parameters?: Array<{
     id: string

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/index.tsx
@@ -63,7 +63,10 @@ const VendorScreenRenderer = memo(function VendorScreenRenderer({
   if (!screen?.sections) return null
 
   return (
-    <div className='flex w-full flex-col gap-6'>
+    // `flex-1 min-h-0` lets a child section (e.g. `module-slots`) claim
+    // the full available height and host its own internal scrollers
+    // instead of forcing the page-level container to scroll.
+    <div className='flex w-full flex-1 min-h-0 flex-col gap-6'>
       {screen.sections.map((section) => (
         <SectionRenderer key={section.id} section={section} moduleSystem={moduleSystem} />
       ))}

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
@@ -456,7 +456,7 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
               <img
                 src={moduleImage}
                 alt={selectedModule.name}
-                className='h-64 w-64 shrink-0 self-start object-contain'
+                className='h-80 w-80 shrink-0 self-start object-contain'
               />
             )}
           </div>

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
@@ -450,15 +450,16 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
               )}
             </div>
 
-            {/* Module image — stretches vertically to the height of
-                the left text block (Slot title -> specs). Has a fixed
-                width so the text column keeps a stable layout. */}
+            {/* Module image — fixed width with a generous min-height,
+                stretches further if the left text block grows past it
+                via self-stretch. Sized to be the visual anchor of the
+                slot card. */}
             {selectedModule && (
-              <div className='flex w-48 shrink-0 items-center justify-center self-stretch overflow-hidden rounded-md border border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900'>
+              <div className='flex min-h-72 w-96 shrink-0 items-center justify-center self-stretch overflow-hidden rounded-md border border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900'>
                 {moduleImage ? (
                   <img src={moduleImage} alt={selectedModule.name} className='h-full w-full object-contain' />
                 ) : (
-                  <span className='text-[10px] text-neutral-400 dark:text-neutral-600'>No image</span>
+                  <span className='text-xs text-neutral-400 dark:text-neutral-600'>No image</span>
                 )}
               </div>
             )}

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
@@ -373,69 +373,69 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
 
         {/* ------ Right: contextual detail pane ------ */}
         <div className='flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto rounded-md border border-neutral-200 p-4 dark:border-neutral-700'>
-          <h3 className='mb-3 font-caption text-base font-semibold text-neutral-950 dark:text-white'>
-            Slot {selectedSlot + 1}
-          </h3>
+          {/* Header: Slot title, module picker, description, specs
+              on the left; module image fills the right column from
+              the top of the card down to the end of the specs. */}
+          <div className='mb-5 flex gap-5'>
+            <div className='flex min-w-0 flex-1 flex-col'>
+              <h3 className='mb-3 font-caption text-base font-semibold text-neutral-950 dark:text-white'>
+                Slot {selectedSlot + 1}
+              </h3>
 
-          {/* Module picker — always visible. Selecting "-- Empty --"
-              clears the slot; selecting another module switches in
-              place without an intermediate clear step. */}
-          <div className='mb-4 flex items-center gap-3'>
-            <Label className='w-20 shrink-0 text-xs font-medium text-neutral-950 dark:text-white'>Module</Label>
-            <Select
-              value={selectedModule ? selectedModule.id : '__empty__'}
-              onValueChange={(v) => handleSlotChange(selectedSlot, v === '__empty__' ? '' : v)}
-            >
-              <SelectTrigger
-                aria-label={`Module for slot ${selectedSlot + 1}`}
-                placeholder='-- Empty --'
-                withIndicator
-                className='flex h-[32px] w-80 items-center justify-between gap-1 rounded-md border border-neutral-100 bg-white px-3 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none data-[state=open]:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
-              />
-              <SelectContent
-                className='h-fit max-h-[280px] w-[--radix-select-trigger-width] overflow-y-auto rounded-lg border border-neutral-100 bg-white outline-none drop-shadow-lg dark:border-brand-medium-dark dark:bg-neutral-950'
-                sideOffset={5}
-                position='popper'
-                align='center'
-                side='bottom'
-              >
-                <SelectItem
-                  value='__empty__'
-                  className='flex w-full cursor-pointer items-center px-2 py-[6px] outline-none hover:bg-neutral-200 dark:hover:bg-neutral-850'
+              {/* Module picker — always visible. Selecting "-- Empty --"
+                  clears the slot; selecting another module switches
+                  in place without an intermediate clear step. */}
+              <div className='mb-4 flex items-center gap-3'>
+                <Label className='w-20 shrink-0 text-xs font-medium text-neutral-950 dark:text-white'>Module</Label>
+                <Select
+                  value={selectedModule ? selectedModule.id : '__empty__'}
+                  onValueChange={(v) => handleSlotChange(selectedSlot, v === '__empty__' ? '' : v)}
                 >
-                  <span className='font-caption text-cp-sm font-medium italic text-neutral-500 dark:text-neutral-400'>
-                    -- Empty --
-                  </span>
-                </SelectItem>
-                {availableModules.map((mod) => (
-                  <SelectItem
-                    key={mod.id}
-                    value={mod.id}
-                    className='flex w-full cursor-pointer items-center px-2 py-[6px] outline-none hover:bg-neutral-200 dark:hover:bg-neutral-850'
+                  <SelectTrigger
+                    aria-label={`Module for slot ${selectedSlot + 1}`}
+                    placeholder='-- Empty --'
+                    withIndicator
+                    className='flex h-[32px] w-80 items-center justify-between gap-1 rounded-md border border-neutral-100 bg-white px-3 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none data-[state=open]:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
+                  />
+                  <SelectContent
+                    className='h-fit max-h-[280px] w-[--radix-select-trigger-width] overflow-y-auto rounded-lg border border-neutral-100 bg-white outline-none drop-shadow-lg dark:border-brand-medium-dark dark:bg-neutral-950'
+                    sideOffset={5}
+                    position='popper'
+                    align='center'
+                    side='bottom'
                   >
-                    <span className='font-caption text-cp-sm font-medium text-neutral-850 dark:text-neutral-300'>
-                      {mod.name}
-                    </span>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+                    <SelectItem
+                      value='__empty__'
+                      className='flex w-full cursor-pointer items-center px-2 py-[6px] outline-none hover:bg-neutral-200 dark:hover:bg-neutral-850'
+                    >
+                      <span className='font-caption text-cp-sm font-medium italic text-neutral-500 dark:text-neutral-400'>
+                        -- Empty --
+                      </span>
+                    </SelectItem>
+                    {availableModules.map((mod) => (
+                      <SelectItem
+                        key={mod.id}
+                        value={mod.id}
+                        className='flex w-full cursor-pointer items-center px-2 py-[6px] outline-none hover:bg-neutral-200 dark:hover:bg-neutral-850'
+                      >
+                        <span className='font-caption text-cp-sm font-medium text-neutral-850 dark:text-neutral-300'>
+                          {mod.name}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
 
-          {selectedModule ? (
-            <div className='flex flex-col gap-5'>
-              {/* Header: description + specs on the left (under the
-                  Module picker above), image on the right. Picture
-                  height grows to match the text block. */}
-              <div className='flex gap-4'>
-                <div className='min-w-0 flex-1'>
+              {selectedModule && (
+                <>
                   {(selectedModule as { description?: string }).description && (
                     <p className='text-xs text-neutral-600 dark:text-neutral-400'>
                       {(selectedModule as { description?: string }).description}
                     </p>
                   )}
                   {(selectedModule as { specs?: Record<string, string> }).specs && (
-                    <dl className='mt-2 grid grid-cols-2 gap-x-4 gap-y-0.5 text-[11px]'>
+                    <dl className='mt-2 flex flex-col gap-0.5 text-xs text-neutral-600 dark:text-neutral-400'>
                       {Object.entries((selectedModule as { specs?: Record<string, string> }).specs ?? {}).map(
                         ([k, v]) => (
                           <div key={k} className='flex gap-1'>
@@ -446,16 +446,26 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
                       )}
                     </dl>
                   )}
-                </div>
-                <div className='flex h-36 w-36 shrink-0 items-center justify-center self-start overflow-hidden rounded-md border border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900'>
-                  {moduleImage ? (
-                    <img src={moduleImage} alt={selectedModule.name} className='h-full w-full object-contain' />
-                  ) : (
-                    <span className='text-[10px] text-neutral-400 dark:text-neutral-600'>No image</span>
-                  )}
-                </div>
-              </div>
+                </>
+              )}
+            </div>
 
+            {/* Module image — stretches vertically to the height of
+                the left text block (Slot title -> specs). Has a fixed
+                width so the text column keeps a stable layout. */}
+            {selectedModule && (
+              <div className='flex w-48 shrink-0 items-center justify-center self-stretch overflow-hidden rounded-md border border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900'>
+                {moduleImage ? (
+                  <img src={moduleImage} alt={selectedModule.name} className='h-full w-full object-contain' />
+                ) : (
+                  <span className='text-[10px] text-neutral-400 dark:text-neutral-600'>No image</span>
+                )}
+              </div>
+            )}
+          </div>
+
+          {selectedModule ? (
+            <div className='flex flex-col gap-5'>
               {/* I/O Mapping */}
               {ioEntriesForSelected.length > 0 && (
                 <section>

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
@@ -1,162 +1,596 @@
+import { collectUsedIecAddresses } from '@root/backend/shared/utils/iec-address'
+import { Checkbox } from '@root/frontend/components/_atoms/checkbox'
+import { Label } from '@root/frontend/components/_atoms/label'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@root/frontend/components/_atoms/select'
+import { boardSelectors } from '@root/frontend/hooks/use-store-selectors'
 import { useOpenPLCStore } from '@root/frontend/store'
+import { generateIecAddress } from '@root/frontend/utils/iec-address'
 import { getSectionPersistenceKey } from '@root/frontend/utils/vpp/persistence-keys'
-import { useMemo } from 'react'
+import type { IoMappingEntry } from '@root/middleware/shared/ports/types'
+import { useDevice } from '@root/middleware/shared/providers/platform-context'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import type { ModuleSystem, ScreenSection } from '../index'
+import type { ModuleDefinition, ModuleSystem, ScreenSection } from '../index'
 
 type ModuleSlotsLayoutProps = {
   section: ScreenSection
   moduleSystem: ModuleSystem
 }
 
+type FieldValue = string | number | boolean
+type SlotConfigMap = Record<string, Record<string, FieldValue>>
+type ModuleConfigState = {
+  slots?: (string | null)[]
+  slotsConfig?: SlotConfigMap
+}
+
+type ConfigFieldDef = {
+  id: string
+  label: string
+  type: string
+  default?: FieldValue
+  help?: string
+  min?: number
+  max?: number
+  step?: number
+  unit?: string
+  options?: Array<string | { value: string; label: string }>
+  visible?: VisibleCondition
+  encoding?: unknown
+}
+
+type VisibleCondition =
+  | { condition: string; operator: string; value?: unknown }
+  | { operator: 'and' | 'or'; conditions: VisibleCondition[] }
+
+type ConfigScreenDefinition = {
+  sections?: Array<{ id: string; title?: string; layout?: string; fields?: ConfigFieldDef[] }>
+}
+
+// Walk a screen definition and return every field that contributes
+// to the configuration form. The screen JSON is a vendor artifact —
+// be tolerant of missing/oddly-shaped fragments rather than crash.
+function collectConfigFields(def: ConfigScreenDefinition | undefined | null): ConfigFieldDef[] {
+  if (!def?.sections) return []
+  const out: ConfigFieldDef[] = []
+  for (const section of def.sections) {
+    if (!section.fields) continue
+    for (const f of section.fields) {
+      if (f && typeof f === 'object' && typeof f.id === 'string') out.push(f)
+    }
+  }
+  return out
+}
+
+function evalVisible(visible: VisibleCondition | undefined, values: Record<string, FieldValue>): boolean {
+  if (!visible) return true
+  if ('conditions' in visible) {
+    const results = visible.conditions.map((c) => evalVisible(c, values))
+    return visible.operator === 'and' ? results.every(Boolean) : results.some(Boolean)
+  }
+  const v = values[visible.condition]
+  switch (visible.operator) {
+    case 'equals':
+      return v === visible.value
+    case 'not-equals':
+      return v !== visible.value
+    case 'in':
+      return Array.isArray(visible.value) && (visible.value as unknown[]).includes(v)
+    case 'exists':
+      return v !== undefined && v !== null && v !== ''
+    case 'not-exists':
+      return v === undefined || v === null || v === ''
+    default:
+      return true
+  }
+}
+
 function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
   const maxSlots = section.maxSlots || moduleSystem?.maxSlots || 8
-  const availableModules = moduleSystem?.modules ?? []
+  // Memoize so hooks depending on this don't fire every render.
+  const availableModules = useMemo(() => moduleSystem?.modules ?? [], [moduleSystem])
 
   const vendorScreenData = useOpenPLCStore((s) => s.deviceDefinitions.configuration.vendorScreenData)
   const setVendorScreenData = useOpenPLCStore((s) => s.deviceActions.setVendorScreenData)
-  // Single source of truth — see `getSectionPersistenceKey` in
-  // ../index.tsx.
-  const persistenceKey = getSectionPersistenceKey(section)
+  const persistenceKey = getSectionPersistenceKey(section) ?? 'module-configuration'
 
-  const storedData =
-    persistenceKey !== null
-      ? (vendorScreenData?.[persistenceKey] as { slots?: (string | null)[] } | undefined)
-      : undefined
-  const slots = storedData?.slots ?? Array<string | null>(maxSlots).fill(null)
+  const moduleConfig = (vendorScreenData?.[persistenceKey] as ModuleConfigState | undefined) ?? {}
+  const slots = useMemo(() => {
+    const stored = moduleConfig.slots ?? []
+    if (stored.length >= maxSlots) return stored.slice(0, maxSlots)
+    return [...stored, ...Array<string | null>(maxSlots - stored.length).fill(null)]
+  }, [moduleConfig.slots, maxSlots])
+  const slotsConfig = useMemo(() => moduleConfig.slotsConfig ?? {}, [moduleConfig.slotsConfig])
+
+  const [selectedSlot, setSelectedSlot] = useState(0)
+  useEffect(() => {
+    if (selectedSlot >= maxSlots) setSelectedSlot(0)
+  }, [maxSlots, selectedSlot])
+
+  const findModule = useCallback(
+    (id: string | null | undefined): ModuleDefinition | undefined =>
+      id ? availableModules.find((m) => m.id === id) : undefined,
+    [availableModules],
+  )
+
+  const selectedModuleId = slots[selectedSlot] ?? null
+  const selectedModule = findModule(selectedModuleId)
+
+  /* ------------------------------------------------------------ */
+  /* Module image (lazy fetch via the SystemPort preview endpoint) */
+  /* ------------------------------------------------------------ */
+  const deviceBoard = boardSelectors.useDeviceBoard()
+  const availableBoards = boardSelectors.useAvailableBoards()
+  const packagePath = availableBoards.get(deviceBoard)?.vpp?.packagePath
+  const devicePort = useDevice()
+  const [moduleImage, setModuleImage] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const imageRel = (selectedModule as { image?: string } | undefined)?.image
+    if (!imageRel || !packagePath) {
+      setModuleImage(null)
+      return
+    }
+    void devicePort
+      .getPreviewImage(imageRel, packagePath)
+      .then((dataUrl: string) => {
+        if (!cancelled) setModuleImage(dataUrl || null)
+      })
+      .catch(() => {
+        if (!cancelled) setModuleImage(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedModule, packagePath, devicePort])
+
+  /* ------------------------------------------------------------ */
+  /* I/O mapping regeneration                                      */
+  /*                                                              */
+  /* Mirrors the standalone io-table-layout: when the slot module */
+  /* list changes, rebuild the IoMappingEntry[] (auto-assigned    */
+  /* addresses) while preserving any user-typed aliases by        */
+  /* slot:channel key. Writes to the 'io-mapping' persistence key */
+  /* so the rest of the compile flow keeps reading the same data. */
+  /* ------------------------------------------------------------ */
+  const lastSlotsRef = useRef<string>('')
+  useEffect(() => {
+    const slotsKey = JSON.stringify(slots)
+    if (slotsKey === lastSlotsRef.current) return
+    lastSlotsRef.current = slotsKey
+
+    const state = useOpenPLCStore.getState()
+    const vsd = state.deviceDefinitions.configuration.vendorScreenData
+    const storedMapping = vsd?.['io-mapping'] as { entries?: IoMappingEntry[] } | undefined
+    const remoteDevices = (state.project.data.remoteDevices ?? []) as Array<{
+      modbusTcpConfig?: { ioGroups?: Array<{ ioPoints: Array<{ iecLocation: string }> }> }
+      ethercatConfig?: { devices?: Array<{ channelMappings?: Array<{ iecLocation: string }> }> }
+    }>
+
+    const existingAliases = new Map<string, string>()
+    for (const entry of storedMapping?.entries ?? []) {
+      if (entry.alias) existingAliases.set(`${entry.slot}:${entry.channelName}`, entry.alias)
+    }
+
+    const usedAddresses = collectUsedIecAddresses(remoteDevices)
+    const newEntries: IoMappingEntry[] = []
+
+    for (let slotIndex = 0; slotIndex < slots.length; slotIndex++) {
+      const moduleId = slots[slotIndex]
+      if (!moduleId) continue
+      const moduleDef = availableModules.find((m) => m.id === moduleId)
+      if (!moduleDef) continue
+      const channels = (
+        moduleDef as {
+          addressMapping?: {
+            channels?: Array<{ name: string; type: string; dataType: string; addressPrefix: string }>
+          }
+        }
+      ).addressMapping?.channels
+      if (!channels) continue
+
+      for (const channel of channels) {
+        const isBit = channel.addressPrefix === '%IX' || channel.addressPrefix === '%QX'
+        const iecAddress = generateIecAddress(channel.addressPrefix, isBit, usedAddresses)
+        usedAddresses.add(iecAddress)
+        const aliasKey = `${slotIndex + 1}:${channel.name}`
+        newEntries.push({
+          slot: slotIndex + 1,
+          moduleId,
+          moduleName: moduleDef.name,
+          channelName: channel.name,
+          channelType: channel.type,
+          dataType: channel.dataType,
+          iecAddress,
+          alias: existingAliases.get(aliasKey) ?? '',
+        })
+      }
+    }
+
+    setVendorScreenData('io-mapping', { entries: newEntries })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slots])
+
+  /* ------------------------------------------------------------ */
+  /* Mutators                                                      */
+  /* ------------------------------------------------------------ */
+  const writeModuleConfig = (next: ModuleConfigState) => {
+    setVendorScreenData(persistenceKey, next)
+  }
 
   const handleSlotChange = (slotIndex: number, moduleId: string) => {
-    if (persistenceKey === null) return
     const next = [...slots]
     next[slotIndex] = moduleId || null
-    setVendorScreenData(persistenceKey, { ...storedData, slots: next })
+    const nextConfig = { ...slotsConfig }
+    if (!moduleId) delete nextConfig[String(slotIndex + 1)]
+    writeModuleConfig({ ...moduleConfig, slots: next, slotsConfig: nextConfig })
   }
 
   const handleClearAll = () => {
-    if (persistenceKey === null) return
-    setVendorScreenData(persistenceKey, { ...storedData, slots: Array<string | null>(maxSlots).fill(null) })
+    writeModuleConfig({ ...moduleConfig, slots: Array<string | null>(maxSlots).fill(null), slotsConfig: {} })
   }
 
-  const ioSummary = useMemo(() => {
-    const totals = { di: 0, do: 0, ai: 0, ao: 0 }
-    for (const moduleId of slots) {
-      if (!moduleId) continue
-      const mod = availableModules.find((m) => m.id === moduleId)
-      if (!mod) continue
-      totals.di += mod.io.digitalInputs
-      totals.do += mod.io.digitalOutputs
-      totals.ai += mod.io.analogInputs
-      totals.ao += mod.io.analogOutputs
+  const handleClearSlot = (slotIndex: number) => handleSlotChange(slotIndex, '')
+
+  const handleFieldChange = (slotIndex: number, fieldId: string, value: FieldValue) => {
+    const key = String(slotIndex + 1)
+    const slotValues = { ...(slotsConfig[key] ?? {}), [fieldId]: value }
+    writeModuleConfig({
+      ...moduleConfig,
+      slots,
+      slotsConfig: { ...slotsConfig, [key]: slotValues },
+    })
+  }
+
+  const handleAliasChange = (slot: number, channelName: string, alias: string) => {
+    const state = useOpenPLCStore.getState()
+    const vsd = state.deviceDefinitions.configuration.vendorScreenData
+    const entries = ((vsd?.['io-mapping'] as { entries?: IoMappingEntry[] } | undefined)?.entries ?? []).map((e) =>
+      e.slot === slot && e.channelName === channelName ? { ...e, alias } : e,
+    )
+    setVendorScreenData('io-mapping', { entries })
+  }
+
+  /* ------------------------------------------------------------ */
+  /* Config field values (with defaults)                           */
+  /* ------------------------------------------------------------ */
+  const configFields = useMemo(
+    () => collectConfigFields(selectedModule?.configScreenDefinition as ConfigScreenDefinition | undefined),
+    [selectedModule],
+  )
+  const slotValues: Record<string, FieldValue> = useMemo(() => {
+    const stored = slotsConfig[String(selectedSlot + 1)] ?? {}
+    const out: Record<string, FieldValue> = {}
+    for (const f of configFields) {
+      out[f.id] = stored[f.id] ?? (f.default as FieldValue) ?? ''
     }
-    return totals
-  }, [slots, availableModules])
+    return out
+  }, [configFields, slotsConfig, selectedSlot])
 
-  const hasAnyModule = slots.some((s) => s !== null)
-
-  const getModuleIoLabel = (moduleId: string) => {
-    const mod = availableModules.find((m) => m.id === moduleId)
+  /* ------------------------------------------------------------ */
+  /* Render                                                        */
+  /* ------------------------------------------------------------ */
+  const slotIoSummary = (moduleId: string | null) => {
+    if (!moduleId) return ''
+    const mod = findModule(moduleId)
     if (!mod) return ''
     const parts: string[] = []
-    if (mod.io.digitalInputs > 0) parts.push(`${mod.io.digitalInputs} DI`)
-    if (mod.io.digitalOutputs > 0) parts.push(`${mod.io.digitalOutputs} DO`)
-    if (mod.io.analogInputs > 0) parts.push(`${mod.io.analogInputs} AI`)
-    if (mod.io.analogOutputs > 0) parts.push(`${mod.io.analogOutputs} AO`)
-    return parts.join(', ')
+    if (mod.io.digitalInputs) parts.push(`${mod.io.digitalInputs}DI`)
+    if (mod.io.digitalOutputs) parts.push(`${mod.io.digitalOutputs}DO`)
+    if (mod.io.analogInputs) parts.push(`${mod.io.analogInputs}AI`)
+    if (mod.io.analogOutputs) parts.push(`${mod.io.analogOutputs}AO`)
+    return parts.join(' / ')
   }
 
+  const ioEntriesForSelected = (() => {
+    const entries = (vendorScreenData?.['io-mapping'] as { entries?: IoMappingEntry[] } | undefined)?.entries ?? []
+    return entries.filter((e) => e.slot === selectedSlot + 1)
+  })()
+
   return (
-    <div className='flex flex-col gap-4'>
+    <div className='flex h-[600px] flex-col gap-3'>
+      {/* Top-level actions (e.g. Clear All Slots) */}
       {section.actions && (
         <div className='flex gap-2'>
-          {(section.actions as Array<{ id: string; label: string; type: string; action?: string }>).map((action) => {
-            if (action.type === 'local' && action.action === 'clear-module-slots') {
-              return (
-                <button
-                  key={action.id}
-                  type='button'
-                  onClick={handleClearAll}
-                  disabled={!hasAnyModule}
-                  className='rounded-md border border-neutral-200 px-3 py-1 text-xs text-neutral-700 hover:bg-neutral-100 disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800'
+          {(section.actions as Array<{ id: string; label: string; type: string; action?: string }>).map((action) =>
+            action.type === 'local' && action.action === 'clear-module-slots' ? (
+              <button
+                key={action.id}
+                type='button'
+                onClick={handleClearAll}
+                disabled={!slots.some((s) => s !== null)}
+                className='rounded-md border border-neutral-200 px-3 py-1 text-xs text-neutral-700 hover:bg-neutral-100 disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800'
+              >
+                {action.label}
+              </button>
+            ) : null,
+          )}
+        </div>
+      )}
+
+      <div className='flex min-h-0 flex-1 gap-4'>
+        {/* ------ Left: slot tree ------ */}
+        <div className='flex w-56 shrink-0 flex-col overflow-y-auto rounded-md border border-neutral-200 dark:border-neutral-700'>
+          {slots.map((moduleId, idx) => {
+            const mod = findModule(moduleId)
+            const isSelected = idx === selectedSlot
+            return (
+              <button
+                key={idx}
+                type='button'
+                onClick={() => setSelectedSlot(idx)}
+                className={`flex flex-col gap-0.5 border-b border-neutral-100 px-3 py-2 text-left last:border-b-0 dark:border-neutral-800 ${
+                  isSelected
+                    ? 'bg-brand-light/20 dark:bg-brand-medium-dark/30'
+                    : 'hover:bg-neutral-50 dark:hover:bg-neutral-900'
+                }`}
+              >
+                <div className='flex items-center justify-between'>
+                  <span className='font-caption text-cp-sm font-semibold text-neutral-950 dark:text-white'>
+                    Slot {idx + 1}
+                  </span>
+                  {mod && (
+                    <span className='text-[10px] text-neutral-400 dark:text-neutral-500'>{slotIoSummary(moduleId)}</span>
+                  )}
+                </div>
+                <span
+                  className={`truncate text-xs ${mod ? 'text-neutral-700 dark:text-neutral-300' : 'italic text-neutral-400 dark:text-neutral-600'}`}
                 >
-                  {action.label}
-                </button>
-              )
-            }
-            return null
+                  {mod?.name ?? 'Empty'}
+                </span>
+              </button>
+            )
           })}
         </div>
-      )}
 
-      <div className='grid grid-cols-4 gap-3'>
-        {slots.map((moduleId, idx) => (
-          <div
-            key={idx}
-            className='flex flex-col gap-1 rounded-md border border-neutral-200 p-2 dark:border-neutral-700'
-          >
-            <span className='text-xs font-medium text-neutral-500 dark:text-neutral-400'>Slot {idx + 1}</span>
-            <Select
-              value={moduleId ?? '__empty__'}
-              onValueChange={(v) => handleSlotChange(idx, v === '__empty__' ? '' : v)}
-            >
-              <SelectTrigger
-                aria-label={`Module slot ${idx + 1}`}
-                placeholder='-- Empty --'
-                withIndicator
-                className='flex h-[28px] w-full items-center justify-between gap-1 rounded-md border border-neutral-100 bg-white px-2 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none data-[state=open]:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
-              />
-              <SelectContent
-                className='h-fit max-h-[200px] w-[--radix-select-trigger-width] overflow-y-auto rounded-lg border border-neutral-100 bg-white outline-none drop-shadow-lg dark:border-brand-medium-dark dark:bg-neutral-950'
-                sideOffset={5}
-                position='popper'
-                align='center'
-                side='bottom'
-              >
-                <SelectItem
-                  value='__empty__'
-                  className='flex w-full cursor-pointer items-center px-2 py-[6px] outline-none hover:bg-neutral-200 dark:hover:bg-neutral-850'
+        {/* ------ Right: contextual detail pane ------ */}
+        <div className='min-w-0 flex-1 overflow-y-auto rounded-md border border-neutral-200 p-4 dark:border-neutral-700'>
+          <h3 className='mb-3 font-caption text-base font-semibold text-neutral-950 dark:text-white'>
+            Slot {selectedSlot + 1}
+          </h3>
+
+          {selectedModule ? (
+            <div className='flex flex-col gap-5'>
+              {/* Header: image + name + description + specs */}
+              <div className='flex gap-4'>
+                <div className='flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-md border border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900'>
+                  {moduleImage ? (
+                    <img src={moduleImage} alt={selectedModule.name} className='h-full w-full object-contain' />
+                  ) : (
+                    <span className='text-[10px] text-neutral-400 dark:text-neutral-600'>No image</span>
+                  )}
+                </div>
+                <div className='min-w-0 flex-1'>
+                  <div className='font-caption text-base font-semibold text-neutral-950 dark:text-white'>
+                    {selectedModule.name}
+                  </div>
+                  {(selectedModule as { description?: string }).description && (
+                    <p className='mt-1 text-xs text-neutral-600 dark:text-neutral-400'>
+                      {(selectedModule as { description?: string }).description}
+                    </p>
+                  )}
+                  {(selectedModule as { specs?: Record<string, string> }).specs && (
+                    <dl className='mt-2 grid grid-cols-2 gap-x-4 gap-y-0.5 text-[11px]'>
+                      {Object.entries((selectedModule as { specs?: Record<string, string> }).specs ?? {}).map(
+                        ([k, v]) => (
+                          <div key={k} className='flex gap-1'>
+                            <dt className='font-medium text-neutral-500 dark:text-neutral-400'>{k}:</dt>
+                            <dd className='text-neutral-700 dark:text-neutral-300'>{v}</dd>
+                          </div>
+                        ),
+                      )}
+                    </dl>
+                  )}
+                </div>
+              </div>
+
+              {/* I/O Mapping */}
+              {ioEntriesForSelected.length > 0 && (
+                <section>
+                  <h4 className='mb-2 font-caption text-sm font-semibold text-neutral-950 dark:text-white'>
+                    I/O Mapping
+                  </h4>
+                  <table className='w-full text-left'>
+                    <thead>
+                      <tr className='border-b border-neutral-200 dark:border-neutral-700'>
+                        <th className='px-2 py-1.5 font-caption text-[11px] font-medium text-neutral-500 dark:text-neutral-400'>
+                          Channel
+                        </th>
+                        <th className='px-2 py-1.5 font-caption text-[11px] font-medium text-neutral-500 dark:text-neutral-400'>
+                          Type
+                        </th>
+                        <th className='px-2 py-1.5 font-caption text-[11px] font-medium text-neutral-500 dark:text-neutral-400'>
+                          IEC Address
+                        </th>
+                        <th className='px-2 py-1.5 font-caption text-[11px] font-medium text-neutral-500 dark:text-neutral-400'>
+                          Alias
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {ioEntriesForSelected.map((entry) => (
+                        <tr
+                          key={`${entry.slot}-${entry.channelName}`}
+                          className='border-b border-neutral-100 last:border-b-0 dark:border-neutral-800'
+                        >
+                          <td className='px-2 py-1.5 font-caption text-cp-sm text-neutral-850 dark:text-neutral-300'>
+                            {entry.channelName}
+                          </td>
+                          <td className='px-2 py-1.5 font-caption text-cp-sm text-neutral-500 dark:text-neutral-400'>
+                            {entry.channelType}
+                          </td>
+                          <td className='px-2 py-1.5 font-mono text-cp-sm font-medium text-brand dark:text-brand-light'>
+                            {entry.iecAddress}
+                          </td>
+                          <td className='px-1 py-1'>
+                            <input
+                              type='text'
+                              value={entry.alias}
+                              onChange={(e) => handleAliasChange(entry.slot, entry.channelName, e.target.value)}
+                              placeholder='Alias...'
+                              className='h-[26px] w-full rounded border border-neutral-100 bg-white px-2 font-caption text-cp-sm text-neutral-850 outline-none placeholder:text-neutral-400 focus:border-brand-medium-dark dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300 dark:placeholder:text-neutral-600'
+                            />
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </section>
+              )}
+
+              {/* Configuration (only when this module has a configScreen) */}
+              {configFields.length > 0 && (
+                <section>
+                  <h4 className='mb-2 font-caption text-sm font-semibold text-neutral-950 dark:text-white'>
+                    Configuration
+                  </h4>
+                  <div className='flex flex-col gap-3'>
+                    {configFields.map((field) => {
+                      if (!evalVisible(field.visible, slotValues)) return null
+                      const current = slotValues[field.id]
+                      const setValue = (v: FieldValue) => handleFieldChange(selectedSlot, field.id, v)
+                      return (
+                        <div key={field.id} className='flex items-center gap-2'>
+                          {field.type === 'boolean' ? (
+                            <>
+                              <Checkbox
+                                id={`slot${selectedSlot + 1}-${field.id}`}
+                                checked={current === true}
+                                onCheckedChange={(c) => setValue(c as boolean)}
+                                className={
+                                  current === true
+                                    ? 'h-[14px] w-[14px] border-brand'
+                                    : 'h-[14px] w-[14px] border-neutral-300'
+                                }
+                              />
+                              <Label
+                                htmlFor={`slot${selectedSlot + 1}-${field.id}`}
+                                className='text-xs text-neutral-950 dark:text-white'
+                              >
+                                {field.label}
+                              </Label>
+                            </>
+                          ) : (
+                            <>
+                              <Label className='w-44 shrink-0 text-xs text-neutral-950 dark:text-white'>
+                                {field.label}
+                              </Label>
+                              {field.type === 'number' ? (
+                                <div className='flex items-center gap-1'>
+                                  <input
+                                    type='number'
+                                    value={String(current ?? '')}
+                                    min={field.min}
+                                    max={field.max}
+                                    step={field.step}
+                                    onChange={(e) => setValue(Number(e.target.value))}
+                                    className='flex h-[30px] w-32 items-center rounded-md border border-neutral-100 bg-white px-2 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none focus:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
+                                  />
+                                  {field.unit && (
+                                    <span className='text-xs text-neutral-500 dark:text-neutral-400'>{field.unit}</span>
+                                  )}
+                                </div>
+                              ) : field.type === 'select' ? (
+                                <Select value={String(current ?? '')} onValueChange={(v) => setValue(v)}>
+                                  <SelectTrigger
+                                    aria-label={field.label}
+                                    placeholder='Select...'
+                                    withIndicator
+                                    className='flex h-[30px] w-64 items-center justify-between gap-1 rounded-md border border-neutral-100 bg-white px-2 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none data-[state=open]:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
+                                  />
+                                  <SelectContent
+                                    className='h-fit max-h-[240px] w-[--radix-select-trigger-width] overflow-y-auto rounded-lg border border-neutral-100 bg-white outline-none drop-shadow-lg dark:border-brand-medium-dark dark:bg-neutral-950'
+                                    sideOffset={5}
+                                    position='popper'
+                                    align='center'
+                                    side='bottom'
+                                  >
+                                    {(field.options ?? []).map((opt) => {
+                                      const v = typeof opt === 'string' ? opt : opt.value
+                                      const l = typeof opt === 'string' ? opt : opt.label
+                                      return (
+                                        <SelectItem
+                                          key={v}
+                                          value={v}
+                                          className='flex w-full cursor-pointer items-center px-2 py-[6px] outline-none hover:bg-neutral-200 dark:hover:bg-neutral-850'
+                                        >
+                                          <span className='font-caption text-cp-sm font-medium text-neutral-850 dark:text-neutral-300'>
+                                            {l}
+                                          </span>
+                                        </SelectItem>
+                                      )
+                                    })}
+                                  </SelectContent>
+                                </Select>
+                              ) : (
+                                <input
+                                  type='text'
+                                  value={String(current ?? '')}
+                                  onChange={(e) => setValue(e.target.value)}
+                                  className='flex h-[30px] w-64 items-center rounded-md border border-neutral-100 bg-white px-2 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none focus:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
+                                />
+                              )}
+                            </>
+                          )}
+                          {field.help && (
+                            <span className='text-[11px] text-neutral-500 dark:text-neutral-500'>{field.help}</span>
+                          )}
+                        </div>
+                      )
+                    })}
+                  </div>
+                </section>
+              )}
+
+              {/* Per-slot actions */}
+              <div className='flex gap-2 pt-2'>
+                <button
+                  type='button'
+                  onClick={() => handleClearSlot(selectedSlot)}
+                  className='rounded-md border border-neutral-200 px-3 py-1 text-xs text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800'
                 >
-                  <span className='font-caption text-cp-sm font-medium text-neutral-500 dark:text-neutral-400'>
-                    -- Empty --
-                  </span>
-                </SelectItem>
-                {availableModules.map((mod) => (
-                  <SelectItem
-                    key={mod.id}
-                    value={mod.id}
-                    className='flex w-full cursor-pointer items-center px-2 py-[6px] outline-none hover:bg-neutral-200 dark:hover:bg-neutral-850'
-                  >
-                    <span className='font-caption text-cp-sm font-medium text-neutral-850 dark:text-neutral-300'>
-                      {mod.name}
-                    </span>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {moduleId && (
-              <span className='text-[10px] text-neutral-400 dark:text-neutral-500'>{getModuleIoLabel(moduleId)}</span>
-            )}
-          </div>
-        ))}
-      </div>
-
-      {hasAnyModule && (
-        <div className='flex gap-4 rounded-md border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-700 dark:bg-neutral-900'>
-          <span className='text-xs font-medium text-neutral-600 dark:text-neutral-400'>Total I/O:</span>
-          {ioSummary.di > 0 && (
-            <span className='text-xs text-neutral-700 dark:text-neutral-300'>{ioSummary.di} DI</span>
-          )}
-          {ioSummary.do > 0 && (
-            <span className='text-xs text-neutral-700 dark:text-neutral-300'>{ioSummary.do} DO</span>
-          )}
-          {ioSummary.ai > 0 && (
-            <span className='text-xs text-neutral-700 dark:text-neutral-300'>{ioSummary.ai} AI</span>
-          )}
-          {ioSummary.ao > 0 && (
-            <span className='text-xs text-neutral-700 dark:text-neutral-300'>{ioSummary.ao} AO</span>
+                  Clear this slot
+                </button>
+              </div>
+            </div>
+          ) : (
+            /* Empty-slot state: just the module picker */
+            <div className='flex flex-col items-start gap-3 py-6'>
+              <p className='text-xs text-neutral-500 dark:text-neutral-400'>
+                This slot is empty. Choose a module to populate it.
+              </p>
+              <Select value='' onValueChange={(v) => handleSlotChange(selectedSlot, v)}>
+                <SelectTrigger
+                  aria-label={`Select module for slot ${selectedSlot + 1}`}
+                  placeholder='-- Pick a module --'
+                  withIndicator
+                  className='flex h-[32px] w-80 items-center justify-between gap-1 rounded-md border border-neutral-100 bg-white px-3 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none data-[state=open]:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
+                />
+                <SelectContent
+                  className='h-fit max-h-[280px] w-[--radix-select-trigger-width] overflow-y-auto rounded-lg border border-neutral-100 bg-white outline-none drop-shadow-lg dark:border-brand-medium-dark dark:bg-neutral-950'
+                  sideOffset={5}
+                  position='popper'
+                  align='center'
+                  side='bottom'
+                >
+                  {availableModules.map((mod) => (
+                    <SelectItem
+                      key={mod.id}
+                      value={mod.id}
+                      className='flex w-full cursor-pointer items-center px-2 py-[6px] outline-none hover:bg-neutral-200 dark:hover:bg-neutral-850'
+                    >
+                      <span className='font-caption text-cp-sm font-medium text-neutral-850 dark:text-neutral-300'>
+                        {mod.name}
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           )}
         </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
@@ -2,6 +2,7 @@ import { collectUsedIecAddresses } from '@root/backend/shared/utils/iec-address'
 import { Checkbox } from '@root/frontend/components/_atoms/checkbox'
 import { Label } from '@root/frontend/components/_atoms/label'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@root/frontend/components/_atoms/select'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@root/frontend/components/_atoms/tooltip'
 import { boardSelectors } from '@root/frontend/hooks/use-store-selectors'
 import { useOpenPLCStore } from '@root/frontend/store'
 import { generateIecAddress } from '@root/frontend/utils/iec-address'
@@ -11,6 +12,31 @@ import { useDevice } from '@root/middleware/shared/providers/platform-context'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { ModuleDefinition, ModuleSystem, ScreenSection } from '../index'
+
+// Same help glyph the HAL Settings form-layout uses, so per-field
+// explanations live in a tooltip instead of cluttering the row.
+function FieldHelpIcon({ text }: { text: string }) {
+  return (
+    <Tooltip delayDuration={150}>
+      <TooltipTrigger asChild>
+        <span
+          tabIndex={0}
+          aria-label='Field help'
+          className='inline-flex h-3.5 w-3.5 cursor-help select-none items-center justify-center rounded-full text-neutral-400 hover:text-neutral-600 focus:outline-none focus-visible:text-neutral-600 dark:text-neutral-500 dark:hover:text-neutral-300'
+        >
+          <svg viewBox='0 0 16 16' fill='none' className='h-3.5 w-3.5'>
+            <circle cx='8' cy='8' r='7' stroke='currentColor' strokeWidth='1.5' />
+            <path d='M8 7.25v4.25' stroke='currentColor' strokeWidth='1.5' strokeLinecap='round' />
+            <circle cx='8' cy='4.75' r='0.85' fill='currentColor' />
+          </svg>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side='right' align='start' sideOffset={6} className='text-xs'>
+        {text}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
 
 type ModuleSlotsLayoutProps = {
   section: ScreenSection
@@ -321,7 +347,7 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
                 key={idx}
                 type='button'
                 onClick={() => setSelectedSlot(idx)}
-                className={`flex flex-col gap-0.5 border-b border-neutral-100 px-3 py-2 text-left last:border-b-0 dark:border-neutral-800 ${
+                className={`flex shrink-0 flex-col gap-0.5 border-b border-neutral-100 px-3 py-2 text-left dark:border-neutral-800 ${
                   isSelected
                     ? 'bg-brand-light/20 dark:bg-brand-medium-dark/30'
                     : 'hover:bg-neutral-50 dark:hover:bg-neutral-900'
@@ -398,16 +424,10 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
 
           {selectedModule ? (
             <div className='flex flex-col gap-5'>
-              {/* Header: image + description + specs (module name
-                  already lives in the picker above) */}
+              {/* Header: description + specs on the left (under the
+                  Module picker above), image on the right. Picture
+                  height grows to match the text block. */}
               <div className='flex gap-4'>
-                <div className='flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-md border border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900'>
-                  {moduleImage ? (
-                    <img src={moduleImage} alt={selectedModule.name} className='h-full w-full object-contain' />
-                  ) : (
-                    <span className='text-[10px] text-neutral-400 dark:text-neutral-600'>No image</span>
-                  )}
-                </div>
                 <div className='min-w-0 flex-1'>
                   {(selectedModule as { description?: string }).description && (
                     <p className='text-xs text-neutral-600 dark:text-neutral-400'>
@@ -425,6 +445,13 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
                         ),
                       )}
                     </dl>
+                  )}
+                </div>
+                <div className='flex h-36 w-36 shrink-0 items-center justify-center self-start overflow-hidden rounded-md border border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900'>
+                  {moduleImage ? (
+                    <img src={moduleImage} alt={selectedModule.name} className='h-full w-full object-contain' />
+                  ) : (
+                    <span className='text-[10px] text-neutral-400 dark:text-neutral-600'>No image</span>
                   )}
                 </div>
               </div>
@@ -496,8 +523,10 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
                   </p>
                 )}
 
-              {/* Configuration (only when this module has a configScreen) */}
+              {/* Configuration (only when this module has a configScreen).
+                  TooltipProvider scopes the help-icon hover behaviour. */}
               {configFields.length > 0 && (
+                <TooltipProvider>
                 <section>
                   <h4 className='mb-2 font-caption text-sm font-semibold text-neutral-950 dark:text-white'>
                     Configuration
@@ -590,14 +619,13 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
                               )}
                             </>
                           )}
-                          {field.help && (
-                            <span className='text-[11px] text-neutral-500 dark:text-neutral-500'>{field.help}</span>
-                          )}
+                          {field.help && <FieldHelpIcon text={field.help} />}
                         </div>
                       )
                     })}
                   </div>
                 </section>
+                </TooltipProvider>
               )}
 
             </div>

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
@@ -231,8 +231,6 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
     writeModuleConfig({ ...moduleConfig, slots: Array<string | null>(maxSlots).fill(null), slotsConfig: {} })
   }
 
-  const handleClearSlot = (slotIndex: number) => handleSlotChange(slotIndex, '')
-
   const handleFieldChange = (slotIndex: number, fieldId: string, value: FieldValue) => {
     const key = String(slotIndex + 1)
     const slotValues = { ...(slotsConfig[key] ?? {}), [fieldId]: value }
@@ -289,7 +287,10 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
   })()
 
   return (
-    <div className='flex h-[600px] flex-col gap-3'>
+    // `flex-1 min-h-0` claims all available vertical space the parent
+    // section grants us; both panes inside scroll independently so the
+    // page-level container never needs to.
+    <div className='flex min-h-0 flex-1 flex-col gap-3'>
       {/* Top-level actions (e.g. Clear All Slots) */}
       {section.actions && (
         <div className='flex gap-2'>
@@ -345,14 +346,60 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
         </div>
 
         {/* ------ Right: contextual detail pane ------ */}
-        <div className='min-w-0 flex-1 overflow-y-auto rounded-md border border-neutral-200 p-4 dark:border-neutral-700'>
+        <div className='flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto rounded-md border border-neutral-200 p-4 dark:border-neutral-700'>
           <h3 className='mb-3 font-caption text-base font-semibold text-neutral-950 dark:text-white'>
             Slot {selectedSlot + 1}
           </h3>
 
+          {/* Module picker — always visible. Selecting "-- Empty --"
+              clears the slot; selecting another module switches in
+              place without an intermediate clear step. */}
+          <div className='mb-4 flex items-center gap-3'>
+            <Label className='w-20 shrink-0 text-xs font-medium text-neutral-950 dark:text-white'>Module</Label>
+            <Select
+              value={selectedModule ? selectedModule.id : '__empty__'}
+              onValueChange={(v) => handleSlotChange(selectedSlot, v === '__empty__' ? '' : v)}
+            >
+              <SelectTrigger
+                aria-label={`Module for slot ${selectedSlot + 1}`}
+                placeholder='-- Empty --'
+                withIndicator
+                className='flex h-[32px] w-80 items-center justify-between gap-1 rounded-md border border-neutral-100 bg-white px-3 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none data-[state=open]:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
+              />
+              <SelectContent
+                className='h-fit max-h-[280px] w-[--radix-select-trigger-width] overflow-y-auto rounded-lg border border-neutral-100 bg-white outline-none drop-shadow-lg dark:border-brand-medium-dark dark:bg-neutral-950'
+                sideOffset={5}
+                position='popper'
+                align='center'
+                side='bottom'
+              >
+                <SelectItem
+                  value='__empty__'
+                  className='flex w-full cursor-pointer items-center px-2 py-[6px] outline-none hover:bg-neutral-200 dark:hover:bg-neutral-850'
+                >
+                  <span className='font-caption text-cp-sm font-medium italic text-neutral-500 dark:text-neutral-400'>
+                    -- Empty --
+                  </span>
+                </SelectItem>
+                {availableModules.map((mod) => (
+                  <SelectItem
+                    key={mod.id}
+                    value={mod.id}
+                    className='flex w-full cursor-pointer items-center px-2 py-[6px] outline-none hover:bg-neutral-200 dark:hover:bg-neutral-850'
+                  >
+                    <span className='font-caption text-cp-sm font-medium text-neutral-850 dark:text-neutral-300'>
+                      {mod.name}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
           {selectedModule ? (
             <div className='flex flex-col gap-5'>
-              {/* Header: image + name + description + specs */}
+              {/* Header: image + description + specs (module name
+                  already lives in the picker above) */}
               <div className='flex gap-4'>
                 <div className='flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-md border border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900'>
                   {moduleImage ? (
@@ -362,11 +409,8 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
                   )}
                 </div>
                 <div className='min-w-0 flex-1'>
-                  <div className='font-caption text-base font-semibold text-neutral-950 dark:text-white'>
-                    {selectedModule.name}
-                  </div>
                   {(selectedModule as { description?: string }).description && (
-                    <p className='mt-1 text-xs text-neutral-600 dark:text-neutral-400'>
+                    <p className='text-xs text-neutral-600 dark:text-neutral-400'>
                       {(selectedModule as { description?: string }).description}
                     </p>
                   )}
@@ -438,6 +482,19 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
                   </table>
                 </section>
               )}
+
+              {/* Defensive hint: manifest declared a configScreen path
+                  but the parsed definition didn't reach us. Almost
+                  always means an installed vpp predates the per-module
+                  screens. Surface it instead of silently dropping the
+                  config form. */}
+              {(selectedModule as { configScreen?: string }).configScreen &&
+                !(selectedModule as { configScreenDefinition?: unknown }).configScreenDefinition && (
+                  <p className='rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-300'>
+                    This module ships a configuration screen but it could not be loaded. Reinstall the vendor package to
+                    pick up the latest assets.
+                  </p>
+                )}
 
               {/* Configuration (only when this module has a configScreen) */}
               {configFields.length > 0 && (
@@ -543,51 +600,13 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
                 </section>
               )}
 
-              {/* Per-slot actions */}
-              <div className='flex gap-2 pt-2'>
-                <button
-                  type='button'
-                  onClick={() => handleClearSlot(selectedSlot)}
-                  className='rounded-md border border-neutral-200 px-3 py-1 text-xs text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800'
-                >
-                  Clear this slot
-                </button>
-              </div>
             </div>
           ) : (
-            /* Empty-slot state: just the module picker */
-            <div className='flex flex-col items-start gap-3 py-6'>
-              <p className='text-xs text-neutral-500 dark:text-neutral-400'>
-                This slot is empty. Choose a module to populate it.
-              </p>
-              <Select value='' onValueChange={(v) => handleSlotChange(selectedSlot, v)}>
-                <SelectTrigger
-                  aria-label={`Select module for slot ${selectedSlot + 1}`}
-                  placeholder='-- Pick a module --'
-                  withIndicator
-                  className='flex h-[32px] w-80 items-center justify-between gap-1 rounded-md border border-neutral-100 bg-white px-3 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none data-[state=open]:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
-                />
-                <SelectContent
-                  className='h-fit max-h-[280px] w-[--radix-select-trigger-width] overflow-y-auto rounded-lg border border-neutral-100 bg-white outline-none drop-shadow-lg dark:border-brand-medium-dark dark:bg-neutral-950'
-                  sideOffset={5}
-                  position='popper'
-                  align='center'
-                  side='bottom'
-                >
-                  {availableModules.map((mod) => (
-                    <SelectItem
-                      key={mod.id}
-                      value={mod.id}
-                      className='flex w-full cursor-pointer items-center px-2 py-[6px] outline-none hover:bg-neutral-200 dark:hover:bg-neutral-850'
-                    >
-                      <span className='font-caption text-cp-sm font-medium text-neutral-850 dark:text-neutral-300'>
-                        {mod.name}
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+            /* Empty-slot state: nothing else to show — the always-
+                visible Module picker above is the only action. */
+            <p className='py-4 text-xs italic text-neutral-500 dark:text-neutral-400'>
+              This slot is empty. Pick a module above to populate it.
+            </p>
           )}
         </div>
       </div>

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
@@ -450,18 +450,14 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
               )}
             </div>
 
-            {/* Module image — fixed width with a generous min-height,
-                stretches further if the left text block grows past it
-                via self-stretch. Sized to be the visual anchor of the
-                slot card. */}
-            {selectedModule && (
-              <div className='flex min-h-72 w-96 shrink-0 items-center justify-center self-stretch overflow-hidden rounded-md border border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900'>
-                {moduleImage ? (
-                  <img src={moduleImage} alt={selectedModule.name} className='h-full w-full object-contain' />
-                ) : (
-                  <span className='text-xs text-neutral-400 dark:text-neutral-600'>No image</span>
-                )}
-              </div>
+            {/* Module image — frameless. The PNGs ship with a
+                transparent background, so no card chrome is needed. */}
+            {selectedModule && moduleImage && (
+              <img
+                src={moduleImage}
+                alt={selectedModule.name}
+                className='h-64 w-64 shrink-0 self-start object-contain'
+              />
             )}
           </div>
 

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/section-renderer.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/section-renderer.tsx
@@ -27,8 +27,13 @@ function SectionRenderer({ section, moduleSystem }: SectionRendererProps) {
     }
   }
 
+  // `module-slots` is a master-detail layout that owns the full visible
+  // area and hosts its own internal scrollers. Other layouts are
+  // content-sized and let the page-level container scroll if necessary.
+  const isFillSection = section.layout === 'module-slots'
+
   return (
-    <div className='flex flex-col gap-3'>
+    <div className={`flex flex-col gap-3 ${isFillSection ? 'min-h-0 flex-1' : ''}`}>
       <div
         className={`flex items-center justify-between ${section.collapsible ? 'cursor-pointer' : ''}`}
         onClick={() => section.collapsible && setCollapsed(!collapsed)}

--- a/src/frontend/components/_features/[workspace]/editor/vendor-screen/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/vendor-screen/index.tsx
@@ -82,7 +82,7 @@ const VendorScreenEditor = () => {
   }
 
   return (
-    <div className='flex min-h-0 flex-1 overflow-y-auto p-4'>
+    <div className='flex min-h-0 flex-1 flex-col overflow-y-auto p-4'>
       <VendorScreenRenderer screenDefinition={screenDefinition} moduleSystem={moduleSystem} />
     </div>
   )

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -387,16 +387,22 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
     },
 
     closeFile: (name) => {
-      // Check if file has unsaved changes
-      const isSaved = getState().fileActions.getSavedState({ name })
-
-      if (!isSaved) {
-        // File has unsaved changes - show save prompt modal
-        getState().modalActions.openModal('save-changes-file', { fileName: name })
-        return { success: false }
+      // Tabs that don't persist any project data (Package Manager,
+      // Library Manager browsing view, ...) never register a file
+      // entry. Treat their absence from the file slice as "nothing
+      // to save" — otherwise getSavedState's `?? false` default
+      // would route them through the save-changes modal, and the
+      // subsequent "Save" path would fail with "File not found"
+      // because executeSaveFile has nothing to write.
+      const fileExists = getState().files[name] !== undefined
+      if (fileExists) {
+        const isSaved = getState().fileActions.getSavedState({ name })
+        if (!isSaved) {
+          getState().modalActions.openModal('save-changes-file', { fileName: name })
+          return { success: false }
+        }
       }
 
-      // File is saved, proceed with close
       return getState().sharedWorkspaceActions.forceCloseFile(name)
     },
 

--- a/src/middleware/shared/ports/package-manifest-schema.ts
+++ b/src/middleware/shared/ports/package-manifest-schema.ts
@@ -1,115 +1,54 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Autonomy / OpenPLC Project
 /**
- * Zod schema for PackageManifest, used at the trust boundary where a
- * `.vpp` package's `manifest.json` enters the editor process. Catches
- * malformed manifests before any of their fields are consumed (and
- * before any field is used as a filesystem path component, which is
- * separately defended by `validatePathId` / `assertPathContained` in
- * `src/backend/shared/utils/path-safety.ts`).
+ * Zod schema for PackageManifest at the editor's trust boundary.
  *
- * The TypeScript `PackageManifest` interface in `./types.ts` stays the
- * editor-internal source of truth for IDE-time shape; this schema is
- * the runtime mirror used at IPC and disk-load boundaries.
+ * Design intent: the editor is agnostic to what a VPP carries inside
+ * its manifest. Authoring-side strictness lives in openplc-packages
+ * (the canonical, vendor-internal VPP builder); at install / load
+ * time the editor enforces only the minimum needed to:
+ *
+ *   1. Confirm the document is shaped roughly like a manifest, so a
+ *      random JSON file is rejected with a clear error rather than
+ *      crashing deep in the loader with `undefined.devices.map(...)`.
+ *
+ *   2. Sanity-type the few fields that drive security-critical
+ *      decisions — `package.id` becomes a filesystem path; `version`
+ *      drives upgrade comparisons. These fields are also guarded at
+ *      use sites by `validatePathId` / `assertPathContained` in
+ *      `src/backend/shared/utils/path-safety.ts`; the schema is a
+ *      thin defence in depth.
+ *
+ * Everything else — device fields, per-module config screens, vendor
+ * extension blocks, future format additions — flows through untouched
+ * via `.passthrough()`. New VPP features therefore do not require an
+ * editor release: the editor's *transport* surface is fully
+ * extensible, and only the *interpretation* surface (layout
+ * dispatcher, field renderer, encoder rules) needs a build when a
+ * brand-new vocabulary is introduced.
+ *
+ * The TypeScript `PackageManifest` interface in `./types.ts` remains
+ * the source of truth for what the editor code *reads*; the schema
+ * below controls only what it *rejects*.
  */
 
 import { z } from 'zod'
 
 import type { PackageManifest } from './types'
 
-const VppModuleSchema = z.object({
-  id: z.string().min(1),
-  name: z.string().min(1),
-  hwId: z.string().optional(),
-  image: z.string().optional(),
-  description: z.string().optional(),
-  specs: z.record(z.string(), z.string()).optional(),
-  configScreen: z.string().optional(),
-  io: z.object({
-    digitalInputs: z.number().int().nonnegative(),
-    digitalOutputs: z.number().int().nonnegative(),
-    analogInputs: z.number().int().nonnegative(),
-    analogOutputs: z.number().int().nonnegative(),
-  }),
-  parameters: z
-    .array(
-      z.object({
+export const PackageManifestSchema = z
+  .object({
+    formatVersion: z.string().min(1),
+    package: z
+      .object({
         id: z.string().min(1),
         name: z.string().min(1),
-        type: z.string().min(1),
-        options: z.array(z.string()).optional(),
-        default: z.unknown().optional(),
-        min: z.number().optional(),
-        max: z.number().optional(),
-      }),
-    )
-    .optional(),
-  addressMapping: z.unknown().optional(),
-})
-
-export const PackageManifestSchema = z.object({
-  formatVersion: z.string().min(1),
-  package: z.object({
-    id: z.string().min(1),
-    name: z.string().min(1),
-    version: z.string().min(1),
-    vendor: z.object({
-      name: z.string().min(1),
-      url: z.string().optional(),
-      logo: z.string(),
-    }),
-    description: z.string(),
-    license: z.string().optional(),
-    minEditorVersion: z.string().optional(),
-  }),
-  devices: z
-    .array(
-      z.object({
-        id: z.string().min(1),
-        name: z.string().min(1),
-        category: z.string().optional(),
-        preview: z.string(),
-        target: z.object({
-          type: z.string().min(1),
-          platform: z.string().optional(),
-          core: z.string().optional(),
-        }),
-        specs: z.record(z.string(), z.string()).optional(),
-        hal: z.object({
-          type: z.string().min(1),
-          pluginType: z.string().optional(),
-          pluginEntry: z.string().optional(),
-          configTemplate: z.string().optional(),
-          requirements: z.string().optional(),
-          source: z.string().optional(),
-        }),
-        defaults: z
-          .object({
-            runtimeIpAddress: z.string().optional(),
-            pins: z
-              .object({
-                defaultDin: z.array(z.string()).optional(),
-                defaultDout: z.array(z.string()).optional(),
-                defaultAin: z.array(z.string()).optional(),
-                defaultAout: z.array(z.string()).optional(),
-              })
-              .optional(),
-          })
-          .optional(),
-        screens: z.record(z.string(), z.string()).optional(),
-        moduleSystem: z
-          .object({
-            enabled: z.boolean(),
-            maxSlots: z.number().int().nonnegative(),
-            discoverySupported: z.boolean().optional(),
-            discoveryCommand: z.string().optional(),
-            modules: z.array(VppModuleSchema),
-          })
-          .optional(),
-      }),
-    )
-    .min(1),
-})
+        version: z.string().min(1),
+      })
+      .passthrough(),
+    devices: z.array(z.object({}).passthrough()).min(1),
+  })
+  .passthrough()
 
 /**
  * Validate an unknown value as a PackageManifest. Returns the typed
@@ -123,5 +62,10 @@ export function parsePackageManifest(value: unknown): PackageManifest | null {
     console.warn('[package-manifest] schema validation failed:', parsed.error.message)
     return null
   }
-  return parsed.data as PackageManifest
+  // The inferred Zod type is intentionally narrower than `PackageManifest`
+  // (only the minimum fields are declared in the schema). Cast through
+  // `unknown` so the consumer-side TypeScript shape still reflects what
+  // editor code reads — at the cost of trusting authoring-side
+  // validation in openplc-packages for the deeper fields.
+  return parsed.data as unknown as PackageManifest
 }

--- a/src/middleware/shared/ports/package-manifest-schema.ts
+++ b/src/middleware/shared/ports/package-manifest-schema.ts
@@ -22,6 +22,9 @@ const VppModuleSchema = z.object({
   name: z.string().min(1),
   hwId: z.string().optional(),
   image: z.string().optional(),
+  description: z.string().optional(),
+  specs: z.record(z.string(), z.string()).optional(),
+  configScreen: z.string().optional(),
   io: z.object({
     digitalInputs: z.number().int().nonnegative(),
     digitalOutputs: z.number().int().nonnegative(),

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -585,6 +585,20 @@ export interface VppModuleDefinition {
    *  manually. */
   hwId?: string
   image?: string
+  /** One-line prose displayed in the per-slot detail pane of the
+   *  backplane editor. */
+  description?: string
+  /** Key/value pairs (channels, resolution, range, ...) rendered as a
+   *  spec list in the per-slot detail pane. */
+  specs?: Record<string, string>
+  /** Path (in the manifest) to this module's configuration screen. The
+   *  backend loads it eagerly and exposes the parsed JSON via
+   *  `configScreenDefinition`; consumers should prefer that field. */
+  configScreen?: string
+  /** Parsed config-screen JSON for this module. Populated by the
+   *  hardware-module loader when `configScreen` resolves to an
+   *  existing, valid screen file. */
+  configScreenDefinition?: unknown
   io: {
     digitalInputs: number
     digitalOutputs: number


### PR DESCRIPTION
## Summary

- Adds a master-detail backplane editor with a per-slot detail pane, letting users configure each module slot independently
- Encodes per-slot `module_config` bytes into the runtime VPP config on compilation
- Polishes the module slot card UI: full-height module image, stacked specs, always-on module picker, and correctly-sized (320 px) module images
- Preserves per-module vendor screen fields when loading a manifest and makes the manifest schema agnostic via passthrough
- Fixes: no longer prompts to save on Package Manager close; backplane editor sizing tweaks

## Changed files

| Area | Summary |
|------|---------|
| `backend/shared/utils/vpp/byte-encoder.ts` | New: encodes module field values into `module_config` byte arrays |
| `backend/shared/utils/vpp/generate-vendor-plugin-config.ts` | New: assembles per-slot config for the runtime VPP config block |
| `frontend/.../module-slots-layout.tsx` | Master-detail backplane editor with per-slot pane |
| `middleware/shared/ports/package-manifest-schema.ts` | Schema made agnostic (passthrough for unknown module fields) |
| `frontend/store/slices/shared/slice.ts` | Save-prompt suppression on Package Manager close |
| Tests | Full unit coverage for byte-encoder and generate-vendor-plugin-config |

## Test plan

- [ ] Open a VPP project with a multi-slot backplane board
- [ ] Verify the backplane editor shows the master list on the left and a detail pane on the right when a slot is selected
- [ ] Confirm module images render at 320 px (full-height, frameless)
- [ ] Select a module and configure per-slot fields; close Package Manager without saving — no save prompt should appear
- [ ] Build the project and verify the compiled runtime config contains the correct `module_config` bytes for each slot
- [ ] Unit tests: `npm test` passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)