### PR TITLE
sync(ai): mirror creditsUsed→acuUsed slice rename + subscription state (DOPE-283)

### DIFF
--- a/src/frontend/store/__tests__/ai-slice.test.ts
+++ b/src/frontend/store/__tests__/ai-slice.test.ts
@@ -39,6 +39,10 @@ describe('createAISlice', () => {
       expect(ai.isEnabled).toBe(false)
       expect(ai.isLoading).toBe(false)
       expect(ai.hasConsented).toBe(false)
+      expect(ai.acuUsed).toBe(0)
+      expect(ai.acuTotal).toBe(0)
+      expect(ai.subscriptionStatus).toBeNull()
+      expect(ai.planSlug).toBeNull()
       expect(ai.creditsUsed).toBe(0)
       expect(ai.creditsTotal).toBe(500)
       expect(ai.tier).toBe('free')
@@ -112,11 +116,50 @@ describe('createAISlice', () => {
     })
   })
 
-  describe('setCredits', () => {
+  describe('setUsage', () => {
+    it('writes the new ACU fields', () => {
+      store.getState().aiActions.setUsage(42, 1000)
+      expect(store.getState().ai.acuUsed).toBe(42)
+      expect(store.getState().ai.acuTotal).toBe(1000)
+    })
+
+    it('mirrors to deprecated creditsUsed/creditsTotal so unmigrated consumers stay in sync', () => {
+      store.getState().aiActions.setUsage(42, 1000)
+      expect(store.getState().ai.creditsUsed).toBe(42)
+      expect(store.getState().ai.creditsTotal).toBe(1000)
+    })
+  })
+
+  describe('setSubscription', () => {
+    it('sets subscriptionStatus, currentPeriodEnd, and planSlug together', () => {
+      store.getState().aiActions.setSubscription('active', '2026-06-01', 'community')
+      const { ai } = store.getState()
+      expect(ai.subscriptionStatus).toBe('active')
+      expect(ai.currentPeriodEnd).toBe('2026-06-01')
+      expect(ai.planSlug).toBe('community')
+    })
+
+    it('accepts null for all three fields (e.g. on logout)', () => {
+      store.getState().aiActions.setSubscription('active', '2026-06-01', 'community')
+      store.getState().aiActions.setSubscription(null, null, null)
+      const { ai } = store.getState()
+      expect(ai.subscriptionStatus).toBeNull()
+      expect(ai.currentPeriodEnd).toBeNull()
+      expect(ai.planSlug).toBeNull()
+    })
+  })
+
+  describe('setCredits (deprecated)', () => {
     it('sets both used and total credits', () => {
       store.getState().aiActions.setCredits(42, 1000)
       expect(store.getState().ai.creditsUsed).toBe(42)
       expect(store.getState().ai.creditsTotal).toBe(1000)
+    })
+
+    it('mirrors to new acuUsed/acuTotal so consumers migrated ahead of their call sites stay correct', () => {
+      store.getState().aiActions.setCredits(42, 1000)
+      expect(store.getState().ai.acuUsed).toBe(42)
+      expect(store.getState().ai.acuTotal).toBe(1000)
     })
   })
 
@@ -614,6 +657,10 @@ describe('createAISliceFactory', () => {
       createAISliceFactory({ isFeatureEnabled: true, hasUserConsented: false, inlineCompletionsEnabled: true }),
     )
     const { ai } = store.getState()
+    expect(ai.acuUsed).toBe(0)
+    expect(ai.acuTotal).toBe(0)
+    expect(ai.subscriptionStatus).toBeNull()
+    expect(ai.planSlug).toBeNull()
     expect(ai.creditsUsed).toBe(0)
     expect(ai.creditsTotal).toBe(500)
     expect(ai.tier).toBe('free')

--- a/src/frontend/store/slices/ai/slice.ts
+++ b/src/frontend/store/slices/ai/slice.ts
@@ -12,6 +12,10 @@ const DEFAULT_AI_STATE: AISlice['ai'] = {
   preferences: {
     inlineCompletionsEnabled: true,
   },
+  acuUsed: 0,
+  acuTotal: 0,
+  subscriptionStatus: null,
+  planSlug: null,
   creditsUsed: 0,
   creditsTotal: 500,
   tier: 'free',
@@ -67,11 +71,37 @@ export function createAISliceFactory(config?: AIFeatureConfig): StateCreator<AIS
           }),
         )
       },
+      setUsage: (used, total) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.acuUsed = used
+            ai.acuTotal = total
+            // Keep deprecated mirror fields in lockstep so unmigrated consumers
+            // (DOPE-287 / DOPE-288 still on `creditsUsed`/`creditsTotal`) read
+            // the same values. Removed once the rename is fully propagated.
+            ai.creditsUsed = used
+            ai.creditsTotal = total
+          }),
+        )
+      },
+      setSubscription: (status, currentPeriodEnd, planSlug) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.subscriptionStatus = status
+            ai.currentPeriodEnd = currentPeriodEnd
+            ai.planSlug = planSlug
+          }),
+        )
+      },
       setCredits: (used, total) => {
         setState(
           produce(({ ai }: AISlice) => {
             ai.creditsUsed = used
             ai.creditsTotal = total
+            // Mirror to the new ACU fields so consumers migrated ahead of their
+            // call-site refactor see the right numbers via either name.
+            ai.acuUsed = used
+            ai.acuTotal = total
           }),
         )
       },

