### PR TITLE
Fix/rc1 simulator stop listener guard

### DIFF
--- a/configs/webpack/webpack.config.renderer.dev.ts
+++ b/configs/webpack/webpack.config.renderer.dev.ts
@@ -148,6 +148,8 @@ const configuration: webpack.Configuration = {
     extensions: ['.ts', '.js'],
     alias: {
       '@src': srcPath,
+      react: resolve(webpackPaths.rootPath, 'node_modules/react'),
+      'react-dom': resolve(webpackPaths.rootPath, 'node_modules/react-dom'),
     },
   },
 

--- a/configs/webpack/webpack.config.renderer.prod.ts
+++ b/configs/webpack/webpack.config.renderer.prod.ts
@@ -7,7 +7,7 @@ import CssMinimizerPlugin from 'css-minimizer-webpack-plugin'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
 import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 import MonacoEditorWebpackPlugin from 'monaco-editor-webpack-plugin'
-import { join } from 'path'
+import { join, resolve } from 'path'
 import tailwindcss from 'tailwindcss'
 import TerserPlugin from 'terser-webpack-plugin'
 import webpack from 'webpack'
@@ -115,6 +115,13 @@ const configuration: webpack.Configuration = {
         ],
       },
     ],
+  },
+
+  resolve: {
+    alias: {
+      react: resolve(webpackPaths.rootPath, 'node_modules/react'),
+      'react-dom': resolve(webpackPaths.rootPath, 'node_modules/react-dom'),
+    },
   },
 
   optimization: {

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -2035,9 +2035,21 @@ class CompilerModule {
       boolean | undefined,
     ]
 
-    const boardRuntime = await this.#getBoardRuntime(boardTarget) // Get the board runtime from the hals.json file
-
-    const halsContent = await CompilerModule.readJSONFile<HalsFile>(this.halsFilePath)
+    let boardRuntime: string
+    let halsContent: HalsFile
+    try {
+      _mainProcessPort.postMessage({ logLevel: 'info', message: `Resolving board target: ${boardTarget}` })
+      boardRuntime = await this.#getBoardRuntime(boardTarget) // Get the board runtime from the hals.json file
+      halsContent = await CompilerModule.readJSONFile<HalsFile>(this.halsFilePath)
+    } catch (error) {
+      _mainProcessPort.postMessage({
+        logLevel: 'error',
+        message: `Error resolving board target "${boardTarget}": ${getErrorMessage(error)}\nStopping compilation process.`,
+      })
+      _mainProcessPort.postMessage({ closePort: true })
+      _mainProcessPort.close()
+      return
+    }
 
     const normalizedProjectPath = projectPath.replace('project.json', '')
 

--- a/src/frontend/assets/icons/project/fbd/Block.tsx
+++ b/src/frontend/assets/icons/project/fbd/Block.tsx
@@ -38,17 +38,17 @@ export default function BlockIcon(props: IBlockIconProps) {
       <path
         d='M10.7273 9.25C10.7273 9.11193 10.8392 9 10.9773 9H17.9783C18.1164 9 18.2283 9.11193 18.2283 9.25V11.4545H10.7273V9.25Z'
         fill='#B4D0FE'
-        fill-opacity='0.5'
+        fillOpacity='0.5'
       />
-      <line x1='5' y1='13.2955' x2='9.90909' y2='13.2955' stroke='#B4D0FE' stroke-opacity='0.5' strokeWidth='1.22727' />
-      <line x1='5' y1='16.5682' x2='9.90909' y2='16.5682' stroke='#B4D0FE' stroke-opacity='0.5' strokeWidth='1.22727' />
+      <line x1='5' y1='13.2955' x2='9.90909' y2='13.2955' stroke='#B4D0FE' strokeOpacity='0.5' strokeWidth='1.22727' />
+      <line x1='5' y1='16.5682' x2='9.90909' y2='16.5682' stroke='#B4D0FE' strokeOpacity='0.5' strokeWidth='1.22727' />
       <line
         x1='18.9091'
         y1='14.9318'
         x2='23.8182'
         y2='14.9318'
         stroke='#B4D0FE'
-        stroke-opacity='0.5'
+        strokeOpacity='0.5'
         strokeWidth='1.22727'
       />
     </svg>

--- a/src/frontend/assets/icons/project/fbd/VariableIn.tsx
+++ b/src/frontend/assets/icons/project/fbd/VariableIn.tsx
@@ -36,15 +36,7 @@ export default function VariableInIcon(props: IBlockIconProps) {
         stroke='#B4D0FE'
         strokeWidth='1.22727'
       />
-      <line
-        x1='18'
-        y1='13.3864'
-        x2='22.9091'
-        y2='13.3864'
-        stroke='#B4D0FE'
-        stroke-opacity='0.5'
-        strokeWidth='1.22727'
-      />
+      <line x1='18' y1='13.3864' x2='22.9091' y2='13.3864' stroke='#B4D0FE' strokeOpacity='0.5' strokeWidth='1.22727' />
     </svg>
   )
 }

--- a/src/frontend/assets/icons/project/fbd/VariableInOut.tsx
+++ b/src/frontend/assets/icons/project/fbd/VariableInOut.tsx
@@ -36,16 +36,8 @@ export default function VariableInOutIcon(props: IBlockIconProps) {
         stroke='#B4D0FE'
         strokeWidth='1.22727'
       />
-      <line
-        x1='18'
-        y1='13.3864'
-        x2='22.9091'
-        y2='13.3864'
-        stroke='#B4D0FE'
-        stroke-opacity='0.5'
-        strokeWidth='1.22727'
-      />
-      <line x1='4' y1='13.3864' x2='8.90909' y2='13.3864' stroke='#B4D0FE' stroke-opacity='0.5' strokeWidth='1.22727' />
+      <line x1='18' y1='13.3864' x2='22.9091' y2='13.3864' stroke='#B4D0FE' strokeOpacity='0.5' strokeWidth='1.22727' />
+      <line x1='4' y1='13.3864' x2='8.90909' y2='13.3864' stroke='#B4D0FE' strokeOpacity='0.5' strokeWidth='1.22727' />
     </svg>
   )
 }

