### PR TITLE
fix: STruC++ LSP regressions + FBD drag + xml2st-parity vars-text

### DIFF
--- a/src/backend/shared/library/__tests__/program-build-helpers.test.ts
+++ b/src/backend/shared/library/__tests__/program-build-helpers.test.ts
@@ -282,9 +282,7 @@ describe('enrichErrorWithPouContext', () => {
     // the header still needs section/bodyLine — otherwise body errors
     // here would slip through as untagged and the hook would only open
     // the tab without moving the cursor.
-    const perPou = new Map([
-      ['noop.st', ['FUNCTION_BLOCK NOOP', '  ;', 'END_FUNCTION_BLOCK'].join('\n')],
-    ])
+    const perPou = new Map([['noop.st', ['FUNCTION_BLOCK NOOP', '  ;', 'END_FUNCTION_BLOCK'].join('\n')]])
     const pous: KnownPou[] = [{ name: 'NOOP', kind: 'FUNCTION_BLOCK', language: 'st' }]
     const err: StrucppCompileError = { ...baseError, file: 'noop.st', line: 2 }
     const enriched = enrichErrorWithPouContext(err, pous, perPou)
@@ -309,7 +307,10 @@ describe('enrichErrorWithPouContext', () => {
     // no filename, but defensively: an err.file with line === 0
     // shouldn't divide by section either.
     const perPou = new Map([
-      ['cvavava.st', ['FUNCTION_BLOCK CVAVAVA', 'VAR', '  X : INT;', 'END_VAR', '  ;', 'END_FUNCTION_BLOCK'].join('\n')],
+      [
+        'cvavava.st',
+        ['FUNCTION_BLOCK CVAVAVA', 'VAR', '  X : INT;', 'END_VAR', '  ;', 'END_FUNCTION_BLOCK'].join('\n'),
+      ],
     ])
     const err: StrucppCompileError = { ...baseError, file: 'cvavava.st', line: 0 }
     const enriched = enrichErrorWithPouContext(err, knownPous, perPou)

--- a/src/backend/shared/library/__tests__/program-build-helpers.test.ts
+++ b/src/backend/shared/library/__tests__/program-build-helpers.test.ts
@@ -12,7 +12,8 @@
 import type * as strucpp from 'strucpp'
 
 import type { PLCPou } from '../../types/PLC/open-plc'
-import { buildKnownPous, formatErrorWithPouContext } from '../program-build-helpers'
+import type { KnownPou } from '../../utils/PLC/split-program-st'
+import { buildKnownPous, enrichErrorWithPouContext, formatErrorWithPouContext } from '../program-build-helpers'
 
 type StrucppCompileError = strucpp.CompileError
 type StrucppFormatDiagnostic = typeof strucpp.formatDiagnostic
@@ -154,5 +155,165 @@ describe('formatErrorWithPouContext', () => {
     const spy = jest.fn<string, Parameters<StrucppFormatDiagnostic>>(() => '<stub>')
     formatErrorWithPouContext(baseError, spy as unknown as StrucppFormatDiagnostic, fakeSourceMap)
     expect(spy).toHaveBeenCalledWith(baseError, fakeSourceMap, { preferBodyLine: true })
+  })
+})
+
+describe('enrichErrorWithPouContext', () => {
+  const knownPous: KnownPou[] = [
+    { name: 'CVAVAVA', kind: 'FUNCTION_BLOCK', language: 'st' },
+    { name: 'Main', kind: 'PROGRAM', language: 'st' },
+  ]
+
+  it('returns the error unchanged when pouName is already set', () => {
+    // The semantic annotation pass has already attached context — the
+    // enricher must not clobber strucpp's own attribution.
+    const err: StrucppCompileError = { ...baseError, file: 'cvavava.st', line: 12, pouName: 'OTHER' }
+    expect(enrichErrorWithPouContext(err, knownPous)).toBe(err)
+  })
+
+  it('returns the error unchanged when no filename is available', () => {
+    // Errors from the synthetic _types.st / _config.st sections or the
+    // pre-compile gate have no file — enrichment cannot guess.
+    const err: StrucppCompileError = { ...baseError, line: 0 }
+    expect(enrichErrorWithPouContext(err, knownPous)).toBe(err)
+  })
+
+  it('returns the error unchanged when the filename matches no known POU', () => {
+    // A stray `.st` file that isn't one of the project's POUs (or a
+    // typo in strucpp's filename plumbing) — we don't fabricate a
+    // pouName because the navigation lookup would silently fail anyway.
+    const err: StrucppCompileError = { ...baseError, file: 'ghost.st', line: 1 }
+    expect(enrichErrorWithPouContext(err, knownPous)).toBe(err)
+  })
+
+  it('populates pouName + pouKind from the filename (case-insensitive)', () => {
+    // The reported regression: strucpp's parse-error path emits
+    // `cvavava.st:12:3` with no pouName, the editor's hook bails at
+    // `if (!err.pouName) return`, and the click does nothing.  The
+    // enricher must turn the lowercase filename into the canonical
+    // project name so the lookup hits.
+    const err: StrucppCompileError = { ...baseError, file: 'cvavava.st', line: 1 }
+    const enriched = enrichErrorWithPouContext(err, knownPous)
+    expect(enriched.pouName).toBe('CVAVAVA')
+    expect(enriched.pouKind).toBe('FUNCTION_BLOCK')
+  })
+
+  it('tags errors above the last END_VAR as `var-block`', () => {
+    // Parse errors inside a VAR block — the user's `TON0 : TON;`
+    // repro — should route the navigation hook into the variables
+    // panel, not the body view.
+    const perPou = new Map([
+      [
+        'cvavava.st',
+        ['FUNCTION_BLOCK CVAVAVA', 'VAR', '  TON0 : TON;', 'END_VAR', '  ;', 'END_FUNCTION_BLOCK'].join('\n'),
+      ],
+    ])
+    const err: StrucppCompileError = { ...baseError, file: 'cvavava.st', line: 3 }
+    const enriched = enrichErrorWithPouContext(err, knownPous, perPou)
+    expect(enriched.section).toBe('var-block')
+    expect(enriched.bodyLine).toBeUndefined()
+  })
+
+  it('tags errors at or after the body boundary as `body` with bodyLine remapped', () => {
+    // First body statement sits on per-POU line 5; the editor's body
+    // Monaco view shows that as line 1.  Verify the offset math.
+    const perPou = new Map([
+      [
+        'cvavava.st',
+        ['FUNCTION_BLOCK CVAVAVA', 'VAR', '  X : INT;', 'END_VAR', '  X := X + 1;', 'END_FUNCTION_BLOCK'].join('\n'),
+      ],
+    ])
+    const err: StrucppCompileError = { ...baseError, file: 'cvavava.st', line: 5 }
+    const enriched = enrichErrorWithPouContext(err, knownPous, perPou)
+    expect(enriched.section).toBe('body')
+    expect(enriched.bodyLine).toBe(1)
+  })
+
+  it('skips blank separator lines between END_VAR and the body', () => {
+    // The ST generators (`pou-text-serializer.ts` and xml2st on the
+    // compile path) insert blank lines after END_VAR for readability.
+    // Those blanks live in the per-POU file the splitter feeds
+    // strucpp but NOT in `pou.body.value`, which is what the body
+    // Monaco editor renders.  Treating the blank as bodyLine 1 used
+    // to shift the cursor one line past the editor's actual line
+    // count and crash `getLineMaxColumn`.  The enricher must look
+    // through the blank(s) to find the first real body line.
+    const perPou = new Map([
+      [
+        'cvavava.st',
+        [
+          'FUNCTION_BLOCK CVAVAVA', // 1 — header
+          'VAR', // 2
+          '  X : INT;', // 3
+          'END_VAR', // 4
+          '', // 5 — blank separator
+          '  X := X + 1;', // 6 — first body line
+          'END_FUNCTION_BLOCK', // 7
+        ].join('\n'),
+      ],
+    ])
+    const err: StrucppCompileError = { ...baseError, file: 'cvavava.st', line: 6 }
+    const enriched = enrichErrorWithPouContext(err, knownPous, perPou)
+    expect(enriched.section).toBe('body')
+    expect(enriched.bodyLine).toBe(1)
+  })
+
+  it('looks up the per-POU file case-insensitively', () => {
+    // Strucpp echoes the filename it was handed at compile time —
+    // case can differ from the splitter's map key (the project may
+    // store POU names in any case the user typed).  Without the
+    // case-insensitive lookup, `perPouSources.get(err.file)` returns
+    // undefined and section/bodyLine never get populated even though
+    // the file content is right there.
+    const perPou = new Map([
+      [
+        'CVAVAVA.st',
+        ['FUNCTION_BLOCK CVAVAVA', 'VAR', '  X : INT;', 'END_VAR', '  X := X + 1;', 'END_FUNCTION_BLOCK'].join('\n'),
+      ],
+    ])
+    const err: StrucppCompileError = { ...baseError, file: 'cvavava.st', line: 5 }
+    const enriched = enrichErrorWithPouContext(err, knownPous, perPou)
+    expect(enriched.section).toBe('body')
+    expect(enriched.bodyLine).toBe(1)
+  })
+
+  it('handles POUs without any var blocks (body starts at line 2)', () => {
+    // A FUNCTION_BLOCK whose first body statement lives directly under
+    // the header still needs section/bodyLine — otherwise body errors
+    // here would slip through as untagged and the hook would only open
+    // the tab without moving the cursor.
+    const perPou = new Map([
+      ['noop.st', ['FUNCTION_BLOCK NOOP', '  ;', 'END_FUNCTION_BLOCK'].join('\n')],
+    ])
+    const pous: KnownPou[] = [{ name: 'NOOP', kind: 'FUNCTION_BLOCK', language: 'st' }]
+    const err: StrucppCompileError = { ...baseError, file: 'noop.st', line: 2 }
+    const enriched = enrichErrorWithPouContext(err, pous, perPou)
+    expect(enriched.section).toBe('body')
+    expect(enriched.bodyLine).toBe(1)
+  })
+
+  it('skips section tagging when the per-POU source map is not provided', () => {
+    // Pipeline runs in monolithic-fallback (splitter bailed) skip the
+    // source map entirely.  pouName still gets derived from the
+    // filename — the click opens the tab — but section/bodyLine stay
+    // undefined so the hook's "open tab, no cursor jump" branch fires.
+    const err: StrucppCompileError = { ...baseError, file: 'cvavava.st', line: 3 }
+    const enriched = enrichErrorWithPouContext(err, knownPous)
+    expect(enriched.pouName).toBe('CVAVAVA')
+    expect(enriched.section).toBeUndefined()
+    expect(enriched.bodyLine).toBeUndefined()
+  })
+
+  it('skips section tagging when err.line is 0 (no source location)', () => {
+    // Pre-compile gate errors (missing libraries) carry line: 0 with
+    // no filename, but defensively: an err.file with line === 0
+    // shouldn't divide by section either.
+    const perPou = new Map([
+      ['cvavava.st', ['FUNCTION_BLOCK CVAVAVA', 'VAR', '  X : INT;', 'END_VAR', '  ;', 'END_FUNCTION_BLOCK'].join('\n')],
+    ])
+    const err: StrucppCompileError = { ...baseError, file: 'cvavava.st', line: 0 }
+    const enriched = enrichErrorWithPouContext(err, knownPous, perPou)
+    expect(enriched.pouName).toBe('CVAVAVA')
+    expect(enriched.section).toBeUndefined()
   })
 })

--- a/src/backend/shared/library/program-build-helpers.ts
+++ b/src/backend/shared/library/program-build-helpers.ts
@@ -60,6 +60,89 @@ export function buildKnownPous(pous: PLCPou[]): KnownPou[] {
  * new fields are populated (e.g. errors in synthetic _types.st /
  * _config.st sections, or before the splitter ran).
  */
+/**
+ * Strucpp populates `pouName` / `section` / `bodyLine` on errors during
+ * its semantic annotation pass.  Parse errors short-circuit that pass:
+ * they ship with `file` (the per-POU `.st` filename) and `line`/`column`,
+ * but no POU context — so both the editor's bracketed click target
+ * (rendered from `formatErrorWithPouContext`) and the navigation hook's
+ * `pouName` lookup (see `use-navigate-to-compile-error.ts`) lose their
+ * anchor and clicking the diagnostic becomes a no-op.
+ *
+ * Derive the missing fields from the filename + per-POU source:
+ *   - `pouName` / `pouKind` come from matching `err.file` against the
+ *     project's known POUs (case-insensitive — strucpp uppercases per
+ *     IEC).
+ *   - `section` / `bodyLine` come from scanning the synthetic per-POU
+ *     `.st` text the splitter handed strucpp.  Body starts on the line
+ *     after the last `END_VAR` (or line 2 when the POU has no var
+ *     blocks).  Errors before that boundary are tagged `'var-block'`;
+ *     errors at/after it are `'body'` with the offset remapped to the
+ *     body view's 1-indexed numbering.
+ *
+ * Returns the error unchanged when there's nothing useful to add
+ * (already enriched, no filename, or no matching POU).
+ */
+export function enrichErrorWithPouContext(
+  err: StrucppCompileError,
+  pous: KnownPou[],
+  perPouSources?: Map<string, string>,
+): StrucppCompileError {
+  if (err.pouName) return err
+  if (!err.file) return err
+  const baseName = err.file.replace(/\.st$/i, '')
+  const pou = pous.find((p) => p.name.toLowerCase() === baseName.toLowerCase())
+  if (!pou) return err
+
+  const enriched: StrucppCompileError = { ...err, pouName: pou.name, pouKind: pou.kind }
+
+  // Case-insensitive filename lookup: strucpp may emit `cvavava.st`
+  // (lowercase) while the splitter keyed the map by the project's
+  // canonical casing.  Matching pouName already normalised via the
+  // pou table lookup above, but the per-POU file map is keyed by the
+  // filename string strucpp can echo back in any case the user
+  // originally typed.
+  let source: string | undefined
+  if (perPouSources) {
+    const targetKey = err.file.toLowerCase()
+    for (const [key, value] of perPouSources) {
+      if (key.toLowerCase() === targetKey) {
+        source = value
+        break
+      }
+    }
+  }
+  if (source && err.line > 0) {
+    const lines = source.split('\n')
+    let lastEndVar = -1
+    for (let i = 0; i < lines.length; i++) {
+      if (/^\s*END_VAR\b/i.test(lines[i])) lastEndVar = i + 1 // 1-indexed
+    }
+    // Body starts after the last END_VAR, but the ST generator
+    // (`pou-text-serializer.ts` and xml2st on the compile path)
+    // inserts blank separator lines between END_VAR and the body
+    // content.  Those blank lines exist in the per-POU file the
+    // splitter handed strucpp but NOT in `pou.body.value`, which is
+    // what the body Monaco editor renders.  Counting them shifts
+    // bodyLine past the editor's actual line count and used to
+    // surface as `BugIndicatingError: Illegal value for lineNumber`
+    // from `getLineMaxColumn` on click-to-navigate.  Scan past any
+    // consecutive blank lines to land on the first real body line.
+    let bodyStart = lastEndVar > 0 ? lastEndVar + 1 : 2
+    while (bodyStart <= lines.length && /^\s*$/.test(lines[bodyStart - 1])) {
+      bodyStart++
+    }
+    if (err.line >= bodyStart) {
+      enriched.section = 'body'
+      enriched.bodyLine = err.line - bodyStart + 1
+    } else if (err.line >= 2) {
+      enriched.section = 'var-block'
+    }
+  }
+
+  return enriched
+}
+
 export function formatErrorWithPouContext(
   err: StrucppCompileError,
   formatDiagnostic: StrucppFormatDiagnostic,

--- a/src/backend/shared/library/program-build-pipeline.ts
+++ b/src/backend/shared/library/program-build-pipeline.ts
@@ -37,7 +37,7 @@ import type * as strucpp from 'strucpp'
 
 import type { KnownPou } from '../utils/PLC/split-program-st'
 import { splitProgramSt } from '../utils/PLC/split-program-st'
-import { formatErrorWithPouContext } from './program-build-helpers'
+import { enrichErrorWithPouContext, formatErrorWithPouContext } from './program-build-helpers'
 import { loadStrucpp } from './strucpp-runtime'
 
 type StrucppCompileError = strucpp.CompileError
@@ -196,18 +196,32 @@ export function runProgramBuildPipeline(opts: ProgramBuildPipelineOptions): Prog
     : [{ fileName: stFileName, source }]
   const diagSourceMap = strucppBuildSourceMap(diagFiles)
 
+  // Per-POU file map so the error enricher can locate `END_VAR` and
+  // remap parse-error line numbers into the editor's body / var-block
+  // sections.  Only meaningful when the splitter ran — monolithic
+  // fallback skips enrichment, which is fine because the only
+  // available filename there is `program.st` and there's no per-POU
+  // segmentation to remap into.
+  const perPouSources = split ? split.files : undefined
+
   if (!result.success) {
     return {
       success: false,
       files: [],
-      errors: result.errors.map((err) => ({
-        formatted: formatErrorWithPouContext(err, strucppFormatDiagnostic, diagSourceMap),
-        raw: err,
-      })),
-      warnings: result.warnings.map((warn) => ({
-        formatted: formatErrorWithPouContext(warn, strucppFormatDiagnostic, diagSourceMap),
-        raw: warn,
-      })),
+      errors: result.errors.map((err) => {
+        const enriched = enrichErrorWithPouContext(err, pous, perPouSources)
+        return {
+          formatted: formatErrorWithPouContext(enriched, strucppFormatDiagnostic, diagSourceMap),
+          raw: enriched,
+        }
+      }),
+      warnings: result.warnings.map((warn) => {
+        const enriched = enrichErrorWithPouContext(warn, pous, perPouSources)
+        return {
+          formatted: formatErrorWithPouContext(enriched, strucppFormatDiagnostic, diagSourceMap),
+          raw: enriched,
+        }
+      }),
       md5Hash: md5,
       splitterFallbackMessage,
       debugMapSummary: null,
@@ -263,10 +277,13 @@ export function runProgramBuildPipeline(opts: ProgramBuildPipelineOptions): Prog
     success: true,
     files,
     errors: [],
-    warnings: result.warnings.map((warn) => ({
-      formatted: formatErrorWithPouContext(warn, strucppFormatDiagnostic, diagSourceMap),
-      raw: warn,
-    })),
+    warnings: result.warnings.map((warn) => {
+      const enriched = enrichErrorWithPouContext(warn, pous, perPouSources)
+      return {
+        formatted: formatErrorWithPouContext(enriched, strucppFormatDiagnostic, diagSourceMap),
+        raw: enriched,
+      }
+    }),
     md5Hash: md5,
     splitterFallbackMessage,
     debugMapSummary,

--- a/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
@@ -461,8 +461,21 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
     // doesn't carry an end-column we'd rather show "this whole line
     // is the problem" than land an invisible caret somewhere mid-line.
     const model = ed.getModel()
-    const lineLength = model ? model.getLineMaxColumn(target.lineNumber) : target.column
-    const range = new monacoInst.Range(target.lineNumber, 1, target.lineNumber, lineLength)
+    // Clamp to the model's valid line range.  `getLineMaxColumn` and
+    // `Range` both throw `BugIndicatingError: Illegal value for
+    // lineNumber` when lineNumber < 1 or > getLineCount(), and a
+    // compile-error click for a POU whose Monaco model is empty
+    // (freshly opened tab) or whose body line count is smaller than
+    // strucpp's reported line would otherwise propagate that throw
+    // through React's commit phase and unmount the editor.
+    const safeLine = model ? Math.max(1, Math.min(model.getLineCount(), target.lineNumber)) : target.lineNumber
+    if (model && safeLine !== target.lineNumber) {
+      console.warn(
+        `[monaco] cursor target line ${target.lineNumber} out of range (model has ${model.getLineCount()} lines); clamped to ${safeLine}`,
+      )
+    }
+    const lineLength = model ? model.getLineMaxColumn(safeLine) : target.column
+    const range = new monacoInst.Range(safeLine, 1, safeLine, lineLength)
     ed.setSelection(range)
     ed.revealRangeInCenter(range)
     ed.focus()
@@ -891,15 +904,18 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
       // Definition or compile-error click that fired before this
       // editor's mount completed).  The reactive useEffect above
       // handles subsequent jumps on the already-mounted editor.
+      // Same clamp as the reactive path — see the comment there.
       const monacoInst = monacoInstance
       const model = editorInstance.getModel()
-      const lineLength = model ? model.getLineMaxColumn(editor.cursorPosition.lineNumber) : editor.cursorPosition.column
-      const range = new monacoInst.Range(
-        editor.cursorPosition.lineNumber,
-        1,
-        editor.cursorPosition.lineNumber,
-        lineLength,
-      )
+      const targetLine = editor.cursorPosition.lineNumber
+      const safeLine = model ? Math.max(1, Math.min(model.getLineCount(), targetLine)) : targetLine
+      if (model && safeLine !== targetLine) {
+        console.warn(
+          `[monaco-mount] cursor target line ${targetLine} out of range (model has ${model.getLineCount()} lines); clamped to ${safeLine}`,
+        )
+      }
+      const lineLength = model ? model.getLineMaxColumn(safeLine) : editor.cursorPosition.column
+      const range = new monacoInst.Range(safeLine, 1, safeLine, lineLength)
       editorInstance.setSelection(range)
       editorInstance.revealRangeInCenter(range)
     }

--- a/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
@@ -840,6 +840,45 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
     focusDisposables.current.onFocus?.dispose()
     focusDisposables.current.onBlur?.dispose()
 
+    // ST POU body editors silently lose plain-Space keystrokes after
+    // the STruC++ LSP completion provider became active in the v4.2.0
+    // RC line.  Symptom: with the suggest widget mounted (visible OR
+    // just tracking — the "active suggest model" state), `onKeyDown`
+    // for Space fires, `defaultPrevented` is false, no built-in
+    // Space binding exists in the editor surface (only Ctrl+Space /
+    // Cmd+Space for trigger-suggest), yet `onDidType(" ")` never
+    // fires and the model stays unchanged.  The break only shows up
+    // when the LSP provider is registered; every other Monaco editor
+    // surface in the app (IL, Python, C++) types space fine because
+    // no LSP provider attaches.  Reproduced cleanly with `if<Space>`
+    // (widget filtering on the keyword list) and inside snippet
+    // placeholders after Tab-accepting a suggestion.
+    //
+    // The fix is byte-equivalent to what Monaco's default Space
+    // dispatch *should* do: invoke the `type` core command with a
+    // single space, and dismiss the suggest widget so it doesn't
+    // dangle.  Binding via `addCommand(KeyCode.Space, …)` registers
+    // an editor-scoped keybinding at the highest user-priority slot;
+    // it never collides with built-in shortcuts because Monaco
+    // reserves Space only with modifiers (Ctrl/Cmd) and only for
+    // trigger-suggest, which still works because that binding lives
+    // at a different chord.  See `node_modules/monaco-editor/esm/vs/
+    // editor/contrib/suggest/browser/suggestController.js:676` for
+    // the only Space-key registration in editor scope.
+    //
+    // Root cause of the upstream interference between the LSP
+    // semantic-tokens / completion-model flow and Monaco's default
+    // type pipeline is still open — left for an upstream Monaco /
+    // strucpp-LSP investigation since the regression sits below the
+    // surface our converters touch (items carry no commitCharacters
+    // and no itemDefaults; the suggestModel just stops dispatching
+    // type for Space).  This binding restores the expected typing
+    // behaviour with zero side effects on other editors.
+    editorInstance.addCommand(monacoInstance.KeyCode.Space, () => {
+      editorInstance.trigger('keyboard', 'type', { text: ' ' })
+      editorInstance.trigger('keyboard', 'hideSuggestWidget', {})
+    })
+
     focusDisposables.current.onFocus = editorInstance.onDidFocusEditorText(() => {
       openPLCStoreBase.getState().editorActions.setMonacoFocused(true)
     })

--- a/src/frontend/components/_molecules/graphical-editor/fbd/index.tsx
+++ b/src/frontend/components/_molecules/graphical-editor/fbd/index.tsx
@@ -678,7 +678,12 @@ export const FBDBody = ({ rung, nodeDivergences = [], isDebuggerActive = false }
 
       handleAddElementByDropping(position, blockType as CustomFbdNodeTypes, library)
     },
-    [rung, reactFlowInstance],
+    // `libraries.user` and `pous` aren't read here, but
+    // `handleAddElementByDropping` captures both — omit them and a
+    // freshly created user FB stays invisible to the memoized closure
+    // until something else forces a re-bind (full project save resets
+    // `rung`, which is why "Save Project" used to mask this).
+    [rung, reactFlowInstance, libraries.user, pous],
   )
 
   /**

--- a/src/frontend/components/_organisms/display-recent-projects/index.tsx
+++ b/src/frontend/components/_organisms/display-recent-projects/index.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps, useEffect, useRef, useState } from 'react'
 
-import { useProject, useSystem } from '../../../../middleware/shared/providers'
+import { useProject } from '../../../../middleware/shared/providers'
 import { useOpenPLCStore } from '../../../store'
 import { File } from '../../_atoms/file'
 import { toast } from '../../_features/[app]/toast/use-toast'
@@ -16,7 +16,6 @@ const DisplayRecentProjects = ({ searchNameFilterValue, ...props }: IDisplayRece
     sharedWorkspaceActions: { handleOpenProjectResponse },
   } = useOpenPLCStore()
 
-  const system = useSystem()
   const project = useProject()
 
   const [recentProjects, setRecentProjects] = useState(recent)
@@ -85,11 +84,12 @@ const DisplayRecentProjects = ({ searchNameFilterValue, ...props }: IDisplayRece
     }
   }, [])
 
+  // Refetch from projects.json (the same source as the initial hydration).
+  // The project service evicts the dead entry on ENOENT before returning,
+  // so this read shows the post-eviction list.
   const updateUserRecentProjects = async () => {
-    const recentList = await system.getStoreValue('recentProjects')
-    if (Array.isArray(recentList)) {
-      setRecent(recentList as typeof recent)
-    }
+    const recentList = await project.getRecentProjects()
+    setRecent(recentList)
   }
 
   const handleOpenProjectByPath = async (projectPath: string) => {

--- a/src/frontend/components/_organisms/variables-code-editor/index.tsx
+++ b/src/frontend/components/_organisms/variables-code-editor/index.tsx
@@ -89,8 +89,21 @@ const VariablesCodeEditor = ({
       return
     }
     const model = ed.getModel()
-    const lineLength = model ? model.getLineMaxColumn(cursorPosition.lineNumber) : cursorPosition.column
-    const range = new monaco.Range(cursorPosition.lineNumber, 1, cursorPosition.lineNumber, lineLength)
+    // Clamp to the model's valid line range so an out-of-bounds cursor
+    // (e.g. a compile-error click whose remapped line points past the
+    // generated vars-text content) lands on the closest valid line
+    // instead of crashing the editor with `BugIndicatingError: Illegal
+    // value for lineNumber` from `getLineMaxColumn` / `Range`.
+    const safeLine = model
+      ? Math.max(1, Math.min(model.getLineCount(), cursorPosition.lineNumber))
+      : cursorPosition.lineNumber
+    if (model && safeLine !== cursorPosition.lineNumber) {
+      console.warn(
+        `[variables-code-editor] cursor target line ${cursorPosition.lineNumber} out of range (model has ${model.getLineCount()} lines); clamped to ${safeLine}`,
+      )
+    }
+    const lineLength = model ? model.getLineMaxColumn(safeLine) : cursorPosition.column
+    const range = new monaco.Range(safeLine, 1, safeLine, lineLength)
     ed.setSelection(range)
     ed.revealRangeInCenter(range)
     ed.focus()

--- a/src/frontend/services/st-lsp/__tests__/boot.test.ts
+++ b/src/frontend/services/st-lsp/__tests__/boot.test.ts
@@ -10,6 +10,7 @@ const startStLsp = jest.fn()
 const attachProjectSync = jest.fn()
 const attachLibrarySync = jest.fn()
 const attachEnabledLibrariesSync = jest.fn()
+const attachBundledLibrariesSync = jest.fn()
 
 jest.mock('../index', () => ({
   startStLsp: (...args: unknown[]) => startStLsp(...args),
@@ -18,6 +19,7 @@ jest.mock('../project-sync', () => ({
   attachProjectSync: (...args: unknown[]) => attachProjectSync(...args),
   attachLibrarySync: (...args: unknown[]) => attachLibrarySync(...args),
   attachEnabledLibrariesSync: (...args: unknown[]) => attachEnabledLibrariesSync(...args),
+  attachBundledLibrariesSync: (...args: unknown[]) => attachBundledLibrariesSync(...args),
 }))
 
 import { bootStLsp } from '../boot'
@@ -42,6 +44,7 @@ beforeEach(() => {
   attachProjectSync.mockReset()
   attachLibrarySync.mockReset()
   attachEnabledLibrariesSync.mockReset()
+  attachBundledLibrariesSync.mockReset()
 
   startStLsp.mockReturnValue({
     ready: Promise.resolve(),
@@ -58,6 +61,7 @@ beforeEach(() => {
   })
   attachLibrarySync.mockReturnValue(jest.fn())
   attachEnabledLibrariesSync.mockReturnValue(jest.fn())
+  attachBundledLibrariesSync.mockReturnValue(jest.fn())
 })
 
 describe('bootStLsp', () => {
@@ -85,6 +89,7 @@ describe('bootStLsp', () => {
     expect(attachProjectSync).toHaveBeenCalledTimes(1)
     expect(attachLibrarySync).toHaveBeenCalledTimes(1)
     expect(attachEnabledLibrariesSync).toHaveBeenCalledTimes(1)
+    expect(attachBundledLibrariesSync).toHaveBeenCalledTimes(1)
   })
 
   it('dispose() tears down every subscription and the service', () => {
@@ -95,22 +100,26 @@ describe('bootStLsp', () => {
     expect(attachProjectSync.mock.results[0].value.dispose).toHaveBeenCalledTimes(1)
     expect(attachLibrarySync.mock.results[0].value).toHaveBeenCalledTimes(1)
     expect(attachEnabledLibrariesSync.mock.results[0].value).toHaveBeenCalledTimes(1)
+    expect(attachBundledLibrariesSync.mock.results[0].value).toHaveBeenCalledTimes(1)
   })
 
-  it('passes an onAfterRefresh callback to both library subscriptions that calls forceResync', () => {
+  it('passes an onAfterRefresh callback to every library subscription that calls forceResync', () => {
     bootStLsp(makePorts(), monacoStub)
     const projectSyncHandle = attachProjectSync.mock.results[0].value as {
       forceResync: jest.Mock
     }
     const librarySyncCallback = attachLibrarySync.mock.calls[0][1] as () => void
     const enabledSyncCallback = attachEnabledLibrariesSync.mock.calls[0][1] as () => void
+    const bundledSyncCallback = attachBundledLibrariesSync.mock.calls[0][1] as () => void
 
     expect(typeof librarySyncCallback).toBe('function')
     expect(typeof enabledSyncCallback).toBe('function')
+    expect(typeof bundledSyncCallback).toBe('function')
 
     librarySyncCallback()
     enabledSyncCallback()
+    bundledSyncCallback()
 
-    expect(projectSyncHandle.forceResync).toHaveBeenCalledTimes(2)
+    expect(projectSyncHandle.forceResync).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/frontend/services/st-lsp/boot.ts
+++ b/src/frontend/services/st-lsp/boot.ts
@@ -20,7 +20,12 @@ import type { PlatformPorts } from '../../../middleware/shared/providers/types'
 import { toast } from '../../utils/toast'
 import { startStLsp } from './index'
 import { attachMonacoModelSync, type MonacoModelSyncHandle } from './monaco-model-sync'
-import { attachEnabledLibrariesSync, attachLibrarySync, attachProjectSync } from './project-sync'
+import {
+  attachBundledLibrariesSync,
+  attachEnabledLibrariesSync,
+  attachLibrarySync,
+  attachProjectSync,
+} from './project-sync'
 import type { StLspService } from './types'
 
 export interface StLspBootHandle {
@@ -92,6 +97,7 @@ export function bootStLsp(
   const forceResync = () => projectSync.forceResync()
   const unsubscribeLibrarySync = attachLibrarySync(service, forceResync)
   const unsubscribeEnabledLibrariesSync = attachEnabledLibrariesSync(service, forceResync)
+  const unsubscribeBundledLibrariesSync = attachBundledLibrariesSync(service, forceResync)
 
   // Pre-register Monaco models for every POU so cross-POU
   // references / peek-definition / go-to-references resolve through
@@ -110,6 +116,7 @@ export function bootStLsp(
   return {
     service,
     dispose() {
+      unsubscribeBundledLibrariesSync()
       unsubscribeEnabledLibrariesSync()
       unsubscribeLibrarySync()
       projectSync.dispose()

--- a/src/frontend/services/st-lsp/index.ts
+++ b/src/frontend/services/st-lsp/index.ts
@@ -192,15 +192,20 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
 
   async function pushAllStlibs(): Promise<void> {
     const sources = await stlibSource.listStlibs()
-    // Honor the project's enabled-library set.  The adapter returns
-    // every system-installed archive; the project policy lives in the
-    // store, so the service applies it here.  An archive that isn't
-    // enabled for the current project must not contribute symbols to
-    // the LSP — otherwise the user can reference types from libraries
-    // they never opted in to.
-    const enabled = new Set(openPLCStoreBase.getState().enabledLibraries)
+    // Honor the project's enabled-library set, plus the always-on
+    // bundled archives.  The adapter returns every system-installed
+    // archive; the project policy lives in the store, so the service
+    // applies it here.  Bundled libs (e.g. the IEC standard FBs like
+    // `TON`) are tracked separately in `bundledLibraryNames` and are
+    // intentionally absent from `enabledLibraries`, so filtering on
+    // the latter alone would starve the LSP of every standard symbol
+    // and surface as "Undefined type 'TON'" diagnostics.  Anything
+    // outside the union must still be excluded — otherwise the user
+    // can reference types from libraries they never opted in to.
+    const state = openPLCStoreBase.getState()
+    const allowed = new Set([...state.enabledLibraries, ...state.bundledLibraryNames])
     for (const source of sources) {
-      if (!enabled.has(source.name)) continue
+      if (!allowed.has(source.name)) continue
       try {
         const payload = await stlibSource.readStlib(source.sourceLabel)
         await connection.sendRequest(LOAD_STLIB_BUFFER, {

--- a/src/frontend/services/st-lsp/project-sync.ts
+++ b/src/frontend/services/st-lsp/project-sync.ts
@@ -263,3 +263,27 @@ export function attachEnabledLibrariesSync(service: StLspService, onAfterRefresh
     },
   )
 }
+
+/**
+ * Wires the always-on bundled-library list to `refreshStlibs()`.
+ *
+ * `bundledLibraryNames` is populated asynchronously at app boot by
+ * `hydrateLibraries()` in `App.tsx`, in parallel with `bootStLsp`.
+ * If the LSP finishes initialising before the bundled list lands,
+ * the initial `pushAllStlibs` filters with an empty bundled set and
+ * standard archives (IEC FBs like `TON`, `CTU`, …) never reach the
+ * worker — surfacing as "Undefined type 'TON'" diagnostics.  This
+ * subscription closes that race: as soon as bundled names arrive
+ * (or later toggle), the cache is repushed and open documents are
+ * re-analysed.
+ */
+export function attachBundledLibrariesSync(service: StLspService, onAfterRefresh?: () => void): () => void {
+  return openPLCStoreBase.subscribe(
+    (state) => state.bundledLibraryNames.slice().sort().join('|'),
+    () => {
+      void service.refreshStlibs().then(() => {
+        onAfterRefresh?.()
+      })
+    },
+  )
+}

--- a/src/frontend/utils/PLC/__tests__/pou-signature-serializer.test.ts
+++ b/src/frontend/utils/PLC/__tests__/pou-signature-serializer.test.ts
@@ -135,7 +135,8 @@ describe('serializePouSignatureToST', () => {
         body: { language: 'fbd', value: {} as never },
       })
       const result = serializePouSignatureToST(pou)
-      expect(result).toContain('VAR\nEND_VAR')
+      // Block keywords carry the xml2st-parity 2-space indent.
+      expect(result).toContain('  VAR\n  END_VAR')
     })
 
     it('respects variable class — input goes to VAR_INPUT', () => {
@@ -146,8 +147,10 @@ describe('serializePouSignatureToST', () => {
         body: { language: 'ld', value: {} as never },
       })
       const lines = serializePouSignatureToST(pou).split('\n')
-      const inputBlockStart = lines.findIndex((l) => l.startsWith('VAR_INPUT'))
-      const inputBlockEnd = lines.findIndex((l, idx) => idx > inputBlockStart && l.startsWith('END_VAR'))
+      // Block keywords ship with a 2-space indent now; the closing
+      // keyword check needs to ignore that prefix.
+      const inputBlockStart = lines.findIndex((l) => l.trimStart().startsWith('VAR_INPUT'))
+      const inputBlockEnd = lines.findIndex((l, idx) => idx > inputBlockStart && l.trimStart().startsWith('END_VAR'))
       const inputSlice = lines.slice(inputBlockStart, inputBlockEnd + 1).join('\n')
       expect(inputSlice).toContain('in1')
       expect(inputSlice).not.toContain('out1')

--- a/src/frontend/utils/__tests__/generate-iec-variables-to-string.test.ts
+++ b/src/frontend/utils/__tests__/generate-iec-variables-to-string.test.ts
@@ -161,6 +161,8 @@ describe('generateIecVariablesToString', () => {
       makeVariable({ name: 'outA', class: 'output' }),
     ]
     const result = generateIecVariablesToString(vars)
-    expect(result).toBe(['  VAR_INPUT', '    inA : INT;', '  END_VAR', '  VAR_OUTPUT', '    outA : INT;', '  END_VAR'].join('\n'))
+    expect(result).toBe(
+      ['  VAR_INPUT', '    inA : INT;', '  END_VAR', '  VAR_OUTPUT', '    outA : INT;', '  END_VAR'].join('\n'),
+    )
   })
 })

--- a/src/frontend/utils/__tests__/generate-iec-variables-to-string.test.ts
+++ b/src/frontend/utils/__tests__/generate-iec-variables-to-string.test.ts
@@ -11,22 +11,28 @@ const makeVariable = (overrides: Partial<PLCVariable> & Pick<PLCVariable, 'name'
   debug: overrides.debug ?? false,
 })
 
