### PR TITLE
sync(ai): mirror BillingErrorPayload + billingError slice field (DOPE-287)

### DIFF
--- a/src/frontend/store/__tests__/ai-slice.test.ts
+++ b/src/frontend/store/__tests__/ai-slice.test.ts
@@ -47,6 +47,7 @@ describe('createAISlice', () => {
       expect(ai.creditsTotal).toBe(500)
       expect(ai.tier).toBe('free')
       expect(ai.currentPeriodEnd).toBeNull()
+      expect(ai.billingError).toBeNull()
       expect(ai.messages).toEqual([])
       expect(ai.activeEditorPou).toBeNull()
       expect(ai.isAgenticLoopRunning).toBe(false)
@@ -186,6 +187,32 @@ describe('createAISlice', () => {
       store.getState().aiActions.setCurrentPeriodEnd('2026-04-01')
       store.getState().aiActions.setCurrentPeriodEnd(null)
       expect(store.getState().ai.currentPeriodEnd).toBeNull()
+    })
+  })
+
+  describe('setBillingError', () => {
+    it('sets the structured 402 payload', () => {
+      store.getState().aiActions.setBillingError({
+        code: 'insufficient_acu',
+        message: 'Out of ACU',
+        remaining: 0,
+        required: 12,
+        monthlyLimit: 613,
+      })
+      const { billingError } = store.getState().ai
+      expect(billingError?.code).toBe('insufficient_acu')
+      expect(billingError?.required).toBe(12)
+      expect(billingError?.monthlyLimit).toBe(613)
+    })
+
+    it('clears the billing error when passed null', () => {
+      store.getState().aiActions.setBillingError({
+        code: 'subscription_inactive',
+        message: 'Payment failed',
+        subscriptionStatus: 'past_due',
+      })
+      store.getState().aiActions.setBillingError(null)
+      expect(store.getState().ai.billingError).toBeNull()
     })
   })
 
@@ -665,6 +692,7 @@ describe('createAISliceFactory', () => {
     expect(ai.creditsTotal).toBe(500)
     expect(ai.tier).toBe('free')
     expect(ai.currentPeriodEnd).toBeNull()
+    expect(ai.billingError).toBeNull()
     expect(ai.messages).toEqual([])
     expect(ai.activeEditorPou).toBeNull()
     expect(ai.isAgenticLoopRunning).toBe(false)

--- a/src/frontend/store/slices/ai/slice.ts
+++ b/src/frontend/store/slices/ai/slice.ts
@@ -20,6 +20,7 @@ const DEFAULT_AI_STATE: AISlice['ai'] = {
   creditsTotal: 500,
   tier: 'free',
   currentPeriodEnd: null,
+  billingError: null,
   messages: [],
   activeEditorPou: null,
   isAgenticLoopRunning: false,
@@ -116,6 +117,13 @@ export function createAISliceFactory(config?: AIFeatureConfig): StateCreator<AIS
         setState(
           produce(({ ai }: AISlice) => {
             ai.currentPeriodEnd = date
+          }),
+        )
+      },
+      setBillingError: (error) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.billingError = error
           }),
         )
       },

--- a/src/frontend/store/slices/ai/types.ts
+++ b/src/frontend/store/slices/ai/types.ts
@@ -1,12 +1,13 @@
 import type {
   AIChatContentBlock,
+  BillingErrorPayload,
   ChatMessage,
   ChatMessageRole,
   SubscriptionStatus,
 } from '../../../../middleware/shared/ports/types'
 import type { DiffHunk } from '../../../utils/ai-diff-review'
 
-export type { AIChatContentBlock, ChatMessage, ChatMessageRole, SubscriptionStatus }
+export type { AIChatContentBlock, BillingErrorPayload, ChatMessage, ChatMessageRole, SubscriptionStatus }
 
 // ---------------------------------------------------------------------------
 // Conversation summary (returned by GET /ai/conversations)
