### PR TITLE
refactor(project-service): share WriteProjectFiles enumeration

### DIFF
--- a/src/backend/editor/services/project-service/index.ts
+++ b/src/backend/editor/services/project-service/index.ts
@@ -1,6 +1,8 @@
+import { iterateWriteProjectFiles } from '@root/backend/shared/project/iterate-write-project-files'
 import { projectDefaultFilesMapSchema } from '@root/backend/shared/project/project-files-schema'
 import { PLCProject } from '@root/backend/shared/types/PLC/open-plc'
 import { getDefaultSchemaValues } from '@root/backend/shared/utils/default-zod-schema-values'
+import type { WriteProjectFiles } from '@root/middleware/shared/ports/project-port'
 import {
   CreateProjectFileProps,
   IProjectRecentHistoryEntry,
@@ -377,39 +379,15 @@ class ProjectService {
   /**
    * Write pre-serialized project files to disk.
    * The frontend handles all serialization — this method is a dumb batch file writer.
+   *
+   * The "which files exist in a save" enumeration lives in the
+   * shared `iterateWriteProjectFiles` so the web adapter's API
+   * envelope packer walks the same category list — no more
+   * hand-maintained twin lists drifting when a new file category
+   * (like `library.json`) gets added.
    */
-  async writeProjectFiles(files: {
-    projectPath: string
-    projectJson: string
-    /** Library projects don't own `devices/configuration.json`; the
-     *  renderer sends `undefined` for those, and we skip the write
-     *  here instead of truncating the on-disk copy to an empty
-     *  string. */
-    deviceConfig?: string
-    /** Same optional-on-libraries semantics as `deviceConfig`. */
-    pinMapping?: string
-    /** Library projects' manifest (`library.json`).  PLC projects
-     *  send `undefined`; libraries whose manifest tab hasn't been
-     *  mounted this session also send `undefined` (no pending edits
-     *  to flush).  Skipped on the write side when undefined so the
-     *  on-disk copy stays intact. */
-    libraryManifest?: string
-    pouFiles: Array<{ relativePath: string; content: string }>
-    serverFiles: Array<{ relativePath: string; content: string }>
-    remoteDeviceFiles: Array<{ relativePath: string; content: string }>
-    deletions: string[]
-  }): Promise<IProjectServiceResponse> {
-    const {
-      projectPath,
-      projectJson,
-      deviceConfig,
-      pinMapping,
-      libraryManifest,
-      pouFiles,
-      serverFiles,
-      remoteDeviceFiles,
-      deletions,
-    } = files
+  async writeProjectFiles(files: WriteProjectFiles): Promise<IProjectServiceResponse> {
+    const { projectPath, deletions } = files
 
     if (!projectPath) {
       return {
@@ -422,46 +400,27 @@ class ProjectService {
     const dir = normalized.endsWith('/project.json') ? normalized.slice(0, -'/project.json'.length) : normalized
 
     try {
-      // Ensure standard directories exist
+      // Defensive mkdir for the project's canonical directory shape.
+      // Keeps these paths present even when the corresponding file
+      // arrays are empty (e.g. fresh library with no servers yet),
+      // so callers can rely on them existing.
       await Promise.all(
         ['pous/programs', 'pous/functions', 'pous/function-blocks', 'devices/servers', 'devices/remote'].map((d) =>
           promises.mkdir(join(dir, d), { recursive: true }),
         ),
       )
 
-      // Write config files.  `deviceConfig` / `pinMapping` /
-      // `libraryManifest` are optional — each is skipped by project
-      // types that don't own it, so the renderer sends `undefined`
-      // and we leave the on-disk copies untouched rather than
-      // overwriting them with an empty string.
-      const writes: Promise<void>[] = [promises.writeFile(join(dir, 'project.json'), projectJson, 'utf-8')]
-      if (deviceConfig !== undefined) {
-        writes.push(promises.writeFile(join(dir, 'devices/configuration.json'), deviceConfig, 'utf-8'))
-      }
-      if (pinMapping !== undefined) {
-        writes.push(promises.writeFile(join(dir, 'devices/pin-mapping.json'), pinMapping, 'utf-8'))
-      }
-      if (libraryManifest !== undefined) {
-        writes.push(promises.writeFile(join(dir, 'library.json'), libraryManifest, 'utf-8'))
-      }
-      await Promise.all(writes)
-
-      // Write POU files
-      for (const file of pouFiles) {
-        const filePath = join(dir, file.relativePath)
-        await promises.mkdir(dirname(filePath), { recursive: true })
-        await promises.writeFile(filePath, file.content, 'utf-8')
-      }
-
-      // Write server files
-      for (const file of serverFiles) {
-        await promises.writeFile(join(dir, file.relativePath), file.content, 'utf-8')
-      }
-
-      // Write remote device files
-      for (const file of remoteDeviceFiles) {
-        await promises.writeFile(join(dir, file.relativePath), file.content, 'utf-8')
-      }
+      // Single source of truth for the file shape lives in the
+      // shared iterator.  Each yielded entry is one independent
+      // file write; the batch fans out in parallel since paths
+      // are distinct and mkdir(recursive) is idempotent.
+      await Promise.all(
+        Array.from(iterateWriteProjectFiles(files), async (entry) => {
+          const filePath = join(dir, entry.relativePath)
+          await promises.mkdir(dirname(filePath), { recursive: true })
+          await promises.writeFile(filePath, entry.content, 'utf-8')
+        }),
+      )
 
       // Process deletions
       for (const relativePath of deletions) {

--- a/src/backend/shared/project/__tests__/iterate-write-project-files.test.ts
+++ b/src/backend/shared/project/__tests__/iterate-write-project-files.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the single-source-of-truth iterator over a
+ * `WriteProjectFiles` payload.  Adapter sides on both the editor
+ * (filesystem writer) and the web (Edge API envelope packer) iterate
+ * this generator to learn "which relative paths exist in a save
+ * request" — keeping the category list in one place is the whole
+ * point.  Pinning the shape with tests means a future contributor
+ * who adds a new file category can't ship a half-wired change that
+ * works on one platform but silently drops the file on the other.
+ */
+
+import type { WriteProjectFiles } from '../../../../middleware/shared/ports/project-port'
+import { iterateWriteProjectFiles } from '../iterate-write-project-files'
+
+const baseFiles: WriteProjectFiles = {
+  projectPath: '/p',
+  projectJson: '{"meta":{}}',
+  pouFiles: [],
+  serverFiles: [],
+  remoteDeviceFiles: [],
+  deletions: [],
+}
+
+function collect(files: WriteProjectFiles) {
+  return Array.from(iterateWriteProjectFiles(files))
+}
+
+describe('iterateWriteProjectFiles', () => {
+  it('always yields project.json first', () => {
+    const entries = collect(baseFiles)
+    expect(entries[0]).toEqual({ category: 'project-json', relativePath: 'project.json', content: '{"meta":{}}' })
+  })
+
+  it('yields nothing else for an empty PLC project (no optionals, no arrays)', () => {
+    expect(collect(baseFiles)).toHaveLength(1)
+  })
+
+  describe('optional top-level files', () => {
+    it('yields deviceConfig when defined', () => {
+      const entries = collect({ ...baseFiles, deviceConfig: '{"board":"x"}' })
+      expect(entries).toContainEqual({
+        category: 'device-config',
+        relativePath: 'devices/configuration.json',
+        content: '{"board":"x"}',
+      })
+    })
+
+    it('omits deviceConfig when undefined', () => {
+      const categories = collect(baseFiles).map((e) => e.category)
+      expect(categories).not.toContain('device-config')
+    })
+
+    it('yields deviceConfig even when empty string (caller opted in to an empty file)', () => {
+      const entries = collect({ ...baseFiles, deviceConfig: '' })
+      expect(entries).toContainEqual({
+        category: 'device-config',
+        relativePath: 'devices/configuration.json',
+        content: '',
+      })
+    })
+
+    it('yields pinMapping when defined', () => {
+      const entries = collect({ ...baseFiles, pinMapping: '[]' })
+      expect(entries).toContainEqual({
+        category: 'pin-mapping',
+        relativePath: 'devices/pin-mapping.json',
+        content: '[]',
+      })
+    })
+
+    it('omits pinMapping when undefined', () => {
+      const categories = collect(baseFiles).map((e) => e.category)
+      expect(categories).not.toContain('pin-mapping')
+    })
+
+    it('yields libraryManifest when defined', () => {
+      const entries = collect({ ...baseFiles, libraryManifest: '{"name":"foo"}' })
+      expect(entries).toContainEqual({
+        category: 'library-manifest',
+        relativePath: 'library.json',
+        content: '{"name":"foo"}',
+      })
+    })
+
+    it('omits libraryManifest when undefined', () => {
+      const categories = collect(baseFiles).map((e) => e.category)
+      expect(categories).not.toContain('library-manifest')
+    })
+  })
+
+  describe('file arrays', () => {
+    it('yields each POU file preserving relativePath verbatim', () => {
+      const entries = collect({
+        ...baseFiles,
+        pouFiles: [
+          { relativePath: 'pous/programs/main.st', content: 'PROGRAM main\nEND_PROGRAM' },
+          { relativePath: 'pous/function-blocks/counter.fbd', content: '<fbd/>' },
+        ],
+      })
+      expect(entries.filter((e) => e.category === 'pou')).toEqual([
+        { category: 'pou', relativePath: 'pous/programs/main.st', content: 'PROGRAM main\nEND_PROGRAM' },
+        { category: 'pou', relativePath: 'pous/function-blocks/counter.fbd', content: '<fbd/>' },
+      ])
+    })
+
+    it('yields each server file preserving relativePath verbatim', () => {
+      const entries = collect({
+        ...baseFiles,
+        serverFiles: [
+          { relativePath: 'devices/servers/modbus.json', content: '{"port":502}' },
+          { relativePath: 'devices/servers/opcua.json', content: '{"port":4840}' },
+        ],
+      })
+      expect(entries.filter((e) => e.category === 'server')).toEqual([
+        { category: 'server', relativePath: 'devices/servers/modbus.json', content: '{"port":502}' },
+        { category: 'server', relativePath: 'devices/servers/opcua.json', content: '{"port":4840}' },
+      ])
+    })
+
+    it('yields each remote device file preserving relativePath verbatim', () => {
+      const entries = collect({
+        ...baseFiles,
+        remoteDeviceFiles: [{ relativePath: 'devices/remote/bus0.json', content: '{"id":"bus0"}' }],
+      })
+      expect(entries.filter((e) => e.category === 'remote-device')).toEqual([
+        { category: 'remote-device', relativePath: 'devices/remote/bus0.json', content: '{"id":"bus0"}' },
+      ])
+    })
+  })
+
+  describe('whole-project shapes', () => {
+    it('PLC project: project.json + device-config + pin-mapping + POUs, no library-manifest', () => {
+      const entries = collect({
+        ...baseFiles,
+        deviceConfig: '{"board":"uno"}',
+        pinMapping: '[]',
+        pouFiles: [{ relativePath: 'pous/programs/main.st', content: 'PROGRAM main\nEND_PROGRAM' }],
+      })
+      expect(entries.map((e) => e.category)).toEqual(['project-json', 'device-config', 'pin-mapping', 'pou'])
+    })
+
+    it('library project: project.json + library-manifest, no device files, no POUs', () => {
+      const entries = collect({ ...baseFiles, libraryManifest: '{"name":"mylib","version":"0.1.0"}' })
+      expect(entries.map((e) => e.category)).toEqual(['project-json', 'library-manifest'])
+    })
+
+    it('library project with content: project.json + library-manifest + POUs', () => {
+      const entries = collect({
+        ...baseFiles,
+        libraryManifest: '{"name":"mylib"}',
+        pouFiles: [
+          { relativePath: 'pous/functions/add.st', content: 'FUNCTION add' },
+          { relativePath: 'pous/function-blocks/timer.st', content: 'FUNCTION_BLOCK timer' },
+        ],
+      })
+      expect(entries.map((e) => e.category)).toEqual(['project-json', 'library-manifest', 'pou', 'pou'])
+    })
+  })
+
+  describe('ordering', () => {
+    it('emits in a stable order: project.json, device-config, pin-mapping, library-manifest, pous, servers, remote-devices', () => {
+      const entries = collect({
+        ...baseFiles,
+        deviceConfig: 'D',
+        pinMapping: 'P',
+        libraryManifest: 'L',
+        pouFiles: [{ relativePath: 'pous/programs/a.st', content: 'A' }],
+        serverFiles: [{ relativePath: 'devices/servers/s.json', content: 'S' }],
+        remoteDeviceFiles: [{ relativePath: 'devices/remote/r.json', content: 'R' }],
+      })
+      expect(entries.map((e) => e.category)).toEqual([
+        'project-json',
+        'device-config',
+        'pin-mapping',
+        'library-manifest',
+        'pou',
+        'server',
+        'remote-device',
+      ])
+    })
+  })
+})

--- a/src/backend/shared/project/iterate-write-project-files.ts
+++ b/src/backend/shared/project/iterate-write-project-files.ts
@@ -1,0 +1,70 @@
+/**
+ * Single source of truth for the file shape a project ships with.
+ *
+ * `WriteProjectFiles` carries a flat collection of pre-serialized
+ * file contents the renderer wants to persist.  Each platform
+ * adapter (editor → filesystem, web → Edge API envelope) has to
+ * translate that collection into its storage layout.  Both used to
+ * enumerate the file categories by hand, which drifted: when
+ * `libraryManifest` was added to the WriteProjectFiles shape, the
+ * editor's filesystem writer was updated but the web's envelope
+ * packer wasn't — silently dropping `library.json` on save and
+ * surfacing as "library.json not found" at compile time.
+ *
+ * This module is the one place that knows "what relative paths /
+ * categories live in a WriteProjectFiles".  Adapter sides iterate
+ * this generator and dispatch on `category`; adding a new file
+ * category means updating this file once.
+ */
+
+import type { WriteProjectFiles } from '../../../middleware/shared/ports/project-port'
+
+/**
+ * One file in a WriteProjectFiles.  `relativePath` is always the
+ * project-root-relative path (matches the on-disk shape on the
+ * editor side and the canonical contract for web envelope packing).
+ * `category` lets adapters dispatch when the destination shape
+ * needs category awareness — the web's envelope nests pous under
+ * `apiFiles.pous[subcategory][filename]`, for instance.
+ */
+export type WriteProjectFileEntry =
+  | { category: 'project-json'; relativePath: 'project.json'; content: string }
+  | { category: 'device-config'; relativePath: 'devices/configuration.json'; content: string }
+  | { category: 'pin-mapping'; relativePath: 'devices/pin-mapping.json'; content: string }
+  | { category: 'library-manifest'; relativePath: 'library.json'; content: string }
+  | { category: 'pou'; relativePath: string; content: string }
+  | { category: 'server'; relativePath: string; content: string }
+  | { category: 'remote-device'; relativePath: string; content: string }
+
+/**
+ * Yield every file in a WriteProjectFiles as a `WriteProjectFileEntry`.
+ *
+ * Order is stable but not semantically significant — adapters are
+ * free to fan out writes in parallel.  Optional top-level files
+ * (`deviceConfig`, `pinMapping`, `libraryManifest`) are skipped
+ * when `undefined`, matching the "renderer didn't touch it, leave
+ * the on-disk copy alone" contract documented on the port shape.
+ */
+export function* iterateWriteProjectFiles(files: WriteProjectFiles): Generator<WriteProjectFileEntry> {
+  yield { category: 'project-json', relativePath: 'project.json', content: files.projectJson }
+
+  if (files.deviceConfig !== undefined) {
+    yield { category: 'device-config', relativePath: 'devices/configuration.json', content: files.deviceConfig }
+  }
+  if (files.pinMapping !== undefined) {
+    yield { category: 'pin-mapping', relativePath: 'devices/pin-mapping.json', content: files.pinMapping }
+  }
+  if (files.libraryManifest !== undefined) {
+    yield { category: 'library-manifest', relativePath: 'library.json', content: files.libraryManifest }
+  }
+
+  for (const f of files.pouFiles) {
+    yield { category: 'pou', relativePath: f.relativePath, content: f.content }
+  }
+  for (const f of files.serverFiles) {
+    yield { category: 'server', relativePath: f.relativePath, content: f.content }
+  }
+  for (const f of files.remoteDeviceFiles) {
+    yield { category: 'remote-device', relativePath: f.relativePath, content: f.content }
+  }
+}


### PR DESCRIPTION
## Summary
- Extract the WriteProjectFiles → on-disk-file-shape enumeration into a single shared generator at \`backend/shared/project/iterate-write-project-files.ts\`.
- Refactor \`writeProjectFiles\` in \`project-service\` to consume the iterator instead of its hand-rolled enumeration.
- Adds 16 unit tests for the iterator at 100% coverage on the new file.

## Why
The same enumeration ("project.json, devices/configuration.json, devices/pin-mapping.json, library.json, pous/{cat}/{file}, devices/servers/{file}, devices/remote/{file}") lives in TWO places: this writer (writing to disk) and the openplc-web project adapter (packing into the Edge API envelope). They drifted: \`library.json\` was wired on the editor side but the web's envelope packer never picked it up — surfacing as blank manifests on web library project load and "library.json not found" at library compile. This is the editor half of the fix; the web half lives at <https://github.com/Autonomy-Logic/openplc-web/pull/new/refactor/thin-saveFile-shared-iterator> and the shared iterator file is byte-identical between the two repos.

## What changed
- New: \`src/backend/shared/project/iterate-write-project-files.ts\` (~75 LOC). Generator yielding tagged entries per file category. Adding a new file category propagates to every adapter that consumes the iterator.
- New: \`src/backend/shared/project/__tests__/iterate-write-project-files.test.ts\` (16 tests).
- Modified: \`src/backend/editor/services/project-service/index.ts\` — \`writeProjectFiles\` is now ~25 lines instead of ~91. Same files written with same contents, same deletion behaviour. Internal write fan-out is more aggressively parallelised (paths are distinct, \`mkdir(recursive: true)\` is idempotent).

## Test plan
- [x] \`npm test\` — iterator tests (16) + adapter tests (41) pass
- [x] 100% coverage on the new iterator file (functions/lines/statements/branches)
- [x] \`npm run lint\` clean (only pre-existing unrelated warnings)
- [x] Typecheck clean
- [x] Manually verified on desktop: PLC project save/reopen, library project create/edit-manifest/add-blocks/save/reopen, library compile produces \`.stlib\`, POU deletion still works

## Out of scope
- The matching openplc-web changes ship in a separate PR — they include the byte-identical iterator copy + a thin-layer rewrite of the web's \`saveFile\` (load-patch-save) + envelope helpers.
- The autonomy-edge orchestrator seeding \`library.json\` on library project creation is a separate concern in a separate repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized project file writing logic for improved performance and maintainability.

* **Tests**
  * Added comprehensive test coverage for project file operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autonomy-Logic/openplc-editor/pull/793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->