### PR TITLE
fix(debug): treat missing target MD5 as uploadable mismatch

### DIFF
--- a/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
@@ -455,15 +455,21 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
         // Disconnect before re-upload; the recursive call will reconnect
         await debuggerPort.disconnect()
 
+        const mismatchMessage = verifyResult.targetMd5Unavailable
+          ? (verifyResult.error ?? 'Target did not provide a program MD5.')
+          : `MD5 mismatch. Target: ${verifyResult.targetMd5}, Expected: ${md5Result.md5}`
+
         consoleActions.addLog({
           id: crypto.randomUUID(),
           level: 'warning',
-          message: `MD5 mismatch. Target: ${verifyResult.targetMd5}, Expected: ${md5Result.md5}`,
+          message: mismatchMessage,
         })
         const response = await showDebuggerMessage(
           'warning',
           'Program Mismatch',
-          'The program on the target does not match. Upload the current project?',
+          verifyResult.targetMd5Unavailable
+            ? 'The target does not have a verifiable OpenPLC program yet. Upload the current project?'
+            : 'The program on the target does not match. Upload the current project?',
           ['Yes', 'No'],
         )
         if (response === 0) {

--- a/src/main/modules/debugger/md5-verification.spec.ts
+++ b/src/main/modules/debugger/md5-verification.spec.ts
@@ -1,0 +1,27 @@
+import { createMd5UnavailableResult, isRecoverableMd5ReadError } from './md5-verification'
+
+describe('md5-verification', () => {
+  it('treats first-upload target MD5 failures as recoverable', () => {
+    expect(isRecoverableMd5ReadError(new Error('Failed to get MD5 hash after retries'))).toBe(true)
+    expect(isRecoverableMd5ReadError(new Error('Target returned error code: 0x02'))).toBe(true)
+    expect(isRecoverableMd5ReadError(new Error('Request timeout'))).toBe(true)
+  })
+
+  it('looks through error causes for recoverable MD5 failures', () => {
+    const error = Object.assign(new Error('Failed to get MD5 hash after retries'), {
+      cause: new Error('Function code mismatch'),
+    })
+
+    expect(isRecoverableMd5ReadError(error)).toBe(true)
+  })
+
+  it('creates a mismatch result when the target MD5 is unavailable', () => {
+    expect(createMd5UnavailableResult()).toEqual({
+      success: true,
+      match: false,
+      targetMd5Unavailable: true,
+      error:
+        'Target did not provide a program MD5. This usually means the device has not been flashed with an OpenPLC program yet.',
+    })
+  })
+})

--- a/src/main/modules/debugger/md5-verification.ts
+++ b/src/main/modules/debugger/md5-verification.ts
@@ -1,0 +1,63 @@
+import type { Md5VerifyResult } from '@root/middleware/shared/ports'
+
+const RECOVERABLE_MD5_ERROR_MESSAGES = [
+  'Failed to get MD5 hash after retries',
+  'Function code mismatch',
+  'Invalid response: too short',
+  'Request timeout',
+  'Target returned error code',
+]
+
+const TARGET_MD5_UNAVAILABLE_MESSAGE =
+  'Target did not provide a program MD5. This usually means the device has not been flashed with an OpenPLC program yet.'
+
+export function isRecoverableMd5ReadError(error: unknown): boolean {
+  const messages = collectErrorMessages(error)
+
+  return messages.some((message) =>
+    RECOVERABLE_MD5_ERROR_MESSAGES.some((recoverableMessage) => message.includes(recoverableMessage)),
+  )
+}
+
+export function createMd5UnavailableResult(): Md5VerifyResult {
+  return {
+    success: true,
+    match: false,
+    targetMd5Unavailable: true,
+    error: TARGET_MD5_UNAVAILABLE_MESSAGE,
+  }
+}
+
+function collectErrorMessages(error: unknown): string[] {
+  const messages: string[] = []
+  const visited = new Set<unknown>()
+  let current: unknown = error
+
+  while (current && !visited.has(current)) {
+    visited.add(current)
+
+    if (current instanceof Error) {
+      messages.push(current.message)
+      current = 'cause' in current ? current.cause : null
+      continue
+    }
+
+    if (typeof current === 'string') {
+      messages.push(current)
+      break
+    }
+
+    if (
+      typeof current === 'object' &&
+      current !== null &&
+      'message' in current &&
+      typeof current.message === 'string'
+    ) {
+      messages.push(current.message)
+    }
+
+    break
+  }
+
+  return messages
+}

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -35,6 +35,7 @@ import { getOpenProjectPath, getProjectPath } from '../../../backend/editor/util
 import { WebSocketDebugTransport } from '../../../backend/shared/debug/websocket-debug-transport'
 import { SimulatorModule } from '../../../backend/shared/simulator/simulator-module'
 import { VirtualSerialPort } from '../../../backend/shared/simulator/virtual-serial-port'
+import { createMd5UnavailableResult, isRecoverableMd5ReadError } from '../debugger/md5-verification'
 
 class MainProcessBridge implements MainIpcModule {
   ipcMain
@@ -1160,6 +1161,7 @@ class MainProcessBridge implements MainIpcModule {
     targetMd5?: string
     targetEndian?: 'le' | 'be'
     error?: string
+    targetMd5Unavailable?: boolean
   }> => {
     let client: ModbusTcpClient | ModbusRtuClient | null = null
     let wsClient: WebSocketDebugTransport | null = null
@@ -1174,7 +1176,12 @@ class MainProcessBridge implements MainIpcModule {
           serialPort: virtualPort,
         })
         await client.connect()
-        const { md5: targetMd5, targetEndian } = await client.getMd5Hash()
+        const md5ReadResult = await this.readTargetMd5(client)
+        if (md5ReadResult.unavailableResult) {
+          client.disconnect()
+          return md5ReadResult.unavailableResult
+        }
+        const { targetMd5, targetEndian } = md5ReadResult
         const match = targetMd5.toLowerCase() === expectedMd5.toLowerCase()
 
         // Keep the client for subsequent debug operations
@@ -1198,7 +1205,12 @@ class MainProcessBridge implements MainIpcModule {
           wsClient = this.debuggerWebSocketClient
         }
 
-        const { md5: targetMd5, targetEndian } = await wsClient.getMd5Hash()
+        const md5ReadResult = await this.readTargetMd5(wsClient)
+        if (md5ReadResult.unavailableResult) {
+          wsClient.disconnect()
+          return md5ReadResult.unavailableResult
+        }
+        const { targetMd5, targetEndian } = md5ReadResult
 
         const match = targetMd5.toLowerCase() === expectedMd5.toLowerCase()
 
@@ -1230,7 +1242,14 @@ class MainProcessBridge implements MainIpcModule {
           this.debuggerConnectionType === 'rtu' &&
           this.debuggerRtuPort === connectionParams.port
         ) {
-          const { md5: targetMd5, targetEndian } = await this.debuggerModbusClient.getMd5Hash()
+          const md5ReadResult = await this.readTargetMd5(this.debuggerModbusClient)
+          if (md5ReadResult.unavailableResult) {
+            this.debuggerModbusClient.disconnect()
+            this.debuggerModbusClient = null
+            this.debuggerConnectionType = null
+            return md5ReadResult.unavailableResult
+          }
+          const { targetMd5, targetEndian } = md5ReadResult
           const match = targetMd5.toLowerCase() === expectedMd5.toLowerCase()
           return { success: true, match, targetMd5, targetEndian }
         }
@@ -1244,7 +1263,12 @@ class MainProcessBridge implements MainIpcModule {
       }
 
       await client.connect()
-      const { md5: targetMd5, targetEndian } = await client.getMd5Hash()
+      const md5ReadResult = await this.readTargetMd5(client)
+      if (md5ReadResult.unavailableResult) {
+        client.disconnect()
+        return md5ReadResult.unavailableResult
+      }
+      const { targetMd5, targetEndian } = md5ReadResult
 
       const match = targetMd5.toLowerCase() === expectedMd5.toLowerCase()
 
@@ -1266,6 +1290,37 @@ class MainProcessBridge implements MainIpcModule {
         success: false,
         error: error instanceof Error ? error.message : 'Unknown error during MD5 verification',
       }
+    }
+  }
+
+  private async readTargetMd5(client: ModbusTcpClient | ModbusRtuClient | WebSocketDebugTransport): Promise<
+    | {
+        targetMd5: string
+        targetEndian?: 'le' | 'be'
+        unavailableResult?: never
+      }
+    | {
+        targetMd5?: never
+        targetEndian?: never
+        unavailableResult: {
+          success: boolean
+          match?: boolean
+          targetMd5?: string
+          targetEndian?: 'le' | 'be'
+          error?: string
+          targetMd5Unavailable?: boolean
+        }
+      }
+  > {
+    try {
+      const { md5: targetMd5, targetEndian } = await client.getMd5Hash()
+      return { targetMd5, targetEndian }
+    } catch (error) {
+      if (isRecoverableMd5ReadError(error)) {
+        return { unavailableResult: createMd5UnavailableResult() }
+      }
+
+      throw error
     }
   }
 

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -354,8 +354,14 @@ const rendererProcessBridge = {
       jwtToken?: string
     },
     expectedMd5: string,
