### PR TITLE
feat(device): LAN device discovery on Board Settings

### DIFF
--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/board.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/board.tsx
@@ -4,6 +4,7 @@ import { useCapabilities, useDevice, useRuntime } from '@root/middleware/shared/
 import { resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { MagnifierIcon } from '../../../../../../assets/icons/interface/Magnifier'
 import { MinusIcon } from '../../../../../../assets/icons/interface/Minus'
 import { PlusIcon } from '../../../../../../assets/icons/interface/Plus'
 import { RefreshIcon } from '../../../../../../assets/icons/interface/Refresh'
@@ -460,8 +461,18 @@ const Board = memo(function () {
                   value={runtimeIpAddress}
                   onChange={(e) => setRuntimeIpAddress(e.target.value)}
                   placeholder='127.0.0.1 or localhost'
-                  className='flex h-[30px] w-full items-center justify-between gap-1 rounded-md border border-neutral-100 bg-white px-2 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none focus:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
+                  className='flex h-[30px] min-w-0 flex-1 items-center justify-between gap-1 rounded-md border border-neutral-100 bg-white px-2 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none focus:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
                 />
+                <button
+                  type='button'
+                  aria-label='Search for devices'
+                  title='Search for devices on the local network'
+                  onClick={() => openModal('runtime-discover-devices', null)}
+                  className='flex h-[30px] items-center gap-1 rounded-md bg-neutral-100 px-3 font-caption text-cp-sm font-medium text-neutral-1000 hover:bg-neutral-200 dark:bg-neutral-850 dark:text-neutral-100 dark:hover:bg-neutral-800'
+                >
+                  <MagnifierIcon size='sm' className='h-4 w-4 stroke-neutral-1000 dark:stroke-neutral-100' />
+                  Search
+                </button>
               </div>
               <div id='runtime-connect-button-container' className='flex w-full items-center justify-start'>
                 <button

--- a/src/frontend/components/_organisms/modals/index.ts
+++ b/src/frontend/components/_organisms/modals/index.ts
@@ -1,2 +1,3 @@
 export { RuntimeCreateUserModal } from './runtime-create-user-modal'
+export { RuntimeDiscoverDevicesModal } from './runtime-discover-devices-modal'
 export { RuntimeLoginModal } from './runtime-login-modal'

--- a/src/frontend/components/_organisms/modals/runtime-discover-devices-modal.tsx
+++ b/src/frontend/components/_organisms/modals/runtime-discover-devices-modal.tsx
@@ -123,7 +123,7 @@ const RuntimeDiscoverDevicesModal = () => {
         <div className='mb-3 flex items-center justify-between'>
           <span className='text-sm font-medium text-neutral-850 dark:text-neutral-300'>
             {phase === 'scanning' && (
-              <span className='inline-block h-3 w-3 animate-pulse rounded-full bg-brand mr-2 align-middle' />
+              <span className='mr-2 inline-block h-3 w-3 animate-pulse rounded-full bg-brand align-middle' />
             )}
             {headline}
           </span>
@@ -155,15 +155,12 @@ const RuntimeDiscoverDevicesModal = () => {
                       className={cn(
                         'flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-sm',
                         isSelected
-                          ? 'bg-brand/20 font-bold shadow-[inset_3px_0_0_var(--primary-default)] dark:bg-brand/30'
+                          ? 'bg-brand/20 dark:bg-brand/30 font-bold shadow-[inset_3px_0_0_var(--primary-default)]'
                           : 'text-neutral-850 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-850',
                       )}
                     >
                       <span
-                        className={cn(
-                          'text-neutral-950 dark:text-white',
-                          isSelected ? 'font-bold' : 'font-medium',
-                        )}
+                        className={cn('text-neutral-950 dark:text-white', isSelected ? 'font-bold' : 'font-medium')}
                       >
                         {device.hostname || '(unknown host)'}
                       </span>

--- a/src/frontend/components/_organisms/modals/runtime-discover-devices-modal.tsx
+++ b/src/frontend/components/_organisms/modals/runtime-discover-devices-modal.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { DiscoveredRuntimeDevice } from '../../../../middleware/shared/ports'
+import { useRuntime } from '../../../../middleware/shared/providers'
+import { useOpenPLCStore } from '../../../store'
+import { cn } from '../../../utils/cn'
+import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'
+
+const RuntimeDiscoverDevicesModal = () => {
+  const { modals, modalActions, deviceActions } = useOpenPLCStore()
+  const runtime = useRuntime()
+
+  const isOpen = modals['runtime-discover-devices']?.open || false
+
+  const [phase, setPhase] = useState<'scanning' | 'done'>('scanning')
+  const [devices, setDevices] = useState<DiscoveredRuntimeDevice[]>([])
+  const [selectedIp, setSelectedIp] = useState<string | null>(null)
+  const [error, setError] = useState<string>('')
+  // Latest-scan token so live "discovered" callbacks from a stale scan
+  // can be ignored without races.
+  const scanIdRef = useRef(0)
+
+  const runScan = useCallback(async () => {
+    setError('')
+    setDevices([])
+    setSelectedIp(null)
+    setPhase('scanning')
+
+    const myScanId = ++scanIdRef.current
+    if (!runtime.discoverDevices) {
+      setError('Device discovery is not supported by this platform.')
+      setPhase('done')
+      return
+    }
+
+    const result = await runtime.discoverDevices({ durationMs: 3000 })
+    if (myScanId !== scanIdRef.current) return
+
+    if (!result.success) {
+      setError(result.error || 'Discovery failed')
+      setPhase('done')
+      return
+    }
+
+    // The live subscription has been appending devices throughout the
+    // scan; this final merge guarantees we end up with the authoritative
+    // list even if some "discovered" events were missed.
+    setDevices((prev) => {
+      const merged = new Map(prev.map((d) => [d.ipAddress, d]))
+      for (const d of result.devices ?? []) {
+        merged.set(d.ipAddress, d)
+      }
+      return Array.from(merged.values())
+    })
+    setPhase('done')
+  }, [runtime])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    if (!runtime.onDeviceDiscovered) {
+      void runScan()
+      return
+    }
+
+    // Subscribe BEFORE kicking off the scan so the first replies aren't
+    // dropped on the floor.
+    const unsubscribe = runtime.onDeviceDiscovered((device) => {
+      setDevices((prev) => {
+        if (prev.some((d) => d.ipAddress === device.ipAddress)) {
+          return prev.map((d) => (d.ipAddress === device.ipAddress ? device : d))
+        }
+        return [...prev, device]
+      })
+    })
+
+    void runScan()
+    return () => {
+      unsubscribe()
+    }
+    // runScan is stable per-runtime; we want this to re-run only on
+    // open/close of the modal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, runtime])
+
+  const handleClose = () => {
+    scanIdRef.current++ // invalidate any in-flight scan callbacks
+    setDevices([])
+    setSelectedIp(null)
+    setError('')
+    setPhase('scanning')
+    modalActions.closeModal()
+  }
+
+  const handleOk = () => {
+    if (!selectedIp) return
+    deviceActions.setRuntimeIpAddress(selectedIp)
+    handleClose()
+  }
+
+  const headline =
+    phase === 'scanning'
+      ? 'Searching devices...'
+      : devices.length === 0
+        ? 'No devices found'
+        : `Found ${devices.length} device${devices.length === 1 ? '' : 's'}`
+
+  return (
+    <Modal
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) handleClose()
+        modalActions.onOpenChange('runtime-discover-devices', open)
+      }}
+    >
+      <ModalContent className='flex h-[480px] w-[480px] select-none flex-col rounded-lg p-6'>
+        <ModalTitle className='mb-2 text-xl font-semibold'>Search for Devices</ModalTitle>
+
+        <p className='mb-4 text-sm text-neutral-600 dark:text-neutral-400'>
+          Broadcasting on the local network to find OpenPLC runtime devices.
+        </p>
+
+        <div className='mb-3 flex items-center justify-between'>
+          <span className='text-sm font-medium text-neutral-850 dark:text-neutral-300'>
+            {phase === 'scanning' && (
+              <span className='inline-block h-3 w-3 animate-pulse rounded-full bg-brand mr-2 align-middle' />
+            )}
+            {headline}
+          </span>
+          <button
+            type='button'
+            onClick={() => void runScan()}
+            disabled={phase === 'scanning'}
+            className='rounded-md bg-neutral-100 px-3 py-1 text-xs font-medium text-neutral-1000 hover:bg-neutral-200 disabled:opacity-50 dark:bg-neutral-850 dark:text-neutral-100'
+          >
+            Rescan
+          </button>
+        </div>
+
+        <div className='flex-1 overflow-auto rounded-md border border-neutral-200 dark:border-neutral-800'>
+          {devices.length === 0 ? (
+            <div className='flex h-full items-center justify-center text-sm text-neutral-500 dark:text-neutral-400'>
+              {phase === 'scanning' ? 'Waiting for responses...' : 'No devices replied.'}
+            </div>
+          ) : (
+            <ul className='divide-y divide-neutral-200 dark:divide-neutral-800'>
+              {devices.map((device) => {
+                const isSelected = selectedIp === device.ipAddress
+                return (
+                  <li key={device.ipAddress}>
+                    <button
+                      type='button'
+                      onClick={() => setSelectedIp(device.ipAddress)}
+                      aria-selected={isSelected}
+                      className={cn(
+                        'flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-sm',
+                        isSelected
+                          ? 'bg-brand/20 font-bold shadow-[inset_3px_0_0_var(--primary-default)] dark:bg-brand/30'
+                          : 'text-neutral-850 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-850',
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          'text-neutral-950 dark:text-white',
+                          isSelected ? 'font-bold' : 'font-medium',
+                        )}
+                      >
+                        {device.hostname || '(unknown host)'}
+                      </span>
+                      <span
+                        className={cn(
+                          'text-xs',
+                          isSelected
+                            ? 'font-bold text-neutral-950 dark:text-white'
+                            : 'text-neutral-600 dark:text-neutral-400',
+                        )}
+                      >
+                        {device.ipAddress}
+                        {device.runtimeVersion ? ` · ${device.runtimeVersion}` : ''}
+                      </span>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+
+        {error && <p className='mt-3 text-sm text-red-600 dark:text-red-400'>{error}</p>}
+
+        <div className='mt-4 flex gap-3'>
+          <button
+            type='button'
+            onClick={handleOk}
+            disabled={!selectedIp}
+            className='flex-1 rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-medium-dark disabled:opacity-50'
+          >
+            OK
+          </button>
+          <button
+            type='button'
+            onClick={handleClose}
+            className='flex-1 rounded-md bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-1000 hover:bg-neutral-200 dark:bg-neutral-850 dark:text-neutral-100'
+          >
+            Cancel
+          </button>
+        </div>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export { RuntimeDiscoverDevicesModal }

--- a/src/frontend/components/_templates/app-layout.tsx
+++ b/src/frontend/components/_templates/app-layout.tsx
@@ -9,7 +9,7 @@ import Toaster from '../_features/[app]/toast/toaster'
 import { ProjectModal } from '../_features/[start]/new-project/project-modal'
 import { AIConsentModal } from '../_features/[workspace]/editor/monaco/ai-consent-modal'
 import AboutModal from '../_organisms/about-modal'
-import { RuntimeCreateUserModal, RuntimeLoginModal } from '../_organisms/modals'
+import { RuntimeCreateUserModal, RuntimeDiscoverDevicesModal, RuntimeLoginModal } from '../_organisms/modals'
 import { DebuggerMessageModal } from '../_organisms/modals/debugger-message-modal'
 import { ConfirmDeleteElementModal } from '../_organisms/modals/delete-confirmation-modal'
 import { MissingLibrariesModal } from '../_organisms/modals/missing-libraries-modal'
@@ -121,6 +121,7 @@ const AppLayout = ({ children, ...rest }: AppLayoutProps): ReactNode => {
           {modals?.['missing-libraries']?.open === true && <MissingLibrariesModal />}
           {modals?.['runtime-login']?.open === true && <RuntimeLoginModal />}
           {modals?.['runtime-create-user']?.open === true && <RuntimeCreateUserModal />}
+          {modals?.['runtime-discover-devices']?.open === true && <RuntimeDiscoverDevicesModal />}
           {modals?.['ai-consent']?.open === true && <AIConsentModal />}
           <AboutModal />
           <AcceleratorHandler />

--- a/src/frontend/store/__tests__/modal-slice.test.ts
+++ b/src/frontend/store/__tests__/modal-slice.test.ts
@@ -20,6 +20,7 @@ const ALL_MODAL_TYPES: ModalTypes[] = [
   'confirm-device-switch',
   'quit-application',
   'runtime-create-user',
+  'runtime-discover-devices',
   'runtime-login',
   'server-ip-mismatch',
   'runtime-connection-lost',

--- a/src/frontend/store/slices/modal/slice.ts
+++ b/src/frontend/store/slices/modal/slice.ts
@@ -16,6 +16,7 @@ const ALL_MODAL_TYPES: ModalTypes[] = [
   'confirm-device-switch',
   'quit-application',
   'runtime-create-user',
+  'runtime-discover-devices',
   'runtime-login',
   'server-ip-mismatch',
   'runtime-connection-lost',

--- a/src/frontend/store/slices/modal/types.ts
+++ b/src/frontend/store/slices/modal/types.ts
@@ -15,6 +15,7 @@ export type ModalTypes =
   | 'confirm-device-switch'
   | 'quit-application'
   | 'runtime-create-user'
+  | 'runtime-discover-devices'
   | 'runtime-login'
   | 'server-ip-mismatch'
   | 'runtime-connection-lost'

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -17,11 +17,13 @@ import type {
 } from '@root/middleware/shared/ports/ethercat-types'
 import { CreatePouFileProps } from '@root/types/IPC/pou-service'
 import { CreateProjectFileProps } from '@root/types/IPC/project-service'
+import dgram from 'dgram'
 import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron'
 import { app, dialog, nativeTheme, shell } from 'electron'
 import { readFile, realpathSync, stat, statSync, unwatchFile, watchFile } from 'fs'
 import type { IncomingHttpHeaders, IncomingMessage } from 'http'
 import https from 'https'
+import { networkInterfaces } from 'os'
 import { join, resolve, sep } from 'path'
 import { platform } from 'process'
 
@@ -562,6 +564,144 @@ class MainProcessBridge implements MainIpcModule {
     return { success: true }
   }
 
+  // ===================== RUNTIME LAN DISCOVERY =====================
+  private readonly DISCOVERY_PORT = 33333
+  private readonly DISCOVERY_MAGIC = 'OPENPLC_DISCOVER_V1'
+  private readonly DISCOVERY_DEFAULT_DURATION_MS = 3000
+
+  /**
+   * Compute the directed broadcast address for an IPv4 interface
+   * given its address and netmask in dotted-quad form.  Returns
+   * `255.255.255.255` for /32 or otherwise-degenerate masks where a
+   * meaningful broadcast cannot be derived.
+   */
+  private computeBroadcastAddress(address: string, netmask: string): string {
+    const toOctets = (s: string): number[] | null => {
+      const parts = s.split('.').map((p) => Number(p))
+      if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+        return null
+      }
+      return parts
+    }
+    const addr = toOctets(address)
+    const mask = toOctets(netmask)
+    if (!addr || !mask) {
+      return '255.255.255.255'
+    }
+    const broadcast = addr.map((octet, i) => (octet & mask[i]) | (~mask[i] & 0xff))
+    return broadcast.join('.')
+  }
+
+  handleRuntimeDiscoverDevices = (
+    event: IpcMainInvokeEvent,
+    opts?: { durationMs?: number },
+  ): Promise<{
+    success: boolean
+    devices?: Array<{ ipAddress: string; hostname: string; runtimeVersion: string; apiPort: number }>
+    error?: string
+  }> => {
+    const duration = Math.max(500, Math.min(10000, opts?.durationMs ?? this.DISCOVERY_DEFAULT_DURATION_MS))
+    const senderWebContents = event.sender
+
+    return new Promise((resolveOuter) => {
+      const sock = dgram.createSocket({ type: 'udp4', reuseAddr: true })
+      // Dedup by source IP; last reply wins so a runtime updating its
+      // hostname mid-scan still settles on fresh data.
+      const discovered = new Map<
+        string,
+        { ipAddress: string; hostname: string; runtimeVersion: string; apiPort: number }
+      >()
+      let settled = false
+      let timer: NodeJS.Timeout | null = null
+
+      const finish = (err?: Error) => {
+        if (settled) return
+        settled = true
+        if (timer) clearTimeout(timer)
+        try {
+          sock.close()
+        } catch {
+          /* socket already closed */
+        }
+        if (err) {
+          resolveOuter({ success: false, error: err.message })
+        } else {
+          resolveOuter({ success: true, devices: Array.from(discovered.values()) })
+        }
+      }
+
+      sock.on('error', (err) => finish(err))
+
+      sock.on('message', (msg, rinfo) => {
+        let parsed: unknown
+        try {
+          parsed = JSON.parse(msg.toString('utf-8'))
+        } catch {
+          return
+        }
+        if (
+          typeof parsed !== 'object' ||
+          parsed === null ||
+          (parsed as { service?: unknown }).service !== 'openplc-runtime'
+        ) {
+          return
+        }
+        const p = parsed as {
+          runtime_version?: unknown
+          hostname?: unknown
+          api_port?: unknown
+        }
+        const device = {
+          ipAddress: rinfo.address,
+          hostname: typeof p.hostname === 'string' ? p.hostname : '',
+          runtimeVersion: typeof p.runtime_version === 'string' ? p.runtime_version : '',
+          apiPort: typeof p.api_port === 'number' ? p.api_port : 8443,
+        }
+        discovered.set(device.ipAddress, device)
+        // Stream the live update to the renderer so the modal can
+        // append rows as devices come in, instead of waiting for the
+        // full timeout.
+        if (!senderWebContents.isDestroyed()) {
+          senderWebContents.send('runtime:device-discovered', device)
+        }
+      })
+
+      sock.bind(0, () => {
+        try {
+          sock.setBroadcast(true)
+        } catch (err) {
+          finish(err as Error)
+          return
+        }
+
+        const magic = new Uint8Array(Buffer.from(this.DISCOVERY_MAGIC, 'utf-8'))
+        const targets = new Set<string>(['255.255.255.255'])
+        const ifaces = networkInterfaces()
+        for (const list of Object.values(ifaces)) {
+          if (!list) continue
+          for (const ifaceInfo of list) {
+            if (ifaceInfo.family !== 'IPv4' || ifaceInfo.internal) continue
+            const broadcast = this.computeBroadcastAddress(ifaceInfo.address, ifaceInfo.netmask)
+            targets.add(broadcast)
+          }
+        }
+
+        for (const target of targets) {
+          sock.send(magic, this.DISCOVERY_PORT, target, (sendErr) => {
+            // Per-target send errors are logged but don't abort the
+            // scan; some interfaces (e.g. VPN tun adapters) reject
+            // broadcast and that's fine.
+            if (sendErr) {
+              logger.debug(`Discovery send to ${target} failed: ${sendErr.message}`)
+            }
+          })
+        }
+
+        timer = setTimeout(() => finish(), duration)
+      })
+    })
+  }
+
   handleRuntimeGetSerialPorts = async (
     _event: IpcMainInvokeEvent,
     ipAddress: string,
@@ -708,6 +848,7 @@ class MainProcessBridge implements MainIpcModule {
     this.registerHandle('runtime:get-logs', this.handleRuntimeGetLogs)
     this.registerHandle('runtime:clear-credentials', this.handleRuntimeClearCredentials)
     this.registerHandle('runtime:get-serial-ports', this.handleRuntimeGetSerialPorts)
+    this.registerHandle('runtime:discover-devices', this.handleRuntimeDiscoverDevices)
 
     // ===================== ETHERCAT DISCOVERY =====================
     this.registerHandle('ethercat:get-interfaces', this.handleEtherCATGetInterfaces)

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -1,4 +1,4 @@
-import type { RuntimeLogEntry } from '@root/middleware/shared/ports'
+import type { DiscoveredRuntimeDevice, RuntimeLogEntry } from '@root/middleware/shared/ports'
 import type { ESIDevice, ESIRepositoryItemLight } from '@root/middleware/shared/ports/esi-types'
 import type {
   EtherCATRuntimeStatusResponse,
@@ -462,6 +462,14 @@ const rendererProcessBridge = {
     jwtToken: string,
   ): Promise<{ success: boolean; ports?: Array<{ device: string; description?: string }>; error?: string }> =>
     ipcRenderer.invoke('runtime:get-serial-ports', ipAddress, jwtToken),
+  runtimeDiscoverDevices: (opts?: {
+    durationMs?: number
+  }): Promise<{ success: boolean; devices?: DiscoveredRuntimeDevice[]; error?: string }> =>
+    ipcRenderer.invoke('runtime:discover-devices', opts),
+  onRuntimeDeviceDiscovered: (callback: (_event: IpcRendererEvent, device: DiscoveredRuntimeDevice) => void) => {
+    ipcRenderer.on('runtime:device-discovered', callback)
+    return () => ipcRenderer.removeListener('runtime:device-discovered', callback)
+  },
   onRuntimeTokenRefreshed: (callback: (_event: IpcRendererEvent, newToken: string) => void) => {
     ipcRenderer.on('runtime:token-refreshed', callback)
     return () => ipcRenderer.removeListener('runtime:token-refreshed', callback)

--- a/src/middleware/adapters/editor/__tests__/runtime-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/runtime-adapter.test.ts
@@ -393,9 +393,7 @@ describe('IP address getter', () => {
 
 describe('discoverDevices', () => {
   it('delegates to bridge with options', async () => {
-    const devices = [
-      { ipAddress: '192.168.1.50', hostname: 'plc-1', runtimeVersion: 'v4.1.0', apiPort: 8443 },
-    ]
+    const devices = [{ ipAddress: '192.168.1.50', hostname: 'plc-1', runtimeVersion: 'v4.1.0', apiPort: 8443 }]
     ;(window.bridge.runtimeDiscoverDevices as jest.Mock).mockResolvedValue({ success: true, devices })
 
     const result = await adapter.discoverDevices!({ durationMs: 2000 })

--- a/src/middleware/adapters/editor/__tests__/runtime-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/runtime-adapter.test.ts
@@ -22,6 +22,8 @@ beforeEach(() => {
     }),
     runtimeClearCredentials: jest.fn().mockResolvedValue({ success: true }),
     onRuntimeTokenRefreshed: jest.fn().mockImplementation(() => jest.fn()),
+    runtimeDiscoverDevices: jest.fn().mockResolvedValue({ success: true, devices: [] }),
+    onRuntimeDeviceDiscovered: jest.fn().mockImplementation(() => jest.fn()),
   } as unknown as typeof window.bridge
 
   adapter = createEditorRuntimeAdapter(() => mockIpAddress)
@@ -384,6 +386,57 @@ describe('IP address getter', () => {
 // ---------------------------------------------------------------------------
 // isReadyForDebug
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// discoverDevices / onDeviceDiscovered
+// ---------------------------------------------------------------------------
+
+describe('discoverDevices', () => {
+  it('delegates to bridge with options', async () => {
+    const devices = [
+      { ipAddress: '192.168.1.50', hostname: 'plc-1', runtimeVersion: 'v4.1.0', apiPort: 8443 },
+    ]
+    ;(window.bridge.runtimeDiscoverDevices as jest.Mock).mockResolvedValue({ success: true, devices })
+
+    const result = await adapter.discoverDevices!({ durationMs: 2000 })
+
+    expect(window.bridge.runtimeDiscoverDevices).toHaveBeenCalledWith({ durationMs: 2000 })
+    expect(result).toEqual({ success: true, devices })
+  })
+
+  it('works without options', async () => {
+    await adapter.discoverDevices!()
+    expect(window.bridge.runtimeDiscoverDevices).toHaveBeenCalledWith(undefined)
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeDiscoverDevices as jest.Mock).mockRejectedValue(new Error('UDP bind failed'))
+    const result = await adapter.discoverDevices!()
+    expect(result).toEqual({ success: false, error: 'UDP bind failed' })
+  })
+})
+
+describe('onDeviceDiscovered', () => {
+  it('subscribes to bridge events and forwards device payload', () => {
+    let bridgeHandler: ((_event: unknown, device: unknown) => void) | null = null
+    const unsubscribe = jest.fn()
+    ;(window.bridge.onRuntimeDeviceDiscovered as jest.Mock).mockImplementation(
+      (handler: (_event: unknown, device: unknown) => void) => {
+        bridgeHandler = handler
+        return unsubscribe
+      },
+    )
+
+    const callback = jest.fn()
+    const unsub = adapter.onDeviceDiscovered!(callback)
+
+    const device = { ipAddress: '10.0.0.5', hostname: 'rpi-3', runtimeVersion: 'v4.1.0', apiPort: 8443 }
+    bridgeHandler!({}, device)
+
+    expect(callback).toHaveBeenCalledWith(device)
+    expect(unsub).toBe(unsubscribe)
+  })
+})
 
 describe('isReadyForDebug', () => {
   it('returns false when no IP and no token', () => {

--- a/src/middleware/adapters/editor/runtime-adapter.ts
+++ b/src/middleware/adapters/editor/runtime-adapter.ts
@@ -15,6 +15,9 @@
 import { getErrorMessage } from '../../../frontend/utils/get-error-message'
 import type {
   CompilationStatusResult,
+  DiscoverDevicesOptions,
+  DiscoverDevicesResult,
+  DiscoveredRuntimeDevice,
   LoginParams,
   LoginResult,
   RuntimeLogsResult,
@@ -190,6 +193,21 @@ export function createEditorRuntimeAdapter(getIpAddress: () => string): RuntimeP
       } catch (err) {
         return { success: false, error: getErrorMessage(err) }
       }
+    },
+
+    // --- LAN discovery ---
+
+    async discoverDevices(opts?: DiscoverDevicesOptions): Promise<DiscoverDevicesResult> {
+      try {
+        return await window.bridge.runtimeDiscoverDevices(opts)
+      } catch (err) {
+        return { success: false, error: getErrorMessage(err) }
+      }
+    },
+
+    onDeviceDiscovered(callback: (device: DiscoveredRuntimeDevice) => void): Unsubscribe {
+      const handler = (_event: unknown, device: DiscoveredRuntimeDevice) => callback(device)
+      return window.bridge.onRuntimeDeviceDiscovered(handler)
     },
   }
 }

--- a/src/middleware/shared/ports/index.ts
+++ b/src/middleware/shared/ports/index.ts
@@ -153,6 +153,9 @@ export type {
 export type {
   CompilationStatusResult,
   CreateUserParams,
+  DiscoverDevicesOptions,
+  DiscoverDevicesResult,
+  DiscoveredRuntimeDevice,
   LoginParams,
   LoginResult,
   RuntimeLogsResult,

--- a/src/middleware/shared/ports/runtime-port.ts
+++ b/src/middleware/shared/ports/runtime-port.ts
@@ -95,6 +95,31 @@ export interface RuntimeLogsResult {
   error?: string
 }
 
+/**
+ * A runtime device discovered on the LAN via UDP broadcast.
+ *
+ * `ipAddress` is the reachable address learned from the response
+ * packet's source IP — that's authoritative even when the runtime
+ * has multiple interfaces and doesn't know its outward-facing one.
+ */
+export interface DiscoveredRuntimeDevice {
+  ipAddress: string
+  hostname: string
+  runtimeVersion: string
+  apiPort: number
+}
+
+export interface DiscoverDevicesOptions {
+  /** How long to listen for replies after sending the probe. */
+  durationMs?: number
+}
+
+export interface DiscoverDevicesResult {
+  success: boolean
+  devices?: DiscoveredRuntimeDevice[]
+  error?: string
+}
+
 export interface RuntimePort {
   /** Set the target device for subsequent API calls. */
   setDeviceContext?(context: { agentId: string; deviceId: string } | null): void
@@ -154,6 +179,21 @@ export interface RuntimePort {
    * Returns unsubscribe function.
    */
   onTokenRefreshed?(callback: (newToken: string) => void): Unsubscribe
+
+  // --- LAN discovery (UDP broadcast) ---
+
+  /**
+   * Probe the local network for OpenPLC runtime devices.  Resolves
+   * with the full set after the listen window closes.  Use
+   * `onDeviceDiscovered` for live updates while the scan is in flight.
+   */
+  discoverDevices?(opts?: DiscoverDevicesOptions): Promise<DiscoverDevicesResult>
+
+  /**
+   * Subscribe to live device-discovered notifications.  Fires once
+   * per unique source IP during a `discoverDevices` call.
+   */
+  onDeviceDiscovered?(callback: (device: DiscoveredRuntimeDevice) => void): Unsubscribe
 
   // --- EtherCAT Discovery (runtime device commands) ---
 


### PR DESCRIPTION
## Summary
- Adds a "Search" button next to the IP Address field on Board Settings that broadcasts on the local network to find OpenPLC runtime devices.
- New modal collects responses for ~3s, streams live updates as devices reply, and writes the selected IP back to the field on OK.
- Main-process IPC handler uses node `dgram` to send `OPENPLC_DISCOVER_V1` to `255.255.255.255` plus each interface's directed broadcast, then forwards unicast replies to the renderer.
- `RuntimePort` gains optional `discoverDevices` / `onDeviceDiscovered` methods so the web adapter (which can't broadcast from a browser) can stub them out.
- Selection style mirrors the library manager: blue inset tag on the left, brand-tint background, bold text.

Requires the matching runtime change in `openplc-runtime` (`feat/network-discovery`) to be deployed on target devices.

## Test plan
- [x] `npx jest src/middleware src/frontend/store` — 1703 tests pass (new tests added for the discover/onDeviceDiscovered adapter methods)
- [x] `npm run validate:arch` clean
- [x] `npx tsc --noEmit -p .` clean
- [x] `npm run build:main` succeeds
- [x] Manual smoke test against a live runtime on the LAN: button appears, scan finds the device, selection style is clear, OK populates the IP field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device discovery: scan the local network for OpenPLC runtimes and show live incremental results.
  * Discovery modal: selectable, scrollable device list with Rescan, empty/error messaging, and OK/Cancel actions.
  * Board settings: added Search button to open the discovery modal and persist selected runtime IP.

* **Tests**
  * Added test coverage for discovery APIs and modal behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autonomy-Logic/openplc-editor/pull/783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->