### PR TITLE
fix(ui): show scroll indicators in Select dropdowns

### DIFF
--- a/src/frontend/components/_atoms/select/index.tsx
+++ b/src/frontend/components/_atoms/select/index.tsx
@@ -47,7 +47,7 @@ const SelectContent = forwardRef<ElementRef<typeof PrimitiveSelect.Content>, ISe
       <PrimitiveSelect.Portal>
         <PrimitiveSelect.Content
           ref={forwardedRef}
-          className={className}
+          className={cn('flex flex-col', className)}
           sideOffset={sideOffset}
           alignOffset={alignOffset}
           position={position}
@@ -55,9 +55,18 @@ const SelectContent = forwardRef<ElementRef<typeof PrimitiveSelect.Content>, ISe
           side={side}
           {...res}
         >
-          <PrimitiveSelect.Viewport ref={viewportRef} className='oplc-select-viewport h-full w-full'>
+          <PrimitiveSelect.ScrollUpButton className='flex h-6 cursor-default select-none items-center justify-center'>
+            <ArrowIcon direction='up' size='sm' className='stroke-neutral-400 dark:stroke-neutral-600' />
+          </PrimitiveSelect.ScrollUpButton>
+          <PrimitiveSelect.Viewport
+            ref={viewportRef}
+            className='oplc-select-viewport min-h-0 w-full flex-1 overflow-auto'
+          >
             {children}
           </PrimitiveSelect.Viewport>
+          <PrimitiveSelect.ScrollDownButton className='flex h-6 cursor-default select-none items-center justify-center'>
+            <ArrowIcon direction='down' size='sm' className='stroke-neutral-400 dark:stroke-neutral-600' />
+          </PrimitiveSelect.ScrollDownButton>
         </PrimitiveSelect.Content>
       </PrimitiveSelect.Portal>
     )


### PR DESCRIPTION
## Summary

Adds Radix Select scroll buttons to dropdown content so users can see when additional options are available above or below the visible viewport.

This is useful for long Select menus where the current styling can hide the fact that the list is scrollable.

## Changes

- Render `ScrollUpButton` and `ScrollDownButton` inside `SelectContent`
- Use the existing arrow icon for the indicators
- Make the Select content a vertical flex container so the viewport can scroll between the indicators

## Validation

- `git diff --check`
- ESLint on touched files: no errors