### PR TITLE
sync(ai): mirror AcuExhaustionModal (DOPE-285)

### DIFF
--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
@@ -1,0 +1,89 @@
+import type { BillingErrorPayload } from '../../../../../middleware/shared/ports/types'
+import { Modal, ModalContent, ModalHeader, ModalTitle } from '../../../_molecules/modal'
+
+export type AcuExhaustionModalProps = {
+  /** Pulled from `ai.billingError`. Modal renders when non-null. */
+  billingError: BillingErrorPayload | null
+  /**
+   * Called when the user dismisses the modal (close button, ESC, click
+   * outside). Consumers typically wire this to `setBillingError(null)` so
+   * the slice clears and the modal won't re-open until the next 402.
+   */
+  onDismiss: () => void
+  /**
+   * URL for the upgrade / reactivate CTA. The consumer is expected to
+   * compose this from the edge-frontend origin + the right settings deep-
+   * link (e.g. `${getEdgeFrontendBaseUrl()}/profile/settings?tab=usage`).
+   * The `subscription_inactive` variant prefers its own `reactivateUrl`
+   * from the 402 payload when present and falls back to this prop.
+   */
+  upgradeUrl: string
+}
+
+/**
+ * Renders the right copy + CTA for whichever 402 variant landed on the
+ * slice. Pure presentational: the workspace screen owns the slice
+ * subscription and passes the payload + dismissal callback as props so
+ * this component stays platform-agnostic and trivially testable in both
+ * Vitest and Jest.
+ */
+export const AcuExhaustionModal = ({ billingError, onDismiss, upgradeUrl }: AcuExhaustionModalProps) => {
+  if (!billingError) return null
+
+  const isInactive = billingError.code === 'subscription_inactive'
+
+  const title = isInactive ? 'Subscription required' : "You're out of ACU"
+  const description = isInactive
+    ? billingError.message ||
+      `Your subscription is ${billingError.subscriptionStatus ?? 'inactive'}. Reactivate to keep using AI features.`
+    : billingError.message ||
+      `You've used all ${billingError.monthlyLimit ?? 0} ACU for this billing period. Upgrade your plan for more, or wait for the next reset.`
+  const ctaLabel = isInactive ? 'Reactivate subscription' : 'Upgrade plan'
+  // subscription_inactive carries its own reactivation URL; insufficient_acu doesn't.
+  const ctaUrl = isInactive && billingError.reactivateUrl ? billingError.reactivateUrl : upgradeUrl
+
+  return (
+    <Modal open onOpenChange={(open) => !open && onDismiss()}>
+      <ModalContent
+        data-testid='acu-exhaustion-modal'
+        // `ModalContent` defaults to a 525×500 modal anchored via `inset-0`
+        // for project-loading flows. Reset the inset cage and re-center via
+        // translate so the modal wraps its actual content height instead of
+        // stretching top-to-bottom.
+        className='inset-auto left-1/2 top-1/2 m-0 h-auto w-[440px] max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 gap-3 p-6'
+        onClose={onDismiss}
+      >
+        <ModalHeader>
+          <ModalTitle className='text-[16px] font-semibold text-neutral-900 dark:text-white'>{title}</ModalTitle>
+        </ModalHeader>
+        <p className='text-[13px] leading-[1.5] text-neutral-600 dark:text-neutral-300'>{description}</p>
+        {billingError.code === 'insufficient_acu' &&
+          typeof billingError.remaining === 'number' &&
+          typeof billingError.required === 'number' && (
+            <p className='text-[12px] text-neutral-500 dark:text-neutral-400'>
+              This request needed {billingError.required} ACU; only {billingError.remaining} remaining.
+            </p>
+          )}
+        <div className='mt-2 flex items-center justify-end gap-2'>
+          <button
+            type='button'
+            onClick={onDismiss}
+            className='rounded px-3 py-1.5 text-[13px] text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-neutral-900 dark:text-neutral-300 dark:hover:bg-white/[0.06] dark:hover:text-white'
+          >
+            Dismiss
+          </button>
+          <a
+            href={ctaUrl}
+            target='_blank'
+            rel='noreferrer'
+            onClick={onDismiss}
+            data-testid='acu-exhaustion-cta'
+            className='cursor-pointer rounded bg-brand px-3 py-1.5 text-[13px] font-medium text-white shadow-sm transition-colors hover:bg-blue-600'
+          >
+            {ctaLabel}
+          </a>
+        </div>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/__tests__/AcuExhaustionModal.test.tsx
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/__tests__/AcuExhaustionModal.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import type { BillingErrorPayload } from '../../../../../../middleware/shared/ports/types'
+import { AcuExhaustionModal } from '../AcuExhaustionModal'
+
+const TEST_UPGRADE_URL = 'http://localhost:5173/profile/settings?tab=usage'
+
+const insufficientAcu: BillingErrorPayload = {
+  code: 'insufficient_acu',
+  message: 'Out of ACU — upgrade to keep chatting',
+  remaining: 0,
+  required: 12,
+  monthlyLimit: 613,
+}
+
+const subscriptionInactive: BillingErrorPayload = {
+  code: 'subscription_inactive',
+  message: 'Your subscription was canceled. Reactivate to continue.',
+  subscriptionStatus: 'canceled',
+  reactivateUrl: 'https://billing.example/reactivate',
+}
+
+describe('AcuExhaustionModal', () => {
+  it('renders nothing when billingError is null', () => {
+    const { container } = render(<AcuExhaustionModal billingError={null} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the "Out of ACU" variant with the upgrade CTA and ACU figures', () => {
+    render(<AcuExhaustionModal billingError={insufficientAcu} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
+    expect(screen.getByText("You're out of ACU")).toBeTruthy()
+    expect(screen.getByText('Out of ACU — upgrade to keep chatting')).toBeTruthy()
+    expect(screen.getByText(/This request needed 12 ACU; only 0 remaining/)).toBeTruthy()
+    const cta = screen.getByTestId('acu-exhaustion-cta') as HTMLAnchorElement
+    expect(cta.textContent).toBe('Upgrade plan')
+    expect(cta.href).toBe(TEST_UPGRADE_URL)
+  })
+
+  it('renders the "Subscription required" variant with reactivate CTA pointing at reactivateUrl', () => {
+    render(<AcuExhaustionModal billingError={subscriptionInactive} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
+    expect(screen.getByText('Subscription required')).toBeTruthy()
+    expect(screen.getByText('Your subscription was canceled. Reactivate to continue.')).toBeTruthy()
+    const cta = screen.getByTestId('acu-exhaustion-cta') as HTMLAnchorElement
+    expect(cta.textContent).toBe('Reactivate subscription')
+    expect(cta.href).toBe('https://billing.example/reactivate')
+  })
+
+  it('falls back to upgradeUrl when subscription_inactive has no reactivateUrl', () => {
+    const noReactivate: BillingErrorPayload = {
+      code: 'subscription_inactive',
+      message: 'paused',
+      subscriptionStatus: 'paused',
+    }
+    render(
+      <AcuExhaustionModal
+        billingError={noReactivate}
+        onDismiss={vi.fn()}
+        upgradeUrl='https://override.example/billing'
+      />,
+    )
+    const cta = screen.getByTestId('acu-exhaustion-cta') as HTMLAnchorElement
+    expect(cta.href).toBe('https://override.example/billing')
+  })
+
+  it('falls back to a default description when billing.message is empty', () => {
+    render(
+      <AcuExhaustionModal
+        billingError={{ ...insufficientAcu, message: '' }}
+        onDismiss={vi.fn()}
+        upgradeUrl={TEST_UPGRADE_URL}
+      />,
+    )
+    expect(screen.getByText(/used all 613 ACU/)).toBeTruthy()
+  })
+
+  it('omits the "needed N / M remaining" line when remaining/required are missing', () => {
+    render(
+      <AcuExhaustionModal
+        billingError={{ code: 'insufficient_acu', message: 'short body' }}
+        onDismiss={vi.fn()}
+        upgradeUrl={TEST_UPGRADE_URL}
+      />,
+    )
+    expect(screen.queryByText(/needed.*remaining/)).toBeNull()
+  })
+
+  it('calls onDismiss when the dismiss button is clicked', () => {
+    const onDismiss = vi.fn()
+    render(<AcuExhaustionModal billingError={insufficientAcu} onDismiss={onDismiss} upgradeUrl={TEST_UPGRADE_URL} />)
+    fireEvent.click(screen.getByText('Dismiss'))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onDismiss when the upgrade CTA is clicked (so the modal closes after the link opens)', () => {
+    const onDismiss = vi.fn()
+    render(<AcuExhaustionModal billingError={insufficientAcu} onDismiss={onDismiss} upgradeUrl={TEST_UPGRADE_URL} />)
+    fireEvent.click(screen.getByTestId('acu-exhaustion-cta'))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses dialog ARIA semantics (Radix Dialog)', () => {
+    render(<AcuExhaustionModal billingError={insufficientAcu} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeTruthy()
+  })
+})

--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/index.ts
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/index.ts
@@ -1,0 +1,2 @@
+export type { AcuExhaustionModalProps } from './AcuExhaustionModal'
+export { AcuExhaustionModal } from './AcuExhaustionModal'


### PR DESCRIPTION
## Summary

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/404. Keeps the shared React frontend byte-identical between the two IDEs per CLAUDE.md.

Three new files under `src/frontend/components/_features/[workspace]/ai-settings-panel/`:

- `AcuExhaustionModal.tsx` — pure presentational modal. Two variants (insufficient_acu, subscription_inactive). Takes `billingError` / `onDismiss` / `upgradeUrl` as props.
- `index.ts` — barrel export.
- `__tests__/AcuExhaustionModal.test.tsx` — 9 tests covering both variants, CTA URL fallback, dismiss behaviors, ARIA semantics.

The editor doesn't currently consume the AI slice (no AI adapter, `PlatformPorts.ai?` is optional), so the modal isn't rendered here today. This PR exists purely to keep the shared component definition in lockstep for future editor-side AI work.

All adapter-layer plumbing (web's `index-page.tsx` mount, `get-env.ts` helper, `api-client.ts` / `agentic-loop.ts` / `ai-chat-panel.tsx` fixes) is web-only and lives in the openplc-web PR — see that PR for the full context.

## Test plan

- [x] `npx jest --testPathPatterns=AcuExhaustionModal` — 9/9 pass.
- [x] `npm run validate:arch` — clean.
- [x] `npm run lint` — 0 errors.
- [x] `npx tsc --noEmit` — clean.
- [x] All three files verified byte-identical against openplc-web's PR via `diff -q`.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)