--- a/src/frontend/store/slices/ai/types.ts
+++ b/src/frontend/store/slices/ai/types.ts
@@ -1,7 +1,12 @@
-import type { AIChatContentBlock, ChatMessage, ChatMessageRole } from '../../../../middleware/shared/ports/types'
+import type {
+  AIChatContentBlock,
+  ChatMessage,
+  ChatMessageRole,
+  SubscriptionStatus,
+} from '../../../../middleware/shared/ports/types'
 import type { DiffHunk } from '../../../utils/ai-diff-review'
 
-export type { AIChatContentBlock, ChatMessage, ChatMessageRole }
+export type { AIChatContentBlock, ChatMessage, ChatMessageRole, SubscriptionStatus }
 
 // ---------------------------------------------------------------------------
 // Conversation summary (returned by GET /ai/conversations)
@@ -60,8 +65,31 @@ export type AIState = {
     isLoading: boolean
     hasConsented: boolean
     preferences: AIPreferences
+    /** ACU consumed in the current billing period. Replaces `creditsUsed`. */
+    acuUsed: number
+    /** ACU monthly cap for the active plan. Replaces `creditsTotal`. */
+    acuTotal: number
+    /**
+     * Paddle subscription status from `/me/entitlements`. `null` before the
+     * first fetch completes.
+     */
+    subscriptionStatus: SubscriptionStatus | null
+    /** Plan slug from `/me/entitlements` (e.g. `'community'`, `'standard'`). `null` before first fetch. */
+    planSlug: string | null
+    /**
+     * @deprecated Use `acuUsed`. Kept in sync by `setUsage` and the legacy
+     * `setCredits` setter for one release.
+     */
     creditsUsed: number
+    /**
+     * @deprecated Use `acuTotal`. Kept in sync by `setUsage` and the legacy
+     * `setCredits` setter for one release.
+     */
     creditsTotal: number
+    /**
+     * @deprecated Pre-Paddle tier flag. Use `subscriptionStatus` + `planSlug`.
+     * Retained for one release while UI surfaces migrate.
+     */
     tier: 'free' | 'pro'
     currentPeriodEnd: string | null
     messages: ChatMessage[]
@@ -94,7 +122,29 @@ export type AIActions = {
   setAILoading: (loading: boolean) => void
   setAIConsented: (consented: boolean) => void
   setPreference: <K extends keyof AIPreferences>(key: K, value: AIPreferences[K]) => void
+  /**
+   * Set the ACU usage counters from `/me/usage`. Also writes the deprecated
+   * `creditsUsed` / `creditsTotal` fields to keep unmigrated consumers in sync.
+   */
+  setUsage: (used: number, total: number) => void
+  /**
+   * Set the subscription source fields from `/me/entitlements`. `null` clears
+   * them (e.g. on logout or before the first fetch resolves).
+   */
+  setSubscription: (
+    status: SubscriptionStatus | null,
+    currentPeriodEnd: string | null,
+    planSlug: string | null,
+  ) => void
+  /**
+   * @deprecated Use `setUsage`. Writes to both legacy (`creditsUsed`/`creditsTotal`)
+   * and new (`acuUsed`/`acuTotal`) fields during the deprecation window.
+   */
   setCredits: (used: number, total: number) => void
+  /**
+   * @deprecated Use `setSubscription`. `tier` is the pre-Paddle 'free'|'pro'
+   * flag; the new Paddle world uses `subscriptionStatus` + `planSlug`.
+   */
   setTier: (tier: 'free' | 'pro') => void
   setCurrentPeriodEnd: (date: string | null) => void
   setAIError: (error: string | null) => void


### PR DESCRIPTION
## Summary

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/400. Keeps the shared React frontend under `src/frontend/store/` byte-identical between the two IDEs per CLAUDE.md.

Three files mirrored (verified byte-identical pre-edit on both repos):
- `src/frontend/store/slices/ai/types.ts` — adds new ACU + subscription fields and actions to AIState/AIActions; deprecates the credits/tier surface
- `src/frontend/store/slices/ai/slice.ts` — implements `setUsage` + `setSubscription`; updates default state; back-compat mirroring in both new and deprecated setters
- `src/frontend/store/__tests__/ai-slice.test.ts` — covers the new actions and the deprecation-window mirroring

See the openplc-web PR for full design rationale (split actions, field duplication over getter aliases, deferred consumer migration).

## Test plan

- [x] `npx jest --testPathPatterns=ai-slice` — 73/73 pass
- [x] `npm run validate:arch` — clean
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [x] Diff vs openplc-web's PR is byte-identical (verified with `diff -q` across all three files)
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)