### PR TITLE
sync(ai): Phase 5 — AI billing integration shared code (mirror)

### DIFF
--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
@@ -18,6 +18,12 @@ export type AcuExhaustionModalProps = {
    * from the 402 payload when present and falls back to this prop.
    */
   upgradeUrl: string
+  /**
+   * Optional callback fired right before the upgrade CTA navigates. Used
+   * by the consumer to fire the `upgrade_cta_clicked` telemetry event;
+   * left undefined in contexts (tests, future surfaces) that don't need it.
+   */
+  onUpgradeClick?: () => void
 }
 
 /**
@@ -27,7 +33,12 @@ export type AcuExhaustionModalProps = {
  * this component stays platform-agnostic and trivially testable in both
  * Vitest and Jest.
  */
-export const AcuExhaustionModal = ({ billingError, onDismiss, upgradeUrl }: AcuExhaustionModalProps) => {
+export const AcuExhaustionModal = ({
+  billingError,
+  onDismiss,
+  upgradeUrl,
+  onUpgradeClick,
+}: AcuExhaustionModalProps) => {
   if (!billingError) return null
 
   const isInactive = billingError.code === 'subscription_inactive'
@@ -76,7 +87,10 @@ export const AcuExhaustionModal = ({ billingError, onDismiss, upgradeUrl }: AcuE
             href={ctaUrl}
             target='_blank'
             rel='noreferrer'
-            onClick={onDismiss}
+            onClick={() => {
+              onUpgradeClick?.()
+              onDismiss()
+            }}
             data-testid='acu-exhaustion-cta'
             className='cursor-pointer rounded bg-brand px-3 py-1.5 text-[13px] font-medium text-white shadow-sm transition-colors hover:bg-blue-600'
           >

--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
@@ -1,0 +1,89 @@
+import type { BillingErrorPayload } from '../../../../../middleware/shared/ports/types'
+import { Modal, ModalContent, ModalHeader, ModalTitle } from '../../../_molecules/modal'
+
+export type AcuExhaustionModalProps = {
+  /** Pulled from `ai.billingError`. Modal renders when non-null. */
+  billingError: BillingErrorPayload | null
+  /**
+   * Called when the user dismisses the modal (close button, ESC, click
+   * outside). Consumers typically wire this to `setBillingError(null)` so
+   * the slice clears and the modal won't re-open until the next 402.
+   */
+  onDismiss: () => void
+  /**
+   * URL for the upgrade / reactivate CTA. The consumer is expected to
+   * compose this from the edge-frontend origin + the right settings deep-
+   * link (e.g. `${getEdgeFrontendBaseUrl()}/profile/settings?tab=usage`).
+   * The `subscription_inactive` variant prefers its own `reactivateUrl`
+   * from the 402 payload when present and falls back to this prop.
+   */
+  upgradeUrl: string
+}
+
+/**
+ * Renders the right copy + CTA for whichever 402 variant landed on the
+ * slice. Pure presentational: the workspace screen owns the slice
+ * subscription and passes the payload + dismissal callback as props so
+ * this component stays platform-agnostic and trivially testable in both
+ * Vitest and Jest.
+ */
+export const AcuExhaustionModal = ({ billingError, onDismiss, upgradeUrl }: AcuExhaustionModalProps) => {
+  if (!billingError) return null
+
+  const isInactive = billingError.code === 'subscription_inactive'
+
+  const title = isInactive ? 'Subscription required' : "You're out of ACU"
+  const description = isInactive
+    ? billingError.message ||
+      `Your subscription is ${billingError.subscriptionStatus ?? 'inactive'}. Reactivate to keep using AI features.`
+    : billingError.message ||
+      `You've used all ${billingError.monthlyLimit ?? 0} ACU for this billing period. Upgrade your plan for more, or wait for the next reset.`
+  const ctaLabel = isInactive ? 'Reactivate subscription' : 'Upgrade plan'
+  // subscription_inactive carries its own reactivation URL; insufficient_acu doesn't.
+  const ctaUrl = isInactive && billingError.reactivateUrl ? billingError.reactivateUrl : upgradeUrl
+
+  return (
+    <Modal open onOpenChange={(open) => !open && onDismiss()}>
+      <ModalContent
+        data-testid='acu-exhaustion-modal'
+        // `ModalContent` defaults to a 525×500 modal anchored via `inset-0`
+        // for project-loading flows. Reset the inset cage and re-center via
+        // translate so the modal wraps its actual content height instead of
+        // stretching top-to-bottom.
+        className='inset-auto left-1/2 top-1/2 m-0 h-auto w-[440px] max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 gap-3 p-6'
+        onClose={onDismiss}
+      >
+        <ModalHeader>
+          <ModalTitle className='text-[16px] font-semibold text-neutral-900 dark:text-white'>{title}</ModalTitle>
+        </ModalHeader>
+        <p className='text-[13px] leading-[1.5] text-neutral-600 dark:text-neutral-300'>{description}</p>
+        {billingError.code === 'insufficient_acu' &&
+          typeof billingError.remaining === 'number' &&
+          typeof billingError.required === 'number' && (
+            <p className='text-[12px] text-neutral-500 dark:text-neutral-400'>
+              This request needed {billingError.required} ACU; only {billingError.remaining} remaining.
+            </p>
+          )}
+        <div className='mt-2 flex items-center justify-end gap-2'>
+          <button
+            type='button'
+            onClick={onDismiss}
+            className='rounded px-3 py-1.5 text-[13px] text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-neutral-900 dark:text-neutral-300 dark:hover:bg-white/[0.06] dark:hover:text-white'
+          >
+            Dismiss
+          </button>
+          <a
+            href={ctaUrl}
+            target='_blank'
+            rel='noreferrer'
+            onClick={onDismiss}
+            data-testid='acu-exhaustion-cta'
+            className='cursor-pointer rounded bg-brand px-3 py-1.5 text-[13px] font-medium text-white shadow-sm transition-colors hover:bg-blue-600'
+          >
+            {ctaLabel}
+          </a>
+        </div>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
@@ -44,11 +44,15 @@ export const AcuExhaustionModal = ({
   const isInactive = billingError.code === 'subscription_inactive'
 
   const title = isInactive ? 'Subscription required' : "You're out of ACU"
+  // Frontend-controlled copy: the backend `CreditGuard` message is geared
+  // toward operators/logs and still references the (now-descoped) Haiku
+  // model quick-switch from DOPE-288. We pull only the structured fields
+  // (subscriptionStatus, monthlyLimit) and compose user-facing text here.
   const description = isInactive
-    ? billingError.message ||
-      `Your subscription is ${billingError.subscriptionStatus ?? 'inactive'}. Reactivate to keep using AI features.`
-    : billingError.message ||
-      `You've used all ${billingError.monthlyLimit ?? 0} ACU for this billing period. Upgrade your plan for more, or wait for the next reset.`
+    ? `Your subscription is ${billingError.subscriptionStatus ?? 'inactive'}. Reactivate it to keep using AI features.`
+    : billingError.monthlyLimit != null
+      ? `You've used all ${billingError.monthlyLimit} ACU for this billing period. Buy more ACU or upgrade your plan to keep going.`
+      : "You're out of ACU for this billing period. Buy more ACU or upgrade your plan to keep going."
   const ctaLabel = isInactive ? 'Reactivate subscription' : 'Upgrade plan'
   // subscription_inactive carries its own reactivation URL; insufficient_acu doesn't.
   const ctaUrl = isInactive && billingError.reactivateUrl ? billingError.reactivateUrl : upgradeUrl

--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/__tests__/AcuExhaustionModal.test.tsx
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/__tests__/AcuExhaustionModal.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import type { BillingErrorPayload } from '../../../../../../middleware/shared/ports/types'
+import { AcuExhaustionModal } from '../AcuExhaustionModal'
+
+const TEST_UPGRADE_URL = 'http://localhost:5173/profile/settings?tab=usage'
+
+const insufficientAcu: BillingErrorPayload = {
+  code: 'insufficient_acu',
+  message: 'Out of ACU — upgrade to keep chatting',
+  remaining: 0,
+  required: 12,
+  monthlyLimit: 613,
+}
+
+const subscriptionInactive: BillingErrorPayload = {
+  code: 'subscription_inactive',
+  message: 'Your subscription was canceled. Reactivate to continue.',
+  subscriptionStatus: 'canceled',
+  reactivateUrl: 'https://billing.example/reactivate',
+}
+
+describe('AcuExhaustionModal', () => {
+  it('renders nothing when billingError is null', () => {
+    const { container } = render(<AcuExhaustionModal billingError={null} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the "Out of ACU" variant with the upgrade CTA and ACU figures', () => {
+    render(<AcuExhaustionModal billingError={insufficientAcu} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
+    expect(screen.getByText("You're out of ACU")).toBeTruthy()
+    expect(screen.getByText('Out of ACU — upgrade to keep chatting')).toBeTruthy()
+    expect(screen.getByText(/This request needed 12 ACU; only 0 remaining/)).toBeTruthy()
+    const cta = screen.getByTestId('acu-exhaustion-cta') as HTMLAnchorElement
+    expect(cta.textContent).toBe('Upgrade plan')
+    expect(cta.href).toBe(TEST_UPGRADE_URL)
+  })
+
+  it('renders the "Subscription required" variant with reactivate CTA pointing at reactivateUrl', () => {
+    render(<AcuExhaustionModal billingError={subscriptionInactive} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
+    expect(screen.getByText('Subscription required')).toBeTruthy()
+    expect(screen.getByText('Your subscription was canceled. Reactivate to continue.')).toBeTruthy()
+    const cta = screen.getByTestId('acu-exhaustion-cta') as HTMLAnchorElement
+    expect(cta.textContent).toBe('Reactivate subscription')
+    expect(cta.href).toBe('https://billing.example/reactivate')
+  })
+
+  it('falls back to upgradeUrl when subscription_inactive has no reactivateUrl', () => {
+    const noReactivate: BillingErrorPayload = {
+      code: 'subscription_inactive',
+      message: 'paused',
+      subscriptionStatus: 'paused',
+    }
+    render(
+      <AcuExhaustionModal
+        billingError={noReactivate}
+        onDismiss={vi.fn()}
+        upgradeUrl='https://override.example/billing'
+      />,
+    )
+    const cta = screen.getByTestId('acu-exhaustion-cta') as HTMLAnchorElement
+    expect(cta.href).toBe('https://override.example/billing')
+  })
+
+  it('falls back to a default description when billing.message is empty', () => {
+    render(
+      <AcuExhaustionModal
+        billingError={{ ...insufficientAcu, message: '' }}
+        onDismiss={vi.fn()}
+        upgradeUrl={TEST_UPGRADE_URL}
+      />,
+    )
+    expect(screen.getByText(/used all 613 ACU/)).toBeTruthy()
+  })
+
+  it('omits the "needed N / M remaining" line when remaining/required are missing', () => {
+    render(
+      <AcuExhaustionModal
+        billingError={{ code: 'insufficient_acu', message: 'short body' }}
+        onDismiss={vi.fn()}
+        upgradeUrl={TEST_UPGRADE_URL}
+      />,
+    )
+    expect(screen.queryByText(/needed.*remaining/)).toBeNull()
+  })
+
+  it('calls onDismiss when the dismiss button is clicked', () => {
+    const onDismiss = vi.fn()
+    render(<AcuExhaustionModal billingError={insufficientAcu} onDismiss={onDismiss} upgradeUrl={TEST_UPGRADE_URL} />)
+    fireEvent.click(screen.getByText('Dismiss'))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onDismiss when the upgrade CTA is clicked (so the modal closes after the link opens)', () => {
+    const onDismiss = vi.fn()
+    render(<AcuExhaustionModal billingError={insufficientAcu} onDismiss={onDismiss} upgradeUrl={TEST_UPGRADE_URL} />)
+    fireEvent.click(screen.getByTestId('acu-exhaustion-cta'))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses dialog ARIA semantics (Radix Dialog)', () => {
+    render(<AcuExhaustionModal billingError={insufficientAcu} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeTruthy()
+  })
+})

--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/__tests__/AcuExhaustionModal.test.tsx
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/__tests__/AcuExhaustionModal.test.tsx
@@ -26,10 +26,12 @@ describe('AcuExhaustionModal', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('renders the "Out of ACU" variant with the upgrade CTA and ACU figures', () => {
+  it('renders the "Out of ACU" variant with frontend copy + ACU figures', () => {
     render(<AcuExhaustionModal billingError={insufficientAcu} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
     expect(screen.getByText("You're out of ACU")).toBeTruthy()
-    expect(screen.getByText('Out of ACU — upgrade to keep chatting')).toBeTruthy()
+    // Frontend copy — ignores the backend message which still mentions the
+    // descoped Haiku quick-switch.
+    expect(screen.getByText(/used all 613 ACU.*Buy more ACU or upgrade your plan/)).toBeTruthy()
     expect(screen.getByText(/This request needed 12 ACU; only 0 remaining/)).toBeTruthy()
     const cta = screen.getByTestId('acu-exhaustion-cta') as HTMLAnchorElement
     expect(cta.textContent).toBe('Upgrade plan')
@@ -39,7 +41,8 @@ describe('AcuExhaustionModal', () => {
   it('renders the "Subscription required" variant with reactivate CTA pointing at reactivateUrl', () => {
     render(<AcuExhaustionModal billingError={subscriptionInactive} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
     expect(screen.getByText('Subscription required')).toBeTruthy()
-    expect(screen.getByText('Your subscription was canceled. Reactivate to continue.')).toBeTruthy()
+    // Frontend copy — uses subscriptionStatus, ignores the backend message.
+    expect(screen.getByText(/Your subscription is canceled.*Reactivate it to keep using AI features/)).toBeTruthy()
     const cta = screen.getByTestId('acu-exhaustion-cta') as HTMLAnchorElement
     expect(cta.textContent).toBe('Reactivate subscription')
     expect(cta.href).toBe('https://billing.example/reactivate')
@@ -62,15 +65,27 @@ describe('AcuExhaustionModal', () => {
     expect(cta.href).toBe('https://override.example/billing')
   })
 
-  it('falls back to a default description when billing.message is empty', () => {
+  it('ignores the backend `message` field — frontend composes its own copy', () => {
+    // Backend's `CreditGuard` still emits "Switch to Haiku..." text from the
+    // descoped DOPE-288 era. The modal must not surface that to the user.
+    const stalePayload: BillingErrorPayload = {
+      ...insufficientAcu,
+      message: 'Switch to Haiku to use fewer credits, or upgrade your plan.',
+    }
+    render(<AcuExhaustionModal billingError={stalePayload} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
+    expect(screen.queryByText(/Switch to Haiku/)).toBeNull()
+    expect(screen.getByText(/Buy more ACU or upgrade your plan/)).toBeTruthy()
+  })
+
+  it('falls back to a generic out-of-ACU description when monthlyLimit is missing', () => {
     render(
       <AcuExhaustionModal
-        billingError={{ ...insufficientAcu, message: '' }}
+        billingError={{ code: 'insufficient_acu', message: '' }}
         onDismiss={vi.fn()}
         upgradeUrl={TEST_UPGRADE_URL}
       />,
     )
-    expect(screen.getByText(/used all 613 ACU/)).toBeTruthy()
+    expect(screen.getByText(/out of ACU for this billing period/)).toBeTruthy()
   })
 
   it('omits the "needed N / M remaining" line when remaining/required are missing', () => {

--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/__tests__/AcuExhaustionModal.test.tsx
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/__tests__/AcuExhaustionModal.test.tsx
@@ -22,7 +22,9 @@ const subscriptionInactive: BillingErrorPayload = {
 
 describe('AcuExhaustionModal', () => {
   it('renders nothing when billingError is null', () => {
-    const { container } = render(<AcuExhaustionModal billingError={null} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
+    const { container } = render(
+      <AcuExhaustionModal billingError={null} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />,
+    )
     expect(container.firstChild).toBeNull()
   })
 

--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/__tests__/AcuExhaustionModal.test.tsx
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/__tests__/AcuExhaustionModal.test.tsx
@@ -98,6 +98,32 @@ describe('AcuExhaustionModal', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1)
   })
 
+  it('fires onUpgradeClick before dismissing so the consumer can emit telemetry', () => {
+    const onDismiss = vi.fn()
+    const onUpgradeClick = vi.fn()
+    render(
+      <AcuExhaustionModal
+        billingError={insufficientAcu}
+        onDismiss={onDismiss}
+        upgradeUrl={TEST_UPGRADE_URL}
+        onUpgradeClick={onUpgradeClick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('acu-exhaustion-cta'))
+    expect(onUpgradeClick).toHaveBeenCalledTimes(1)
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+    // onUpgradeClick must fire before onDismiss so the consumer's telemetry
+    // helper can read fresh state before the slice clears.
+    expect(onUpgradeClick.mock.invocationCallOrder[0]).toBeLessThan(onDismiss.mock.invocationCallOrder[0])
+  })
+
+  it('skips onUpgradeClick when the prop is not provided (back-compat for legacy callers)', () => {
+    const onDismiss = vi.fn()
+    render(<AcuExhaustionModal billingError={insufficientAcu} onDismiss={onDismiss} upgradeUrl={TEST_UPGRADE_URL} />)
+    expect(() => fireEvent.click(screen.getByTestId('acu-exhaustion-cta'))).not.toThrow()
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
   it('uses dialog ARIA semantics (Radix Dialog)', () => {
     render(<AcuExhaustionModal billingError={insufficientAcu} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
     const dialog = screen.getByRole('dialog')

--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/index.ts
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/index.ts
@@ -1,0 +1,2 @@
+export type { AcuExhaustionModalProps } from './AcuExhaustionModal'
+export { AcuExhaustionModal } from './AcuExhaustionModal'

--- a/src/frontend/store/__tests__/ai-slice.test.ts
+++ b/src/frontend/store/__tests__/ai-slice.test.ts
@@ -47,6 +47,7 @@ describe('createAISlice', () => {
       expect(ai.creditsTotal).toBe(500)
       expect(ai.tier).toBe('free')
       expect(ai.currentPeriodEnd).toBeNull()
+      expect(ai.billingError).toBeNull()
       expect(ai.messages).toEqual([])
       expect(ai.activeEditorPou).toBeNull()
       expect(ai.isAgenticLoopRunning).toBe(false)
@@ -186,6 +187,32 @@ describe('createAISlice', () => {
       store.getState().aiActions.setCurrentPeriodEnd('2026-04-01')
       store.getState().aiActions.setCurrentPeriodEnd(null)
       expect(store.getState().ai.currentPeriodEnd).toBeNull()
+    })
+  })
+
+  describe('setBillingError', () => {
+    it('sets the structured 402 payload', () => {
+      store.getState().aiActions.setBillingError({
+        code: 'insufficient_acu',
+        message: 'Out of ACU',
+        remaining: 0,
+        required: 12,
+        monthlyLimit: 613,
+      })
+      const { billingError } = store.getState().ai
+      expect(billingError?.code).toBe('insufficient_acu')
+      expect(billingError?.required).toBe(12)
+      expect(billingError?.monthlyLimit).toBe(613)
+    })
+
+    it('clears the billing error when passed null', () => {
+      store.getState().aiActions.setBillingError({
+        code: 'subscription_inactive',
+        message: 'Payment failed',
+        subscriptionStatus: 'past_due',
+      })
+      store.getState().aiActions.setBillingError(null)
+      expect(store.getState().ai.billingError).toBeNull()
     })
   })
 
@@ -665,6 +692,7 @@ describe('createAISliceFactory', () => {
     expect(ai.creditsTotal).toBe(500)
     expect(ai.tier).toBe('free')
     expect(ai.currentPeriodEnd).toBeNull()
+    expect(ai.billingError).toBeNull()
     expect(ai.messages).toEqual([])
     expect(ai.activeEditorPou).toBeNull()
     expect(ai.isAgenticLoopRunning).toBe(false)

--- a/src/frontend/store/__tests__/ai-slice.test.ts
+++ b/src/frontend/store/__tests__/ai-slice.test.ts
@@ -39,6 +39,10 @@ describe('createAISlice', () => {
       expect(ai.isEnabled).toBe(false)
       expect(ai.isLoading).toBe(false)
       expect(ai.hasConsented).toBe(false)
+      expect(ai.acuUsed).toBe(0)
+      expect(ai.acuTotal).toBe(0)
+      expect(ai.subscriptionStatus).toBeNull()
+      expect(ai.planSlug).toBeNull()
       expect(ai.creditsUsed).toBe(0)
       expect(ai.creditsTotal).toBe(500)
       expect(ai.tier).toBe('free')
@@ -112,11 +116,50 @@ describe('createAISlice', () => {
     })
   })
 
-  describe('setCredits', () => {
+  describe('setUsage', () => {
+    it('writes the new ACU fields', () => {
+      store.getState().aiActions.setUsage(42, 1000)
+      expect(store.getState().ai.acuUsed).toBe(42)
+      expect(store.getState().ai.acuTotal).toBe(1000)
+    })
+
+    it('mirrors to deprecated creditsUsed/creditsTotal so unmigrated consumers stay in sync', () => {
+      store.getState().aiActions.setUsage(42, 1000)
+      expect(store.getState().ai.creditsUsed).toBe(42)
+      expect(store.getState().ai.creditsTotal).toBe(1000)
+    })
+  })
+
+  describe('setSubscription', () => {
+    it('sets subscriptionStatus, currentPeriodEnd, and planSlug together', () => {
+      store.getState().aiActions.setSubscription('active', '2026-06-01', 'community')
+      const { ai } = store.getState()
+      expect(ai.subscriptionStatus).toBe('active')
+      expect(ai.currentPeriodEnd).toBe('2026-06-01')
+      expect(ai.planSlug).toBe('community')
+    })
+
+    it('accepts null for all three fields (e.g. on logout)', () => {
+      store.getState().aiActions.setSubscription('active', '2026-06-01', 'community')
+      store.getState().aiActions.setSubscription(null, null, null)
+      const { ai } = store.getState()
+      expect(ai.subscriptionStatus).toBeNull()
+      expect(ai.currentPeriodEnd).toBeNull()
+      expect(ai.planSlug).toBeNull()
+    })
+  })
+
+  describe('setCredits (deprecated)', () => {
     it('sets both used and total credits', () => {
       store.getState().aiActions.setCredits(42, 1000)
       expect(store.getState().ai.creditsUsed).toBe(42)
       expect(store.getState().ai.creditsTotal).toBe(1000)
+    })
+
+    it('mirrors to new acuUsed/acuTotal so consumers migrated ahead of their call sites stay correct', () => {
+      store.getState().aiActions.setCredits(42, 1000)
+      expect(store.getState().ai.acuUsed).toBe(42)
+      expect(store.getState().ai.acuTotal).toBe(1000)
     })
   })
 
@@ -614,6 +657,10 @@ describe('createAISliceFactory', () => {
       createAISliceFactory({ isFeatureEnabled: true, hasUserConsented: false, inlineCompletionsEnabled: true }),
     )
     const { ai } = store.getState()
+    expect(ai.acuUsed).toBe(0)
+    expect(ai.acuTotal).toBe(0)
+    expect(ai.subscriptionStatus).toBeNull()
+    expect(ai.planSlug).toBeNull()
     expect(ai.creditsUsed).toBe(0)
     expect(ai.creditsTotal).toBe(500)
     expect(ai.tier).toBe('free')

--- a/src/frontend/store/slices/ai/slice.ts
+++ b/src/frontend/store/slices/ai/slice.ts
@@ -20,6 +20,7 @@ const DEFAULT_AI_STATE: AISlice['ai'] = {
   creditsTotal: 500,
   tier: 'free',
   currentPeriodEnd: null,
+  billingError: null,
   messages: [],
   activeEditorPou: null,
   isAgenticLoopRunning: false,
@@ -116,6 +117,13 @@ export function createAISliceFactory(config?: AIFeatureConfig): StateCreator<AIS
         setState(
           produce(({ ai }: AISlice) => {
             ai.currentPeriodEnd = date
+          }),
+        )
+      },
+      setBillingError: (error) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.billingError = error
           }),
         )
       },

--- a/src/frontend/store/slices/ai/slice.ts
+++ b/src/frontend/store/slices/ai/slice.ts
@@ -12,6 +12,10 @@ const DEFAULT_AI_STATE: AISlice['ai'] = {
   preferences: {
     inlineCompletionsEnabled: true,
   },
+  acuUsed: 0,
+  acuTotal: 0,
+  subscriptionStatus: null,
+  planSlug: null,
   creditsUsed: 0,
   creditsTotal: 500,
   tier: 'free',
@@ -67,11 +71,37 @@ export function createAISliceFactory(config?: AIFeatureConfig): StateCreator<AIS
           }),
         )
       },
+      setUsage: (used, total) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.acuUsed = used
+            ai.acuTotal = total
+            // Keep deprecated mirror fields in lockstep so unmigrated consumers
+            // (DOPE-287 / DOPE-288 still on `creditsUsed`/`creditsTotal`) read
+            // the same values. Removed once the rename is fully propagated.
+            ai.creditsUsed = used
+            ai.creditsTotal = total
+          }),
+        )
+      },
+      setSubscription: (status, currentPeriodEnd, planSlug) => {
+        setState(
+          produce(({ ai }: AISlice) => {
+            ai.subscriptionStatus = status
+            ai.currentPeriodEnd = currentPeriodEnd
+            ai.planSlug = planSlug
+          }),
+        )
+      },
       setCredits: (used, total) => {
         setState(
           produce(({ ai }: AISlice) => {
             ai.creditsUsed = used
             ai.creditsTotal = total
+            // Mirror to the new ACU fields so consumers migrated ahead of their
+            // call-site refactor see the right numbers via either name.
+            ai.acuUsed = used
+            ai.acuTotal = total
           }),
         )
       },

--- a/src/frontend/store/slices/ai/types.ts
+++ b/src/frontend/store/slices/ai/types.ts
@@ -1,7 +1,12 @@
-import type { AIChatContentBlock, ChatMessage, ChatMessageRole } from '../../../../middleware/shared/ports/types'
+import type {
+  AIChatContentBlock,
+  ChatMessage,
+  ChatMessageRole,
+  SubscriptionStatus,
+} from '../../../../middleware/shared/ports/types'
 import type { DiffHunk } from '../../../utils/ai-diff-review'
 
-export type { AIChatContentBlock, ChatMessage, ChatMessageRole }
+export type { AIChatContentBlock, ChatMessage, ChatMessageRole, SubscriptionStatus }
 
 // ---------------------------------------------------------------------------
 // Conversation summary (returned by GET /ai/conversations)
@@ -60,8 +65,31 @@ export type AIState = {
     isLoading: boolean
     hasConsented: boolean
     preferences: AIPreferences
+    /** ACU consumed in the current billing period. Replaces `creditsUsed`. */
+    acuUsed: number
+    /** ACU monthly cap for the active plan. Replaces `creditsTotal`. */
+    acuTotal: number
+    /**
+     * Paddle subscription status from `/me/entitlements`. `null` before the
+     * first fetch completes.
+     */
+    subscriptionStatus: SubscriptionStatus | null
+    /** Plan slug from `/me/entitlements` (e.g. `'community'`, `'standard'`). `null` before first fetch. */
+    planSlug: string | null
+    /**
+     * @deprecated Use `acuUsed`. Kept in sync by `setUsage` and the legacy
+     * `setCredits` setter for one release.
+     */
     creditsUsed: number
+    /**
+     * @deprecated Use `acuTotal`. Kept in sync by `setUsage` and the legacy
+     * `setCredits` setter for one release.
+     */
     creditsTotal: number
+    /**
+     * @deprecated Pre-Paddle tier flag. Use `subscriptionStatus` + `planSlug`.
+     * Retained for one release while UI surfaces migrate.
+     */
     tier: 'free' | 'pro'
     currentPeriodEnd: string | null
     messages: ChatMessage[]
@@ -94,7 +122,29 @@ export type AIActions = {
   setAILoading: (loading: boolean) => void
   setAIConsented: (consented: boolean) => void
   setPreference: <K extends keyof AIPreferences>(key: K, value: AIPreferences[K]) => void
+  /**
+   * Set the ACU usage counters from `/me/usage`. Also writes the deprecated
+   * `creditsUsed` / `creditsTotal` fields to keep unmigrated consumers in sync.
+   */
+  setUsage: (used: number, total: number) => void
+  /**
+   * Set the subscription source fields from `/me/entitlements`. `null` clears
+   * them (e.g. on logout or before the first fetch resolves).
+   */
+  setSubscription: (
+    status: SubscriptionStatus | null,
+    currentPeriodEnd: string | null,
+    planSlug: string | null,
+  ) => void
+  /**
+   * @deprecated Use `setUsage`. Writes to both legacy (`creditsUsed`/`creditsTotal`)
+   * and new (`acuUsed`/`acuTotal`) fields during the deprecation window.
+   */
   setCredits: (used: number, total: number) => void
+  /**
+   * @deprecated Use `setSubscription`. `tier` is the pre-Paddle 'free'|'pro'
+   * flag; the new Paddle world uses `subscriptionStatus` + `planSlug`.
+   */
   setTier: (tier: 'free' | 'pro') => void
   setCurrentPeriodEnd: (date: string | null) => void
   setAIError: (error: string | null) => void

--- a/src/frontend/store/slices/ai/types.ts
+++ b/src/frontend/store/slices/ai/types.ts
@@ -139,11 +139,7 @@ export type AIActions = {
    * Set the subscription source fields from `/me/entitlements`. `null` clears
    * them (e.g. on logout or before the first fetch resolves).
    */
-  setSubscription: (
-    status: SubscriptionStatus | null,
-    currentPeriodEnd: string | null,
-    planSlug: string | null,
-  ) => void
+  setSubscription: (status: SubscriptionStatus | null, currentPeriodEnd: string | null, planSlug: string | null) => void
   /**
    * @deprecated Use `setUsage`. Writes to both legacy (`creditsUsed`/`creditsTotal`)
    * and new (`acuUsed`/`acuTotal`) fields during the deprecation window.

--- a/src/frontend/store/slices/ai/types.ts
+++ b/src/frontend/store/slices/ai/types.ts
@@ -1,12 +1,13 @@
 import type {
   AIChatContentBlock,
+  BillingErrorPayload,
   ChatMessage,
   ChatMessageRole,
   SubscriptionStatus,
 } from '../../../../middleware/shared/ports/types'
 import type { DiffHunk } from '../../../utils/ai-diff-review'
 
-export type { AIChatContentBlock, ChatMessage, ChatMessageRole, SubscriptionStatus }
+export type { AIChatContentBlock, BillingErrorPayload, ChatMessage, ChatMessageRole, SubscriptionStatus }
 
 // ---------------------------------------------------------------------------
 // Conversation summary (returned by GET /ai/conversations)
@@ -92,6 +93,13 @@ export type AIState = {
      */
     tier: 'free' | 'pro'
     currentPeriodEnd: string | null
+    /**
+     * Structured billing error from the most recent 402 (insufficient ACU or
+     * inactive subscription). Read by the exhaustion-modal consumer
+     * (DOPE-285). `null` while no billing block is active — cleared on the
+     * next successful AI request.
+     */
+    billingError: BillingErrorPayload | null
     messages: ChatMessage[]
     activeEditorPou: string | null
     isAgenticLoopRunning: boolean
@@ -147,6 +155,12 @@ export type AIActions = {
    */
   setTier: (tier: 'free' | 'pro') => void
   setCurrentPeriodEnd: (date: string | null) => void
+  /**
+   * Set or clear the structured 402 payload. Called by the chat panel /
+   * inline completion provider when an AIRequestError(402) surfaces, and
+   * cleared (passed `null`) on the next successful request.
+   */
+  setBillingError: (error: BillingErrorPayload | null) => void
   setAIError: (error: string | null) => void
   setActiveEditorPou: (pouName: string | null) => void
   setAgenticLoopRunning: (running: boolean) => void

--- a/src/middleware/shared/ports/ai-port.ts
+++ b/src/middleware/shared/ports/ai-port.ts
@@ -5,7 +5,7 @@
  * implementations that handle HTTP streaming, SSE parsing, and API authentication.
  */
 
-import type { AIFeatureConfig } from './types'
+import type { AIEntitlements, AIFeatureConfig, AIUsage } from './types'
 
 // ---------------------------------------------------------------------------
 // Parameter & result types
@@ -35,7 +35,13 @@ export interface AIChatParams {
   model?: 'haiku' | 'sonnet'
 }
 
-/** Credit status returned by fetchCredits. */
+/**
+ * Credit status returned by `fetchCredits`.
+ *
+ * @deprecated Use `AIEntitlements` + `AIUsage` (via the new `fetchEntitlements`
+ * / `fetchUsage` port methods). Retained for one release while UI call sites
+ * migrate to the ACU-based billing surface.
+ */
 export interface AICreditStatus {
   credits_used: number
   credits_total: number
@@ -76,7 +82,22 @@ export interface AIPort extends AIFeatureConfig {
   streamChat(params: AIChatParams, signal?: AbortSignal): AsyncGenerator<string, void, unknown>
 
   /**
+   * Fetch the user's resolved entitlements (plan limits, ACU cap, feature flags).
+   * Backed by `GET /me/entitlements` on the Edge API billing chassis.
+   */
+  fetchEntitlements(signal?: AbortSignal): Promise<AIEntitlements>
+
+  /**
+   * Fetch the user's current usage (resource counters + ACU consumption).
+   * Backed by `GET /me/usage` on the Edge API billing chassis.
+   */
+  fetchUsage(signal?: AbortSignal): Promise<AIUsage>
+
+  /**
    * Fetch current AI credit status.
+   *
+   * @deprecated Use `fetchEntitlements` + `fetchUsage` instead. Kept for one
+   * release as a fallback while UI call sites migrate to the new shape.
    */
   fetchCredits(signal?: AbortSignal): Promise<AICreditStatus>
 

--- a/src/middleware/shared/ports/ai-port.ts
+++ b/src/middleware/shared/ports/ai-port.ts
@@ -63,6 +63,16 @@ export type AITelemetryEventName =
   | 'conversation_loaded'
   | 'conversation_renamed'
   | 'conversation_deleted'
+  /**
+   * Fired when `AcuExhaustionModal` opens (transition from `null` to a
+   * billing block on the slice). Data: `{ source: 'usage_limit'|'subscription', planSlug, remaining }`.
+   */
+  | 'acu_exhausted'
+  /**
+   * Fired when the user clicks the upgrade / reactivate CTA in the
+   * exhaustion modal. Data: `{ source: 'modal' }`.
+   */
+  | 'upgrade_cta_clicked'
 
 // ---------------------------------------------------------------------------
 // Port interface

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -771,13 +771,7 @@ export type ChatMessage = {
 // populated by `EntitlementsService` + `AcuLedgerService`).
 
 /** Subscription status as reported by the backend (Paddle-backed). */
-export type SubscriptionStatus =
-  | 'trialing'
-  | 'active'
-  | 'past_due'
-  | 'paused'
-  | 'canceled'
-  | 'expired'
+export type SubscriptionStatus = 'trialing' | 'active' | 'past_due' | 'paused' | 'canceled' | 'expired'
 
 /** Plan level slug (standard < plus < premium). */
 export type PlanLevelSlug = 'standard' | 'plus' | 'premium'

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -857,6 +857,30 @@ export interface AIUsage {
   }
 }
 
+/**
+ * Structured 402 payload from `/ai/chat` and `/ai/complete`. The backend
+ * `CreditGuard` (autonomy-edge `presentation/guards/credit.guard.ts`) throws
+ * one of two variants depending on whether the user is out of ACU
+ * (`insufficient_acu`) or has a non-active Paddle subscription
+ * (`subscription_inactive`). Surfaced via `AIRequestError.billing` in the
+ * web adapter and stored on `AISlice` as `billingError` for the exhaustion-
+ * modal consumer (DOPE-285).
+ */
+export type BillingErrorPayload = {
+  code: 'insufficient_acu' | 'subscription_inactive'
+  message: string
+  /** Set when `code === 'insufficient_acu'`. ACU remaining in the period. */
+  remaining?: number
+  /** Set when `code === 'insufficient_acu'`. ACU the request would have used. */
+  required?: number
+  /** Set when `code === 'insufficient_acu'`. Plan's monthly ACU cap. */
+  monthlyLimit?: number
+  /** Set when `code === 'subscription_inactive'`. Reason the subscription is blocking. */
+  subscriptionStatus?: SubscriptionStatus
+  /** Optional deep-link to the autonomy-edge billing portal. */
+  reactivateUrl?: string
+}
+
 // ---------------------------------------------------------------------------
 // Graphical Editor Flow Data Shapes
 // ---------------------------------------------------------------------------

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -762,6 +762,102 @@ export type ChatMessage = {
 }
 
 // ---------------------------------------------------------------------------
+// AI Billing — Entitlements + Usage (Phase 5)
+// ---------------------------------------------------------------------------
+//
+// Mirrors the backend `ResolvedEntitlements` / `ResolvedUsage` shapes from
+// autonomy-edge `infrastructure/services/billing/entitlements.service.ts`.
+// Surfaced via `GET /me/entitlements` and `GET /me/usage` (Gustavo's chassis,
+// populated by `EntitlementsService` + `AcuLedgerService`).
+
+/** Subscription status as reported by the backend (Paddle-backed). */
+export type SubscriptionStatus =
+  | 'trialing'
+  | 'active'
+  | 'past_due'
+  | 'paused'
+  | 'canceled'
+  | 'expired'
+
+/** Plan level slug (standard < plus < premium). */
+export type PlanLevelSlug = 'standard' | 'plus' | 'premium'
+
+/**
+ * Feature flags resolved from the active plan level. Open-ended map; only
+ * declared keys are typed statically — backend may emit additional booleans
+ * as new plan-gated features land.
+ */
+export type PlanFeatures = {
+  hasAiEngineer?: boolean
+  hasAiChat?: boolean
+  hasPrivateProjects?: boolean
+  hasOrganizations?: boolean
+  hasCodesysImporter?: boolean
+  hasOnPrem?: boolean
+  hasSla?: boolean
+  hasSoc2Badge?: boolean
+  hasVersionControl?: boolean
+  [key: string]: boolean | undefined
+}
+
+/** Shared header on both `/me/entitlements` and `/me/usage`. */
+export interface EntitlementSource {
+  subscriptionId: string
+  subscriptionStatus: SubscriptionStatus
+  planSlug: string
+  planDisplayName: string
+  planLevelSlug: PlanLevelSlug
+  tier: number
+}
+
+/** Numeric counter with a nullable cap (null = unlimited). */
+export interface UsageCounter {
+  used: number
+  limit: number | null
+  remaining: number | null
+}
+
+/** Response shape of `GET /me/entitlements`. */
+export interface AIEntitlements {
+  source: EntitlementSource
+  limits: {
+    maxOrchestrators: number | null
+    maxDevices: number | null
+    maxPrivateProjects: number | null
+    maxPublicProjects: number | null
+    maxOrgMembers: number | null
+    maxTeamWorkspaces: number | null
+  }
+  acu: {
+    monthlyAcu: number
+    rateLimitWindowHours: number
+    rateLimitWindowPercent: number
+    marginPercent: number | null
+  }
+  features: PlanFeatures
+}
+
+/** Response shape of `GET /me/usage`. */
+export interface AIUsage {
+  source: EntitlementSource
+  orchestrators: UsageCounter
+  devices: UsageCounter
+  privateProjects: UsageCounter
+  publicProjects: UsageCounter
+  organizations: {
+    used: number
+    allowed: boolean
+  }
+  acu: {
+    used: number
+    monthlyLimit: number
+    remaining: number
+    rateLimitWindowHours: number
+    rateLimitWindowPercent: number
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Graphical Editor Flow Data Shapes
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Lands the shared-code half of the Phase 5 frontend epic, mirroring https://github.com/Autonomy-Logic/openplc-web/pull/407. Keeps the React frontend (\`src/frontend/**\`) and the AI port surface (\`src/middleware/shared/ports/**\`) byte-identical between the two IDEs per the workspace shared-code policy.

The editor doesn't currently consume the AI slice (\`PlatformPorts.ai?\` is optional and \`editor-platform.ts\` does not set it), so the AI features merged here are inert in the editor today. This PR exists to keep the contract aligned for future editor-side AI work.

## What's in this mirror

### Shared changes from the web PR

- **DOPE-282** — \`BillingErrorPayload\` + \`AIEntitlements\` / \`AIUsage\` types + \`fetchEntitlements\` / \`fetchUsage\` port methods on \`AIPort\`.
- **DOPE-283** — AI slice extended with \`acuUsed\` / \`acuTotal\` / \`subscriptionStatus\` / \`planSlug\` fields + \`setUsage\` / \`setSubscription\` actions.
- **DOPE-287** — \`billingError\` slice field + \`setBillingError\` action.
- **DOPE-285** — \`AcuExhaustionModal\` component (\`src/frontend/components/_features/[workspace]/ai-settings-panel/\`) + tests.
- **DOPE-289** — \`acu_exhausted\` + \`upgrade_cta_clicked\` event names on the \`AITelemetryEventName\` port type; modal \`onUpgradeClick\` callback.
- Modal copy follow-up — frontend-controlled description ignoring the backend's "Switch to Haiku" text.

### Not mirrored (intentionally)

Web-only adapter code stayed in the web PR:
- API client (\`api-client.ts\`) — envelope unwrap + 402 body parsing
- Chat panel (\`ai-chat-panel.tsx\`) — migration to \`fetchUsage\` + \`fetchEntitlements\` + billing-error wiring
- Inline completion provider — 402 billing capture
- Telemetry helpers + module — \`track*\` functions
- Mount wiring — \`router/pages/index-page.tsx\`
- Env helper — \`get-env.ts\`'s \`getEdgeFrontendBaseUrl\`
- \`.env.example\`

### Descoped Phase 5 tickets (closed)

DOPE-284 (AcuMeter), DOPE-286 (SubscriptionStatusBanner), DOPE-288 (Model quick-switch), DOPE-243…249 (legacy AI settings) — superseded by autonomy-edge's user settings UI. DOPE-290 (E2E) deferred.

## Test plan

- [x] \`npx jest --testPathPatterns=\"ai-slice|AcuExhaustionModal\"\` — passes on the merged integration branch (75 slice + 12 modal tests).
- [x] \`npm run validate:arch\` — clean.
- [x] \`npm run lint\` — 0 errors.
- [x] \`npx tsc --noEmit\` — clean.
- [x] Shared files verified byte-identical against openplc-web's PR via \`diff -q\`.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a modal dialog that appears when users exhaust their ACU balance or subscription becomes inactive, allowing them to upgrade or reactivate their account.
  * Enhanced billing and usage tracking with new endpoints for fetching entitlements and current usage metrics.
  * Improved subscription state management to monitor plan status and billing errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autonomy-Logic/openplc-editor/pull/772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->