### PR TITLE
refactor(compile-errors): use shared emitCompileErrorEvents helper

### DIFF
--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -27,7 +27,7 @@ import {
   prepareXmlForLibraryBuild,
 } from '@root/backend/shared/library/build-pipeline'
 import { deployRuntimeProgram } from '@root/backend/shared/library/deploy-runtime-program'
-import { buildKnownPous } from '@root/backend/shared/library/program-build-helpers'
+import { buildKnownPous, emitCompileErrorEvents } from '@root/backend/shared/library/program-build-helpers'
 import { runProgramBuildPipeline } from '@root/backend/shared/library/program-build-pipeline'
 import { loadStrucpp } from '@root/backend/shared/library/strucpp-runtime'
 import type { KnownPou } from '@root/backend/shared/utils/PLC/split-program-st'
@@ -745,19 +745,16 @@ class CompilerModule {
     }
 
     if (!result.success) {
-      // Emit one structured log entry per error so the renderer's
-      // console can attach a click-to-open handler to each one.  The
-      // formatted text is what the user sees; the third argument
-      // carries the raw `CompileError` (pouName / section / bodyLine
-      // / variableName / …) for navigation.  We then throw a short
-      // marker so the outer catch posts only the high-level
-      // "STruC++ compilation failed" line — without re-dumping every
-      // error blob a second time through the catch's plain-message
-      // path.
-      handleOutputData('STruC++ compilation failed:', 'error')
-      for (const err of result.errors) {
-        handleOutputData(err.formatted, 'error', err.raw)
-      }
+      // Hand the structured diagnostics to the shared
+      // `emitCompileErrorEvents` helper so the editor and the web
+      // build emit the exact same per-error log shape — the
+      // bracketed `[POU / body line N]` first line that the
+      // renderer's `useNavigateToCompileError` hook uses as a click
+      // target.  `handleOutputData` already has the right signature
+      // (`message, level, compileError?`) — no adapter needed.
+      // Throw afterwards so the outer catch posts only the
+      // high-level marker line without re-dumping every error blob.
+      emitCompileErrorEvents(result.errors, handleOutputData)
       throw new Error('STruC++ compilation failed')
     }
 

--- a/src/backend/shared/library/__tests__/program-build-helpers.test.ts
+++ b/src/backend/shared/library/__tests__/program-build-helpers.test.ts
@@ -13,7 +13,12 @@ import type * as strucpp from 'strucpp'
 
 import type { PLCPou } from '../../types/PLC/open-plc'
 import type { KnownPou } from '../../utils/PLC/split-program-st'
-import { buildKnownPous, enrichErrorWithPouContext, formatErrorWithPouContext } from '../program-build-helpers'
+import {
+  buildKnownPous,
+  emitCompileErrorEvents,
+  enrichErrorWithPouContext,
+  formatErrorWithPouContext,
+} from '../program-build-helpers'
 
 type StrucppCompileError = strucpp.CompileError
 type StrucppFormatDiagnostic = typeof strucpp.formatDiagnostic
@@ -316,5 +321,59 @@ describe('enrichErrorWithPouContext', () => {
     const enriched = enrichErrorWithPouContext(err, knownPous, perPou)
     expect(enriched.pouName).toBe('CVAVAVA')
     expect(enriched.section).toBeUndefined()
+  })
+})
+
+describe('emitCompileErrorEvents', () => {
+  const mkErr = (overrides: Partial<StrucppCompileError> = {}): StrucppCompileError => ({
+    message: 'test error',
+    line: 1,
+    column: 1,
+    severity: 'error',
+    ...overrides,
+  })
+
+  it('emits a single header line when the errors list is empty', () => {
+    // Defensive: callers shouldn't invoke this with an empty list
+    // (success path is gated elsewhere), but if they do, the header
+    // alone is still useful and the loop must not throw.
+    const calls: Array<{ msg: string; level: string; raw?: StrucppCompileError }> = []
+    emitCompileErrorEvents([], (msg, level, raw) => calls.push({ msg, level, raw }))
+    expect(calls).toEqual([{ msg: 'STruC++ compilation failed:', level: 'error', raw: undefined }])
+  })
+
+  it('emits one event per error, each carrying the structured `raw`', () => {
+    // The renderer keys click-to-navigate off `compileError.pouName`
+    // — every per-error event must therefore reach the sink with the
+    // raw attached, never as a joined string that drops the
+    // structured fields.
+    const e1 = mkErr({ pouName: 'Foo', section: 'body', bodyLine: 3, message: 'first' })
+    const e2 = mkErr({ pouName: 'Bar', section: 'var-block', message: 'second' })
+    const diags = [
+      { formatted: '[Foo / body line 3]\nfoo.st:5:1: error: first', raw: e1 },
+      { formatted: '[Bar / variable x]\nbar.st:2:1: error: second', raw: e2 },
+    ]
+    const calls: Array<{ msg: string; level: string; raw?: StrucppCompileError }> = []
+    emitCompileErrorEvents(diags, (msg, level, raw) => calls.push({ msg, level, raw }))
+    expect(calls).toHaveLength(3)
+    expect(calls[0]).toEqual({ msg: 'STruC++ compilation failed:', level: 'error', raw: undefined })
+    expect(calls[1]).toEqual({ msg: diags[0].formatted, level: 'error', raw: e1 })
+    expect(calls[2]).toEqual({ msg: diags[1].formatted, level: 'error', raw: e2 })
+  })
+
+  it('falls back through formatted → raw.message → "unknown error" when formatted is missing', () => {
+    // Defensive: a malformed entry where `formatted` is empty should
+    // still produce something the user can read.  The raw is still
+    // attached so click-to-navigate works even on the fallback path.
+    const eOk = mkErr({ pouName: 'Ok', message: 'has message' })
+    const eEmpty = mkErr({ pouName: 'Empty', message: '' })
+    const diags = [
+      { formatted: '', raw: eOk }, // empty formatted, falls to raw.message
+      { formatted: '', raw: eEmpty }, // empty formatted + empty message → last-resort literal
+    ]
+    const calls: Array<{ msg: string; level: string; raw?: StrucppCompileError }> = []
+    emitCompileErrorEvents(diags, (msg, level, raw) => calls.push({ msg, level, raw }))
+    expect(calls[1]).toEqual({ msg: 'has message', level: 'error', raw: eOk })
+    expect(calls[2]).toEqual({ msg: 'unknown error', level: 'error', raw: eEmpty })
   })
 })

