### PR TITLE
fix(web): mirror — restore exit-to-host and tighten resize handle gaps

### DIFF
--- a/src/frontend/components/_organisms/modals/save-changes-modal.tsx
+++ b/src/frontend/components/_organisms/modals/save-changes-modal.tsx
@@ -1,6 +1,6 @@
 import { ComponentPropsWithoutRef } from 'react'
 
-import { useCapabilities, useProject, useWindow } from '../../../../middleware/shared/providers'
+import { useCapabilities, useNavigation, useProject, useWindow } from '../../../../middleware/shared/providers'
 import { WarningIcon } from '../../../assets/icons/interface/Warning'
 import { executeSaveProject } from '../../../services/save-actions'
 import { useOpenPLCStore } from '../../../store'
@@ -39,6 +39,7 @@ const SaveChangesModal = ({ isOpen, validationContext, onAfterAction, ...rest }:
 
   const projectPort = useProject()
   const windowPort = useWindow()
+  const navigation = useNavigation()
   const capabilities = useCapabilities()
 
   const {
@@ -48,9 +49,6 @@ const SaveChangesModal = ({ isOpen, validationContext, onAfterAction, ...rest }:
   const clearAndClose = () => {
     clearStatesOnCloseProject()
     setEditingState('initial-state')
-    if (!capabilities.hasLocalFilesystem) {
-      window.history.back()
-    }
   }
 
   const handleAcceptCloseModal = async (operation: 'save' | 'not-saving') => {
@@ -76,6 +74,7 @@ const SaveChangesModal = ({ isOpen, validationContext, onAfterAction, ...rest }:
         return
       case 'close-project':
         clearAndClose()
+        navigation.exitToHost()
         return
       case 'close-app':
         if (capabilities.isNativeApplication) {

--- a/src/frontend/components/_organisms/workspace-activity-bar/index.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/index.tsx
@@ -1,6 +1,7 @@
 import { Files, GitBranch } from 'lucide-react'
 import { useCallback } from 'react'
 
+import { useNavigation } from '../../../../middleware/shared/providers'
 import { useOpenPLCStore } from '../../../store'
 import { cn } from '../../../utils/cn'
 import { DividerActivityBar } from '../../_atoms/workspace-activity-bar/divider'
@@ -30,12 +31,18 @@ type ActivityBarProps = {
 export const WorkspaceActivityBar = ({ defaultActivityBar, explorer, sourceControl }: ActivityBarProps) => {
   const editor = useOpenPLCStore(useCallback((s) => s.editor, []))
   const { closeProject } = useOpenPLCStore(useCallback((s) => s.sharedWorkspaceActions, []))
+  const navigation = useNavigation()
 
   const isFBDEditor = editor?.type === 'plc-graphical' && editor?.meta.language === 'fbd'
   const isLadderEditor = editor?.type === 'plc-graphical' && editor?.meta.language === 'ld'
 
   const handleExitApplication = () => {
-    closeProject()
+    const { pendingConfirmation } = closeProject()
+    // When the modal opens, defer exiting to the modal's save/discard
+    // path so the user's choice is respected.
+    if (!pendingConfirmation) {
+      navigation.exitToHost()
+    }
   }
   return (
     <>

--- a/src/frontend/screens/workspace-screen.tsx
+++ b/src/frontend/screens/workspace-screen.tsx
@@ -384,7 +384,7 @@ const WorkspaceScreen = () => {
           <ResizablePanelGroup
             id='mainContentPanelGroup'
             direction='horizontal'
-            className='relative flex h-full w-full gap-2'
+            className='relative flex h-full w-full'
           >
             {hasVersionControl && activePanel === 'source-control' ? (
               <SourceControlPanel

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -1429,10 +1429,12 @@ describe('createSharedSlice', () => {
       it('opens save-changes modal when there are unsaved changes', () => {
         store.getState().workspaceActions.setEditingState('unsaved')
 
-        store.getState().sharedWorkspaceActions.closeProject()
+        const result = store.getState().sharedWorkspaceActions.closeProject()
 
         const modalState = store.getState().modalActions.getModalState('save-changes-project')
         expect(modalState.open).toBe(true)
+        // Caller should defer host navigation until the modal resolves.
+        expect(result).toEqual({ pendingConfirmation: true })
       })
 
       it('clears state when everything is saved', () => {
@@ -1440,11 +1442,13 @@ describe('createSharedSlice', () => {
         store.getState().fileActions.updateFile({ name: 'TestPou', saved: true })
         store.getState().workspaceActions.setEditingState('saved')
 
-        store.getState().sharedWorkspaceActions.closeProject()
+        const result = store.getState().sharedWorkspaceActions.closeProject()
 
         // State should be cleared
         expect(store.getState().tabs).toHaveLength(0)
         expect(store.getState().project.data.pous).toHaveLength(0)
+        // Caller should navigate to the host immediately.
+        expect(result).toEqual({ pendingConfirmation: false })
       })
     })
 

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -434,9 +434,10 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
         getState().modalActions.openModal('save-changes-project', {
           validationContext: 'close-project',
         })
-        return
+        return { pendingConfirmation: true }
       }
       getState().sharedWorkspaceActions.clearStatesOnCloseProject()
+      return { pendingConfirmation: false }
     },
 
     clearStatesOnCloseProject: () => {

--- a/src/frontend/store/slices/shared/types.ts
+++ b/src/frontend/store/slices/shared/types.ts
@@ -140,9 +140,11 @@ export type SharedWorkspaceActions = {
   forceCloseFile: (name: string) => { success: boolean }
   /**
    * Close project: checks save state, shows save-changes modal if unsaved,
-   * or clears all state if saved.
+   * or clears all state if saved. Returns `{ pendingConfirmation: true }`
+   * when the modal was opened so the caller can defer post-close work
+   * (e.g. host navigation) until the modal resolves.
    */
-  closeProject: () => void
+  closeProject: () => { pendingConfirmation: boolean }
   /** Reset all slice state for project close. */
   clearStatesOnCloseProject: () => void
   /**

--- a/src/middleware/adapters/editor/navigation-adapter.ts
+++ b/src/middleware/adapters/editor/navigation-adapter.ts
@@ -31,5 +31,11 @@ export function createEditorNavigationAdapter(): NavigationPort {
     openInNewWindow(path: string, search?: NavigationSearch): void {
       window.open(buildNavigationUrl(path, search), '_blank')
     },
+
+    exitToHost(): void {
+      // The editor has no host to return to — the start screen appears
+      // automatically once `clearStatesOnCloseProject` has reset project
+      // state, so this is intentionally a no-op.
+    },
   }
 }

--- a/src/middleware/shared/ports/navigation-port.ts
+++ b/src/middleware/shared/ports/navigation-port.ts
@@ -42,6 +42,20 @@ export interface NavigationPort {
    * Editor: `window.open(url, '_blank')` (new BrowserWindow).
    */
   openInNewWindow(path: string, search?: NavigationSearch): void
+
+  /**
+   * Exit the editor surface back to the host that embedded it.
+   * Web: hard-redirects to the autonomy-edge project list
+   *      (`${VITE_EDGE_FRONTEND_URL}/projects`).
+   * Editor: no-op — the start screen reappears automatically once
+   *         the project state has been cleared by the caller.
+   *
+   * Callers are expected to clear project state first (via the shared
+   * `clearStatesOnCloseProject` action) so the editor view is in a
+   * coherent "no project loaded" state before the platform decides
+   * whether to stay (editor) or navigate away (web).
+   */
+  exitToHost(): void
 }
 
 /**


### PR DESCRIPTION
## Summary

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/406 — diffs are byte-identical for all shared files (`src/frontend/**` and `src/middleware/shared/**`).

Two visual / navigation regressions surfaced in the web editor but the shared-frontend changes need to land in the editor at the same time per the workspace mirror policy.

### 1. Sidebar exit arrow no longer returns to the host

Introduces `NavigationPort.exitToHost()`:

- **Editor adapter** (this repo): no-op. The start screen reappears automatically once project state is cleared via `clearStatesOnCloseProject`.
- **Web adapter** (sibling repo): `window.location.href = ${VITE_EDGE_FRONTEND_URL}/projects` with a same-origin `/projects` fallback.

`closeProject()` now returns `{ pendingConfirmation }` so the activity
bar can defer host navigation until the save-changes modal resolves.
The `window.history.back()` shim is removed from the save-changes
modal.

### 2. Resize-handle gaps too wide

The mainContentPanelGroup wrapper had `gap-2` (8px) applied on both
sides of each 4px resize handle, producing a ~20px visual stripe
between Explorer ↔ Editor (and Editor ↔ AI Chat on web). Dropping
`gap-2` collapses the gap to just the 4px handle. Drag affordance is
unchanged.

## Test plan

- [ ] **Exit-to-host (editor)**: with a project loaded, click the back arrow → returns to the start screen (no project loaded).
- [ ] **Exit-to-host with unsaved changes**: click back arrow → save-changes modal opens; both "Save and close" and "Close without saving" end up back at the start screen; "Cancel" keeps the project open.
- [ ] **Resize gap**: explorer divider visually narrows; dragging the handle still resizes the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced exit flow that properly defers navigation when unsaved changes require confirmation.

* **Bug Fixes**
  * Improved handling of project closure to correctly manage pending confirmation modals before exiting.

* **Style**
  * Adjusted workspace panel spacing for better layout consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autonomy-Logic/openplc-editor/pull/771?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->