--- a/src/frontend/assets/icons/project/fbd/VariableOut.tsx
+++ b/src/frontend/assets/icons/project/fbd/VariableOut.tsx
@@ -36,7 +36,7 @@ export default function VariableOutIcon(props: IBlockIconProps) {
         stroke='#B4D0FE'
         strokeWidth='1.22727'
       />
-      <line x1='4' y1='13.3864' x2='8.90909' y2='13.3864' stroke='#B4D0FE' stroke-opacity='0.5' strokeWidth='1.22727' />
+      <line x1='4' y1='13.3864' x2='8.90909' y2='13.3864' stroke='#B4D0FE' strokeOpacity='0.5' strokeWidth='1.22727' />
     </svg>
   )
 }

--- a/src/frontend/components/_features/[workspace]/branches/branch-status-bar.tsx
+++ b/src/frontend/components/_features/[workspace]/branches/branch-status-bar.tsx
@@ -9,7 +9,7 @@ import { UnsavedChangesWarningModal } from './unsaved-changes-warning-modal'
 
 type BranchStatusBarProps = {
   projectId: string
-  onBranchSwitch?: (branchName: string) => void
+  onBranchSwitch?: (branchName: string) => void | Promise<void>
 }
 
 export function BranchStatusBar({ projectId, onBranchSwitch }: BranchStatusBarProps) {
@@ -30,7 +30,7 @@ export function BranchStatusBar({ projectId, onBranchSwitch }: BranchStatusBarPr
       try {
         await versionControl.switchBranch(projectId, branch.name)
         setActiveBranch(branch.name)
-        onBranchSwitch?.(branch.name)
+        void onBranchSwitch?.(branch.name)
       } catch (error) {
         console.error('Failed to switch branch:', error)
       }
@@ -56,7 +56,7 @@ export function BranchStatusBar({ projectId, onBranchSwitch }: BranchStatusBarPr
         // If we can't check, proceed with switch
       }
 
-      doSwitch(branch)
+      void doSwitch(branch)
     },
     [activeBranchName, projectId, versionControl, doSwitch],
   )
