### PR TITLE
chore(web-capabilities): enable hasStLSP for web in shared defaults

### DIFF
--- a/src/middleware/shared/ports/platform-capabilities.ts
+++ b/src/middleware/shared/ports/platform-capabilities.ts
@@ -151,7 +151,14 @@ export const WEB_CAPABILITIES: PlatformCapabilities = {
   hasVersionControl: true,
   hasAboutDialog: false,
   hasPythonLSP: false,
-  hasStLSP: false,
+  // The STruC++ worker bundle runs in any modern browser; web's
+  // stlib-source adapter (HTTP-backed, mirror of editor's IPC-backed
+  // one) lands alongside the library port and lets `bootStLsp`
+  // populate the worker with the user's enabled archives.  Web only
+  // compiles to Runtime v4 targets — the matiec / iec2c flow is
+  // Electron-only — so there's no scenario where the LSP isn't the
+  // right tool for ST tooling on web.
+  hasStLSP: true,
   hasUndoRedoHistory: false,
   hasFileWatcher: false,
   hasAIAssistant: true,


### PR DESCRIPTION
## Summary

`WEB_CAPABILITIES.hasStLSP` was `false` while the web side waited for its stlib-source adapter to land.  Web only compiles to Runtime v4 targets — matiec / iec2c are Electron-only — so the LSP is the correct ST tooling path on web, same as on editor.

## Change
- `WEB_CAPABILITIES.hasStLSP: false → true`.

## Impact
- **Editor**: no behavior change.  Editor wires `EDITOR_CAPABILITIES` (unchanged) for its `PlatformPorts.capabilities`.
- **Web**: when the byte-identical sync brings this to web's rc1 branch, `bootStLsp` will fire once the library / stlib-source adapters land (already in flight on web side).

## Test plan
- [x] `npx tsc --noEmit --project .` clean
- [x] `npx jest` — 4041 passing (pre-existing `use-runtime-polling` failure remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)