### PR TITLE
fix(electron): guard startup paths during window teardown

### DIFF
--- a/src/frontend/components/_templates/app-layout.tsx
+++ b/src/frontend/components/_templates/app-layout.tsx
@@ -44,14 +44,23 @@ const AppLayout = ({ children, ...rest }: AppLayoutProps): ReactNode => {
   // System initialization
   useEffect(() => {
     const initSystem = async () => {
-      const sysInfo = await system.getSystemInfo()
-      setSystemConfigs({
-        OS: sysInfo.OS,
-        arch: sysInfo.architecture,
-        isWindowMaximized: sysInfo.isWindowMaximized,
-      })
-      const recent = await projectPort.getRecentProjects()
-      setRecent(recent)
+      try {
+        const sysInfo = await system.getSystemInfo()
+        setSystemConfigs({
+          OS: sysInfo.OS,
+          arch: sysInfo.architecture,
+          isWindowMaximized: sysInfo.isWindowMaximized,
+        })
+      } catch (error) {
+        console.error('Failed to read system info during app layout initialization:', error)
+      }
+
+      try {
+        const recent = await projectPort.getRecentProjects()
+        setRecent(recent)
+      } catch (error) {
+        console.error('Failed to read recent projects during app layout initialization:', error)
+      }
     }
     void initSystem()
   }, [system, projectPort, setSystemConfigs, setRecent])

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -93,12 +93,15 @@ const installExtensions = async () => {
   const forceDownload = !!process.env.UPGRADE_EXTENSIONS
   const extensions = ['REACT_DEVELOPER_TOOLS']
 
-  return installer
-    .default(
+  try {
+    return await installer.default(
       extensions.map((name) => installer[name as keyof typeof Installer]),
       forceDownload,
     )
-    .catch((err: unknown) => logger.error(getErrorMessage(err)))
+  } catch (error) {
+    logger.warn(`Skipping development extension installation: ${getErrorMessage(error)}`)
+    return []
+  }
 }
 
 const createMainWindow = async () => {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -32,7 +32,19 @@ export default class MenuBuilder {
     this.projectService = new ProjectService(mainWindow)
   }
 
+  private hasLiveWindow(): boolean {
+    return !this.mainWindow.isDestroyed()
+  }
+
+  private getFallbackMenu(): Menu {
+    return Menu.getApplicationMenu() ?? Menu.buildFromTemplate([])
+  }
+
   async buildMenu(): Promise<Menu> {
+    if (!this.hasLiveWindow()) {
+      return this.getFallbackMenu()
+    }
+
     if (process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true') {
       this.setupDevelopmentEnvironment()
     }
@@ -129,13 +141,18 @@ export default class MenuBuilder {
    */
 
   setupDevelopmentEnvironment(): void {
+    if (!this.hasLiveWindow()) return
+
     this.mainWindow.webContents.on('context-menu', (_, props) => {
+      if (!this.hasLiveWindow()) return
+
       const { x, y } = props
 
       Menu.buildFromTemplate([
         {
           label: 'Inspect element',
           click: () => {
+            if (!this.hasLiveWindow()) return
             this.mainWindow.webContents.inspectElement(x, y)
           },
         },
@@ -147,7 +164,9 @@ export default class MenuBuilder {
     const newTheme = nativeTheme.shouldUseDarkColors ? 'light' : 'dark'
     nativeTheme.themeSource = newTheme
     store.set('theme', newTheme)
-    this.mainWindow.webContents.send('system:update-theme')
+    if (this.hasLiveWindow()) {
+      this.mainWindow.webContents.send('system:update-theme')
+    }
     void this.buildMenu()
   }
 

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -1079,7 +1079,11 @@ class MainProcessBridge implements MainIpcModule {
     this.simulatorModule.stop()
     this.mainWindow?.webContents.reload()
   }
-  handleWindowRebuildMenu = () => void this.menuBuilder.buildMenu()
+  handleWindowRebuildMenu = () => {
+    void this.menuBuilder.buildMenu().catch((error) => {
+      console.error('Error rebuilding application menu:', error)
+    })
+  }
 
   // Hardware handlers
   handleHardwareGetAvailableCommunicationPorts = async () => this.hardwareModule.getAvailableSerialPorts()


### PR DESCRIPTION
## Summary

Hardens a few Electron startup and menu paths against teardown races.

During development or fast window shutdown/reload flows, the app can still receive async menu, system info, or devtools initialization work after the BrowserWindow has started closing. These guards prevent those paths from throwing noisy `Object has been destroyed` style errors.

## Changes

- Guard menu build/context-menu/theme update paths when the main window has been destroyed
- Catch asynchronous menu rebuild failures
- Downgrade optional React DevTools installation failures to a compact warning
- Split app-layout system info and recent-project loading into independent guarded calls

## Validation

- `git diff --check`
- ESLint on touched files: no errors