-  ): Promise<{ success: boolean; match?: boolean; targetMd5?: string; error?: string }> =>
-    ipcRenderer.invoke('debugger:verify-md5', connectionType, connectionParams, expectedMd5),
+  ): Promise<{
+    success: boolean
+    match?: boolean
+    targetMd5?: string
+    targetEndian?: 'le' | 'be'
+    targetMd5Unavailable?: boolean
+    error?: string
+  }> => ipcRenderer.invoke('debugger:verify-md5', connectionType, connectionParams, expectedMd5),
 
   debuggerReadProgramStMd5: (
     projectPath: string,

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -868,6 +868,7 @@ export interface Md5VerifyResult {
    *  trailer.  Renderer-side debug components feed this into the
    *  swap layer at read / write boundaries.  Omitted on failure. */
   targetEndian?: 'le' | 'be'
+  targetMd5Unavailable?: boolean
   error?: string
 }
 


### PR DESCRIPTION
## Summary

Treats recoverable target-MD5 read failures as an uploadable program mismatch instead of a hard debugger connection failure.

This helps the first-upload/debugger path: when a target has not yet been flashed with an OpenPLC program, it may not provide a valid program MD5. In that case the editor should still offer to upload the current project rather than stopping at the MD5 verification step.

## Changes

- Add a helper for recognizing recoverable MD5 read failures
- Return a successful mismatch result with `targetMd5Unavailable` when the target cannot provide an MD5 yet
- Preserve the existing `targetEndian` behavior for successful MD5 reads
- Show a clearer upload prompt when the target MD5 is unavailable
- Add unit coverage for the recoverable-MD5 helper/result

## Validation

- `git diff --check`
- ESLint on touched files: no errors

Note: local Jest execution is currently blocked on this RC checkout because `strucpp/libs/iec-types.json` cannot be resolved in the local environment.