### PR TITLE
fix(graphical-editor): rebind drop handler on libraries.system change

### DIFF
--- a/src/frontend/components/_molecules/graphical-editor/fbd/index.tsx
+++ b/src/frontend/components/_molecules/graphical-editor/fbd/index.tsx
@@ -678,12 +678,16 @@ export const FBDBody = ({ rung, nodeDivergences = [], isDebuggerActive = false }
 
       handleAddElementByDropping(position, blockType as CustomFbdNodeTypes, library)
     },
-    // `libraries.user` and `pous` aren't read here, but
-    // `handleAddElementByDropping` captures both — omit them and a
-    // freshly created user FB stays invisible to the memoized closure
-    // until something else forces a re-bind (full project save resets
-    // `rung`, which is why "Save Project" used to mask this).
-    [rung, reactFlowInstance, libraries.user, pous],
+    // `libraries.system`, `libraries.user`, and `pous` aren't read
+    // directly in onDrop's body — `handleAddElementByDropping` closes
+    // over all three.  Omitting any one means the memoized callback
+    // keeps a reference to the pre-update handler, so a freshly
+    // installed system library / freshly created user FB / freshly
+    // saved POU stays invisible until something else forces a re-bind
+    // (full project save resets `rung`, which is why "Save Project"
+    // used to mask this — and why catalog-installed libs threw
+    // "block type ... does not exist" on first drop).
+    [rung, reactFlowInstance, libraries.system, libraries.user, pous],
   )
 
   /**

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/body.tsx
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/body.tsx
@@ -859,7 +859,24 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
       // Then add the node to the rung
       handleAddNode(blockType, library)
     },
-    [rung, rungLocal, setReactFlowPanelExtent, reactFlowPanelExtent, isDebuggerActive],
+    // `libraries.system`, `libraries.user`, and `pous` aren't read
+    // directly here — `handleAddNode` closes over all three.  Omitting
+    // any of them means the memoized callback keeps a reference to the
+    // pre-update handler, so a freshly installed system library /
+    // freshly created user FB / freshly saved POU stays invisible
+    // until something else forces a re-bind (matches the FBD onDrop
+    // dep set; same failure mode: catalog-installed libs threw
+    // "block type ... does not exist" on first drop).
+    [
+      rung,
+      rungLocal,
+      setReactFlowPanelExtent,
+      reactFlowPanelExtent,
+      isDebuggerActive,
+      libraries.system,
+      libraries.user,
+      pous,
+    ],
   )
 
   return (


### PR DESCRIPTION
## Summary
Mirror of openplc-web PR #446 (frontend/ is byte-identical between repos; CI sync check enforces). Pure useCallback dependency fix — drag-and-drop of a freshly-installed system library onto an FBD (or Ladder) canvas was throwing "Can not add block — The block type system/<lib>/<fb> does not exist in the library" until the page was refreshed. Only the closure was stale; \`libraries.system\` was already populated.

## Root cause
\`handleAddElementByDropping\` (FBD) and \`handleAddNode\` (Ladder) read \`libraries.system\`, \`libraries.user\`, and \`pous\`. Both \`onDrop\` \`useCallback\`s omitted some/all of those deps:

- \`fbd/index.tsx:686\` had \`libraries.user\` and \`pous\` (a previous fix) but missed \`libraries.system\`.
- \`ladder/rung/body.tsx:862\` had none of them.

When the catalog-install path dispatched the fresh archive into Zustand \`libraries.system\`, the memoized \`onDrop\` kept pointing at the pre-update handler, so the lookup ran against the stale system pool.

## Fix
Add \`libraries.system\`, \`libraries.user\`, and \`pous\` to both dep lists.

## Reproduce + verify (desktop, OPENPLC_EDGE_API_URL=https://api-staging.autonomylogic.com)
1. Library Manager → Project Libraries → minus on \`test-lib\` → Save
2. Library Manager → System Libraries → minus (uninstall) → Save
3. Quit + relaunch (or hard refresh in the renderer)
4. System Libraries → Add from the internet → install \`test-lib\`
5. Project Libraries → plus on \`test-lib\`
6. Open an FBD POU and drag \`test-lib/TRAFFICLIGHT\` onto the canvas
   - **Before:** toast "Can not add block — ... does not exist in the library"
   - **After:** block placed cleanly

## Shared-surface
\`scripts/compare-surfaces.py\` reports 0 diffs across 1023 files between this branch and openplc-web's \`fix/drop-handler-stale-libraries-system\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the FBD and ladder diagram editors where newly added blocks would not function correctly when system libraries, user libraries, or POU configurations changed during the editing session. This ensures reliable block addition and usage after updating library or POU settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->