### PR TITLE
fix(orchestrators): mirror stats-panel stack layout from openplc-web

### DIFF
--- a/src/frontend/components/_features/[workspace]/editor/device/orchestrators/orchestrators-list.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/orchestrators/orchestrators-list.tsx
@@ -337,257 +337,260 @@ const OrchestratorsList = () => {
   }, [])
 
   return (
-    <div className='flex h-full w-full'>
-      <DeviceEditorSlot heading='Device Orchestrators'>
-        <div id='orchestrators-container' className='flex h-full w-full flex-col gap-4'>
-          <div id='orchestrators-header' className='flex items-center justify-between'>
-            <p className='text-sm text-neutral-600 dark:text-neutral-400'>
-              Select a device from your orchestrators to connect to.
-            </p>
-            <button
-              type='button'
-              onClick={() => void handleRefresh()}
-              disabled={isRefreshing}
-              className={cn('group', isRefreshing && 'cursor-not-allowed opacity-50')}
-              aria-label='Refresh orchestrators'
-            >
-              <RefreshIcon size='sm' className={isRefreshing ? 'animate-spin' : ''} />
-            </button>
-          </div>
-
-          {/* Simulator option — always visible */}
-          <div
-            className={cn(
-              'cursor-pointer rounded-lg border px-4 py-3',
-              isSimulatorSelected && runtimeConnection.connectionStatus !== 'connected'
-                ? 'bg-brand/5 dark:bg-brand/10 border-brand dark:border-brand'
-                : 'border-neutral-200 bg-neutral-50 hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:bg-neutral-800',
-            )}
-            onClick={handleSimulatorSelect}
-          >
-            <div className='flex items-center justify-between'>
-              <div className='flex flex-col'>
-                <span className='text-sm font-medium text-neutral-900 dark:text-white'>OpenPLC Simulator</span>
-                <span className='text-xs text-neutral-500 dark:text-neutral-400'>
-                  Built-in simulator — no hardware required
-                </span>
-              </div>
-              {isSimulatorSelected && runtimeConnection.connectionStatus !== 'connected' && (
-                <span className='inline-flex items-center rounded px-2 py-0.5 text-xs font-medium text-brand'>
-                  Selected
-                </span>
-              )}
-            </div>
-          </div>
-
-          {loading && (
-            <div className='flex items-center justify-center py-8'>
-              <p className='text-sm text-neutral-500 dark:text-neutral-400'>Loading orchestrators...</p>
-            </div>
-          )}
-
-          {error && (
-            <div className='rounded-md bg-red-50 p-4 dark:bg-red-900/20'>
-              <p className='text-sm text-red-600 dark:text-red-400'>{error}</p>
-            </div>
-          )}
-
-          {!loading && !error && orchestrators.length === 0 && (
-            <div className='flex flex-col items-center justify-center gap-2 py-8'>
-              <p className='text-sm text-neutral-500 dark:text-neutral-400'>No orchestrators found.</p>
-              <p className='text-xs text-neutral-400 dark:text-neutral-500'>
-                Register an orchestrator in the Autonomy Edge platform to see it here.
+    <div className='flex h-full w-full flex-col'>
+      <div className='min-h-0 flex-1'>
+        <DeviceEditorSlot heading='Device Orchestrators'>
+          <div id='orchestrators-container' className='flex h-full w-full flex-col gap-4'>
+            <div id='orchestrators-header' className='flex items-center justify-between'>
+              <p className='text-sm text-neutral-600 dark:text-neutral-400'>
+                Select a device from your orchestrators to connect to.
               </p>
+              <button
+                type='button'
+                onClick={() => void handleRefresh()}
+                disabled={isRefreshing}
+                className={cn('group', isRefreshing && 'cursor-not-allowed opacity-50')}
+                aria-label='Refresh orchestrators'
+              >
+                <RefreshIcon size='sm' className={isRefreshing ? 'animate-spin' : ''} />
+              </button>
             </div>
-          )}
 
-          {!loading && !error && orchestrators.length > 0 && (
-            <div id='orchestrators-list' className='flex flex-col gap-2'>
-              {orchestrators.map((orchestrator) => {
-                const isExpanded = expandedOrchestrators.has(orchestrator.id)
-                const hasDevices = orchestrator.devices.length > 0
-
-                return (
-                  <div
-                    key={orchestrator.id}
-                    className='rounded-lg border border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900'
-                  >
-                    <div
-                      className={cn(
-                        'flex cursor-pointer items-center gap-2 px-4 py-3',
-                        hasDevices && 'hover:bg-neutral-100 dark:hover:bg-neutral-800',
-                      )}
-                      onClick={() => hasDevices && toggleOrchestratorExpanded(orchestrator.id)}
-                    >
-                      {hasDevices ? (
-                        <ArrowIcon
-                          direction='right'
-                          className={cn(
-                            'h-4 w-4 stroke-neutral-500 transition-transform dark:stroke-neutral-400',
-                            isExpanded && 'rotate-90',
-                          )}
-                        />
-                      ) : (
-                        <div className='h-4 w-4' />
-                      )}
-                      <div className='flex flex-1 flex-col'>
-                        <span className='text-sm font-medium text-neutral-900 dark:text-white'>
-                          {orchestrator.name}
-                        </span>
-                        {orchestrator.description && (
-                          <span className='text-xs text-neutral-500 dark:text-neutral-400'>
-                            {orchestrator.description}
-                          </span>
-                        )}
-                      </div>
-                      <span className='text-xs text-neutral-400 dark:text-neutral-500'>
-                        {orchestrator.devices.length} device{orchestrator.devices.length !== 1 ? 's' : ''}
-                      </span>
-                    </div>
-
-                    {isExpanded && hasDevices && (
-                      <div className='border-t border-neutral-200 dark:border-neutral-700'>
-                        {orchestrator.devices.map((device) => {
-                          const isSelected =
-                            selectedDevice?.orchestratorId === orchestrator.id && selectedDevice?.deviceId === device.id
-                          const isConnected =
-                            runtimeConnection.connectionStatus === 'connected' &&
-                            runtimeConnection.selectedDevice?.deviceId === device.id
-                          const isInactive = device.active === false
-                          const isHighlighted = !isInactive && (isSelected || isConnected)
-
-                          return (
-                            <div
-                              key={device.id}
-                              className={cn(
-                                'flex items-center gap-3 px-4 py-2 pl-10',
-                                isInactive && 'cursor-not-allowed opacity-60',
-                                !isInactive &&
-                                  !isHighlighted &&
-                                  'cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-800',
-                                isHighlighted && 'cursor-pointer bg-neutral-100 dark:bg-neutral-800',
-                              )}
-                              onClick={() =>
-                                handleDeviceSelect(
-                                  orchestrator.id,
-                                  orchestrator.agentId,
-                                  device.id,
-                                  device.name,
-                                  device.active !== false,
-                                )
-                              }
-                            >
-                              <span className='flex-1 text-sm text-neutral-800 dark:text-neutral-200'>
-                                {device.name}
-                              </span>
-                              <StatusBadge status={device.status} />
-                              {isConnected && (
-                                <span className='text-xs font-medium text-green-600 dark:text-green-400'>
-                                  Connected
-                                </span>
-                              )}
-                            </div>
-                          )
-                        })}
-                      </div>
-                    )}
-                  </div>
-                )
-              })}
-            </div>
-          )}
-
-          {selectedDevice && (
+            {/* Simulator option — always visible */}
             <div
-              id='connection-actions'
-              className='mt-4 flex flex-col gap-2 border-t border-neutral-200 pt-4 dark:border-neutral-700'
+              className={cn(
+                'cursor-pointer rounded-lg border px-4 py-3',
+                isSimulatorSelected && runtimeConnection.connectionStatus !== 'connected'
+                  ? 'bg-brand/5 dark:bg-brand/10 border-brand dark:border-brand'
+                  : 'border-neutral-200 bg-neutral-50 hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:bg-neutral-800',
+              )}
+              onClick={handleSimulatorSelect}
             >
-              <div className='flex items-center gap-4'>
-                {runtimeConnection.connectionStatus === 'connected' ? (
-                  <button
-                    type='button'
-                    onClick={() => void handleDisconnect()}
-                    disabled={isDisconnecting}
-                    className={cn(
-                      'h-[30px] rounded-md bg-brand px-4 py-1 font-caption text-cp-sm font-medium text-white hover:bg-brand-medium-dark',
-                      isDisconnecting && 'cursor-not-allowed opacity-50',
-                    )}
-                  >
-                    {isDisconnecting ? 'Disconnecting...' : 'Disconnect'}
-                  </button>
-                ) : (
-                  <button
-                    type='button'
-                    onClick={() => void handleConnect()}
-                    disabled={isConnecting}
-                    className={cn(
-                      'h-[30px] rounded-md bg-brand px-4 py-1 font-caption text-cp-sm font-medium text-white hover:bg-brand-medium-dark',
-                      isConnecting && 'cursor-not-allowed opacity-50',
-                    )}
-                  >
-                    {isConnecting ? 'Connecting...' : 'Connect'}
-                  </button>
-                )}
-              </div>
-              {runtimeConnection.connectionStatus === 'connected' && runtimeConnection.plcStatus && (
-                <div className='flex items-center gap-2'>
-                  <span className='text-xs text-neutral-500 dark:text-neutral-400'>PLC Status:</span>
-                  <span
-                    className={cn(
-                      'text-xs font-medium',
-                      runtimeConnection.plcStatus === 'RUNNING' && 'text-green-600 dark:text-green-400',
-                      runtimeConnection.plcStatus === 'STOPPED' && 'text-red-600 dark:text-red-400',
-                      runtimeConnection.plcStatus === 'EMPTY' && 'text-yellow-600 dark:text-yellow-400',
-                      runtimeConnection.plcStatus === 'INIT' && 'text-blue-600 dark:text-blue-400',
-                      runtimeConnection.plcStatus === 'ERROR' && 'text-red-600 dark:text-red-400',
-                      runtimeConnection.plcStatus === 'UNKNOWN' && 'text-neutral-500 dark:text-neutral-400',
-                    )}
-                  >
-                    {runtimeConnection.plcStatus}
+              <div className='flex items-center justify-between'>
+                <div className='flex flex-col'>
+                  <span className='text-sm font-medium text-neutral-900 dark:text-white'>OpenPLC Simulator</span>
+                  <span className='text-xs text-neutral-500 dark:text-neutral-400'>
+                    Built-in simulator — no hardware required
                   </span>
                 </div>
-              )}
-              {connectionError && <p className='text-sm text-red-600 dark:text-red-400'>{connectionError}</p>}
-            </div>
-          )}
-
-          {/* Device Switch Confirmation Modal */}
-          <Modal open={showSwitchConfirmModal} onOpenChange={setShowSwitchConfirmModal}>
-            <ModalContent className='flex h-[320px] w-[400px] select-none flex-col items-center justify-evenly rounded-lg'>
-              <ModalTitle className='hidden'>Switch Device</ModalTitle>
-              <div className='flex select-none flex-col items-center gap-6 p-4'>
-                <WarningIcon className='h-[60px] w-[60px]' />
-                <div className='text-center'>
-                  <p className='text-sm font-medium text-neutral-900 dark:text-neutral-100'>
-                    You are currently connected to <strong>{runtimeConnection.selectedDevice?.deviceName}</strong>.
-                  </p>
-                  <p className='mt-2 text-sm text-neutral-600 dark:text-neutral-400'>
-                    To connect to <strong>{pendingDeviceSwitch?.deviceName}</strong>, you must disconnect from the
-                    current device first.
-                  </p>
-                </div>
-
-                <div className='flex w-full flex-col gap-2'>
-                  <button
-                    onClick={() => void handleConfirmDeviceSwitch()}
-                    className='w-full rounded-lg bg-brand px-4 py-2 text-center text-sm font-medium text-white hover:bg-brand-medium-dark'
-                  >
-                    Disconnect and Switch
-                  </button>
-                  <button
-                    onClick={handleCancelDeviceSwitch}
-                    className='w-full rounded-lg bg-neutral-100 px-4 py-2 text-center text-sm font-medium text-neutral-1000 hover:bg-neutral-200 dark:bg-neutral-850 dark:text-neutral-100'
-                  >
-                    Cancel
-                  </button>
-                </div>
+                {isSimulatorSelected && runtimeConnection.connectionStatus !== 'connected' && (
+                  <span className='inline-flex items-center rounded px-2 py-0.5 text-xs font-medium text-brand'>
+                    Selected
+                  </span>
+                )}
               </div>
-            </ModalContent>
-          </Modal>
-        </div>
-      </DeviceEditorSlot>
+            </div>
 
-      {/* Right side panel - Scan Cycle + EtherCAT + plugin-contributed
+            {loading && (
+              <div className='flex items-center justify-center py-8'>
+                <p className='text-sm text-neutral-500 dark:text-neutral-400'>Loading orchestrators...</p>
+              </div>
+            )}
+
+            {error && (
+              <div className='rounded-md bg-red-50 p-4 dark:bg-red-900/20'>
+                <p className='text-sm text-red-600 dark:text-red-400'>{error}</p>
+              </div>
+            )}
+
+            {!loading && !error && orchestrators.length === 0 && (
+              <div className='flex flex-col items-center justify-center gap-2 py-8'>
+                <p className='text-sm text-neutral-500 dark:text-neutral-400'>No orchestrators found.</p>
+                <p className='text-xs text-neutral-400 dark:text-neutral-500'>
+                  Register an orchestrator in the Autonomy Edge platform to see it here.
+                </p>
+              </div>
+            )}
+
+            {!loading && !error && orchestrators.length > 0 && (
+              <div id='orchestrators-list' className='flex flex-col gap-2'>
+                {orchestrators.map((orchestrator) => {
+                  const isExpanded = expandedOrchestrators.has(orchestrator.id)
+                  const hasDevices = orchestrator.devices.length > 0
+
+                  return (
+                    <div
+                      key={orchestrator.id}
+                      className='rounded-lg border border-neutral-200 bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900'
+                    >
+                      <div
+                        className={cn(
+                          'flex cursor-pointer items-center gap-2 px-4 py-3',
+                          hasDevices && 'hover:bg-neutral-100 dark:hover:bg-neutral-800',
+                        )}
+                        onClick={() => hasDevices && toggleOrchestratorExpanded(orchestrator.id)}
+                      >
+                        {hasDevices ? (
+                          <ArrowIcon
+                            direction='right'
+                            className={cn(
+                              'h-4 w-4 stroke-neutral-500 transition-transform dark:stroke-neutral-400',
+                              isExpanded && 'rotate-90',
+                            )}
+                          />
+                        ) : (
+                          <div className='h-4 w-4' />
+                        )}
+                        <div className='flex flex-1 flex-col'>
+                          <span className='text-sm font-medium text-neutral-900 dark:text-white'>
+                            {orchestrator.name}
+                          </span>
+                          {orchestrator.description && (
+                            <span className='text-xs text-neutral-500 dark:text-neutral-400'>
+                              {orchestrator.description}
+                            </span>
+                          )}
+                        </div>
+                        <span className='text-xs text-neutral-400 dark:text-neutral-500'>
+                          {orchestrator.devices.length} device{orchestrator.devices.length !== 1 ? 's' : ''}
+                        </span>
+                      </div>
+
+                      {isExpanded && hasDevices && (
+                        <div className='border-t border-neutral-200 dark:border-neutral-700'>
+                          {orchestrator.devices.map((device) => {
+                            const isSelected =
+                              selectedDevice?.orchestratorId === orchestrator.id &&
+                              selectedDevice?.deviceId === device.id
+                            const isConnected =
+                              runtimeConnection.connectionStatus === 'connected' &&
+                              runtimeConnection.selectedDevice?.deviceId === device.id
+                            const isInactive = device.active === false
+                            const isHighlighted = !isInactive && (isSelected || isConnected)
+
+                            return (
+                              <div
+                                key={device.id}
+                                className={cn(
+                                  'flex items-center gap-3 px-4 py-2 pl-10',
+                                  isInactive && 'cursor-not-allowed opacity-60',
+                                  !isInactive &&
+                                    !isHighlighted &&
+                                    'cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-800',
+                                  isHighlighted && 'cursor-pointer bg-neutral-100 dark:bg-neutral-800',
+                                )}
+                                onClick={() =>
+                                  handleDeviceSelect(
+                                    orchestrator.id,
+                                    orchestrator.agentId,
+                                    device.id,
+                                    device.name,
+                                    device.active !== false,
+                                  )
+                                }
+                              >
+                                <span className='flex-1 text-sm text-neutral-800 dark:text-neutral-200'>
+                                  {device.name}
+                                </span>
+                                <StatusBadge status={device.status} />
+                                {isConnected && (
+                                  <span className='text-xs font-medium text-green-600 dark:text-green-400'>
+                                    Connected
+                                  </span>
+                                )}
+                              </div>
+                            )
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+
+            {selectedDevice && (
+              <div
+                id='connection-actions'
+                className='mt-4 flex flex-col gap-2 border-t border-neutral-200 pt-4 dark:border-neutral-700'
+              >
+                <div className='flex items-center gap-4'>
+                  {runtimeConnection.connectionStatus === 'connected' ? (
+                    <button
+                      type='button'
+                      onClick={() => void handleDisconnect()}
+                      disabled={isDisconnecting}
+                      className={cn(
+                        'h-[30px] rounded-md bg-brand px-4 py-1 font-caption text-cp-sm font-medium text-white hover:bg-brand-medium-dark',
+                        isDisconnecting && 'cursor-not-allowed opacity-50',
+                      )}
+                    >
+                      {isDisconnecting ? 'Disconnecting...' : 'Disconnect'}
+                    </button>
+                  ) : (
+                    <button
+                      type='button'
+                      onClick={() => void handleConnect()}
+                      disabled={isConnecting}
+                      className={cn(
+                        'h-[30px] rounded-md bg-brand px-4 py-1 font-caption text-cp-sm font-medium text-white hover:bg-brand-medium-dark',
+                        isConnecting && 'cursor-not-allowed opacity-50',
+                      )}
+                    >
+                      {isConnecting ? 'Connecting...' : 'Connect'}
+                    </button>
+                  )}
+                </div>
+                {runtimeConnection.connectionStatus === 'connected' && runtimeConnection.plcStatus && (
+                  <div className='flex items-center gap-2'>
+                    <span className='text-xs text-neutral-500 dark:text-neutral-400'>PLC Status:</span>
+                    <span
+                      className={cn(
+                        'text-xs font-medium',
+                        runtimeConnection.plcStatus === 'RUNNING' && 'text-green-600 dark:text-green-400',
+                        runtimeConnection.plcStatus === 'STOPPED' && 'text-red-600 dark:text-red-400',
+                        runtimeConnection.plcStatus === 'EMPTY' && 'text-yellow-600 dark:text-yellow-400',
+                        runtimeConnection.plcStatus === 'INIT' && 'text-blue-600 dark:text-blue-400',
+                        runtimeConnection.plcStatus === 'ERROR' && 'text-red-600 dark:text-red-400',
+                        runtimeConnection.plcStatus === 'UNKNOWN' && 'text-neutral-500 dark:text-neutral-400',
+                      )}
+                    >
+                      {runtimeConnection.plcStatus}
+                    </span>
+                  </div>
+                )}
+                {connectionError && <p className='text-sm text-red-600 dark:text-red-400'>{connectionError}</p>}
+              </div>
+            )}
+
+            {/* Device Switch Confirmation Modal */}
+            <Modal open={showSwitchConfirmModal} onOpenChange={setShowSwitchConfirmModal}>
+              <ModalContent className='flex h-[320px] w-[400px] select-none flex-col items-center justify-evenly rounded-lg'>
+                <ModalTitle className='hidden'>Switch Device</ModalTitle>
+                <div className='flex select-none flex-col items-center gap-6 p-4'>
+                  <WarningIcon className='h-[60px] w-[60px]' />
+                  <div className='text-center'>
+                    <p className='text-sm font-medium text-neutral-900 dark:text-neutral-100'>
+                      You are currently connected to <strong>{runtimeConnection.selectedDevice?.deviceName}</strong>.
+                    </p>
+                    <p className='mt-2 text-sm text-neutral-600 dark:text-neutral-400'>
+                      To connect to <strong>{pendingDeviceSwitch?.deviceName}</strong>, you must disconnect from the
+                      current device first.
+                    </p>
+                  </div>
+
+                  <div className='flex w-full flex-col gap-2'>
+                    <button
+                      onClick={() => void handleConfirmDeviceSwitch()}
+                      className='w-full rounded-lg bg-brand px-4 py-2 text-center text-sm font-medium text-white hover:bg-brand-medium-dark'
+                    >
+                      Disconnect and Switch
+                    </button>
+                    <button
+                      onClick={handleCancelDeviceSwitch}
+                      className='w-full rounded-lg bg-neutral-100 px-4 py-2 text-center text-sm font-medium text-neutral-1000 hover:bg-neutral-200 dark:bg-neutral-850 dark:text-neutral-100'
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </ModalContent>
+            </Modal>
+          </div>
+        </DeviceEditorSlot>
+      </div>
+
+      {/* Bottom panel - Scan Cycle + EtherCAT + plugin-contributed
        *  statistics. Mirrors the board screen's stats panel: same
        *  components, same TimingStats shape, same plugin_stats fan-out.
        *  Web builds (orchestrator-driven) and Electron builds (board-
@@ -596,7 +599,7 @@ const OrchestratorsList = () => {
       {runtimeConnection.connectionStatus === 'connected' && (
         <div
           id='scan-cycle-stats-panel'
-          className='flex h-full w-1/2 flex-col gap-6 overflow-y-auto overflow-x-hidden p-4 lg:px-8 lg:py-4'
+          className='flex w-full shrink-0 flex-col gap-6 overflow-y-auto overflow-x-hidden p-4 lg:px-8 lg:py-4'
         >
           {runtimeConnection.timingStats && <ScanCycleStats timingStats={runtimeConnection.timingStats} />}
           <EtherCATStats />


### PR DESCRIPTION
## Summary
- Byte-identical mirror of João's web-side fix ([openplc-web `d17778a8`](https://github.com/Autonomy-Logic/openplc-web/commit/d17778a8), 2026-05-26): stack Scan Cycle / EtherCAT stats panels below the Device Orchestrators list instead of in a cramped right-side column.
- Closes the one-file byte-identity drift between editor's and web's `origin/development` on the shared `orchestrators-list.tsx`.

## Test plan
- [ ] CI byte-identity check (`compare-surfaces.py`) passes — file now matches web's `origin/development`
- [ ] No runtime regression: open a project with multiple orchestrators on desktop, confirm the stats panels render stacked under the orchestrators list (not side-by-side) and the orchestrators list keeps full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Restructured orchestrators editor layout to optimize the statistics panel display and improve overall space utilization in the connected view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autonomy-Logic/openplc-editor/pull/784?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->