### PR TITLE
fix(ai): quick suggestions when inline off + integer ACU display

### DIFF
--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
@@ -51,7 +51,7 @@ export const AcuExhaustionModal = ({
   const description = isInactive
     ? `Your subscription is ${billingError.subscriptionStatus ?? 'inactive'}. Reactivate it to keep using AI features.`
     : billingError.monthlyLimit != null
-      ? `You've used all ${billingError.monthlyLimit} ACU for this billing period. Buy more ACU or upgrade your plan to keep going.`
+      ? `You've used all ${Math.round(billingError.monthlyLimit)} ACU for this billing period. Buy more ACU or upgrade your plan to keep going.`
       : "You're out of ACU for this billing period. Buy more ACU or upgrade your plan to keep going."
   const ctaLabel = isInactive ? 'Reactivate subscription' : 'Upgrade plan'
   // subscription_inactive carries its own reactivation URL; insufficient_acu doesn't.

--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
@@ -76,7 +76,8 @@ export const AcuExhaustionModal = ({
           typeof billingError.remaining === 'number' &&
           typeof billingError.required === 'number' && (
             <p className='text-[12px] text-neutral-500 dark:text-neutral-400'>
-              This request needed {billingError.required} ACU; only {billingError.remaining} remaining.
+              This request needed {Math.round(billingError.required)} ACU; only {Math.round(billingError.remaining)}{' '}
+              remaining.
             </p>
           )}
         <div className='mt-2 flex items-center justify-end gap-2'>

--- a/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
@@ -1257,6 +1257,19 @@ void loop()
   // Editor options
   // -----------------------------------------------------------------------
 
+  // Inline AI completions take over the suggest widget only while they are
+  // actually active (same gate as the provider registration above). When the
+  // user turns inline completions off, fall back to Monaco's normal quick
+  // suggestions (the auto-dropdown). Ctrl+Space still triggers the suggest
+  // widget manually in both modes — `quickSuggestions` only governs the
+  // automatic popup, and `suppressSuggestions` only suppresses the auto popup
+  // while an inline suggestion is showing.
+  const inlineCompletionsActive =
+    capabilities.hasAIAssistant &&
+    aiState.isEnabled &&
+    aiState.hasConsented &&
+    aiState.preferences.inlineCompletionsEnabled
+
   const monacoEditorUserOptions: monacoEditorOptionsType = {
     minimap: { enabled: false },
     dropIntoEditor: { enabled: true },
@@ -1273,7 +1286,7 @@ void loop()
     tabSize: 4,
     insertSpaces: true,
     detectIndentation: false,
-    quickSuggestions: capabilities.hasAIAssistant ? false : undefined,
+    quickSuggestions: inlineCompletionsActive ? false : undefined,
     // Pinned for cross-platform consistency with the variables-code-editor.
     // Monaco's default is platform-dependent (12 on macOS, 14 elsewhere) —
     // without this both surfaces would mismatch on Linux/Windows even
@@ -1295,7 +1308,7 @@ void loop()
     // `document.body` with `position: fixed`, so they escape both
     // the editor container and the variables table above it.
     fixedOverflowWidgets: true,
-    ...(capabilities.hasAIAssistant && {
+    ...(inlineCompletionsActive && {
       inlineSuggest: {
         enabled: true,
         suppressSuggestions: true,


### PR DESCRIPTION
## Summary
Two post-release AI fixes (shared frontend — **mirror of openplc-web#425**, diffs are byte-identical):

1. **Quick suggestions vs. inline completion.** Quick suggestions were hard-disabled whenever the AI assistant was available, so turning inline completion **off** left the user with no autocomplete. Now `quickSuggestions` / `inlineSuggest` are gated on the same condition as the inline-completion provider (`hasAIAssistant && isEnabled && hasConsented && preferences.inlineCompletionsEnabled`):
   - Inline **ON** → quick suggestions suppressed automatically, available via Ctrl+Space (unchanged).
   - Inline **OFF** → quick suggestions appear automatically; Ctrl+Space still works.
2. **Integer ACU display.** `AcuExhaustionModal` rounds `monthlyLimit` for display (ACU is a float internally).

## Files
- `src/frontend/components/_features/[workspace]/editor/monaco/index.tsx`
- `src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx`

## Mirror
Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/425

## Test plan
- [ ] Inline ON: ghost text shows, no auto-dropdown, Ctrl+Space opens suggestions.
- [ ] Inline OFF (AI settings toggle): auto-dropdown appears as you type; Ctrl+Space still works.
- [ ] ACU exhaustion modal shows a whole-number limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ACU exhaustion and insufficient-ACU messages now display rounded values for clearer user-facing counts.

* **Improvements**
  * Inline completion behavior now respects AI assistant enablement, explicit consent, and inline-completions preference before activating.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autonomy-Logic/openplc-editor/pull/791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->