--- a/src/backend/shared/library/program-build-helpers.ts
+++ b/src/backend/shared/library/program-build-helpers.ts
@@ -169,3 +169,48 @@ export function formatErrorWithPouContext(
   }
   return `${prefix}\n${base}`
 }
+
+/**
+ * Platform-agnostic log sink the compile orchestrator hands to
+ * `emitCompileErrorEvents`.  Editor and web wire this to their
+ * respective channels — Electron's `handleOutputData(text, level,
+ * compileError?)` IPC callback, and web's `onProgress({ stage:
+ * 'error', message, compileError? })` event bus — by adapting their
+ * own signature to this minimal shape inside a one-line closure.
+ *
+ * Keeping the adapter trivial is the whole point: the iteration
+ * pattern + bracketed header + per-error attachment of
+ * `compileError` lives in one shared place, while platforms keep
+ * full control of how the emission actually reaches the renderer.
+ */
+export type CompileLogEmit = (message: string, level: 'info' | 'error', compileError?: StrucppCompileError) => void
+
+/**
+ * Emit one log entry per error in a failed strucpp pipeline result,
+ * with the structured `CompileError` attached to each line.
+ *
+ * The renderer's console (see `console/log.tsx`) keys click-to-open
+ * navigation off `compileError.pouName`.  Joining errors into a
+ * single string discards that structured data and breaks the
+ * bracketed-prefix click target — every consumer must funnel through
+ * here so the shape stays uniform across platforms.
+ *
+ * Emits a plain "STruC++ compilation failed:" header first (no
+ * `compileError` — it's a section break, not navigable), then one
+ * event per error carrying `err.raw`.  Callers should pass through
+ * the diagnostics exactly as returned by `runProgramBuildPipeline`;
+ * no preprocessing is required.
+ */
+export function emitCompileErrorEvents(
+  errors: { formatted: string; raw: StrucppCompileError }[],
+  emit: CompileLogEmit,
+): void {
+  emit('STruC++ compilation failed:', 'error')
+  for (const err of errors) {
+    // Falsy fallback (`||`) rather than nullish (`??`) so an
+    // accidentally-empty `formatted` (defensive, the pipeline never
+    // produces one in practice) still surfaces something readable
+    // from the raw strucpp message instead of an empty log row.
+    emit(err.formatted || err.raw?.message || 'unknown error', 'error', err.raw)
+  }
+}


### PR DESCRIPTION
## Summary
Collapses the editor compiler-module's inline per-error log loop into a shared `emitCompileErrorEvents` helper (added to `program-build-helpers.ts` alongside the existing `enrichErrorWithPouContext` / `formatErrorWithPouContext`).

The editor has had the correct per-error emission shape since day one — one `handleOutputData(err.formatted, 'error', err.raw)` per error so the renderer can attach click-to-navigate.  The web side was joining errors into a single string with `; ` separator and dropping the structured `compileError` fields entirely (separate bug, same surface).  The companion web PR routes through the same helper, so both platforms now produce identical log shapes by construction.

## Companion PR
- openplc-web: https://github.com/Autonomy-Logic/openplc-web/pull/420 — uses the same helper.  These two must merge in lockstep so the byte-identity sync rule on `src/backend/shared/library/` stays satisfied.

## Why share the loop?
The per-error iteration + bracketed header + `compileError` attachment is the kind of thing that quietly drifts the moment one repo adds a field the other doesn't.  The shared helper takes a `CompileLogEmit` callback `(message, level, compileError?) => void`; each platform adapts its own log channel (Electron IPC vs web `onProgress`) in a one-line closure.

## Test plan
- [ ] CI byte-identity sync passes (helper file + test file are byte-identical with web PR)
- [ ] All existing tests pass (compiler-module, program-build-helpers, program-build-pipeline)
- [ ] Smoke test: trigger an ST parse error, click the bracketed POU line in the console → editor jumps to POU + body line (regression of #785's click-to-navigate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated error handling logic for compilation failures to improve consistency and structure of error reporting during the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autonomy-Logic/openplc-editor/pull/788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->