@@ -103,7 +103,7 @@ export function BranchStatusBar({ projectId, onBranchSwitch }: BranchStatusBarPr
         .then(({ branches }) => {
           const defaultBranch = branches.find((b) => b.isDefault)
           if (defaultBranch) {
-            doSwitch(defaultBranch)
+            void doSwitch(defaultBranch)
           }
         })
         .catch(() => {})
@@ -133,7 +133,7 @@ export function BranchStatusBar({ projectId, onBranchSwitch }: BranchStatusBarPr
         currentBranchName={activeBranchName}
         anchorRef={branchButtonRef}
         onClose={() => setShowSwitcher(false)}
-        onSelect={handleSelect}
+        onSelect={(branch) => void handleSelect(branch)}
         onDelete={handleDelete}
         onMerge={handleMerge}
       />
@@ -152,7 +152,7 @@ export function BranchStatusBar({ projectId, onBranchSwitch }: BranchStatusBarPr
       <UnsavedChangesWarningModal
         isOpen={showUnsavedWarning}
         targetBranchName={pendingBranchSwitch?.name ?? ''}
-        onDiscard={handleDiscardAndSwitch}
+        onDiscard={() => void handleDiscardAndSwitch()}
         onCancel={handleCancelSwitch}
       />
     </>

--- a/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
@@ -154,6 +154,7 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
     const freshProjectData = useOpenPLCStore.getState().project.data
 
     try {
+      let streamedError = false
       const result = await compiler.compileProgram(
         {
           projectData: freshProjectData,
@@ -170,6 +171,9 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
             useOpenPLCStore
               .getState()
               .deviceActions.setPlcRuntimeStatus(event.plcStatus as NonNullable<RuntimeConnection['plcStatus']>)
+          }
+          if (event.level === 'error' || event.stage === 'error') {
+            streamedError = true
           }
           logCompilerEvent(event, addLog)
           if (event.firmwarePath && isSimulatorBoard) {
@@ -194,7 +198,7 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
         },
       )
 
-      if (!result.success) {
+      if (!result.success && !streamedError) {
         addLog({ id: crypto.randomUUID(), level: 'error', message: result.error ?? 'Compilation failed' })
       }
     } catch (err: unknown) {

--- a/src/frontend/screens/workspace-screen.tsx
+++ b/src/frontend/screens/workspace-screen.tsx
@@ -469,7 +469,7 @@ const WorkspaceScreen = () => {
             <ResizablePanel
               id='workspacePanel'
               order={2}
-              defaultSize={68}
+              defaultSize={100 - leftPanelSize}
               minSize={50}
               className='flex h-full min-h-0 overflow-hidden'
             >

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -1009,7 +1009,14 @@ class MainProcessBridge implements MainIpcModule {
 
   handleRunCompileProgram = (event: IpcMainEvent, args: Array<string | PLCProjectData>) => {
     const mainProcessPort = event.ports[0]
-    void this.compilerModule.compileProgram(args, mainProcessPort, this)
+    void this.compilerModule.compileProgram(args, mainProcessPort, this).catch((error) => {
+      mainProcessPort.postMessage({
+        logLevel: 'error',
+        message: `${getErrorMessage(error)}\nStopping compilation process.`,
+      })
+      mainProcessPort.postMessage({ closePort: true })
+      mainProcessPort.close()
+    })
   }
 
   handleRunDebugCompilation = (event: IpcMainEvent, args: Array<string | PLCProjectData>) => {

--- a/src/middleware/adapters/editor/__tests__/accelerator-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/accelerator-adapter.test.ts
@@ -128,3 +128,34 @@ describe('onOpenRecent', () => {
     expect(cb).not.toHaveBeenCalled()
   })
 })
+
+describe('missing bridge listeners', () => {
+  it('returns no-op unsubscribers when the preload bridge is unavailable', () => {
+    window.bridge = undefined as unknown as typeof window.bridge
+    adapter = createEditorAcceleratorAdapter()
+
+    const methods: Array<keyof AcceleratorPort> = [
+      'onCreateProject',
+      'onOpenProject',
+      'onOpenRecent',
+      'onSaveProject',
+      'onSaveFile',
+      'onCloseProject',
+      'onExportProject',
+      'onCloseTab',
+      'onDeleteFile',
+      'onFindInProject',
+      'onUndo',
+      'onRedo',
+      'onSwitchPerspective',
+      'onAbout',
+      'onQuitApp',
+    ]
+
+    for (const method of methods) {
+      const unsub = (adapter[method] as (cb: () => void) => () => void)(jest.fn())
+      expect(typeof unsub).toBe('function')
+      expect(unsub).not.toThrow()
+    }
+  })
+})

--- a/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
@@ -261,6 +261,29 @@ describe('createEditorCompilerAdapter', () => {
 
       expect(result).toEqual({ success: false, error: 'Compilation failed: missing file' })
       expect(progressEvents.some((e) => e.stage === 'error')).toBe(true)
+      expect(progressEvents.some((e) => e.stage === 'done' && e.message === 'Compilation complete')).toBe(false)
+    })
+
+    it('ignores duplicate closePort events after an error', async () => {
+      const progressEvents: CompileProgressEvent[] = []
+      const promise = adapter.compileProgram(
+        {
+          projectData: mockProjectData,
+          boardTarget: 'Arduino Mega',
+          projectPath: '/path',
+        },
+        (event) => progressEvents.push(event),
+      )
+
+      await flushMicrotasks()
+      compileCallback!({ message: 'Board not found', logLevel: 'error' })
+      compileCallback!({ closePort: true })
+      compileCallback!({ closePort: true })
+
+      const result = await promise
+
+      expect(result).toEqual({ success: false, error: 'Board not found' })
+      expect(progressEvents).toEqual([{ stage: 'error', message: 'Board not found', level: 'error' }])
     })
 
     it('captures simulatorFirmwarePath as hexPath', async () => {

--- a/src/middleware/adapters/editor/__tests__/device-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/device-adapter.test.ts
@@ -73,4 +73,12 @@ describe('createEditorDeviceAdapter', () => {
     await adapter.getPreviewImage('motor-shield.png', '/path/to/pkg')
     expect(window.bridge.getPreviewImage).toHaveBeenCalledWith('motor-shield.png', '/path/to/pkg')
   })
+
+  it('returns empty communication ports when the preload bridge is unavailable', async () => {
+    window.bridge = undefined as unknown as typeof window.bridge
+    adapter = createEditorDeviceAdapter()
+
+    await expect(adapter.getCommunicationPorts()).resolves.toEqual([])
+    await expect(adapter.refreshCommunicationPorts()).resolves.toEqual([])
+  })
 })

--- a/src/middleware/adapters/editor/__tests__/library-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/library-adapter.test.ts
@@ -22,6 +22,12 @@ describe('loadAll', () => {
     expect(window.bridge.loadAllLibraries).toHaveBeenCalledTimes(1)
     expect(result).toEqual([{ manifest: { name: 'IEC' } }])
   })
+
+  it('returns an empty list when bridge is unavailable', async () => {
+    window.bridge = undefined as unknown as typeof window.bridge
+
+    await expect(createEditorLibraryAdapter().loadAll()).resolves.toEqual([])
+  })
 })
 
 describe('listInstalled', () => {
@@ -30,6 +36,12 @@ describe('listInstalled', () => {
 
     expect(window.bridge.listInstalledLibraries).toHaveBeenCalledTimes(1)
     expect(result).toEqual([{ name: 'IEC', bundled: true }])
+  })
+
+  it('returns an empty list when bridge is unavailable', async () => {
+    window.bridge = undefined as unknown as typeof window.bridge
+
+    await expect(createEditorLibraryAdapter().listInstalled()).resolves.toEqual([])
   })
 })
 
@@ -80,5 +92,13 @@ describe('onLibrariesChanged', () => {
 
     expect(window.bridge.onLibrariesChanged).toHaveBeenCalledWith(callback)
     expect(returned).toBe(unsub)
+  })
+
+  it('returns a no-op unsubscribe when bridge is unavailable', () => {
+    window.bridge = undefined as unknown as typeof window.bridge
+
+    const returned = createEditorLibraryAdapter().onLibrariesChanged(jest.fn())
+
+    expect(() => returned()).not.toThrow()
   })
 })

--- a/src/middleware/adapters/editor/__tests__/project-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/project-adapter.test.ts
@@ -470,6 +470,14 @@ describe('createEditorProjectAdapter', () => {
       expect(window.bridge.retrieveRecent).toHaveBeenCalledTimes(1)
       expect(result).toEqual(mockRecentProjects)
     })
+
+    it('returns an empty list when the preload bridge is unavailable', async () => {
+      window.bridge = undefined as unknown as typeof window.bridge
+
+      const result = await adapter.getRecentProjects()
+
+      expect(result).toEqual([])
+    })
   })
 
   describe('readFileContent', () => {

--- a/src/middleware/adapters/editor/__tests__/simulator-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/simulator-adapter.test.ts
@@ -154,6 +154,21 @@ describe('onStopped', () => {
     expect(window.bridge.onSimulatorStopped).toHaveBeenCalled()
   })
 
+  it('does not throw when simulator stopped event bridge is unavailable', () => {
+    window.bridge = {
+      ...window.bridge,
+      onSimulatorStopped: undefined,
+    } as unknown as typeof window.bridge
+
+    expect(() => createEditorSimulatorAdapter()).not.toThrow()
+  })
+
+  it('does not throw when the bridge is unavailable during adapter creation', () => {
+    window.bridge = undefined as unknown as typeof window.bridge
+
+    expect(() => createEditorSimulatorAdapter()).not.toThrow()
+  })
+
   it('fires callback when main process signals stopped', async () => {
     const cb = jest.fn()
     adapter.onStopped(cb)

--- a/src/middleware/adapters/editor/__tests__/system-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/system-adapter.test.ts
@@ -69,3 +69,21 @@ describe('log', () => {
     expect(window.bridge.log).toHaveBeenCalledWith('error', 'error message')
   })
 })
+
+describe('missing preload bridge', () => {
+  it('uses browser-safe fallbacks', async () => {
+    window.bridge = undefined as unknown as typeof window.bridge
+    ;(window.matchMedia as jest.Mock | undefined) = jest.fn().mockReturnValue({ matches: false })
+    adapter = createEditorSystemAdapter()
+
+    await expect(adapter.getSystemInfo()).resolves.toEqual({
+      OS: '',
+      architecture: '',
+      prefersDarkMode: false,
+      isWindowMaximized: false,
+    })
+    await expect(adapter.openExternalLink('https://example.com')).resolves.toEqual({ success: false })
+
+    expect(() => adapter.log('info', 'ignored')).not.toThrow()
+  })
+})

--- a/src/middleware/adapters/editor/__tests__/theme-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/theme-adapter.test.ts
@@ -100,3 +100,19 @@ describe('onThemeChanged', () => {
     expect(cb).not.toHaveBeenCalled()
   })
 })
