### PR TITLE
fix(compile): block compilation on blank FBD variable blocks

### DIFF
--- a/src/backend/shared/compile/__tests__/pipeline.test.ts
+++ b/src/backend/shared/compile/__tests__/pipeline.test.ts
@@ -221,6 +221,70 @@ describe('runCompilePipeline — simulator path', () => {
   })
 })
 
+describe('runCompilePipeline — blank FBD variable guard', () => {
+  const fbdPouWithEmptyVar = {
+    type: 'program',
+    data: {
+      name: 'main',
+      language: 'fbd',
+      variables: [],
+      documentation: '',
+      body: {
+        language: 'fbd',
+        value: {
+          name: 'main',
+          rung: {
+            comment: '',
+            nodes: [
+              {
+                id: 'blk',
+                type: 'block',
+                position: { x: 0, y: 0 },
+                draggable: true,
+                selectable: true,
+                data: { variant: { name: 'blink_py' }, variable: { name: 'BLINK_PY0' } },
+              },
+              {
+                id: 'n1',
+                type: 'output-variable',
+                position: { x: 16, y: 32 },
+                draggable: true,
+                selectable: true,
+                data: { variable: { name: '' } },
+              },
+            ],
+            edges: [{ id: 'e1', source: 'blk', sourceHandle: 'blink_out', target: 'n1', targetHandle: 'in' }],
+          },
+        },
+      },
+    },
+  }
+
+  it('bails at the validate stage before XML generation when an FBD variable is unnamed', async () => {
+    const port = makePort()
+    const { events, emit } = captureEvents()
+
+    const projectData = {
+      ...projectDataFixture,
+      pous: [fbdPouWithEmptyVar],
+    } as unknown as PLCProjectData
+
+    const result = await runCompilePipeline(makeArgs({ projectData }), port, emit)
+
+    expect(result.success).toBe(false)
+    // Validation runs before XML generation / xml2st.
+    expect(mockedXmlGen).not.toHaveBeenCalled()
+    expect(port.transpileXmlToSt).not.toHaveBeenCalled()
+    // The user-facing error names the POU and the kind of block.
+    const validateError = events.find((e) => e.stage === 'validate' && e.level === 'error')
+    expect(validateError?.message).toContain('POU "main"')
+    expect(validateError?.message).toContain('output variable block has no name')
+    // Identifies what the block is wired to rather than raw coordinates.
+    expect(validateError?.message).toContain('connected to "blink_out" of "BLINK_PY0"')
+    expect(events.some((e) => e.message === 'Stopping compilation process.')).toBe(true)
+  })
+})
+
 describe('runCompilePipeline — arduino direct path', () => {
   it('uploads to the physical board when isSimulator=false and not compileOnly', async () => {
     const port = makePort()

--- a/src/backend/shared/compile/__tests__/validate-empty-variables.test.ts
+++ b/src/backend/shared/compile/__tests__/validate-empty-variables.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the pre-compile blank-FBD-variable guard.
+ *
+ * An unnamed FBD input/output variable block becomes an empty
+ * `<expression/>` in the PLCopen XML, which crashes xml2st with
+ * `'NoneType' object has no attribute 'split'`.  These tests pin the
+ * detector that lets the pipeline bail with a clear message — naming
+ * what the block is wired to, or its position when it is wired to
+ * nothing.
+ */
+
+import type { PLCProjectData } from '../../types/PLC/open-plc'
+import { findEmptyFbdVariables } from '../steps/validate-empty-variables'
+
+type TestNode = {
+  id: string
+  type: string
+  position: { x: number; y: number }
+  draggable: boolean
+  selectable: boolean
+  data: unknown
+}
+
+type TestEdge = { id: string; source: string; sourceHandle: string; target: string; targetHandle: string }
+
+function makeNode(id: string, type: string, data: unknown, x = 0, y = 0): TestNode {
+  return { id, type, position: { x, y }, draggable: true, selectable: true, data }
+}
+
+function varNode(id: string, type: string, name: string | undefined, x = 0, y = 0): TestNode {
+  return makeNode(id, type, name === undefined ? {} : { variable: { name } }, x, y)
+}
+
+function makeFbdPou(name: string, nodes: TestNode[], edges: TestEdge[] = []) {
+  return {
+    type: 'program',
+    data: {
+      name,
+      language: 'fbd',
+      variables: [],
+      documentation: '',
+      body: { language: 'fbd', value: { name, rung: { comment: '', nodes, edges } } },
+    },
+  }
+}
+
+function makeProject(pous: unknown[]): PLCProjectData {
+  return {
+    pous,
+    dataTypes: [],
+    configuration: { resource: { tasks: [], instances: [], globalVariables: [] } },
+  } as unknown as PLCProjectData
+}
+
+describe('findEmptyFbdVariables — detection', () => {
+  it('flags an FBD input variable block with an empty name', () => {
+    const issues = findEmptyFbdVariables(
+      makeProject([makeFbdPou('main', [varNode('v1', 'input-variable', '', 16, 32)])]),
+    )
+    expect(issues).toEqual([{ pouName: 'main', kind: 'input', connectedTo: null, x: 16, y: 32 }])
+  })
+
+  it('flags an FBD output variable block with an empty name', () => {
+    const issues = findEmptyFbdVariables(
+      makeProject([makeFbdPou('main', [varNode('v1', 'output-variable', '', 48, 64)])]),
+    )
+    expect(issues).toEqual([{ pouName: 'main', kind: 'output', connectedTo: null, x: 48, y: 64 }])
+  })
+
+  it('treats a whitespace-only name as empty', () => {
+    expect(
+      findEmptyFbdVariables(makeProject([makeFbdPou('main', [varNode('v1', 'input-variable', '   ')])])),
+    ).toHaveLength(1)
+  })
+
+  it('flags a variable node whose data has no variable field', () => {
+    const issues = findEmptyFbdVariables(
+      makeProject([makeFbdPou('main', [varNode('v1', 'output-variable', undefined)])]),
+    )
+    expect(issues[0]).toMatchObject({ pouName: 'main', kind: 'output', connectedTo: null })
+  })
+
+  it('passes named variable blocks', () => {
+    const nodes = [varNode('v1', 'input-variable', 'T#1s'), varNode('v2', 'output-variable', 'blink_out')]
+    expect(findEmptyFbdVariables(makeProject([makeFbdPou('main', nodes)]))).toEqual([])
+  })
+
+  it('ignores non-variable FBD nodes (blocks, comments, connectors)', () => {
+    const nodes = [makeNode('b', 'block', {}), makeNode('c', 'comment', {}), varNode('k', 'connector', '')]
+    expect(findEmptyFbdVariables(makeProject([makeFbdPou('main', nodes)]))).toEqual([])
+  })
+
+  it('ignores non-FBD POUs', () => {
+    const stPou = {
+      type: 'program',
+      data: { name: 'st_pou', language: 'st', variables: [], documentation: '', body: { language: 'st', value: '' } },
+    }
+    expect(findEmptyFbdVariables(makeProject([stPou]))).toEqual([])
+  })
+
+  it('reports one entry per offending block across multiple POUs', () => {
+    const a = makeFbdPou('a', [varNode('v1', 'input-variable', ''), varNode('v2', 'output-variable', 'ok')])
+    const b = makeFbdPou('b', [varNode('v3', 'output-variable', '')])
+    const issues = findEmptyFbdVariables(makeProject([a, b]))
+    expect(issues).toHaveLength(2)
+    expect(issues.map((i) => i.pouName)).toEqual(['a', 'b'])
+  })
+})
+
+describe('findEmptyFbdVariables — connection description', () => {
+  it('describes the block output an empty output variable is wired to', () => {
+    // The real-world bug: an unnamed output wired to a function-block instance's output pin.
+    const block = makeNode('blk', 'block', { variant: { name: 'blink_py' }, variable: { name: 'BLINK_PY0' } })
+    const empty = varNode('out', 'output-variable', '')
+    const edge: TestEdge = { id: 'e1', source: 'blk', sourceHandle: 'blink_out', target: 'out', targetHandle: 'in' }
+    const issues = findEmptyFbdVariables(makeProject([makeFbdPou('main', [block, empty], [edge])]))
+    expect(issues[0].connectedTo).toBe('"blink_out" of "BLINK_PY0"')
+  })
+
+  it('describes the block input pin an empty input variable drives', () => {
+    const block = makeNode('blk', 'block', { variant: { name: 'TON' } })
+    const empty = varNode('in', 'input-variable', '')
+    const edge: TestEdge = { id: 'e1', source: 'in', sourceHandle: 'out', target: 'blk', targetHandle: 'PT' }
+    const issues = findEmptyFbdVariables(makeProject([makeFbdPou('main', [empty, block], [edge])]))
+    // No instance name → falls back to the block type.
+    expect(issues[0].connectedTo).toBe('"PT" of "TON"')
+  })
+
+  it('labels a wired block by its type when the instance name is blank', () => {
+    const block = makeNode('blk', 'block', { variant: { name: 'TON' }, variable: { name: '' } })
+    const empty = varNode('out', 'output-variable', '')
+    const edge: TestEdge = { id: 'e1', source: 'blk', sourceHandle: 'Q', target: 'out', targetHandle: 'in' }
+    const issues = findEmptyFbdVariables(makeProject([makeFbdPou('main', [block, empty], [edge])]))
+    expect(issues[0].connectedTo).toBe('"Q" of "TON"')
+  })
+
+  it('falls back to the handle alone when the wired block has no label', () => {
+    const block = makeNode('blk', 'block', {})
+    const empty = varNode('out', 'output-variable', '')
+    const edge: TestEdge = { id: 'e1', source: 'blk', sourceHandle: 'Q', target: 'out', targetHandle: 'in' }
+    const issues = findEmptyFbdVariables(makeProject([makeFbdPou('main', [block, empty], [edge])]))
+    expect(issues[0].connectedTo).toBe('the "Q" pin of a block')
+  })
+
+  it('describes a wired non-block neighbour by its name', () => {
+    const other = varNode('src', 'input-variable', 'sensor')
+    const empty = varNode('out', 'output-variable', '')
+    const edge: TestEdge = { id: 'e1', source: 'src', sourceHandle: 'out', target: 'out', targetHandle: 'in' }
+    const issues = findEmptyFbdVariables(makeProject([makeFbdPou('main', [other, empty], [edge])]))
+    expect(issues[0].connectedTo).toBe('"sensor"')
+  })
+
+  it('returns null when the wired neighbour cannot be labelled', () => {
+    const other = varNode('src', 'continuation', '')
+    const empty = varNode('out', 'output-variable', '')
+    const edge: TestEdge = { id: 'e1', source: 'src', sourceHandle: 'out', target: 'out', targetHandle: 'in' }
+    const issues = findEmptyFbdVariables(makeProject([makeFbdPou('main', [other, empty], [edge])]))
+    expect(issues[0].connectedTo).toBeNull()
+  })
+
+  it('returns null when the edge points at a missing node', () => {
+    const empty = varNode('out', 'output-variable', '')
+    const edge: TestEdge = { id: 'e1', source: 'ghost', sourceHandle: 'out', target: 'out', targetHandle: 'in' }
+    const issues = findEmptyFbdVariables(makeProject([makeFbdPou('main', [empty], [edge])]))
+    expect(issues[0].connectedTo).toBeNull()
+  })
+})

--- a/src/backend/shared/compile/pipeline.ts
+++ b/src/backend/shared/compile/pipeline.ts
@@ -43,6 +43,7 @@ import { XmlGenerator } from '../utils/PLC/xml-generator'
 import { buildCBlocksFromPous, composeFirmwareBundle } from './steps/compose-firmware-bundle'
 import { generateRuntimeConfs } from './steps/generate-confs'
 import { generateDefinesContent } from './steps/generate-defines'
+import { findEmptyFbdVariables } from './steps/validate-empty-variables'
 
 // ---------------------------------------------------------------------------
 // Public contract
@@ -57,6 +58,7 @@ import { generateDefinesContent } from './steps/generate-defines'
 export interface PipelineProgressEvent {
   stage:
     | 'preprocess'
+    | 'validate'
     | 'xml'
     | 'st'
     | 'strucpp'
@@ -306,6 +308,28 @@ async function runCompilePipelineInner(
     originalCppPous?: Array<{ name: string; code: string; variables: unknown[] }>
   }
   const originalCppPous = processedData.originalCppPous ?? []
+
+  // ---------------------------------------------------------------------
+  // Step 0b: Reject blank FBD variable blocks before XML generation.
+  //
+  // An unnamed FBD in/out variable serialises to an empty
+  // `<expression/>`, which makes xml2st crash with the opaque
+  // `'NoneType' object has no attribute 'split'`.  Catch it here and
+  // tell the user exactly which POU to fix.
+  // ---------------------------------------------------------------------
+  const emptyVariables = findEmptyFbdVariables(processedData)
+  if (emptyVariables.length > 0) {
+    for (const variable of emptyVariables) {
+      const where =
+        variable.connectedTo !== null ? `connected to ${variable.connectedTo}` : `at x=${variable.x}, y=${variable.y}`
+      emit({
+        stage: 'validate',
+        message: `POU "${variable.pouName}": an FBD ${variable.kind} variable block has no name (${where}). Name it before compiling.`,
+        level: 'error',
+      })
+    }
+    return bailError(emit, 'validate', 'Compilation aborted: name all variable blocks and try again.')
+  }
 
   // ---------------------------------------------------------------------
   // Step 1: Generate IEC 61131-3 XML from the project JSON.

--- a/src/backend/shared/compile/steps/validate-empty-variables.ts
+++ b/src/backend/shared/compile/steps/validate-empty-variables.ts
@@ -1,0 +1,104 @@
+import { PLCProjectData } from '../../types/PLC/open-plc'
+
+/**
+ * An FBD variable block (input or output) whose name is blank.
+ *
+ * Such a block serialises to an empty `<expression/>` in the PLCopen
+ * XML, which makes xml2st abort the whole compile with the opaque
+ * `'NoneType' object has no attribute 'split'` error.  We catch it
+ * before XML generation and report it in terms the user can act on:
+ * what the block is wired to, falling back to its canvas position when
+ * it is wired to nothing.
+ */
+export type EmptyFbdVariable = {
+  pouName: string
+  kind: 'input' | 'output'
+  /** Human description of the wired neighbour, or `null` when unconnected. */
+  connectedTo: string | null
+  x: number
+  y: number
+}
+
+/** The `input-variable` / `output-variable` FBD node kinds we check. */
+const VARIABLE_NODE_KINDS: Record<string, EmptyFbdVariable['kind']> = {
+  'input-variable': 'input',
+  'output-variable': 'output',
+}
+
+/**
+ * The slices of an FBD node we read.  The flow schema types `node.data`
+ * as `any` (it is platform UI state), so we narrow to the two fields
+ * used to label a node: a variable/instance `name` and a block's
+ * `variant.name` (its type).
+ */
+type FbdNodeData = { variable?: { name?: string }; variant?: { name?: string } }
+
+/** Structural shape of the FBD rung we traverse (subset of the flow schema). */
+type FbdRung = {
+  nodes: ReadonlyArray<{ id: string; type: string; data?: unknown }>
+  edges: ReadonlyArray<{ source: string; sourceHandle: string; target: string; targetHandle: string }>
+}
+
+/** Best user-facing label for a node: its instance/variable name, else its block type. */
+function nodeLabel(data: unknown): string | undefined {
+  const { variable, variant } = (data ?? {}) as FbdNodeData
+  return variable?.name?.trim() || variant?.name?.trim() || undefined
+}
+
+/**
+ * Describe what an FBD variable block is wired to, e.g. `"blink_out" of
+ * "BLINK_PY0"` or `"T#1s"`.  Output variables are fed by an incoming
+ * edge; input variables drive an outgoing one.  Returns `null` when the
+ * block is unconnected or the neighbour cannot be labelled.
+ */
+function describeConnection(nodeId: string, kind: EmptyFbdVariable['kind'], rung: FbdRung): string | null {
+  const edge =
+    kind === 'output' ? rung.edges.find((e) => e.target === nodeId) : rung.edges.find((e) => e.source === nodeId)
+  if (edge === undefined) return null
+
+  const neighbourId = kind === 'output' ? edge.source : edge.target
+  const handle = kind === 'output' ? edge.sourceHandle : edge.targetHandle
+  const neighbour = rung.nodes.find((n) => n.id === neighbourId)
+  if (neighbour === undefined) return null
+
+  const label = nodeLabel(neighbour.data)
+  if (neighbour.type === 'block' && handle) {
+    return label ? `"${handle}" of "${label}"` : `the "${handle}" pin of a block`
+  }
+  return label ? `"${label}"` : null
+}
+
+/**
+ * Scan every FBD POU body for variable blocks with a blank name.
+ *
+ * Returns one entry per offending block.  Only FBD bodies are checked:
+ * the Ladder editor never lets a variable block go unnamed, and textual
+ * bodies cannot express this case.
+ */
+export function findEmptyFbdVariables(projectData: PLCProjectData): EmptyFbdVariable[] {
+  const issues: EmptyFbdVariable[] = []
+
+  for (const pou of projectData.pous) {
+    const body = pou.data.body
+    if (body.language !== 'fbd') continue
+    const rung = body.value.rung
+
+    for (const node of rung.nodes) {
+      const kind = VARIABLE_NODE_KINDS[node.type]
+      if (kind === undefined) continue
+
+      const name = (node.data as FbdNodeData | undefined)?.variable?.name
+      if (name === undefined || name.trim() === '') {
+        issues.push({
+          pouName: pou.data.name,
+          kind,
+          connectedTo: describeConnection(node.id, kind, rung),
+          x: node.position.x,
+          y: node.position.y,
+        })
+      }
+    }
+  }
+
+  return issues
+}


### PR DESCRIPTION
## What

Adds a shared pre-compile guard that blocks compilation when an FBD body contains an **input/output variable block with a blank name**.

An unnamed FBD variable serialises to an empty `<expression/>` in the PLCopen XML, which makes xml2st abort the whole compile with the opaque error:

```
'NoneType' object has no attribute 'split'
```

## How

`findEmptyFbdVariables()` (new, in `src/backend/shared/compile/steps/`) scans every FBD POU for blank input/output variable nodes. The pipeline runs it before XML generation (new `validate` stage) and bails with a clear, per-block console message identifying **what the offending block is wired to**, e.g.:

```
POU "main": an FBD output variable block has no name (connected to "blink_out" of "BLINK_PY0"). Name it before compiling.
```

Falls back to the block's canvas position when it is wired to nothing.

## Scope

FBD only — the Ladder editor never lets a variable block go unnamed, and textual bodies can't express this case.

## Notes

- Lives entirely in the shared surface (`src/backend/shared/compile/`); no platform adapter needed.
- **Paired with openplc-web PR #438** — shared surface stays byte-identical.

## Tests

New unit tests for the validator + a pipeline test asserting it bails before XML/xml2st. Full compile suite green (122 tests); 100% enforced coverage on the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compilation validation to detect unnamed variables in FBD diagrams earlier with detailed error reporting.

* **Tests**
  * Added comprehensive test coverage for FBD variable validation detection and error message generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autonomy-Logic/openplc-editor/pull/801?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->