### PR TITLE
fix(codesys): add XHTML namespace to XML root

### DIFF
--- a/src/frontend/utils/PLC/xml-generator/codesys/__tests__/base-xml.test.ts
+++ b/src/frontend/utils/PLC/xml-generator/codesys/__tests__/base-xml.test.ts
@@ -4,6 +4,7 @@ describe('getBaseCodeSysXmlStructure', () => {
   it('returns a BaseXml with the codesys namespace', () => {
     const xml = getBaseCodeSysXmlStructure()
     expect(xml.project['@xmlns']).toBe('http://www.plcopen.org/xml/tc6_0200')
+    expect(xml.project['@xmlns:xhtml']).toBe('http://www.w3.org/1999/xhtml')
   })
 
   it('has default fileHeader fields', () => {

--- a/src/frontend/utils/PLC/xml-generator/codesys/base-xml.ts
+++ b/src/frontend/utils/PLC/xml-generator/codesys/base-xml.ts
@@ -5,6 +5,7 @@ import { formatDate } from '../../../format-date'
 const getBaseCodeSysXmlStructure = (): BaseXml => ({
   project: {
     '@xmlns': 'http://www.plcopen.org/xml/tc6_0200',
+    '@xmlns:xhtml': 'http://www.w3.org/1999/xhtml',
     fileHeader: {
       '@companyName': 'Unknown',
       '@productName': 'Unnamed',

--- a/src/middleware/shared/ports/xml-types/codesys/base-diagram.ts
+++ b/src/middleware/shared/ports/xml-types/codesys/base-diagram.ts
@@ -9,6 +9,7 @@ import { variableXMLSchema } from './variable/variable-diagram'
 const baseXmlSchema = z.object({
   project: z.object({
     '@xmlns': z.string().default('http://www.plcopen.org/xml/tc6_0200'),
+    '@xmlns:xhtml': z.string().default('http://www.w3.org/1999/xhtml'),
 
     fileHeader: z.object({
       '@companyName': z.string().default('Unknown'),


### PR DESCRIPTION
## Summary

Adds the missing XHTML namespace declaration to the root CODESYS PLCOpen XML project node.

Some exported CODESYS XML content uses XHTML-formatted documentation fields. Without the root `xmlns:xhtml` declaration, consumers can reject or misinterpret those namespaced documentation nodes.

## Changes

- Add `@xmlns:xhtml="http://www.w3.org/1999/xhtml"` to the base CODESYS XML structure
- Add the same field to the shared CODESYS base XML schema
- Extend the base XML test to assert the namespace is present

## Validation

- `git diff --check`
- ESLint on touched files: no errors