+
+describe('missing preload bridge', () => {
+  it('keeps local theme state and returns a no-op unsubscribe', () => {
+    window.bridge = undefined as unknown as typeof window.bridge
+    adapter = createEditorThemeAdapter()
+
+    expect(() => adapter.setTheme('light')).not.toThrow()
+    expect(adapter.getCurrentTheme()).toBe('light')
+    expect(() => adapter.toggleTheme()).not.toThrow()
+    expect(adapter.getCurrentTheme()).toBe('dark')
+
+    const unsub = adapter.onThemeChanged(jest.fn())
+    expect(typeof unsub).toBe('function')
+    expect(unsub).not.toThrow()
+  })
+})

--- a/src/middleware/adapters/editor/__tests__/window-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/window-adapter.test.ts
@@ -160,3 +160,23 @@ describe('onMaximizedChanged', () => {
     unsub()
   })
 })
+
+describe('missing preload bridge', () => {
+  it('turns window operations and listeners into no-ops', () => {
+    window.bridge = undefined as unknown as typeof window.bridge
+    adapter = createEditorWindowAdapter()
+
+    expect(() => adapter.minimize()).not.toThrow()
+    expect(() => adapter.maximize()).not.toThrow()
+    expect(() => adapter.close()).not.toThrow()
+    expect(() => adapter.hide()).not.toThrow()
+    expect(() => adapter.reload()).not.toThrow()
+    expect(() => adapter.quit()).not.toThrow()
+    expect(() => adapter.rebuildMenu()).not.toThrow()
+
+    expect(adapter.onCloseRequested(jest.fn())).not.toThrow()
+    expect(adapter.onDarwinAppQuitting!(jest.fn())).not.toThrow()
+    expect(adapter.enableAutoCloseHandshake!()).not.toThrow()
+    expect(adapter.onMaximizedChanged!(jest.fn())).not.toThrow()
+  })
+})

