### PR TITLE
chore: bump strucpp pin to v0.4.17

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.4.16",
+    "version": "v0.4.17",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }


### PR DESCRIPTION
Pulls in the parser-error-message fix from strucpp PR #120.

End-to-end verified locally: `FUNCTION_BLOCK cvavava { sdfasdfa END_FUNCTION_BLOCK }` now produces a 2-line message with inline suggestion instead of 1,409 lines of alternation paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `strucpp` binary to version v0.4.17.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autonomy-Logic/openplc-editor/pull/786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->