### PR TITLE
chore(capabilities): mirror WEB_CAPABILITIES.hasPythonLSP=true from openplc-web

### DIFF
--- a/src/middleware/shared/ports/platform-capabilities.ts
+++ b/src/middleware/shared/ports/platform-capabilities.ts
@@ -150,7 +150,16 @@ export const WEB_CAPABILITIES: PlatformCapabilities = {
   hasProjectExport: false,
   hasVersionControl: true,
   hasAboutDialog: true,
-  hasPythonLSP: false,
+  // `monaco-pyright-lsp` ships its own ESM worker via
+  // `new Worker(new URL('./worker.js', import.meta.url))` which Vite
+  // resolves to an emitted chunk at build time — no `MonacoEnvironment`
+  // worker-URL handoff required (unlike STruC++, which we pre-warm
+  // through `bootStLsp` with a `?url` import).  Pyright bundle is
+  // ~MB-scale; web users editing Python POUs pay the load once on the
+  // first Python file open since the import is at module-evaluation
+  // time in the body Monaco editor.  Lazy-loading is a follow-up
+  // optimisation if first-paint cost becomes a real concern.
+  hasPythonLSP: true,
   // The STruC++ worker bundle runs in any modern browser; web's
   // stlib-source adapter (HTTP-backed, mirror of editor's IPC-backed
   // one) lands alongside the library port and lets `bootStLsp`


### PR DESCRIPTION
## Summary
Byte-identical mirror of the WEB_CAPABILITIES flip on the web side so `platform-capabilities.ts` stays sync-clean when the web PR merges.

**Zero runtime impact on the desktop editor** — desktop uses `EDITOR_CAPABILITIES` which has had `hasPythonLSP: true` since the ports & adapters migration.  This commit only touches the `WEB_CAPABILITIES` constant inside the shared file.

## Companion PR
- openplc-web: https://github.com/Autonomy-Logic/openplc-web/pull/419 — enables Pyright LSP on web's Python POUs.  These two PRs must merge in lockstep so the byte-identity check on shared surfaces stays clean.

## Test plan
- [ ] CI architecture / byte-identity sync passes (verified locally)
- [ ] No editor regression — desktop continues to use EDITOR_CAPABILITIES; the WEB_CAPABILITIES change is unreachable from editor code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)