--- a/src/middleware/adapters/editor/accelerator-adapter.ts
+++ b/src/middleware/adapters/editor/accelerator-adapter.ts
@@ -29,156 +29,87 @@
 import type { AcceleratorPort } from '../../shared/ports/accelerator-port'
 import type { Unsubscribe } from '../../shared/ports/types'
 
+type BridgeListener = (callback: (...args: unknown[]) => void) => void
+
+const subscribeBridgeEvent = (
+  listener: BridgeListener | undefined,
+  callback: (...args: unknown[]) => void,
+  mapArgs: (...args: unknown[]) => unknown[] = () => [],
+): Unsubscribe => {
+  if (typeof listener !== 'function') {
+    return () => {}
+  }
+
+  let active = true
+  listener((...args: unknown[]) => {
+    if (active) callback(...mapArgs(...args))
+  })
+
+  return () => {
+    active = false
+  }
+}
+
 export function createEditorAcceleratorAdapter(): AcceleratorPort {
   return {
     onCreateProject(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.createProjectAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.createProjectAccelerator, callback)
     },
 
     onOpenProject(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.handleOpenProjectRequest(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.handleOpenProjectRequest, callback)
     },
 
     onOpenRecent(callback: (projectData?: unknown) => void): Unsubscribe {
-      let active = true
-      window.bridge.openRecentAccelerator((_event: unknown, response: unknown) => {
-        if (active) callback(response)
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.openRecentAccelerator, callback, (_event, response) => [response])
     },
 
     onSaveProject(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.saveProjectAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.saveProjectAccelerator, callback)
     },
 
     onSaveFile(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.saveFileAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.saveFileAccelerator, callback)
     },
 
     onCloseProject(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.closeProjectAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.closeProjectAccelerator, callback)
     },
 
     onExportProject(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.exportProjectRequest(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.exportProjectRequest, callback)
     },
 
     onCloseTab(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.closeTabAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.closeTabAccelerator, callback)
     },
 
     onDeleteFile(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.deleteFileAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.deleteFileAccelerator, callback)
     },
 
     onFindInProject(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.findInProjectAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.findInProjectAccelerator, callback)
     },
 
     onUndo(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.handleUndoRequest(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.handleUndoRequest, callback)
     },
 
     onRedo(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.handleRedoRequest(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.handleRedoRequest, callback)
     },
 
     onSwitchPerspective(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.switchPerspective(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.switchPerspective, callback)
     },
 
     onAbout(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.aboutModalAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.aboutModalAccelerator, callback)
     },
 
     onQuitApp(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.quitAppRequest(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return subscribeBridgeEvent(window.bridge?.quitAppRequest, callback)
     },
   }
 }

