### PR TITLE
feat(libraries): browse + install from the public library catalog

### DIFF
--- a/src/backend/editor/library-manager/__tests__/library-manager-module.test.ts
+++ b/src/backend/editor/library-manager/__tests__/library-manager-module.test.ts
@@ -363,4 +363,98 @@ describe('LibraryManagerModule', () => {
       expect(mod.listInstalled()).toEqual([])
     })
   })
+
+  describe('installFromCatalog', () => {
+    function makeStubTransport(
+      archives: Record<string, ReturnType<typeof makeArchive>>,
+      errors: Record<string, string> = {},
+    ) {
+      return {
+        fetchJson: jest.fn(async () => {
+          throw new Error('unused in these tests')
+        }),
+        fetchText: jest.fn(async (path: string) => {
+          // /public/libraries/:id/download
+          const match = path.match(/\/public\/libraries\/([^/]+)\/download/)
+          const id = match ? decodeURIComponent(match[1]) : ''
+          if (errors[id]) throw new Error(errors[id])
+          const archive = archives[id]
+          if (!archive) throw new Error(`Catalog request failed: 404 Not Found`)
+          return JSON.stringify(archive)
+        }),
+      }
+    }
+
+    it('downloads each id, persists it, and returns a per-item summary', async () => {
+      const transport = makeStubTransport({
+        'pub-1': makeArchive('alpha-lib', '1.0.0'),
+        'pub-2': makeArchive('beta-lib', '2.0.0'),
+      })
+      const mod = new LibraryManagerModule({ librariesDir, bundledDir, catalogTransport: transport })
+
+      const batch = await mod.installFromCatalog(['pub-1', 'pub-2'])
+
+      expect(batch.results).toEqual([
+        { publishedLibraryId: 'pub-1', success: true, name: 'alpha-lib', version: '1.0.0' },
+        { publishedLibraryId: 'pub-2', success: true, name: 'beta-lib', version: '2.0.0' },
+      ])
+      // Both files actually land on disk in the user-installed
+      // shape so subsequent listInstalled() picks them up.
+      expect(existsSync(join(librariesDir, 'alpha-lib', 'alpha-lib.stlib'))).toBe(true)
+      expect(existsSync(join(librariesDir, 'beta-lib', 'beta-lib.stlib'))).toBe(true)
+      expect(mod.listInstalled().map((r) => r.name)).toEqual(['alpha-lib', 'beta-lib'])
+    })
+
+    it('reports per-item failures without aborting the batch', async () => {
+      const transport = makeStubTransport(
+        { 'pub-good': makeArchive('good-lib', '1.0.0') },
+        { 'pub-bad': 'Catalog request failed: 503 Service Unavailable' },
+      )
+      const mod = new LibraryManagerModule({ librariesDir, bundledDir, catalogTransport: transport })
+
+      const batch = await mod.installFromCatalog(['pub-bad', 'pub-good'])
+
+      expect(batch.results).toHaveLength(2)
+      expect(batch.results[0]).toMatchObject({
+        publishedLibraryId: 'pub-bad',
+        success: false,
+        error: expect.stringContaining('503'),
+      })
+      expect(batch.results[1]).toMatchObject({
+        publishedLibraryId: 'pub-good',
+        success: true,
+        name: 'good-lib',
+      })
+      // The good one still made it to disk.
+      expect(existsSync(join(librariesDir, 'good-lib', 'good-lib.stlib'))).toBe(true)
+    })
+
+    it('returns an empty batch when called with no ids', async () => {
+      const transport = makeStubTransport({})
+      const mod = new LibraryManagerModule({ librariesDir, bundledDir, catalogTransport: transport })
+
+      const batch = await mod.installFromCatalog([])
+
+      expect(batch.results).toEqual([])
+      expect(transport.fetchText).not.toHaveBeenCalled()
+    })
+
+    it('surfaces a conflict when a download matches a bundled library name', async () => {
+      writeBundled(makeArchive('iec-standard-fb'))
+      const transport = makeStubTransport({
+        'pub-x': makeArchive('iec-standard-fb', '9.9.9'),
+      })
+      const mod = new LibraryManagerModule({ librariesDir, bundledDir, catalogTransport: transport })
+
+      const batch = await mod.installFromCatalog(['pub-x'])
+
+      expect(batch.results).toHaveLength(1)
+      expect(batch.results[0]).toMatchObject({
+        publishedLibraryId: 'pub-x',
+        success: false,
+        name: 'iec-standard-fb',
+        error: expect.stringContaining('bundled library'),
+      })
+    })
+  })
 })

