### PR TITLE
chore: bump strucpp pin to v0.4.18

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.4.17",
+    "version": "v0.4.18",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }


### PR DESCRIPTION
## Summary

Bump the strucpp binary pin from v0.4.17 to v0.4.18. Two fixes since the prior version:

- **vscode-extension quick-fix matchers** (strucpp #124) — "Add missing semicolon" and "Add missing END_*" were silently broken after v0.4.17's parser-error-message rework. The matcher regexes still anchored to chevrotain's old verbose wording (`Expecting token of type --> Semicolon <--`). Updated to the new house-style format (`` Expected `Semicolon`, found … ``).
- **AVR <64 KB flash debugger** (strucpp #119) — `debug_dispatch.hpp` now gates far-PROGMEM accessors on the RAMPZ register so the debugger compiles and runs on smaller AVR devices.

## Test plan

- [x] Local diff: `binary-versions.json` strucpp pin v0.4.17 → v0.4.18
- [ ] CI: build-check + lint + sync + complete-build on PR (requires the v0.4.18 release to be published — release workflow currently building)

## Companion PR

openplc-web `chore/bump-strucpp-0.4.18` (to be linked once opened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `strucpp` dependency to version v0.4.18

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autonomy-Logic/openplc-editor/pull/790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->