--- a/src/middleware/adapters/editor/compiler-adapter.ts
+++ b/src/middleware/adapters/editor/compiler-adapter.ts
@@ -204,6 +204,7 @@ export function createEditorCompilerAdapter(): CompilerPort {
         let hasError = false
         let lastError = ''
         let hexPath: string | undefined
+        let settled = false
 
         window.bridge.runCompileProgram(
           [
@@ -225,7 +226,11 @@ export function createEditorCompilerAdapter(): CompilerPort {
             }
 
             if (data.closePort) {
-              onProgress({ stage: 'done', message: 'Compilation complete' })
+              if (settled) return
+              settled = true
+              if (!hasError) {
+                onProgress({ stage: 'done', message: 'Compilation complete' })
+              }
               resolve(
                 hasError
                   ? { success: false, error: lastError }

--- a/src/middleware/adapters/editor/device-adapter.ts
+++ b/src/middleware/adapters/editor/device-adapter.ts
@@ -24,7 +24,7 @@ export function createEditorDeviceAdapter(): DevicePort {
     },
 
     getCommunicationPorts(): Promise<CommunicationPort[]> {
-      return window.bridge.getAvailableCommunicationPorts()
+      return window.bridge?.getAvailableCommunicationPorts?.() ?? Promise.resolve([])
     },
 
     refreshBoards(): Promise<Array<{ board: string; version: string }>> {
@@ -32,7 +32,7 @@ export function createEditorDeviceAdapter(): DevicePort {
     },
 
     refreshCommunicationPorts(): Promise<CommunicationPort[]> {
-      return window.bridge.refreshCommunicationPorts()
+      return window.bridge?.refreshCommunicationPorts?.() ?? Promise.resolve([])
     },
 
     getPreviewImage(imageName: string, packagePath?: string): Promise<string> {

--- a/src/middleware/adapters/editor/library-adapter.ts
+++ b/src/middleware/adapters/editor/library-adapter.ts
@@ -28,25 +28,45 @@ export function createEditorLibraryAdapter(): LibraryPort {
       // boundary — the structural shape lines up by construction
       // (the main process JSON.parses .stlib files we ship and
       // .stlib files compileStlib produces, both share the contract).
+      if (typeof window.bridge?.loadAllLibraries !== 'function') {
+        return []
+      }
+
       const archives = await window.bridge.loadAllLibraries()
       return archives as StlibArchiveDTO[]
     },
 
     listInstalled(): Promise<InstalledLibrary[]> {
+      if (typeof window.bridge?.listInstalledLibraries !== 'function') {
+        return Promise.resolve([])
+      }
+
       return window.bridge.listInstalledLibraries()
     },
 
     installFromFile(): Promise<LibraryInstallResult> {
+      if (typeof window.bridge?.installLibraryFromFile !== 'function') {
+        return Promise.resolve({ success: false, error: 'Library installation is not available in this context' })
+      }
+
       return window.bridge.installLibraryFromFile()
     },
 
     async uninstall(name: string): Promise<Result> {
+      if (typeof window.bridge?.uninstallLibrary !== 'function') {
+        return { success: false, error: 'Library uninstall is not available in this context' }
+      }
+
       const result = await window.bridge.uninstallLibrary(name)
       if (result.success) return { success: true } as Result
       return { success: false, error: result.error ?? 'Uninstall failed' }
     },
 
     onLibrariesChanged(callback: () => void): Unsubscribe {
+      if (typeof window.bridge?.onLibrariesChanged !== 'function') {
+        return () => undefined
+      }
+
       return window.bridge.onLibrariesChanged(callback)
     },
   }

--- a/src/middleware/adapters/editor/project-adapter.ts
+++ b/src/middleware/adapters/editor/project-adapter.ts
@@ -288,7 +288,7 @@ export function createEditorProjectAdapter(): ProjectPort {
     },
 
     async getRecentProjects(): Promise<RecentProject[]> {
-      return window.bridge.retrieveRecent()
+      return window.bridge?.retrieveRecent?.() ?? []
     },
 
     async readFileContent(filePath: string): Promise<{ success: boolean; content?: string; error?: string }> {

--- a/src/middleware/adapters/editor/simulator-adapter.ts
+++ b/src/middleware/adapters/editor/simulator-adapter.ts
@@ -23,10 +23,13 @@ export function createEditorSimulatorAdapter(
   const stopCallbacks: Array<() => void> = []
 
   // Subscribe to main process simulator stop events once on creation
-  const unsubscribeFromMain = window.bridge.onSimulatorStopped(() => {
-    running = false
-    for (const cb of stopCallbacks) cb()
-  })
+  const unsubscribeFromMain =
+    typeof window.bridge?.onSimulatorStopped === 'function'
+      ? window.bridge.onSimulatorStopped(() => {
+          running = false
+          for (const cb of stopCallbacks) cb()
+        })
+      : undefined
 
   // Keep the unsubscribe reference to allow cleanup if needed
   void unsubscribeFromMain

--- a/src/middleware/adapters/editor/stlib-source-adapter.ts
+++ b/src/middleware/adapters/editor/stlib-source-adapter.ts
@@ -43,6 +43,11 @@ export function createEditorStlibSourceAdapter(): StlibSourcePort {
 
   async function ensureCache(): Promise<Map<string, CachedArchive>> {
     if (archives) return archives
+    if (typeof window.bridge?.loadAllLibraries !== 'function') {
+      archives = new Map<string, CachedArchive>()
+      return archives
+    }
+
     // Returns StlibArchiveDTO[] — the structural shape matches
     // strucpp's `StlibArchive` (just a JSON object).  Each entry
     // carries a full `manifest` block and the chunks/dependencies.

--- a/src/middleware/adapters/editor/system-adapter.ts
+++ b/src/middleware/adapters/editor/system-adapter.ts
@@ -19,23 +19,35 @@ import type { SystemInfo } from '../../shared/ports/types'
 export function createEditorSystemAdapter(): SystemPort {
   return {
     getSystemInfo(): Promise<SystemInfo> {
-      return window.bridge.getSystemInfo()
+      return (
+        window.bridge?.getSystemInfo?.() ??
+        Promise.resolve({
+          OS: '',
+          architecture: '',
+          prefersDarkMode: window.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false,
+          isWindowMaximized: false,
+        })
+      )
     },
 
     getStoreValue(key: string): Promise<unknown> {
-      return window.bridge.getStoreValue(key)
+      return window.bridge?.getStoreValue?.(key) ?? Promise.resolve(localStorage.getItem(key))
     },
 
     setStoreValue(key: string, value: string): void {
-      window.bridge.setStoreValue(key, value)
+      if (typeof window.bridge?.setStoreValue === 'function') {
+        window.bridge.setStoreValue(key, value)
+        return
+      }
+      localStorage.setItem(key, value)
     },
 
     openExternalLink(url: string): Promise<{ success: boolean }> {
-      return window.bridge.openExternalLinkAccelerator(url)
+      return window.bridge?.openExternalLinkAccelerator?.(url) ?? Promise.resolve({ success: false })
     },
 
     log(level: 'info' | 'error', message: string): void {
-      window.bridge.log(level, message)
+      window.bridge?.log?.(level, message)
     },
   }
 }

--- a/src/middleware/adapters/editor/theme-adapter.ts
+++ b/src/middleware/adapters/editor/theme-adapter.ts
@@ -25,12 +25,12 @@ export function createEditorThemeAdapter(): ThemePort {
 
     setTheme(theme: ThemeVariant): void {
       currentTheme = theme
-      window.bridge.winHandleUpdateTheme()
+      window.bridge?.winHandleUpdateTheme?.()
     },
 
     toggleTheme(): void {
       currentTheme = currentTheme === 'dark' ? 'light' : 'dark'
-      window.bridge.winHandleUpdateTheme()
+      window.bridge?.winHandleUpdateTheme?.()
     },
 
     onThemeChanged(callback: (theme: ThemeVariant) => void): Unsubscribe {
@@ -40,6 +40,12 @@ export function createEditorThemeAdapter(): ThemePort {
         if (!active) return
         currentTheme = currentTheme === 'dark' ? 'light' : 'dark'
         callback(currentTheme)
+      }
+
+      if (typeof window.bridge?.handleUpdateTheme !== 'function') {
+        return () => {
+          active = false
+        }
       }
 
       window.bridge.handleUpdateTheme(handler)

--- a/src/middleware/adapters/editor/window-adapter.ts
+++ b/src/middleware/adapters/editor/window-adapter.ts
@@ -25,34 +25,38 @@ import type { WindowPort } from '../../shared/ports/window-port'
 export function createEditorWindowAdapter(): WindowPort {
   return {
     minimize(): void {
-      window.bridge.minimizeWindow()
+      window.bridge?.minimizeWindow?.()
     },
 
     maximize(): void {
-      window.bridge.maximizeWindow()
+      window.bridge?.maximizeWindow?.()
     },
 
     close(): void {
-      window.bridge.handleCloseOrHideWindow()
+      window.bridge?.handleCloseOrHideWindow?.()
     },
 
     hide(): void {
-      window.bridge.hideWindow()
+      window.bridge?.hideWindow?.()
     },
 
     reload(): void {
-      window.bridge.reloadWindow()
+      window.bridge?.reloadWindow?.()
     },
 
     quit(): void {
-      window.bridge.handleQuitApp()
+      window.bridge?.handleQuitApp?.()
     },
 
     rebuildMenu(): void {
-      window.bridge.rebuildMenu()
+      window.bridge?.rebuildMenu?.()
     },
 
     onCloseRequested(callback: () => void): Unsubscribe {
+      if (typeof window.bridge?.windowIsClosing !== 'function') {
+        return () => {}
+      }
+
       let active = true
       window.bridge.windowIsClosing(() => {
         if (active) callback()
@@ -63,6 +67,10 @@ export function createEditorWindowAdapter(): WindowPort {
     },
 
     onDarwinAppQuitting(callback: () => void): Unsubscribe {
+      if (typeof window.bridge?.darwinAppIsClosing !== 'function') {
+        return () => {}
+      }
+
       let active = true
       window.bridge.darwinAppIsClosing(() => {
         if (active) callback()
@@ -73,13 +81,17 @@ export function createEditorWindowAdapter(): WindowPort {
     },
 
     enableAutoCloseHandshake(): Unsubscribe {
-      window.bridge.handleCloseOrHideWindowAccelerator()
+      window.bridge?.handleCloseOrHideWindowAccelerator?.()
       return () => {
-        window.bridge.removeHandleCloseOrHideWindowAccelerator()
+        window.bridge?.removeHandleCloseOrHideWindowAccelerator?.()
       }
     },
 
     onMaximizedChanged(callback: (isMaximized: boolean) => void): Unsubscribe {
+      if (typeof window.bridge?.isMaximizedWindow !== 'function') {
+        return () => {}
+      }
+
       let maximized = false
 
       const handler = () => {


### PR DESCRIPTION
## Summary
- Report board-target resolution failures in the build console instead of leaving compilation hanging.
- Avoid logging `Compilation complete` or duplicating errors after a failed compile stream closes.
- Clean up related dev-console warnings from FBD SVG icons, panel sizing, and async branch callbacks.

## Root Cause
Board resolution can fail before the compiler reaches later progress logs. The main-process IPC path did not forward that failure as a terminal build result, so the renderer stayed in a pending-looking state.

## Validation
- `npx jest src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts --runInBand --no-coverage`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SVG icon rendering with proper React attribute formatting
  * Eliminated duplicate error messages during compilation failures
  * Improved panel layout responsiveness based on panel size changes
  * Enhanced async callback handling in branch switching

* **Improvements**
  * Strengthened error handling and recovery throughout the application with comprehensive fallback mechanisms
  * Added defensive checks to prevent crashes when system components are unavailable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autonomy-Logic/openplc-editor/pull/792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->