--- a/src/backend/editor/library-manager/desktop-catalog-transport.ts
+++ b/src/backend/editor/library-manager/desktop-catalog-transport.ts
@@ -1,0 +1,141 @@
+/**
+ * Desktop implementation of `CatalogTransportPort` for the Electron
+ * main process.
+ *
+ * Wraps Node `https.request` in a small Promise façade that:
+ *   - resolves the base URL from `OPENPLC_EDGE_API_URL` (defaulting
+ *     to https://api.autonomylogic.com),
+ *   - serialises query parameters,
+ *   - accumulates the response body as a utf-8 string,
+ *   - turns non-2xx HTTP responses into thrown `Error`s the catalog
+ *     client surfaces verbatim,
+ *   - honours an AbortSignal so debounced / cancelled UI calls don't
+ *     leak in-flight requests.
+ *
+ * Built on the same `https.request` primitive the runtime-comms code
+ * already uses; deliberately not added on top of `electron.net.fetch`
+ * to stay framework-light and easy to mock in unit tests.
+ */
+
+import https from 'https'
+
+import type { CatalogQueryParams, CatalogTransportPort } from '../../../middleware/shared/ports/catalog-transport-port'
+
+/** Default base URL when no env override is set. */
+const DEFAULT_EDGE_API_URL = 'https://api.autonomylogic.com'
+
+/** Request timeout — covers catalog browsing AND `.stlib` downloads,
+ *  which can be a few hundred KB.  Errs long; the user is in front of
+ *  the modal and would rather see a real result than a premature retry. */
+const REQUEST_TIMEOUT_MS = 30_000
+
+export function getEdgeApiBaseUrl(): string {
+  const fromEnv = process.env.OPENPLC_EDGE_API_URL?.trim()
+  return fromEnv && fromEnv.length > 0 ? fromEnv.replace(/\/+$/, '') : DEFAULT_EDGE_API_URL
+}
+
+export function createDesktopCatalogTransport(): CatalogTransportPort {
+  return {
+    async fetchJson<T>(path: string, params?: CatalogQueryParams, signal?: AbortSignal): Promise<T> {
+      const body = await requestText(buildUrl(path, params), signal)
+      try {
+        return JSON.parse(body) as T
+      } catch (err) {
+        throw new Error(`Catalog response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    },
+
+    fetchText(path: string, signal?: AbortSignal): Promise<string> {
+      return requestText(buildUrl(path), signal)
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+function buildUrl(path: string, params?: CatalogQueryParams): string {
+  const base = getEdgeApiBaseUrl()
+  const url = new URL(path.startsWith('/') ? path : `/${path}`, base + '/')
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null) continue
+      url.searchParams.set(key, String(value))
+    }
+  }
+  return url.toString()
+}
+
+function requestText(url: string, signal?: AbortSignal): Promise<string> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(makeAbortError())
+      return
+    }
+
+    const parsed = new URL(url)
+    const reqOptions: https.RequestOptions = {
+      hostname: parsed.hostname,
+      port: parsed.port || undefined,
+      path: parsed.pathname + parsed.search,
+      method: 'GET',
+      headers: {
+        Accept: 'application/json, application/octet-stream;q=0.9, */*;q=0.5',
+        'User-Agent': 'OpenPLC-Editor/library-catalog',
+      },
+    }
+
+    const req = https.request(reqOptions, (res) => {
+      // Accumulate as a single utf-8 string instead of buffering raw
+      // chunks — sidesteps the Buffer[] vs Uint8Array[] friction in
+      // recent @types/node and matches the existing httpRequest in
+      // main.ts.  The body is JSON or a JSON-formatted .stlib, so
+      // string concatenation is the right model anyway.
+      let body = ''
+      res.setEncoding('utf-8')
+      res.on('data', (chunk: string) => {
+        body += chunk
+      })
+      res.on('end', () => {
+        const status = res.statusCode ?? 0
+        if (status < 200 || status >= 300) {
+          reject(
+            new Error(`Catalog request failed: ${status} ${res.statusMessage ?? ''} ${truncate(body, 200)}`.trim()),
+          )
+          return
+        }
+        resolve(body)
+      })
+    })
+
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      req.destroy(new Error(`Catalog request timed out after ${REQUEST_TIMEOUT_MS}ms`))
+    })
+
+    req.on('error', (err) => reject(err))
+
+    if (signal) {
+      const onAbort = () => {
+        req.destroy(makeAbortError())
+      }
+      if (signal.aborted) {
+        onAbort()
+      } else {
+        signal.addEventListener('abort', onAbort, { once: true })
+      }
+    }
+
+    req.end()
+  })
+}
+
+function makeAbortError(): Error {
+  const err = new Error('Catalog request aborted')
+  err.name = 'AbortError'
+  return err
+}
+
+function truncate(s: string, maxLen: number): string {
+  return s.length <= maxLen ? s : s.slice(0, maxLen) + '…'
+}

--- a/src/backend/editor/library-manager/library-manager-module.ts
+++ b/src/backend/editor/library-manager/library-manager-module.ts
@@ -2,6 +2,7 @@ import { app } from 'electron'
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { basename, extname, join } from 'path'
 
+import type { CatalogTransportPort } from '../../../middleware/shared/ports/catalog-transport-port'
 import type { StlibArchiveDTO } from '../../../middleware/shared/ports/library-port'
 import type { InstalledLibrary, LibraryInstallResult } from '../../../middleware/shared/ports/library-types'
 import { bundledArchiveToInstalledRow, userArchiveToInstalledRow } from '../../shared/library/installed-library-rows'
@@ -10,9 +11,30 @@ import {
   type PreparedLibrary,
   prepareStlibUpload,
 } from '../../shared/library/prepare-library-upload'
+import { downloadPublicLibrary } from '../../shared/library/public-catalog-client'
 import { validatePathId } from '../../shared/utils/path-safety'
 import { assertPathContained } from '../utils/path-containment'
+import { createDesktopCatalogTransport } from './desktop-catalog-transport'
 import type { LibraryRegistry } from './types'
+
+/**
+ * Per-item result of a batch catalog install.  Errors are surfaced
+ * inline so a single bad archive doesn't abort the rest — the modal
+ * renders a per-row pass/fail summary.
+ */
+export interface CatalogInstallItemResult {
+  publishedLibraryId: string
+  success: boolean
+  /** Manifest name once we've parsed the archive — present on success
+   *  and on conflict-style failures ("already installed"). */
+  name?: string
+  version?: string
+  error?: string
+}
+
+export interface CatalogInstallBatchResult {
+  results: CatalogInstallItemResult[]
+}
 
 /**
  * System-wide library pool.
@@ -38,11 +60,16 @@ export class LibraryManagerModule {
   private librariesDir: string
   private registryPath: string
   private bundledDir: string
+  private catalogTransport: CatalogTransportPort
 
-  constructor(opts?: { librariesDir?: string; bundledDir?: string }) {
+  constructor(opts?: { librariesDir?: string; bundledDir?: string; catalogTransport?: CatalogTransportPort }) {
     this.librariesDir = opts?.librariesDir ?? join(app.getPath('userData'), 'libraries')
     this.registryPath = join(this.librariesDir, 'registry.json')
     this.bundledDir = opts?.bundledDir ?? this.resolveDefaultBundledDir()
+    // The catalog transport is injected so tests can stub HTTP — the
+    // default desktop impl reads `OPENPLC_EDGE_API_URL` lazily on
+    // every request, so it picks up env changes without restarting.
+    this.catalogTransport = opts?.catalogTransport ?? createDesktopCatalogTransport()
     mkdirSync(this.librariesDir, { recursive: true })
   }
 
@@ -181,6 +208,52 @@ export class LibraryManagerModule {
       if (archive) out.push(archive)
     }
     return out
+  }
+
+  /**
+   * Install one or more libraries from the public catalog hosted on
+   * autonomy-edge.  Each id is fetched, validated, and persisted via
+   * the same `.stlib` install path the file picker uses — only the
+   * source of the archive bytes differs.
+   *
+   * Failures are per-item: a 404 / parse error / name-collision on
+   * one library doesn't abort the rest, so the modal can show
+   * "5 succeeded, 1 failed" rather than throw away the whole batch.
+   * Emits a single `libraries:changed` after the loop (the IPC
+   * handler does this) so the renderer refreshes once, not N times.
+   */
+  async installFromCatalog(publishedLibraryIds: string[]): Promise<CatalogInstallBatchResult> {
+    const results: CatalogInstallItemResult[] = []
+    for (const id of publishedLibraryIds) {
+      try {
+        const archiveText = await downloadPublicLibrary(this.catalogTransport, { id })
+        const prepared = prepareStlibUpload(archiveText)
+        const persistResult = this.persistPrepared(prepared)
+        if (persistResult.success && !persistResult.canceled) {
+          results.push({
+            publishedLibraryId: id,
+            success: true,
+            name: persistResult.name,
+            version: persistResult.version,
+          })
+        } else if (!persistResult.success) {
+          results.push({
+            publishedLibraryId: id,
+            success: false,
+            name: prepared.name,
+            version: prepared.version,
+            error: persistResult.error,
+          })
+        }
+      } catch (err) {
+        results.push({
+          publishedLibraryId: id,
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+    return { results }
   }
 
   /**

--- a/src/backend/shared/library/public-catalog-client.ts
+++ b/src/backend/shared/library/public-catalog-client.ts
@@ -1,0 +1,175 @@
+/**
+ * Shared public-library catalog client.
+ *
+ * Pure functions over a `CatalogTransportPort` — no platform code.
+ * Mirrors the autonomy-edge `public-libraries` HTTP surface:
+ *
+ *   GET /public/libraries                — paginated list
+ *   GET /public/libraries/:id            — detail + sibling versions
+ *   GET /public/libraries/by-name/:name  — every version of a named library
+ *   GET /public/libraries/:id/download   — raw .stlib bytes
+ *
+ * The desktop editor and the web editor both consume this module
+ * byte-identical; only the transport differs.  Response shapes are
+ * validated with zod so a backend drift surfaces as a precise
+ * "field X missing" message instead of `Cannot read .name of undefined`
+ * downstream.
+ */
+
+import { z } from 'zod'
+
+import type { CatalogTransportPort } from '../../../middleware/shared/ports/catalog-transport-port'
+
+// ---------------------------------------------------------------------------
+// Response schemas — mirror apps/backend/src/presentation/dtos/public-libraries/
+// ---------------------------------------------------------------------------
+
+const ManifestPousSchema = z.object({
+  functions: z.array(z.string()),
+  functionBlocks: z.array(z.string()),
+  types: z.array(z.string()),
+})
+
+const PublicLibrarySchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  name: z.string(),
+  version: z.string(),
+  displayName: z.string(),
+  description: z.string().nullable(),
+  license: z.string().nullable(),
+  authorHandle: z.string(),
+  manifestPous: ManifestPousSchema,
+  sizeBytes: z.number(),
+  sha256: z.string(),
+  downloadsCount: z.number(),
+  publishedAt: z.string(),
+  updatedAt: z.string(),
+  isProjectPublic: z.boolean(),
+  projectUrl: z.string().nullable(),
+  projectStarsCount: z.number().nullable(),
+})
+
+const ListPublicLibrariesResponseSchema = z.object({
+  libraries: z.array(PublicLibrarySchema),
+  total: z.number(),
+  page: z.number(),
+  limit: z.number(),
+  totalPages: z.number(),
+})
+
+const PublicLibraryDetailSchema = PublicLibrarySchema.extend({
+  siblingVersions: z.array(PublicLibrarySchema),
+})
+
+const GetPublicLibraryByNameSchema = z.object({
+  versions: z.array(PublicLibrarySchema),
+})
+
+// ---------------------------------------------------------------------------
+// Exported types — the discriminated union surface the UI consumes.
+// ---------------------------------------------------------------------------
+
+export type PublicLibrary = z.infer<typeof PublicLibrarySchema>
+export type ListPublicLibrariesResponse = z.infer<typeof ListPublicLibrariesResponseSchema>
+export type PublicLibraryDetail = z.infer<typeof PublicLibraryDetailSchema>
+export type GetPublicLibraryByNameResponse = z.infer<typeof GetPublicLibraryByNameSchema>
+
+export type PublicLibrarySort = 'popular' | 'recent'
+
+export interface ListPublicLibrariesArgs {
+  q?: string
+  page?: number
+  /** Server caps at 50; client requests at most that. */
+  limit?: number
+  sort?: PublicLibrarySort
+  signal?: AbortSignal
+}
+
+// ---------------------------------------------------------------------------
+// Client functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Page through `GET /public/libraries`.  Server-side sort options are
+ * `popular` (default) and `recent`; alphabetical sorting is a UI
+ * concern handled after the page arrives.
+ *
+ * Throws on transport failure (network error, non-2xx) and on schema
+ * mismatch (backend response shape drift).  Both render to the modal's
+ * error state the same way.
+ */
+export async function listPublicLibraries(
+  transport: CatalogTransportPort,
+  args: ListPublicLibrariesArgs = {},
+): Promise<ListPublicLibrariesResponse> {
+  const params: Record<string, string | number | boolean | undefined> = {
+    q: args.q,
+    page: args.page,
+    limit: args.limit,
+    sort: args.sort,
+  }
+  const raw = await transport.fetchJson<unknown>('/public/libraries', params, args.signal)
+  // The autonomy-edge response wraps the payload in `{ statusCode, data }`.
+  // We unwrap here so callers consume the schema-validated payload directly.
+  const inner = unwrapHttpEnvelope(raw)
+  return ListPublicLibrariesResponseSchema.parse(inner)
+}
+
+export async function getPublicLibraryDetail(
+  transport: CatalogTransportPort,
+  args: { id: string; signal?: AbortSignal },
+): Promise<PublicLibraryDetail> {
+  const raw = await transport.fetchJson<unknown>(
+    `/public/libraries/${encodeURIComponent(args.id)}`,
+    undefined,
+    args.signal,
+  )
+  const inner = unwrapHttpEnvelope(raw)
+  return PublicLibraryDetailSchema.parse(inner)
+}
+
+export async function getPublicLibraryByName(
+  transport: CatalogTransportPort,
+  args: { name: string; signal?: AbortSignal },
+): Promise<GetPublicLibraryByNameResponse> {
+  const raw = await transport.fetchJson<unknown>(
+    `/public/libraries/by-name/${encodeURIComponent(args.name)}`,
+    undefined,
+    args.signal,
+  )
+  const inner = unwrapHttpEnvelope(raw)
+  return GetPublicLibraryByNameSchema.parse(inner)
+}
+
+/**
+ * Download the raw `.stlib` archive bytes (utf-8 string).  Server
+ * returns `application/octet-stream` with a JSON body — the same
+ * shape `library-manager-module.persistPrepared` already accepts via
+ * the .stlib install path, so the caller can write the response
+ * verbatim to disk.
+ */
+export function downloadPublicLibrary(
+  transport: CatalogTransportPort,
+  args: { id: string; signal?: AbortSignal },
+): Promise<string> {
+  return transport.fetchText(`/public/libraries/${encodeURIComponent(args.id)}/download`, args.signal)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * autonomy-edge wraps every JSON response in `{ statusCode: number,
+ * data: T }`.  The catalog client unwraps once here so every schema
+ * targets the payload (`data`).  Older or off-spec responses (no
+ * envelope) fall through unchanged so a hand-rolled local backend
+ * during development still works.
+ */
+function unwrapHttpEnvelope(raw: unknown): unknown {
+  if (raw && typeof raw === 'object' && 'data' in raw && 'statusCode' in raw) {
+    return (raw as { data: unknown }).data
+  }
+  return raw
+}

--- a/src/backend/shared/library/public-catalog-client.ts
+++ b/src/backend/shared/library/public-catalog-client.ts
@@ -19,6 +19,12 @@
 import { z } from 'zod'
 
 import type { CatalogTransportPort } from '../../../middleware/shared/ports/catalog-transport-port'
+import type {
+  GetPublicLibraryByNameResponse,
+  ListPublicLibrariesArgs,
+  ListPublicLibrariesResponse,
+  PublicLibraryDetail,
+} from '../../../middleware/shared/ports/public-catalog-types'
 
 // ---------------------------------------------------------------------------
 // Response schemas — mirror apps/backend/src/presentation/dtos/public-libraries/
@@ -66,25 +72,15 @@ const GetPublicLibraryByNameSchema = z.object({
   versions: z.array(PublicLibrarySchema),
 })
 
-// ---------------------------------------------------------------------------
-// Exported types — the discriminated union surface the UI consumes.
-// ---------------------------------------------------------------------------
-
-export type PublicLibrary = z.infer<typeof PublicLibrarySchema>
-export type ListPublicLibrariesResponse = z.infer<typeof ListPublicLibrariesResponseSchema>
-export type PublicLibraryDetail = z.infer<typeof PublicLibraryDetailSchema>
-export type GetPublicLibraryByNameResponse = z.infer<typeof GetPublicLibraryByNameSchema>
-
-export type PublicLibrarySort = 'popular' | 'recent'
-
-export interface ListPublicLibrariesArgs {
-  q?: string
-  page?: number
-  /** Server caps at 50; client requests at most that. */
-  limit?: number
-  sort?: PublicLibrarySort
-  signal?: AbortSignal
-}
+// The schemas above guard the wire shape at runtime.  Static types
+// for everything that crosses the port boundary live in
+// `middleware/shared/ports/public-catalog-types.ts` — keeping types
+// there (not next to the schemas) lets the renderer import them
+// without crossing the architecture's `components → backend/shared`
+// boundary.  If the two ever drift, each client function's declared
+// return type forces TypeScript to reconcile its `z.infer<...>`
+// against the port-layer interface; a missing/renamed field surfaces
+// as a compile error at the `return ...Schema.parse(...)` call below.
 
 // ---------------------------------------------------------------------------
 // Client functions

--- a/src/frontend/components/_features/[workspace]/editor/library-manager/system-libraries-tab.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/library-manager/system-libraries-tab.tsx
@@ -66,13 +66,7 @@ const SystemLibrariesTab = ({ installed, onRefresh }: SystemLibrariesTabProps) =
 
   const handleImportFromInternet = useCallback(() => {
     setIsPopoverOpen(false)
-    openModal('debugger-message', {
-      type: 'info',
-      title: 'Coming Soon',
-      message: 'Online library browsing will be available in a future update.',
-      buttons: ['OK'],
-      onResponse: () => {},
-    })
+    openModal('public-catalog-browser')
   }, [openModal])
 
   const handleUninstall = useCallback(async () => {

--- a/src/frontend/components/_organisms/modals/confirm-install-libraries-modal.tsx
+++ b/src/frontend/components/_organisms/modals/confirm-install-libraries-modal.tsx
@@ -1,0 +1,181 @@
+/**
+ * Confirm-install step chained off `public-catalog-browser`.
+ *
+ * The browser hands its selection through `modalActions.openModal(
+ * 'confirm-install-libraries', { libraries: [...] })`; this modal
+ * renders the list verbatim, runs the install on Confirm, and shows
+ * a per-row pass/fail summary while keeping itself open just long
+ * enough for the user to read the result.  On a clean success it
+ * closes the whole modal chain (catalog browser too) and lets the
+ * Library Manager refresh through the existing `libraries:changed`
+ * event the IPC handler fires.
+ */
+
+import { useState } from 'react'
+
+import type { PublicLibrary } from '../../../../backend/shared/library/public-catalog-client'
+import type { CatalogInstallItem } from '../../../../middleware/shared/ports/library-port'
+import { useLibrary } from '../../../../middleware/shared/providers/platform-context'
+import { useOpenPLCStore } from '../../../store'
+import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'
+
+type ModalData = { libraries: PublicLibrary[] } | null
+
+const ConfirmInstallLibrariesModal = () => {
+  const library = useLibrary()
+  const modals = useOpenPLCStore((s) => s.modals)
+  const modalActions = useOpenPLCStore((s) => s.modalActions)
+  const isOpen = modals['confirm-install-libraries']?.open ?? false
+  const data = (modals['confirm-install-libraries']?.data ?? null) as ModalData
+  const selection = data?.libraries ?? []
+
+  const [phase, setPhase] = useState<'ready' | 'installing' | 'done'>('ready')
+  const [results, setResults] = useState<CatalogInstallItem[]>([])
+
+  const handleCancel = () => {
+    // Close only this modal — return the user to the catalog browser
+    // with their selection preserved.
+    modalActions.onOpenChange('confirm-install-libraries', false)
+    setPhase('ready')
+    setResults([])
+  }
+
+  const handleConfirm = async () => {
+    if (selection.length === 0) return
+    if (!library?.installFromCatalog) return
+    setPhase('installing')
+    const batch = await library.installFromCatalog(selection.map((l) => l.id))
+    setResults(batch.results)
+    setPhase('done')
+  }
+
+  const handleClose = () => {
+    // Closes BOTH this modal and the catalog browser underneath.
+    modalActions.closeModal()
+    setPhase('ready')
+    setResults([])
+  }
+
+  const successCount = results.filter((r) => r.success).length
+  const failureCount = results.length - successCount
+
+  return (
+    <Modal
+      open={isOpen}
+      onOpenChange={(open) => {
+        // Closing via Escape / overlay click should drop just this
+        // modal, not the catalog browser below.
+        if (!open && phase !== 'done') handleCancel()
+        if (!open && phase === 'done') handleClose()
+        modalActions.onOpenChange('confirm-install-libraries', open)
+      }}
+    >
+      <ModalContent className='flex max-h-[600px] w-[520px] select-none flex-col rounded-lg p-6'>
+        {phase === 'ready' && (
+          <>
+            <ModalTitle className='mb-2 text-xl font-semibold'>Install libraries</ModalTitle>
+            <p className='mb-4 text-sm text-neutral-600 dark:text-neutral-400'>
+              {selection.length === 1
+                ? 'The following library will be downloaded and installed:'
+                : `${selection.length} libraries will be downloaded and installed:`}
+            </p>
+            <ul className='mb-4 flex-1 overflow-auto rounded-md border border-neutral-200 dark:border-neutral-800'>
+              {selection.map((lib) => (
+                <li
+                  key={lib.id}
+                  className='flex items-center justify-between border-b border-neutral-100 px-3 py-2 last:border-b-0 dark:border-neutral-800'
+                >
+                  <span className='flex flex-col gap-0.5'>
+                    <span className='font-caption text-sm font-medium text-neutral-950 dark:text-white'>
+                      {lib.displayName}
+                    </span>
+                    <span className='text-[11px] text-neutral-500 dark:text-neutral-400'>by {lib.authorHandle}</span>
+                  </span>
+                  <span className='text-xs text-neutral-500 dark:text-neutral-400'>v{lib.version}</span>
+                </li>
+              ))}
+            </ul>
+            <div className='flex justify-end gap-3'>
+              <button
+                type='button'
+                onClick={handleCancel}
+                className='cursor-pointer rounded-md bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-1000 hover:bg-neutral-200 dark:bg-neutral-850 dark:text-neutral-100 dark:hover:bg-neutral-800'
+              >
+                Cancel
+              </button>
+              <button
+                type='button'
+                onClick={() => void handleConfirm()}
+                className='cursor-pointer rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-medium-dark'
+              >
+                Confirm install
+              </button>
+            </div>
+          </>
+        )}
+
+        {phase === 'installing' && (
+          <div className='flex flex-1 flex-col items-center justify-center gap-3 py-6'>
+            <span className='inline-block h-3 w-3 animate-pulse rounded-full bg-brand' />
+            <span className='text-sm text-neutral-700 dark:text-neutral-300'>
+              Installing {selection.length} {selection.length === 1 ? 'library' : 'libraries'}...
+            </span>
+          </div>
+        )}
+
+        {phase === 'done' && (
+          <>
+            <ModalTitle className='mb-2 text-xl font-semibold'>
+              {failureCount === 0 ? 'Install complete' : 'Install finished with errors'}
+            </ModalTitle>
+            <p className='mb-4 text-sm text-neutral-600 dark:text-neutral-400'>
+              {successCount} succeeded
+              {failureCount > 0 ? `, ${failureCount} failed` : ''}.
+            </p>
+            <ul className='mb-4 flex-1 overflow-auto rounded-md border border-neutral-200 dark:border-neutral-800'>
+              {results.map((r) => {
+                const matchedSelection = selection.find((l) => l.id === r.publishedLibraryId)
+                const displayName = r.name ?? matchedSelection?.displayName ?? r.publishedLibraryId
+                return (
+                  <li
+                    key={r.publishedLibraryId}
+                    className='flex flex-col gap-0.5 border-b border-neutral-100 px-3 py-2 last:border-b-0 dark:border-neutral-800'
+                  >
+                    <span className='flex items-baseline justify-between gap-3'>
+                      <span className='truncate text-sm font-medium text-neutral-950 dark:text-white'>
+                        {displayName}
+                      </span>
+                      <span
+                        className={
+                          r.success
+                            ? 'text-xs font-medium text-green-600 dark:text-green-400'
+                            : 'text-xs font-medium text-red-600 dark:text-red-400'
+                        }
+                      >
+                        {r.success ? 'installed' : 'failed'}
+                      </span>
+                    </span>
+                    {!r.success && r.error && (
+                      <span className='text-[11px] text-red-600 dark:text-red-400'>{r.error}</span>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+            <div className='flex justify-end'>
+              <button
+                type='button'
+                onClick={handleClose}
+                className='cursor-pointer rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-medium-dark'
+              >
+                Done
+              </button>
+            </div>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export { ConfirmInstallLibrariesModal }

--- a/src/frontend/components/_organisms/modals/confirm-install-libraries-modal.tsx
+++ b/src/frontend/components/_organisms/modals/confirm-install-libraries-modal.tsx
@@ -13,7 +13,7 @@
 
 import { useState } from 'react'
 
-import type { PublicLibrary } from '../../../../backend/shared/library/public-catalog-client'
+import type { PublicLibrary } from '../../../../middleware/shared/ports/public-catalog-types'
 import type { CatalogInstallItem } from '../../../../middleware/shared/ports/library-port'
 import { useLibrary } from '../../../../middleware/shared/providers/platform-context'
 import { useOpenPLCStore } from '../../../store'

--- a/src/frontend/components/_organisms/modals/confirm-install-libraries-modal.tsx
+++ b/src/frontend/components/_organisms/modals/confirm-install-libraries-modal.tsx
@@ -13,8 +13,8 @@
 
 import { useState } from 'react'
 
-import type { PublicLibrary } from '../../../../middleware/shared/ports/public-catalog-types'
 import type { CatalogInstallItem } from '../../../../middleware/shared/ports/library-port'
+import type { PublicLibrary } from '../../../../middleware/shared/ports/public-catalog-types'
 import { useLibrary } from '../../../../middleware/shared/providers/platform-context'
 import { useOpenPLCStore } from '../../../store'
 import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'

--- a/src/frontend/components/_organisms/modals/public-catalog-browser-modal.tsx
+++ b/src/frontend/components/_organisms/modals/public-catalog-browser-modal.tsx
@@ -1,0 +1,299 @@
+/**
+ * Browse the autonomy-edge public-library catalog.
+ *
+ * Single round-trip to `catalog:list` on open (sort=popular, limit=50);
+ * search + alphabetical sort run client-side over the loaded page so
+ * the UI stays responsive without re-firing requests on every
+ * keystroke.  Selection is multi-select; clicking Install hands the
+ * picked ids to the confirmation modal (chained on top, not chained
+ * in-place) so users see exactly what they're about to commit to.
+ *
+ * For libraries already installed, the row shows a muted "installed"
+ * badge and stays selectable — re-installing the same version is a
+ * no-op overwrite, which is the right behaviour for "I think the
+ * one I have is broken; reinstall."
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import type { PublicLibrary } from '../../../../backend/shared/library/public-catalog-client'
+import { useLibrary } from '../../../../middleware/shared/providers/platform-context'
+import { useOpenPLCStore } from '../../../store'
+import { cn } from '../../../utils/cn'
+import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'
+
+type SortMode = 'popular' | 'name'
+
+const PublicCatalogBrowserModal = () => {
+  const library = useLibrary()
+  const modals = useOpenPLCStore((s) => s.modals)
+  const modalActions = useOpenPLCStore((s) => s.modalActions)
+  const isOpen = modals['public-catalog-browser']?.open ?? false
+
+  // Names of currently-installed libraries (lower-cased for badge
+  // lookup).  Pulled from the store so the modal reflects an install
+  // that happened in a previous session without a fresh listInstalled
+  // call.
+  const installedNames = useMemo(() => {
+    const set = new Set<string>()
+    return set // populated by the effect below
+  }, [])
+  const [installedSet, setInstalledSet] = useState<Set<string>>(installedNames)
+
+  const [phase, setPhase] = useState<'loading' | 'ready' | 'error'>('loading')
+  const [error, setError] = useState<string | null>(null)
+  const [libraries, setLibraries] = useState<PublicLibrary[]>([])
+  const [query, setQuery] = useState('')
+  const [sort, setSort] = useState<SortMode>('popular')
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+
+  // Latest-request token so a slow request that finishes after the
+  // modal closes (or after a Reload click) doesn't overwrite fresher
+  // state.
+  const requestIdRef = useRef(0)
+
+  // Fetch the catalog on open + on every Reload click.
+  const runFetch = async () => {
+    if (!library?.queryPublicCatalog) {
+      setPhase('error')
+      setError('Public catalog is not available on this platform build.')
+      return
+    }
+    const myId = ++requestIdRef.current
+    setPhase('loading')
+    setError(null)
+    const result = await library.queryPublicCatalog({ sort: 'popular', limit: 50 })
+    if (myId !== requestIdRef.current) return
+    if (!result.success) {
+      setPhase('error')
+      setError(result.error)
+      return
+    }
+    setLibraries(result.data.libraries)
+    setPhase('ready')
+  }
+
+  useEffect(() => {
+    if (!isOpen) return
+    // Reset transient state on every open so a previous run's
+    // selection / search / error doesn't bleed in.
+    setQuery('')
+    setSort('popular')
+    setSelectedIds(new Set())
+    void runFetch()
+
+    // Refresh the "already installed" set for the visual badge.
+    if (library?.listInstalled) {
+      void library.listInstalled().then((rows) => {
+        const next = new Set<string>()
+        for (const row of rows) next.add(row.name.toLowerCase())
+        setInstalledSet(next)
+      })
+    }
+    return () => {
+      // Invalidate any in-flight request on close.
+      requestIdRef.current++
+    }
+    // We intentionally re-run on every open; `library` is stable per
+    // platform context.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen])
+
+  // ----- Derived view: search filter + client-side sort -----
+  const visibleLibraries = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    let rows = libraries
+    if (needle.length > 0) {
+      rows = rows.filter((lib) => {
+        return (
+          lib.name.toLowerCase().includes(needle) ||
+          lib.displayName.toLowerCase().includes(needle) ||
+          (lib.description?.toLowerCase().includes(needle) ?? false) ||
+          lib.authorHandle.toLowerCase().includes(needle)
+        )
+      })
+    }
+    if (sort === 'name') {
+      rows = [...rows].sort((a, b) => a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' }))
+    }
+    // 'popular' is the server-side order — preserved as-is.
+    return rows
+  }, [libraries, query, sort])
+
+  const handleClose = () => {
+    modalActions.closeModal()
+  }
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const handleInstall = () => {
+    if (selectedIds.size === 0) return
+    const picks = libraries.filter((l) => selectedIds.has(l.id))
+    modalActions.openModal('confirm-install-libraries', { libraries: picks })
+  }
+
+  const selectionCount = selectedIds.size
+
+  return (
+    <Modal
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) handleClose()
+        modalActions.onOpenChange('public-catalog-browser', open)
+      }}
+    >
+      <ModalContent className='flex h-[600px] w-[680px] select-none flex-col rounded-lg p-6'>
+        <ModalTitle className='mb-1 text-xl font-semibold'>Browse Public Libraries</ModalTitle>
+        <p className='mb-4 text-sm text-neutral-600 dark:text-neutral-400'>
+          Discover and install community-published OpenPLC libraries.
+        </p>
+
+        <div className='mb-3 flex items-center gap-2'>
+          <input
+            type='text'
+            placeholder='Search by name, author, or description...'
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            disabled={phase !== 'ready'}
+            className='flex-1 rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-1000 placeholder:text-neutral-400 focus:border-brand focus:outline-none disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-600'
+          />
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value as SortMode)}
+            disabled={phase !== 'ready'}
+            className='rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-1000 focus:border-brand focus:outline-none disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100'
+          >
+            <option value='popular'>Sort: Popularity</option>
+            <option value='name'>Sort: Name</option>
+          </select>
+        </div>
+
+        <div className='flex-1 overflow-auto rounded-md border border-neutral-200 dark:border-neutral-800'>
+          {phase === 'loading' && (
+            <div className='flex h-full items-center justify-center text-sm text-neutral-500 dark:text-neutral-400'>
+              <span className='mr-2 inline-block h-3 w-3 animate-pulse rounded-full bg-brand' />
+              Loading public catalog...
+            </div>
+          )}
+
+          {phase === 'error' && (
+            <div className='flex h-full flex-col items-center justify-center gap-3 px-6 text-center'>
+              <span className='text-sm text-red-600 dark:text-red-400'>{error ?? 'Could not load catalog.'}</span>
+              <button
+                type='button'
+                onClick={() => void runFetch()}
+                className='cursor-pointer rounded-md bg-brand px-3 py-1 text-xs font-medium text-white hover:bg-brand-medium-dark'
+              >
+                Retry
+              </button>
+            </div>
+          )}
+
+          {phase === 'ready' && visibleLibraries.length === 0 && (
+            <div className='flex h-full items-center justify-center text-sm text-neutral-500 dark:text-neutral-400'>
+              {libraries.length === 0 ? 'No libraries have been published yet.' : 'No results for your search.'}
+            </div>
+          )}
+
+          {phase === 'ready' && visibleLibraries.length > 0 && (
+            <ul className='divide-y divide-neutral-100 dark:divide-neutral-800'>
+              {visibleLibraries.map((lib) => {
+                const isSelected = selectedIds.has(lib.id)
+                const isInstalled = installedSet.has(lib.name.toLowerCase())
+                return (
+                  <li key={lib.id}>
+                    <button
+                      type='button'
+                      onClick={() => toggleSelect(lib.id)}
+                      aria-pressed={isSelected}
+                      className={cn(
+                        'flex w-full cursor-pointer items-start gap-3 px-3 py-2.5 text-left',
+                        isSelected
+                          ? 'bg-brand/15 dark:bg-brand/25 shadow-[inset_3px_0_0_var(--primary-default)]'
+                          : 'hover:bg-neutral-50 dark:hover:bg-neutral-900',
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          'mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border',
+                          isSelected
+                            ? 'border-brand bg-brand'
+                            : 'border-neutral-300 bg-white dark:border-neutral-700 dark:bg-neutral-950',
+                        )}
+                        aria-hidden
+                      >
+                        {isSelected && (
+                          <svg viewBox='0 0 12 12' className='h-3 w-3 stroke-white' fill='none' strokeWidth='2'>
+                            <path d='M2.5 6.5L4.5 8.5L9 3.5' />
+                          </svg>
+                        )}
+                      </span>
+                      <span className='flex min-w-0 flex-1 flex-col gap-0.5'>
+                        <span className='flex items-baseline justify-between gap-3'>
+                          <span className='truncate text-sm font-semibold text-neutral-950 dark:text-white'>
+                            {lib.displayName}
+                          </span>
+                          <span className='flex flex-shrink-0 items-center gap-2 text-[11px] text-neutral-500 dark:text-neutral-400'>
+                            v{lib.version}
+                            {isInstalled && (
+                              <span className='rounded-full bg-neutral-100 px-2 py-0.5 text-[10px] font-medium text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300'>
+                                installed
+                              </span>
+                            )}
+                          </span>
+                        </span>
+                        <span className='truncate text-xs text-neutral-600 dark:text-neutral-400'>
+                          {lib.description ?? 'No description.'}
+                        </span>
+                        <span className='flex items-center gap-3 text-[11px] text-neutral-500 dark:text-neutral-500'>
+                          <span>by {lib.authorHandle}</span>
+                          <span>· {lib.downloadsCount.toLocaleString()} downloads</span>
+                          {typeof lib.projectStarsCount === 'number' && (
+                            <span>· {lib.projectStarsCount.toLocaleString()} stars</span>
+                          )}
+                        </span>
+                      </span>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className='mt-4 flex items-center justify-between gap-3'>
+          <span className='text-xs text-neutral-500 dark:text-neutral-400'>
+            {selectionCount === 0 ? 'Select one or more libraries to install.' : `${selectionCount} selected.`}
+          </span>
+          <div className='flex gap-3'>
+            <button
+              type='button'
+              onClick={handleClose}
+              className='cursor-pointer rounded-md bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-1000 hover:bg-neutral-200 dark:bg-neutral-850 dark:text-neutral-100 dark:hover:bg-neutral-800'
+            >
+              Cancel
+            </button>
+            <button
+              type='button'
+              onClick={handleInstall}
+              disabled={selectionCount === 0}
+              className='cursor-pointer rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-medium-dark disabled:cursor-not-allowed disabled:opacity-50'
+            >
+              Install
+              {selectionCount > 0 ? ` (${selectionCount})` : ''}
+            </button>
+          </div>
+        </div>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export { PublicCatalogBrowserModal }

--- a/src/frontend/components/_organisms/modals/public-catalog-browser-modal.tsx
+++ b/src/frontend/components/_organisms/modals/public-catalog-browser-modal.tsx
@@ -16,7 +16,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 
-import type { PublicLibrary } from '../../../../backend/shared/library/public-catalog-client'
+import type { PublicLibrary } from '../../../../middleware/shared/ports/public-catalog-types'
 import { useLibrary } from '../../../../middleware/shared/providers/platform-context'
 import { useOpenPLCStore } from '../../../store'
 import { cn } from '../../../utils/cn'

--- a/src/frontend/components/_templates/app-layout.tsx
+++ b/src/frontend/components/_templates/app-layout.tsx
@@ -10,9 +10,11 @@ import { ProjectModal } from '../_features/[start]/new-project/project-modal'
 import { AIConsentModal } from '../_features/[workspace]/editor/monaco/ai-consent-modal'
 import AboutModal from '../_organisms/about-modal'
 import { RuntimeCreateUserModal, RuntimeDiscoverDevicesModal, RuntimeLoginModal } from '../_organisms/modals'
+import { ConfirmInstallLibrariesModal } from '../_organisms/modals/confirm-install-libraries-modal'
 import { DebuggerMessageModal } from '../_organisms/modals/debugger-message-modal'
 import { ConfirmDeleteElementModal } from '../_organisms/modals/delete-confirmation-modal'
 import { MissingLibrariesModal } from '../_organisms/modals/missing-libraries-modal'
+import { PublicCatalogBrowserModal } from '../_organisms/modals/public-catalog-browser-modal'
 import { QuitApplicationModal } from '../_organisms/modals/quit-application-modal'
 import { ReadOnlyProjectModal } from '../_organisms/modals/read-only-project-modal'
 import { RuntimeConnectionLostModal } from '../_organisms/modals/runtime-connection-lost-modal'
@@ -120,6 +122,8 @@ const AppLayout = ({ children, ...rest }: AppLayoutProps): ReactNode => {
           {modals?.['runtime-connection-lost']?.open === true && <RuntimeConnectionLostModal />}
           {modals?.['debugger-message']?.open === true && <DebuggerMessageModal />}
           {modals?.['missing-libraries']?.open === true && <MissingLibrariesModal />}
+          {modals?.['public-catalog-browser']?.open === true && <PublicCatalogBrowserModal />}
+          {modals?.['confirm-install-libraries']?.open === true && <ConfirmInstallLibrariesModal />}
           {modals?.['read-only-project']?.open === true && <ReadOnlyProjectModal />}
           {modals?.['runtime-login']?.open === true && <RuntimeLoginModal />}
           {modals?.['runtime-create-user']?.open === true && <RuntimeCreateUserModal />}

--- a/src/frontend/store/slices/modal/slice.ts
+++ b/src/frontend/store/slices/modal/slice.ts
@@ -23,6 +23,8 @@ const ALL_MODAL_TYPES: ModalTypes[] = [
   'debugger-message',
   'debugger-ip-input',
   'missing-libraries',
+  'public-catalog-browser',
+  'confirm-install-libraries',
   'read-only-project',
 ]
 

--- a/src/frontend/store/slices/modal/types.ts
+++ b/src/frontend/store/slices/modal/types.ts
@@ -22,6 +22,13 @@ export type ModalTypes =
   | 'debugger-message'
   | 'debugger-ip-input'
   | 'missing-libraries'
+  /** Browse the autonomy-edge public library catalog.  Replaces the
+   *  "Coming Soon" placeholder in the Library Manager's System tab.
+   *  Multi-select; the install confirmation pops up on top. */
+  | 'public-catalog-browser'
+  /** Confirmation step chained off `public-catalog-browser` — lists
+   *  the user's selection and runs the install on confirm. */
+  | 'confirm-install-libraries'
   /** Surfaced whenever the user tries a write action (save, commit,
    *  create/delete branch, create/rename/delete POU) on a project they
    *  don't have edit permission on.  Shows the "this project belongs to

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -1,6 +1,12 @@
 import { ESIService } from '@root/backend/editor/ethercat'
+import { createDesktopCatalogTransport } from '@root/backend/editor/library-manager/desktop-catalog-transport'
 import { getRuntimeHttpsOptions } from '@root/backend/editor/utils/runtime-https-config'
 import { parseESIDeviceFull } from '@root/backend/shared/ethercat/esi-parser-main'
+import {
+  listPublicLibraries,
+  type ListPublicLibrariesArgs,
+  type ListPublicLibrariesResponse,
+} from '@root/backend/shared/library/public-catalog-client'
 import { PLCProjectData } from '@root/backend/shared/types/PLC/open-plc'
 import { getErrorMessage } from '@root/frontend/utils/get-error-message'
 import { RuntimeLogEntry } from '@root/middleware/shared/ports'
@@ -69,6 +75,11 @@ class MainProcessBridge implements MainIpcModule {
   private packageManagerModule = new PackageManagerModule()
   // System-wide IEC 61131-3 library pool (bundled + user-installed)
   private libraryManagerModule = new LibraryManagerModule()
+  // Shared transport for public-catalog HTTP — re-used by the
+  // `catalog:list` handler so the library-manager-module's batch
+  // install path and the modal's browse path hit the same env-
+  // configured base URL.
+  private catalogTransport = createDesktopCatalogTransport()
   // ESI repository service for EtherCAT device descriptions
   private esiService = new ESIService()
 
@@ -780,6 +791,8 @@ class MainProcessBridge implements MainIpcModule {
     this.registerHandle('libraries:list-installed', this.handleLibrariesListInstalled)
     this.registerHandle('libraries:install-from-file', this.handleLibrariesInstallFromFile)
     this.registerHandle('libraries:uninstall', this.handleLibrariesUninstall)
+    this.registerHandle('catalog:list', this.handleCatalogList)
+    this.registerHandle('catalog:install-many', this.handleCatalogInstallMany)
     this.registerHandle('app:store-retrieve-recent', this.handleStoreRetrieveRecent)
     this.ipcMain.on('app:quit', this.handleAppQuit)
     // this.ipcMain.on('app:reply-if-app-is-closing', (_, shouldQuit) => { ... })
@@ -1117,6 +1130,40 @@ class MainProcessBridge implements MainIpcModule {
       this.mainWindow?.webContents.send('libraries:changed')
     }
     return result
+  }
+
+  /**
+   * Catalog browse — proxies to the shared `listPublicLibraries`
+   * client.  Renderer can't hit autonomy-edge directly (CSP /
+   * cross-origin); the main process is the canonical egress.
+   *
+   * Errors are returned in a `{ success: false, error }` envelope
+   * rather than thrown across the IPC boundary so the modal can
+   * surface the failure without trying to read a rejected promise.
+   */
+  handleCatalogList = async (
+    _event: IpcMainInvokeEvent,
+    args: ListPublicLibrariesArgs,
+  ): Promise<{ success: true; data: ListPublicLibrariesResponse } | { success: false; error: string }> => {
+    try {
+      const data = await listPublicLibraries(this.catalogTransport, args ?? {})
+      return { success: true, data }
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
+  handleCatalogInstallMany = async (_event: IpcMainInvokeEvent, publishedLibraryIds: string[]) => {
+    if (!Array.isArray(publishedLibraryIds) || publishedLibraryIds.length === 0) {
+      return { results: [] }
+    }
+    const batch = await this.libraryManagerModule.installFromCatalog(publishedLibraryIds)
+    // Fire one change event for the whole batch — saves N renderer
+    // refreshes for an N-library install.
+    if (batch.results.some((r) => r.success)) {
+      this.mainWindow?.webContents.send('libraries:changed')
+    }
+    return batch
   }
   handleStoreRetrieveRecent = async () => {
     const pathToUserDataFolder = join(app.getPath('userData'), 'User')

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -2,14 +2,14 @@ import { ESIService } from '@root/backend/editor/ethercat'
 import { createDesktopCatalogTransport } from '@root/backend/editor/library-manager/desktop-catalog-transport'
 import { getRuntimeHttpsOptions } from '@root/backend/editor/utils/runtime-https-config'
 import { parseESIDeviceFull } from '@root/backend/shared/ethercat/esi-parser-main'
-import {
-  listPublicLibraries,
-  type ListPublicLibrariesArgs,
-  type ListPublicLibrariesResponse,
-} from '@root/backend/shared/library/public-catalog-client'
+import { listPublicLibraries } from '@root/backend/shared/library/public-catalog-client'
 import { PLCProjectData } from '@root/backend/shared/types/PLC/open-plc'
 import { getErrorMessage } from '@root/frontend/utils/get-error-message'
 import { RuntimeLogEntry } from '@root/middleware/shared/ports'
+import type {
+  ListPublicLibrariesArgs,
+  ListPublicLibrariesResponse,
+} from '@root/middleware/shared/ports/public-catalog-types'
 import type {
   EtherCATRuntimeStatusResponse,
   EtherCATScanRequest,

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -7,10 +7,6 @@ import { PLCProjectData } from '@root/backend/shared/types/PLC/open-plc'
 import { getErrorMessage } from '@root/frontend/utils/get-error-message'
 import { RuntimeLogEntry } from '@root/middleware/shared/ports'
 import type {
-  ListPublicLibrariesArgs,
-  ListPublicLibrariesResponse,
-} from '@root/middleware/shared/ports/public-catalog-types'
-import type {
   EtherCATRuntimeStatusResponse,
   EtherCATScanRequest,
   EtherCATScanResponse,
@@ -21,6 +17,10 @@ import type {
   EtherCATValidateResponse,
   NetworkInterface,
 } from '@root/middleware/shared/ports/ethercat-types'
+import type {
+  ListPublicLibrariesArgs,
+  ListPublicLibrariesResponse,
+} from '@root/middleware/shared/ports/public-catalog-types'
 import { CreatePouFileProps } from '@root/types/IPC/pou-service'
 import { CreateProjectFileProps } from '@root/types/IPC/project-service'
 import dgram from 'dgram'

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -1,8 +1,8 @@
+import type { DiscoveredRuntimeDevice, RuntimeLogEntry } from '@root/middleware/shared/ports'
 import type {
   ListPublicLibrariesArgs,
   ListPublicLibrariesResponse,
-} from '@root/backend/shared/library/public-catalog-client'
-import type { DiscoveredRuntimeDevice, RuntimeLogEntry } from '@root/middleware/shared/ports'
+} from '@root/middleware/shared/ports/public-catalog-types'
 import type { ESIDevice, ESIRepositoryItemLight } from '@root/middleware/shared/ports/esi-types'
 import type {
   EtherCATRuntimeStatusResponse,

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -1,3 +1,7 @@
+import type {
+  ListPublicLibrariesArgs,
+  ListPublicLibrariesResponse,
+} from '@root/backend/shared/library/public-catalog-client'
 import type { DiscoveredRuntimeDevice, RuntimeLogEntry } from '@root/middleware/shared/ports'
 import type { ESIDevice, ESIRepositoryItemLight } from '@root/middleware/shared/ports/esi-types'
 import type {
@@ -138,6 +142,22 @@ const rendererProcessBridge = {
   > => ipcRenderer.invoke('libraries:install-from-file'),
   uninstallLibrary: (name: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('libraries:uninstall', name),
+  // ----- Public-library catalog (autonomy-edge) -----
+  queryPublicCatalog: (
+    args: ListPublicLibrariesArgs,
+  ): Promise<{ success: true; data: ListPublicLibrariesResponse } | { success: false; error: string }> =>
+    ipcRenderer.invoke('catalog:list', args),
+  installLibrariesFromCatalog: (
+    publishedLibraryIds: string[],
+  ): Promise<{
+    results: Array<{
+      publishedLibraryId: string
+      success: boolean
+      name?: string
+      version?: string
+      error?: string
+    }>
+  }> => ipcRenderer.invoke('catalog:install-many', publishedLibraryIds),
   onLibrariesChanged: (callback: () => void) => {
     const listener = () => callback()
     ipcRenderer.on('libraries:changed', listener)

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -1,8 +1,4 @@
 import type { DiscoveredRuntimeDevice, RuntimeLogEntry } from '@root/middleware/shared/ports'
-import type {
-  ListPublicLibrariesArgs,
-  ListPublicLibrariesResponse,
-} from '@root/middleware/shared/ports/public-catalog-types'
 import type { ESIDevice, ESIRepositoryItemLight } from '@root/middleware/shared/ports/esi-types'
 import type {
   EtherCATRuntimeStatusResponse,
@@ -15,6 +11,10 @@ import type {
   EtherCATValidateResponse,
   NetworkInterface,
 } from '@root/middleware/shared/ports/ethercat-types'
+import type {
+  ListPublicLibrariesArgs,
+  ListPublicLibrariesResponse,
+} from '@root/middleware/shared/ports/public-catalog-types'
 import type { PLCProjectData } from '@root/middleware/shared/ports/types'
 import { CreatePouFileProps, PouServiceResponse } from '@root/types/IPC/pou-service'
 import { CreateProjectFileProps, IProjectServiceResponse } from '@root/types/IPC/project-service'

--- a/src/middleware/adapters/editor/library-adapter.ts
+++ b/src/middleware/adapters/editor/library-adapter.ts
@@ -13,9 +13,17 @@
  *   libraries:install-from-file (invoke)
  *   libraries:uninstall         (invoke)
  *   libraries:changed           (on)
+ *   catalog:list                (invoke) — public-library browse
+ *   catalog:install-many        (invoke) — public-library batch install
  */
 
-import type { LibraryPort, StlibArchiveDTO } from '../../shared/ports/library-port'
+import type { ListPublicLibrariesArgs } from '../../../backend/shared/library/public-catalog-client'
+import type {
+  CatalogInstallBatch,
+  CatalogQueryResult,
+  LibraryPort,
+  StlibArchiveDTO,
+} from '../../shared/ports/library-port'
 import type { InstalledLibrary, LibraryInstallResult } from '../../shared/ports/library-types'
 import type { Result, Unsubscribe } from '../../shared/ports/types'
 
@@ -48,6 +56,14 @@ export function createEditorLibraryAdapter(): LibraryPort {
 
     onLibrariesChanged(callback: () => void): Unsubscribe {
       return window.bridge.onLibrariesChanged(callback)
+    },
+
+    queryPublicCatalog(args: ListPublicLibrariesArgs): Promise<CatalogQueryResult> {
+      return window.bridge.queryPublicCatalog(args)
+    },
+
+    installFromCatalog(publishedLibraryIds: string[]): Promise<CatalogInstallBatch> {
+      return window.bridge.installLibrariesFromCatalog(publishedLibraryIds)
     },
   }
 }

--- a/src/middleware/adapters/editor/library-adapter.ts
+++ b/src/middleware/adapters/editor/library-adapter.ts
@@ -17,13 +17,13 @@
  *   catalog:install-many        (invoke) — public-library batch install
  */
 
-import type { ListPublicLibrariesArgs } from '../../../backend/shared/library/public-catalog-client'
 import type {
   CatalogInstallBatch,
   CatalogQueryResult,
   LibraryPort,
   StlibArchiveDTO,
 } from '../../shared/ports/library-port'
+import type { ListPublicLibrariesArgs } from '../../shared/ports/public-catalog-types'
 import type { InstalledLibrary, LibraryInstallResult } from '../../shared/ports/library-types'
 import type { Result, Unsubscribe } from '../../shared/ports/types'
 

--- a/src/middleware/adapters/editor/library-adapter.ts
+++ b/src/middleware/adapters/editor/library-adapter.ts
@@ -23,8 +23,8 @@ import type {
   LibraryPort,
   StlibArchiveDTO,
 } from '../../shared/ports/library-port'
-import type { ListPublicLibrariesArgs } from '../../shared/ports/public-catalog-types'
 import type { InstalledLibrary, LibraryInstallResult } from '../../shared/ports/library-types'
+import type { ListPublicLibrariesArgs } from '../../shared/ports/public-catalog-types'
 import type { Result, Unsubscribe } from '../../shared/ports/types'
 
 export function createEditorLibraryAdapter(): LibraryPort {

--- a/src/middleware/shared/ports/catalog-transport-port.ts
+++ b/src/middleware/shared/ports/catalog-transport-port.ts
@@ -1,0 +1,47 @@
+/**
+ * CatalogTransportPort — platform-agnostic transport for the
+ * autonomy-edge public-library catalog endpoints.
+ *
+ * The shared catalog client (see `public-catalog-client.ts`) owns the
+ * URL paths, query-string assembly, and response-shape validation;
+ * everything platform-specific (TLS config, base URL resolution,
+ * cookie/header handling) lives behind this port.
+ *
+ *   - Desktop port (Electron main process): wraps Node `https.request`
+ *     and reads `OPENPLC_EDGE_API_URL` for the base URL.
+ *   - Web port (browser, future): wraps `fetch` and reuses the web
+ *     app's existing API client base URL.
+ *
+ * Two methods are deliberately separate so platforms can choose
+ * different encodings for binary-but-JSON payloads (the `.stlib`
+ * archive is JSON content served as `application/octet-stream`; on
+ * Node we accumulate as utf-8 string, on the browser we can read
+ * either text or arrayBuffer).
+ */
+
+/** Query parameter values the catalog client emits — all scalar. */
+export type CatalogQueryParams = Record<string, string | number | boolean | undefined>
+
+export interface CatalogTransportPort {
+  /**
+   * Fetch a JSON-bodied endpoint and return the parsed body.  The
+   * platform impl handles HTTP→Error conversion: non-2xx responses
+   * must throw with a message the catalog client can surface in the
+   * UI (e.g. `Catalog request failed: 503 Service Unavailable`).
+   *
+   * `signal` is honored when supplied — callers (debounced search,
+   * unmounting modals) pass an AbortSignal so the impl can cancel
+   * the in-flight request and avoid setState-after-unmount.
+   */
+  fetchJson<T>(path: string, params?: CatalogQueryParams, signal?: AbortSignal): Promise<T>
+
+  /**
+   * Fetch a binary-ish endpoint (today: the `.stlib` download) and
+   * return its body as a utf-8 string.  The autonomy-edge download
+   * endpoint serves `application/octet-stream`, but the bytes are a
+   * JSON-formatted `.stlib` archive — string is a faithful container
+   * for both consumers (Node `writeFileSync`, browser blob).  Non-2xx
+   * must throw, same contract as `fetchJson`.
+   */
+  fetchText(path: string, signal?: AbortSignal): Promise<string>
+}

--- a/src/middleware/shared/ports/library-port.ts
+++ b/src/middleware/shared/ports/library-port.ts
@@ -16,8 +16,34 @@
  *   backend API following the same shape.
  */
 
+import type {
+  ListPublicLibrariesArgs,
+  ListPublicLibrariesResponse,
+} from '../../../backend/shared/library/public-catalog-client'
 import type { InstalledLibrary, LibraryInstallResult } from './library-types'
 import type { Result, Unsubscribe } from './types'
+
+/**
+ * Per-library outcome of a batch catalog install.  Mirrors the
+ * main-process `CatalogInstallItemResult` shape — kept in the port
+ * layer so renderer + adapter don't pull from `backend/editor/*`
+ * directly (a boundary the architecture lint check enforces).
+ */
+export interface CatalogInstallItem {
+  publishedLibraryId: string
+  success: boolean
+  name?: string
+  version?: string
+  error?: string
+}
+
+export interface CatalogInstallBatch {
+  results: CatalogInstallItem[]
+}
+
+export type CatalogQueryResult =
+  | { success: true; data: ListPublicLibrariesResponse }
+  | { success: false; error: string }
 
 /**
  * Minimal subset of `strucpp.StlibArchive` the editor consumes.
@@ -119,4 +145,23 @@ export interface LibraryPort {
    * additions/removals without a manual refresh.
    */
   onLibrariesChanged(callback: () => void): Unsubscribe
+
+  /**
+   * Page through the public library catalog hosted on autonomy-edge.
+   * Optional — platforms that don't reach the catalog endpoint
+   * (offline builds, unconfigured environments) leave it undefined
+   * and the UI hides the "Add from the internet" entry point.
+   */
+  queryPublicCatalog?(args: ListPublicLibrariesArgs): Promise<CatalogQueryResult>
+
+  /**
+   * Install a batch of libraries selected from the public catalog.
+   * The platform fetches each `.stlib` and routes it through the
+   * same persistence path the file-picker install uses, returning a
+   * per-item pass/fail summary so the UI can render a "5 succeeded,
+   * 1 failed" toast.
+   *
+   * Optional alongside `queryPublicCatalog` — present iff that one is.
+   */
+  installFromCatalog?(publishedLibraryIds: string[]): Promise<CatalogInstallBatch>
 }

--- a/src/middleware/shared/ports/library-port.ts
+++ b/src/middleware/shared/ports/library-port.ts
@@ -16,11 +16,8 @@
  *   backend API following the same shape.
  */
 
-import type {
-  ListPublicLibrariesArgs,
-  ListPublicLibrariesResponse,
-} from '../../../backend/shared/library/public-catalog-client'
 import type { InstalledLibrary, LibraryInstallResult } from './library-types'
+import type { ListPublicLibrariesArgs, ListPublicLibrariesResponse } from './public-catalog-types'
 import type { Result, Unsubscribe } from './types'
 
 /**

--- a/src/middleware/shared/ports/public-catalog-types.ts
+++ b/src/middleware/shared/ports/public-catalog-types.ts
@@ -1,0 +1,67 @@
+/**
+ * Public-catalog DTOs that cross the port boundary.
+ *
+ * The shared `public-catalog-client` (in `backend/shared/library/`)
+ * validates HTTP responses with zod and produces these shapes; the
+ * Library Manager UI consumes them through the port.  Types live
+ * here — not next to the schemas — so the renderer can import them
+ * without the architecture validator flagging a `frontend/components/
+ * → backend/shared/` jump.
+ *
+ * Source of truth for both the schema definitions and these
+ * interfaces is the autonomy-edge `apps/backend/src/presentation/
+ * dtos/public-libraries/` DTOs.  Keep the three in lockstep.
+ */
+
+export interface ManifestPous {
+  functions: string[]
+  functionBlocks: string[]
+  types: string[]
+}
+
+export interface PublicLibrary {
+  id: string
+  projectId: string
+  name: string
+  version: string
+  displayName: string
+  description: string | null
+  license: string | null
+  authorHandle: string
+  manifestPous: ManifestPous
+  sizeBytes: number
+  sha256: string
+  downloadsCount: number
+  publishedAt: string
+  updatedAt: string
+  isProjectPublic: boolean
+  projectUrl: string | null
+  projectStarsCount: number | null
+}
+
+export interface PublicLibraryDetail extends PublicLibrary {
+  siblingVersions: PublicLibrary[]
+}
+
+export interface ListPublicLibrariesResponse {
+  libraries: PublicLibrary[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+export interface GetPublicLibraryByNameResponse {
+  versions: PublicLibrary[]
+}
+
+export type PublicLibrarySort = 'popular' | 'recent'
+
+export interface ListPublicLibrariesArgs {
+  q?: string
+  page?: number
+  /** Server caps at 50; client requests at most that. */
+  limit?: number
+  sort?: PublicLibrarySort
+  signal?: AbortSignal
+}


### PR DESCRIPTION
## Summary
Replaces the "Coming Soon" placeholder in the Library Manager's System Libraries tab with a modal that browses the autonomy-edge public-library catalog and installs one or more `.stlib` archives in a single batch.

## Architecture
Same port-pattern shape we used for the library build orchestrator so the web editor can reuse byte-identical shared files when we move there next.

- **`middleware/shared/ports/catalog-transport-port.ts`** — two-method `fetchJson` / `fetchText` interface, the only platform seam
- **`backend/shared/library/public-catalog-client.ts`** — pure functions + zod schemas mirroring autonomy-edge's `public-libraries` DTOs; unwraps the `{statusCode, data}` envelope once
- **`backend/editor/library-manager/desktop-catalog-transport.ts`** — Electron-main impl on `https.request`; reads `OPENPLC_EDGE_API_URL` (defaults to `https://api.autonomylogic.com`); honors `AbortSignal`
- **`LibraryManagerModule.installFromCatalog(ids)`** — batch path; one bad archive doesn't abort the rest; emits a single `libraries:changed` for the whole batch
- Two new IPC channels (`catalog:list`, `catalog:install-many`) + bridge methods

## UI
Two chained modals (registered in the Zustand modal slice):
- **Browse Public Libraries** — search input + sort selector (Popularity | Name), scrollable multi-select list with "installed" badge on rows already in the user's pool, Cancel + Install footer. Fetches once on open (`sort=popular, limit=50`); search + name sort run client-side.
- **Confirm install** — chained on top with the user's selection, runs install on Confirm, renders per-row pass/fail, closes the whole chain on Done. Cancel/Escape returns to the browser with selection preserved.

## Tests
- 4 new `installFromCatalog` cases in `library-manager-module.test.ts` (happy path, partial failure, empty batch, bundled-name collision)
- All 29 library-manager tests pass
- The two pre-existing failing suites (`use-runtime-polling`, `editor-compiler-platform-port`) are unrelated vitest-API-in-Jest issues, present on `development` before this PR

## Test plan
- [ ] `OPENPLC_EDGE_API_URL=https://api-staging.autonomylogic.com npm start` — staging has the public-library endpoints; production won't until autonomy-edge promotes `development` → `main`
- [ ] Open Library Manager → System Libraries → `+` → **Add from the internet...** — modal opens, catalog populates
- [ ] Type in the search box — list filters live
- [ ] Toggle sort — order changes between Popularity and Name
- [ ] Select 2-3 libraries — counter updates, Install button enables
- [ ] Click Install — confirmation modal lists the selection
- [ ] Click Confirm — progress spinner, then results panel with one row per item
- [ ] Click Done — both modals close; installed list now shows the new libraries with "installed" badge
- [ ] Re-open the catalog modal — previously installed rows now show the "installed" badge
- [ ] Cancel from the confirmation modal — returns to the browser with selection preserved
- [ ] Escape / overlay click — closes only the topmost modal
- [ ] Disconnect network and reopen — modal shows the error state with a Retry button

## Follow-ups (out of scope)
- openplc-web port (copy the shared files verbatim, implement a web `CatalogTransportPort` on the existing `apiFetch`)
- autonomy-edge: merge `development` → `main` so production has the public-library endpoints under the default URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public library catalog: browse, search, multi-select, and install community libraries from the System Libraries tab via a browse modal and confirm/install flow showing progress and per-item success/failure results.
  * UI now shows installed badges, aggregate install summaries, and emits library-changed updates after successful installs.

* **Tests**
  * Added tests for catalog installs covering batch downloads, per-item reporting, empty-batch behavior, and name-conflict detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->