### PR TITLE
chore: bump strucpp v0.4.19 → v0.4.20

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.4.19",
+    "version": "v0.4.20",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }


### PR DESCRIPTION
Pulls in the strucpp release with:

- `TO_<int>(TIME)` family now returns ms — fixes the user report where `TO_UINT(T#5s)` read 61952 instead of 5000.  Affects TIME / LTIME / TOD / LTOD / DT / LDT sources across every numeric and bit-string target.
- DATE literal lowering corrected (was emitting ns, runtime expects days).
- PROGRAM-level DATE / TOD / DT VAR initialisers now lower properly.
- WSTRING → numeric parser surface added (`TO_UINT(WSTRING)` etc.).

Verified locally on this repo by patching `node_modules/strucpp` in place against the v0.4.20 tarball — the simulator now reads 5000 from the `TO_UINT(T#5s)` block in the user's blink-demo-multilanguage project.

Refs: strucpp PR #135 + release PR #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated strucpp binary to version 0.4.20

<!-- end of auto-generated comment: release notes by coderabbit.ai -->