@@ -92,6 +93,13 @@ export type AIState = {
      */
     tier: 'free' | 'pro'
     currentPeriodEnd: string | null
+    /**
+     * Structured billing error from the most recent 402 (insufficient ACU or
+     * inactive subscription). Read by the exhaustion-modal consumer
+     * (DOPE-285). `null` while no billing block is active — cleared on the
+     * next successful AI request.
+     */
+    billingError: BillingErrorPayload | null
     messages: ChatMessage[]
     activeEditorPou: string | null
     isAgenticLoopRunning: boolean
@@ -147,6 +155,12 @@ export type AIActions = {
    */
   setTier: (tier: 'free' | 'pro') => void
   setCurrentPeriodEnd: (date: string | null) => void
+  /**
+   * Set or clear the structured 402 payload. Called by the chat panel /
+   * inline completion provider when an AIRequestError(402) surfaces, and
+   * cleared (passed `null`) on the next successful request.
+   */
+  setBillingError: (error: BillingErrorPayload | null) => void
   setAIError: (error: string | null) => void
   setActiveEditorPou: (pouName: string | null) => void
   setAgenticLoopRunning: (running: boolean) => void

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -857,6 +857,30 @@ export interface AIUsage {
   }
 }
 
+/**
+ * Structured 402 payload from `/ai/chat` and `/ai/complete`. The backend
+ * `CreditGuard` (autonomy-edge `presentation/guards/credit.guard.ts`) throws
+ * one of two variants depending on whether the user is out of ACU
+ * (`insufficient_acu`) or has a non-active Paddle subscription
+ * (`subscription_inactive`). Surfaced via `AIRequestError.billing` in the
+ * web adapter and stored on `AISlice` as `billingError` for the exhaustion-
+ * modal consumer (DOPE-285).
+ */
+export type BillingErrorPayload = {
+  code: 'insufficient_acu' | 'subscription_inactive'
+  message: string
+  /** Set when `code === 'insufficient_acu'`. ACU remaining in the period. */
+  remaining?: number
+  /** Set when `code === 'insufficient_acu'`. ACU the request would have used. */
+  required?: number
+  /** Set when `code === 'insufficient_acu'`. Plan's monthly ACU cap. */
+  monthlyLimit?: number
+  /** Set when `code === 'subscription_inactive'`. Reason the subscription is blocking. */
+  subscriptionStatus?: SubscriptionStatus
+  /** Optional deep-link to the autonomy-edge billing portal. */
+  reactivateUrl?: string
+}
+
 // ---------------------------------------------------------------------------
 // Graphical Editor Flow Data Shapes
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/403. Keeps the shared React frontend + AI port surface byte-identical between the two IDEs per CLAUDE.md.

Four files mirrored:
- \`src/middleware/shared/ports/types.ts\` — new \`BillingErrorPayload\` type (canonical home; consumed by both the web adapter's \`AIRequestError\` and the shared AI slice).
- \`src/frontend/store/slices/ai/types.ts\` — \`billingError: BillingErrorPayload | null\` field + \`setBillingError\` action signature.
- \`src/frontend/store/slices/ai/slice.ts\` — default state + \`setBillingError\` action implementation.
- \`src/frontend/store/__tests__/ai-slice.test.ts\` — 2 new tests + initial-state assertion.

Web-only adapter changes (api-client 402 parsing, chat panel migration to fetchUsage / fetchEntitlements, inline completion provider 402 capture) are not mirrored — the editor has no AI adapter (\`PlatformPorts.ai?\` is optional and \`editor-platform.ts\` does not set it).

See the openplc-web PR for the full rationale + the chat panel migration details.

## Test plan

- [x] \`npx jest --testPathPatterns=ai-slice\` — 75/75 pass.
- [x] \`npm run validate:arch\` — clean.
- [x] \`npm run lint\` — 0 errors.
- [x] \`npx tsc --noEmit\` — clean.
- [x] All four files verified byte-identical against openplc-web's PR via \`diff -q\`.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)