### PR TITLE
sync(ai): mirror fetchEntitlements + fetchUsage port additions (DOPE-282)

### DIFF
--- a/src/middleware/shared/ports/ai-port.ts
+++ b/src/middleware/shared/ports/ai-port.ts
@@ -5,7 +5,7 @@
  * implementations that handle HTTP streaming, SSE parsing, and API authentication.
  */
 
-import type { AIFeatureConfig } from './types'
+import type { AIEntitlements, AIFeatureConfig, AIUsage } from './types'
 
 // ---------------------------------------------------------------------------
 // Parameter & result types
@@ -35,7 +35,13 @@ export interface AIChatParams {
   model?: 'haiku' | 'sonnet'
 }
 
-/** Credit status returned by fetchCredits. */
+/**
+ * Credit status returned by `fetchCredits`.
+ *
+ * @deprecated Use `AIEntitlements` + `AIUsage` (via the new `fetchEntitlements`
+ * / `fetchUsage` port methods). Retained for one release while UI call sites
+ * migrate to the ACU-based billing surface.
+ */
 export interface AICreditStatus {
   credits_used: number
   credits_total: number
@@ -76,7 +82,22 @@ export interface AIPort extends AIFeatureConfig {
   streamChat(params: AIChatParams, signal?: AbortSignal): AsyncGenerator<string, void, unknown>
 
   /**
+   * Fetch the user's resolved entitlements (plan limits, ACU cap, feature flags).
+   * Backed by `GET /me/entitlements` on the Edge API billing chassis.
+   */
+  fetchEntitlements(signal?: AbortSignal): Promise<AIEntitlements>
+
+  /**
+   * Fetch the user's current usage (resource counters + ACU consumption).
+   * Backed by `GET /me/usage` on the Edge API billing chassis.
+   */
+  fetchUsage(signal?: AbortSignal): Promise<AIUsage>
+
+  /**
    * Fetch current AI credit status.
+   *
+   * @deprecated Use `fetchEntitlements` + `fetchUsage` instead. Kept for one
+   * release as a fallback while UI call sites migrate to the new shape.
    */
   fetchCredits(signal?: AbortSignal): Promise<AICreditStatus>
 

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -762,6 +762,102 @@ export type ChatMessage = {
 }
 
 // ---------------------------------------------------------------------------
+// AI Billing — Entitlements + Usage (Phase 5)
+// ---------------------------------------------------------------------------
+//
+// Mirrors the backend `ResolvedEntitlements` / `ResolvedUsage` shapes from
+// autonomy-edge `infrastructure/services/billing/entitlements.service.ts`.
+// Surfaced via `GET /me/entitlements` and `GET /me/usage` (Gustavo's chassis,
+// populated by `EntitlementsService` + `AcuLedgerService`).
+
+/** Subscription status as reported by the backend (Paddle-backed). */
+export type SubscriptionStatus =
+  | 'trialing'
+  | 'active'
+  | 'past_due'
+  | 'paused'
+  | 'canceled'
+  | 'expired'
+
+/** Plan level slug (standard < plus < premium). */
+export type PlanLevelSlug = 'standard' | 'plus' | 'premium'
+
+/**
+ * Feature flags resolved from the active plan level. Open-ended map; only
+ * declared keys are typed statically — backend may emit additional booleans
+ * as new plan-gated features land.
+ */
+export type PlanFeatures = {
+  hasAiEngineer?: boolean
+  hasAiChat?: boolean
+  hasPrivateProjects?: boolean
+  hasOrganizations?: boolean
+  hasCodesysImporter?: boolean
+  hasOnPrem?: boolean
+  hasSla?: boolean
+  hasSoc2Badge?: boolean
+  hasVersionControl?: boolean
+  [key: string]: boolean | undefined
+}
+
+/** Shared header on both `/me/entitlements` and `/me/usage`. */
+export interface EntitlementSource {
+  subscriptionId: string
+  subscriptionStatus: SubscriptionStatus
+  planSlug: string
+  planDisplayName: string
+  planLevelSlug: PlanLevelSlug
+  tier: number
+}
+
+/** Numeric counter with a nullable cap (null = unlimited). */
+export interface UsageCounter {
+  used: number
+  limit: number | null
+  remaining: number | null
+}
+
+/** Response shape of `GET /me/entitlements`. */
+export interface AIEntitlements {
+  source: EntitlementSource
+  limits: {
+    maxOrchestrators: number | null
+    maxDevices: number | null
+    maxPrivateProjects: number | null
+    maxPublicProjects: number | null
+    maxOrgMembers: number | null
+    maxTeamWorkspaces: number | null
+  }
+  acu: {
+    monthlyAcu: number
+    rateLimitWindowHours: number
+    rateLimitWindowPercent: number
+    marginPercent: number | null
+  }
+  features: PlanFeatures
+}
+
+/** Response shape of `GET /me/usage`. */
+export interface AIUsage {
+  source: EntitlementSource
+  orchestrators: UsageCounter
+  devices: UsageCounter
+  privateProjects: UsageCounter
+  publicProjects: UsageCounter
+  organizations: {
+    used: number
+    allowed: boolean
+  }
+  acu: {
+    used: number
+    monthlyLimit: number
+    remaining: number
+    rateLimitWindowHours: number
+    rateLimitWindowPercent: number
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Graphical Editor Flow Data Shapes
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/399. Keeps the shared `AIPort` surface byte-identical between the two IDEs per the workspace shared-code policy.

Touches only the two shared port files:
- `src/middleware/shared/ports/ai-port.ts` — adds `fetchEntitlements` / `fetchUsage` methods to the port; marks `fetchCredits` + `AICreditStatus` `@deprecated`.
- `src/middleware/shared/ports/types.ts` — adds the new AI Billing types section (`SubscriptionStatus`, `PlanLevelSlug`, `PlanFeatures`, `EntitlementSource`, `UsageCounter`, `AIEntitlements`, `AIUsage`).

No editor adapter implementation is added: `PlatformPorts.ai?` is optional and `editor-platform.ts` does not set it (AI features remain web-only for now).

## Mirror policy

Per CLAUDE.md, shared frontend code in either repo must have a matching PR in the sibling. The two changed files exist byte-identically on `development` in both repos pre-change, so this PR keeps them aligned.

Pre-existing `HandleBranch` drift in `types.ts` (separate in-flight ladder mirror) is left untouched.

## Test plan

- [x] `npm run validate:arch` — clean.
- [x] `npm run lint` — 0 errors (only pre-existing warnings).
- [x] `npx tsc --noEmit` — clean.
- [x] Verified diff between the two repos' shared port files now matches openplc-web byte-for-byte (modulo the pre-existing HandleBranch drift).
- [ ] CI passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)