### PR TITLE
fix(shared): mirror pre-deploy fixes from openplc-web

### DIFF
--- a/src/backend/shared/styles/globals.css
+++ b/src/backend/shared/styles/globals.css
@@ -72,6 +72,16 @@
   }
 }
 
+/* Tailwind's animate-spin utility emits `animation: spin 1s linear infinite`
+   but our tailwind.config.ts overrides `theme.keyframes` (instead of
+   extending it), wiping out the default `spin` keyframe. Redefine it here
+   so animate-spin works app-wide. */
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .ai-chat-typing-dot {
   display: inline-block;
   width: 5px;

--- a/src/frontend/components/_molecules/menu-bar/menus/help.tsx
+++ b/src/frontend/components/_molecules/menu-bar/menus/help.tsx
@@ -14,7 +14,7 @@ export const HelpMenu = () => {
 
   const handleOpenCommunitySupport = () => {
     try {
-      window.open('https://openplc.discussion.community/', '_blank')
+      window.open('https://edge.autonomylogic.com/forum', '_blank')
     } catch (error) {
       console.error('Error opening link:', error)
     }

--- a/src/frontend/store/__tests__/ai-slice.test.ts
+++ b/src/frontend/store/__tests__/ai-slice.test.ts
@@ -2,7 +2,6 @@ import { createStore, StoreApi } from 'zustand/vanilla'
 
 import { createAISlice, createAISliceFactory } from '../slices/ai/slice'
 import type { AISlice, ChatMessage } from '../slices/ai/types'
-import { MAX_CONVERSATION_MESSAGES } from '../slices/ai/types'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -282,17 +281,16 @@ describe('createAISlice', () => {
       expect(messages[1].id).toBe('msg-2')
     })
 
-    it('enforces MAX_CONVERSATION_MESSAGES by keeping the most recent messages', () => {
-      expect(MAX_CONVERSATION_MESSAGES).toBe(50)
-
-      for (let i = 0; i < MAX_CONVERSATION_MESSAGES + 5; i++) {
+    it('retains every appended message without truncation', () => {
+      const total = 75
+      for (let i = 0; i < total; i++) {
         store.getState().aiActions.addMessage(makeMessage({ id: `msg-${i}`, content: `Message ${i}` }))
       }
 
       const messages = store.getState().ai.messages
-      expect(messages).toHaveLength(MAX_CONVERSATION_MESSAGES)
-      expect(messages[0].id).toBe('msg-5')
-      expect(messages[MAX_CONVERSATION_MESSAGES - 1].id).toBe(`msg-${MAX_CONVERSATION_MESSAGES + 4}`)
+      expect(messages).toHaveLength(total)
+      expect(messages[0].id).toBe('msg-0')
+      expect(messages[total - 1].id).toBe(`msg-${total - 1}`)
     })
   })
 
@@ -613,17 +611,18 @@ describe('createAISlice', () => {
         expect(store.getState().ai.error).toBeNull()
       })
 
-      it('caps at MAX_CONVERSATION_MESSAGES, keeping the most recent', () => {
+      it('replaces with the full payload without truncation', () => {
+        const total = 75
         const many: ChatMessage[] = []
-        for (let i = 0; i < MAX_CONVERSATION_MESSAGES + 7; i++) {
+        for (let i = 0; i < total; i++) {
           many.push(makeMessage({ id: `m-${i}`, content: `Message ${i}` }))
         }
         store.getState().aiActions.replaceMessages(many)
 
         const messages = store.getState().ai.messages
-        expect(messages).toHaveLength(MAX_CONVERSATION_MESSAGES)
-        expect(messages[0].id).toBe('m-7')
-        expect(messages[MAX_CONVERSATION_MESSAGES - 1].id).toBe(`m-${MAX_CONVERSATION_MESSAGES + 6}`)
+        expect(messages).toHaveLength(total)
+        expect(messages[0].id).toBe('m-0')
+        expect(messages[total - 1].id).toBe(`m-${total - 1}`)
       })
     })
 

--- a/src/frontend/store/slices/ai/index.ts
+++ b/src/frontend/store/slices/ai/index.ts
@@ -1,3 +1,2 @@
 export { createAISlice, createAISliceFactory } from './slice'
 export type { AIActions, AIPreferences, AISlice, AIState, ChatMessage, ChatMessageRole, DiffReviewEntry } from './types'
-export { MAX_CONVERSATION_MESSAGES } from './types'

--- a/src/frontend/store/slices/ai/slice.ts
+++ b/src/frontend/store/slices/ai/slice.ts
@@ -3,7 +3,6 @@ import { StateCreator } from 'zustand'
 
 import type { AIFeatureConfig } from '../../../../middleware/shared/ports/types'
 import type { AISlice } from './types'
-import { MAX_CONVERSATION_MESSAGES } from './types'
 
 const DEFAULT_AI_STATE: AISlice['ai'] = {
   isEnabled: false,
@@ -152,9 +151,6 @@ export function createAISliceFactory(config?: AIFeatureConfig): StateCreator<AIS
         setState(
           produce(({ ai }: AISlice) => {
             ai.messages.push(message)
-            if (ai.messages.length > MAX_CONVERSATION_MESSAGES) {
-              ai.messages = ai.messages.slice(-MAX_CONVERSATION_MESSAGES)
-            }
           }),
         )
       },
@@ -292,8 +288,7 @@ export function createAISliceFactory(config?: AIFeatureConfig): StateCreator<AIS
       replaceMessages: (messages) => {
         setState(
           produce(({ ai }: AISlice) => {
-            ai.messages =
-              messages.length > MAX_CONVERSATION_MESSAGES ? messages.slice(-MAX_CONVERSATION_MESSAGES) : messages
+            ai.messages = messages
             ai.error = null
           }),
         )

--- a/src/frontend/store/slices/ai/types.ts
+++ b/src/frontend/store/slices/ai/types.ts
@@ -193,9 +193,3 @@ export type AIActions = {
 export type AISlice = AIState & {
   aiActions: AIActions
 }
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-export const MAX_CONVERSATION_MESSAGES = 50

--- a/src/frontend/store/slices/index.ts
+++ b/src/frontend/store/slices/index.ts
@@ -1,6 +1,5 @@
 export type { AISlice } from './ai'
 export { createAISlice, createAISliceFactory } from './ai'
-export { MAX_CONVERSATION_MESSAGES } from './ai'
 export type { ConsoleSlice } from './console'
 export { createConsoleSlice } from './console'
 export type { DeviceSlice } from './device'


### PR DESCRIPTION
## Summary

Mirror of [openplc-web#412](https://github.com/Autonomy-Logic/openplc-web/pull/412) — keeps `src/frontend/**` and the shared `src/backend/shared/styles/globals.css` byte-identical between the two IDEs so the Shared Surface Sync CI check stays green.

This PR contains **only** the shared-code changes. The chat UX work, PWA fix, and middleware-adapter changes from the web PR are web-only and not included here.

## Files (byte-identical to the web PR)

- `src/frontend/components/_molecules/menu-bar/menus/help.tsx` — Community Support link points at `edge.autonomylogic.com/forum`.
- `src/frontend/store/slices/ai/types.ts` + `slice.ts` + `index.ts` + `src/frontend/store/slices/index.ts` — drop the silent 50-message store cap (`MAX_CONVERSATION_MESSAGES`). `addMessage` / `replaceMessages` keep every message; the backend's 500/conv cap stays the only ceiling.
- `src/frontend/store/__tests__/ai-slice.test.ts` — flip the two cap-related tests to assert no truncation.
- `src/backend/shared/styles/globals.css` — add `@keyframes spin` so Tailwind's `animate-spin` utility actually spins (the project's tailwind config overrode `theme.keyframes` instead of extending it, silently killing the default keyframe and breaking every `animate-spin` use across the app).

## Mirror of

https://github.com/Autonomy-Logic/openplc-web/pull/412

## Test plan

- [ ] `npm run lint` / `npm run test` pass locally in editor
- [ ] CI Shared Surface Sync now reports the two PRs as in-sync
- [ ] Any spinner in the desktop IDE that uses `animate-spin` now actually spins
- [ ] Help → Community Support opens the new forum URL
- [ ] Long AI chat conversations don't lose oldest turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved spinning animation compatibility issues to ensure animations render correctly across the entire application.

* **Improvements**
  * Conversation message history is now unlimited—users can maintain larger conversation histories without automatic message removal.

* **Updates**
  * Community forum link updated to direct users to the new forum location.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autonomy-Logic/openplc-editor/pull/780?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->