+// Format matches xml2st's PouProgramGenerator output:
+//   * VAR / END_VAR keywords are indented by 2 spaces
+//   * variable declaration lines by 4 spaces
+//   * consecutive var-class blocks have no blank line between them
+// See `generate-iec-variables-to-string.ts` for the rationale.
+
 describe('generateIecVariablesToString', () => {
   it('returns a bare VAR/END_VAR block for an empty array', () => {
-    expect(generateIecVariablesToString([])).toBe('VAR\nEND_VAR')
+    expect(generateIecVariablesToString([])).toBe('  VAR\n  END_VAR')
   })
 
   it('returns a bare VAR/END_VAR block for null/undefined input', () => {
-    expect(generateIecVariablesToString(null as unknown as PLCVariable[])).toBe('VAR\nEND_VAR')
+    expect(generateIecVariablesToString(null as unknown as PLCVariable[])).toBe('  VAR\n  END_VAR')
   })
 
   it('generates a single local variable', () => {
     const vars: PLCVariable[] = [makeVariable({ name: 'counter', class: 'local' })]
     const result = generateIecVariablesToString(vars)
 
-    expect(result).toContain('VAR')
-    expect(result).toContain('\tcounter : INT;')
-    expect(result).toContain('END_VAR')
+    expect(result).toContain('  VAR\n')
+    expect(result).toContain('    counter : INT;')
+    expect(result).toContain('  END_VAR')
   })
 
   it('uses the correct block header for each variable class', () => {
@@ -59,28 +65,28 @@ describe('generateIecVariablesToString', () => {
     const vars: PLCVariable[] = [makeVariable({ name: 'sensor', class: 'local', location: '%IX0.0' })]
     const result = generateIecVariablesToString(vars)
 
-    expect(result).toContain('\tsensor : INT AT %IX0.0;')
+    expect(result).toContain('    sensor : INT AT %IX0.0;')
   })
 
   it('includes the initial value when present', () => {
     const vars: PLCVariable[] = [makeVariable({ name: 'counter', class: 'local', initialValue: '42' })]
     const result = generateIecVariablesToString(vars)
 
-    expect(result).toContain('\tcounter : INT := 42;')
+    expect(result).toContain('    counter : INT := 42;')
   })
 
   it('includes both location and initial value together', () => {
     const vars: PLCVariable[] = [makeVariable({ name: 'x', class: 'local', location: '%QW0', initialValue: '100' })]
     const result = generateIecVariablesToString(vars)
 
-    expect(result).toContain('\tx : INT AT %QW0 := 100;')
+    expect(result).toContain('    x : INT AT %QW0 := 100;')
   })
 
   it('appends documentation as a single-line comment', () => {
     const vars: PLCVariable[] = [makeVariable({ name: 'temp', class: 'local', documentation: 'Temperature sensor' })]
     const result = generateIecVariablesToString(vars)
 
-    expect(result).toContain('\ttemp : INT; (* Temperature sensor *)')
+    expect(result).toContain('    temp : INT; (* Temperature sensor *)')
   })
 
   it('collapses multi-line documentation to a single line', () => {
@@ -116,7 +122,10 @@ describe('generateIecVariablesToString', () => {
     const iIdx = result.indexOf('VAR_INPUT')
     const oIdx = result.indexOf('VAR_OUTPUT')
     const ioIdx = result.indexOf('VAR_IN_OUT')
-    const lIdx = result.indexOf('\nVAR\n')
+    // The local block is bare `VAR` (not VAR_*).  Search for `  VAR\n`
+    // so the index lookup doesn't accidentally hit the start of any
+    // `VAR_INPUT`/`VAR_OUTPUT`/etc. header earlier in the output.
+    const lIdx = result.indexOf('  VAR\n')
     const tIdx = result.indexOf('VAR_TEMP')
 
     expect(gIdx).toBeLessThan(eIdx)
@@ -135,9 +144,23 @@ describe('generateIecVariablesToString', () => {
     const result = generateIecVariablesToString(vars)
 
     expect(result).toContain('VAR_INPUT')
-    expect(result).toContain('\ta : INT;')
-    expect(result).toContain('\tb : BOOL;')
+    expect(result).toContain('    a : INT;')
+    expect(result).toContain('    b : BOOL;')
     // Only one VAR_INPUT block
     expect(result.split('VAR_INPUT').length).toBe(2) // one occurrence = 2 parts
+  })
+
+  it('emits consecutive var-class blocks with no blank line between them (xml2st parity)', () => {
+    // xml2st walks `self.Interface` and emits each var-class block
+    // back-to-back, immediately closing one END_VAR before opening the
+    // next header.  The vars-text editor needs to mirror that exactly
+    // so a manual edit of the text view doesn't get re-formatted into
+    // a different shape on the next save / round-trip.
+    const vars: PLCVariable[] = [
+      makeVariable({ name: 'inA', class: 'input' }),
+      makeVariable({ name: 'outA', class: 'output' }),
+    ]
+    const result = generateIecVariablesToString(vars)
+    expect(result).toBe(['  VAR_INPUT', '    inA : INT;', '  END_VAR', '  VAR_OUTPUT', '    outA : INT;', '  END_VAR'].join('\n'))
   })
 })

--- a/src/frontend/utils/generate-iec-variables-to-string.ts
+++ b/src/frontend/utils/generate-iec-variables-to-string.ts
@@ -10,9 +10,22 @@ const classToVarBlock: Record<string, string> = {
   temp: 'VAR_TEMP',
 }
 
+// Indentation mirrors xml2st's `PLCGenerator.PouProgramGenerator.GenerateProgram`
+// output (see `~/Documents/Code/xml2st/PLCGenerator.py:2414-2478`): two
+// spaces before the var-block keywords, four spaces before each
+// declaration line.  Matching that format keeps the editor's
+// variables-text view byte-identical to the per-POU `.st` file the
+// strucpp pipeline actually compiles — otherwise the user sees one
+// thing in the UI and the compiler sees another, and round-trips
+// through "view text → compile → click error" surface as cosmetic
+// noise and as the off-by-one body-line crash that motivated this
+// fix.
+const VAR_BLOCK_INDENT = '  '
+const VAR_DECL_INDENT = '    '
+
 export const generateIecVariablesToString = (variables: PLCVariable[]): string => {
   if (!variables || variables.length === 0) {
-    return 'VAR\nEND_VAR'
+    return `${VAR_BLOCK_INDENT}VAR\n${VAR_BLOCK_INDENT}END_VAR`
   }
 
   const groupedVariables = variables.reduce(
@@ -34,10 +47,10 @@ export const generateIecVariablesToString = (variables: PLCVariable[]): string =
   orderedGroups.forEach((groupName) => {
     if (groupedVariables[groupName]) {
       const blockHeader = classToVarBlock[groupName]
-      textualDeclaration += `${blockHeader}\n`
+      textualDeclaration += `${VAR_BLOCK_INDENT}${blockHeader}\n`
 
       groupedVariables[groupName].forEach((v) => {
-        let line = `\t${v.name} : ${v.type.value}`
+        let line = `${VAR_DECL_INDENT}${v.name} : ${v.type.value}`
 
         if (v.location) {
           line += ` AT ${v.location}`
@@ -59,9 +72,12 @@ export const generateIecVariablesToString = (variables: PLCVariable[]): string =
         textualDeclaration += line + '\n'
       })
 
-      textualDeclaration += `END_VAR\n\n`
+      // xml2st emits consecutive var-class blocks back-to-back with no
+      // blank line between them — `  END_VAR\n  VAR_INPUT\n...`.  Drop
+      // the prior `END_VAR\n\n` that left a separator behind.
+      textualDeclaration += `${VAR_BLOCK_INDENT}END_VAR\n`
     }
   })
 
-  return textualDeclaration.trim()
+  return textualDeclaration.trimEnd()
 }


### PR DESCRIPTION
## Summary
Six commits — the first is an earlier same-day fix that was sitting unpushed on `editor-fixes`'s base; the other five are the focused regression fixes from the strucpp LSP debugging session.

### Commits

0. **`fix(recent-projects)`** — refetch from `projects.json` after a failed open.  The post-failure refresh in `display-recent-projects` read from `system.getStoreValue('recentProjects')` instead of `project.getRecentProjects()`, so evicted entries kept reappearing in the UI even though the backend had already removed them.  Restores v4.1.4 behaviour.  *(Authored separately by Thiago, lives on this branch because that's where I based my session work.)*
1. **`fix(fbd)`** — re-bind onDrop callback when libraries / pous mutate.  Dragging a newly-created Function Block onto an FBD diagram silently failed until the next full project save; `onDrop`'s `useCallback` deps didn't include `libraries.user`/`pous`, so the memoised closure ran a stale lookup.
2. **`fix(lsp)`** — include always-on bundled stlibs in LSP cache + close startup race.  `pushAllStlibs` filtered by `enabledLibraries` only, starving the worker of bundled IEC FBs (`TON`, `CTU`, …) and surfacing as `Undefined type 'TON'` diagnostics.
3. **`fix(compile-errors)`** — restore click-to-navigate for STruC++ parse diagnostics.  Adds `enrichErrorWithPouContext` so parse errors (which strucpp ships without `pouName`/`section`/`bodyLine`) still get clickable POU + body-line context.  Defensive Monaco line clamps as a permanent guard against any future out-of-range cursor.
4. **`refactor(vars-text)`** — align variables generator with xml2st format.  Closes the blank-line / indentation discrepancy between editor's text-mode VAR generation and the bytes STruC++ actually sees on the compile path.
5. **`fix(monaco)`** — bind Space to type+hideSuggest to dodge LSP-induced swallow.  ST POU body editors silently lost plain-Space keystrokes once the strucpp LSP completion provider became active; explicit `addCommand(Space, …)` binding restores typing behaviour.

### Companion PR
- openplc-web: https://github.com/Autonomy-Logic/openplc-web/pull/417 (byte-identical mirror, must merge in lockstep)

## Test plan
- [ ] CI architecture / byte-identity checks pass
- [ ] Open a Python or ST FB and type `if` + space — space is inserted (regression smoke test for #5)
- [ ] Create a new Function Block and drag it onto an FBD diagram without saving — drop succeeds (regression smoke test for #1)
- [ ] Create an ST POU with `TON0 : TON;` — `TON` is recognised (no `Undefined type` diagnostic, regression smoke test for #2)
- [ ] Trigger a parse error in an ST POU body, click the diagnostic in console — editor jumps to the right POU + body line (regression smoke test for #3)
- [ ] Open a project, delete one of its files outside the editor, then click the "missing" entry in recent projects — the entry disappears from the list after the failed open (regression smoke test for #0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Editor no longer crashes when attempting to jump to line numbers outside the valid range
  * Space key typing behavior restored in the code editor

* **Improvements**
  * Error messages now enriched with additional context about which code section generated the error
  * Standard library synchronization enhanced to ensure bundled libraries are properly loaded

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autonomy-Logic/openplc-editor/pull/785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->