### PR TITLE
fix(python-lsp): require workerUrl from the host, drop the inline require fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,6 @@ import './backend/shared/styles/globals.css'
 // without the body editor) saw Monaco's default vs-dark theme.
 import './frontend/components/_features/[workspace]/editor/monaco/configs'
 
-import { useEffect } from 'react'
-
 // Resolve basedpyright's worker bundle URL through the host
 // bundler.  Editor uses webpack with an `asset/resource` rule on
 // `?url`; web uses Vite's native `?url` query.  The shared
@@ -21,6 +19,7 @@ import { useEffect } from 'react'
 // `App.tsx` keeps the shared zone clean.  See
 // `setPythonLspWorkerUrl` in monaco/python-lsp/index.ts.
 import pyrightWorkerUrl from 'browser-basedpyright/dist/pyright.worker.js?url'
+import { useEffect } from 'react'
 
 import { setPythonLspWorkerUrl } from './frontend/components/_features/[workspace]/editor/monaco/python-lsp'
 import { AppLayout } from './frontend/components/_templates/app-layout'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,16 @@ import './frontend/components/_features/[workspace]/editor/monaco/configs'
 
 import { useEffect } from 'react'
 
+// Resolve basedpyright's worker bundle URL through the host
+// bundler.  Editor uses webpack with an `asset/resource` rule on
+// `?url`; web uses Vite's native `?url` query.  The shared
+// `startPythonLsp` requires this URL as an option — keeping the
+// bundler-specific syntax pinned to the (non-byte-identical)
+// `App.tsx` keeps the shared zone clean.  See
+// `setPythonLspWorkerUrl` in monaco/python-lsp/index.ts.
+import pyrightWorkerUrl from 'browser-basedpyright/dist/pyright.worker.js?url'
+
+import { setPythonLspWorkerUrl } from './frontend/components/_features/[workspace]/editor/monaco/python-lsp'
 import { AppLayout } from './frontend/components/_templates/app-layout'
 import { StartScreen } from './frontend/screens/start-screen'
 import { WorkspaceScreen } from './frontend/screens/workspace-screen'
@@ -55,6 +65,12 @@ hydrateLibraries()
 // install/uninstall/CDN change.  Subscriber lives outside React to
 // catch events fired before any component mounts.
 editorPorts.library.onLibrariesChanged(() => hydrateLibraries())
+
+// Register the basedpyright worker URL so the Monaco-side adapter
+// can spin up the Python LSP on first POU open.  No service
+// start yet — the LSP is lazy-initialised in
+// `monaco/python-lsp/initPythonLSP` when Monaco mounts.
+setPythonLspWorkerUrl(pyrightWorkerUrl)
 
 // Pre-warm the STruC++ LSP worker so the first ST POU opens with
 // completion + diagnostics already streaming.  `bootStLsp` returns

--- a/src/frontend/components/_features/[workspace]/editor/monaco/python-lsp/index.ts
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/python-lsp/index.ts
@@ -32,6 +32,7 @@ import type * as monaco from 'monaco-editor'
 
 let service: PythonLspService | null = null
 let monacoApi: typeof monaco | null = null
+let configuredWorkerUrl: string | null = null
 
 interface EditorWiring {
   pouName: string
@@ -42,15 +43,37 @@ interface EditorWiring {
 const wiringByUri = new Map<string, EditorWiring>()
 
 /**
+ * Register the basedpyright worker bundle URL.  Each platform's
+ * `App.tsx` resolves the URL with its own bundler (`?url` import
+ * on Vite, the same on webpack 5 with `asset/resource`) and calls
+ * this at app startup — the shared service intentionally has no
+ * in-module fallback, see PythonLspStartOptions.workerUrl.
+ *
+ * `initPythonLSP` is a no-op until this has been called.  The
+ * setter races with module evaluation, not with user interaction:
+ * by the time the workspace mounts and Monaco fires its `onMount`
+ * (where `initPythonLSP` runs), App.tsx has already resolved the
+ * URL string and registered it here.
+ */
+export function setPythonLspWorkerUrl(url: string): void {
+  configuredWorkerUrl = url
+}
+
+/**
  * Lazy-initialise the Python LSP service.  Safe to call from every
  * Monaco mount; subsequent calls are no-ops.  Logs (but doesn't
- * throw) when the worker fails to start — the editor still renders,
- * just without language-server diagnostics or completions.
+ * throw) when the worker URL hasn't been registered or the worker
+ * fails to start — the editor still renders, just without
+ * language-server diagnostics or completions.
  */
 export async function initPythonLSP(monacoModule: typeof monaco): Promise<void> {
   if (service) return
+  if (!configuredWorkerUrl) {
+    console.warn('[python-lsp] worker URL not registered; LSP will not start. Call setPythonLspWorkerUrl from App.tsx.')
+    return
+  }
   monacoApi = monacoModule
-  service = startPythonLsp({ monaco: monacoModule })
+  service = startPythonLsp({ workerUrl: configuredWorkerUrl, monaco: monacoModule })
   try {
     await service.ready
   } catch (err) {

--- a/src/frontend/env.d.ts
+++ b/src/frontend/env.d.ts
@@ -10,3 +10,12 @@ declare module '*.svg' {
   const content: string
   export default content
 }
+
+// `?url` query imports — both webpack 5 (`asset/resource` rule
+// with `resourceQuery: /^\?url$/`) and Vite (`?url` query) resolve
+// these to the emitted asset URL at build time.  Used at app boot
+// to hand bundler-resolved worker URLs to the shared LSP services.
+declare module '*?url' {
+  const url: string
+  export default url
+}

--- a/src/frontend/services/python-lsp/__tests__/index.test.ts
+++ b/src/frontend/services/python-lsp/__tests__/index.test.ts
@@ -97,7 +97,7 @@ describe('startPythonLsp configuration', () => {
   it('passes Python-specific config to startLanguageService', () => {
     installMockSharedService()
 
-    startPythonLsp({ workerUrlOverride: 'about:blank' })
+    startPythonLsp({ workerUrl: 'about:blank' })
 
     expect(startLanguageService).toHaveBeenCalledTimes(1)
     const opts = startLanguageService.mock.calls[0][0]
@@ -113,7 +113,7 @@ describe('startPythonLsp configuration', () => {
   it('exposes the shared service ready promise', async () => {
     installMockSharedService()
 
-    const service = startPythonLsp({ workerUrlOverride: 'about:blank' })
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
     await expect(service.ready).resolves.toBeUndefined()
   })
 
@@ -121,7 +121,7 @@ describe('startPythonLsp configuration', () => {
     installMockSharedService()
     const onCrash = jest.fn()
 
-    startPythonLsp({ workerUrlOverride: 'about:blank', onCrash })
+    startPythonLsp({ workerUrl: 'about:blank', onCrash })
 
     const opts = startLanguageService.mock.calls[0][0]
     expect(opts.onCrash).toBe(onCrash)
@@ -130,7 +130,7 @@ describe('startPythonLsp configuration', () => {
   it('omits the monaco option when no Monaco namespace is provided', () => {
     installMockSharedService()
 
-    startPythonLsp({ workerUrlOverride: 'about:blank' })
+    startPythonLsp({ workerUrl: 'about:blank' })
 
     const opts = startLanguageService.mock.calls[0][0]
     expect('monaco' in opts).toBe(false)
@@ -141,7 +141,7 @@ describe('attachPou', () => {
   it('records the body-line offset before opening the document', () => {
     installMockSharedService()
 
-    const service = startPythonLsp({ workerUrlOverride: 'about:blank' })
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
     const vars = [makeBoolVar('red_light', 'input'), makeIntVar('counter', 'output')]
     service.attachPou(POU_URI, POU_NAME, vars, 'red_light = True\n')
 
@@ -158,7 +158,7 @@ describe('attachPou', () => {
   it('opens the document at the .py-suffixed LSP URI with preamble + body', () => {
     const { service: mockService } = installMockSharedService()
 
-    const service = startPythonLsp({ workerUrlOverride: 'about:blank' })
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
     const vars = [makeBoolVar('red_light', 'input')]
     service.attachPou(POU_URI, POU_NAME, vars, 'red_light = True\n')
 
@@ -180,7 +180,7 @@ describe('attachPou', () => {
   it('records a zero offset when no IEC variables map to Python globals', () => {
     installMockSharedService()
 
-    const service = startPythonLsp({ workerUrlOverride: 'about:blank' })
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
     // `local` vars don't get hoisted into module scope; preamble is empty.
     service.attachPou(POU_URI, POU_NAME, [makeBoolVar('x', 'local')], 'pass\n')
 
@@ -190,7 +190,7 @@ describe('attachPou', () => {
   it('sends pyright/createFile before opening the document', () => {
     const { service: mockService, sendNotification } = installMockSharedService()
 
-    const service = startPythonLsp({ workerUrlOverride: 'about:blank' })
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
     service.attachPou(POU_URI, POU_NAME, [makeBoolVar('x', 'input')], 'x = True\n')
 
     // basedpyright only treats files that exist in its in-memory
@@ -210,7 +210,7 @@ describe('notifyBodyChange', () => {
   it('forwards an augmented document with the previously-installed preamble', () => {
     const { service: mockService } = installMockSharedService()
 
-    const service = startPythonLsp({ workerUrlOverride: 'about:blank' })
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
     const vars = [makeBoolVar('red_light', 'input')]
     service.attachPou(POU_URI, POU_NAME, vars, 'red_light = True\n')
     service.notifyBodyChange(POU_URI, 'red_light = False\n')
@@ -228,7 +228,7 @@ describe('notifyBodyChange', () => {
   it('leaves version assignment to the shared service across successive calls', () => {
     const { service: mockService } = installMockSharedService()
 
-    const service = startPythonLsp({ workerUrlOverride: 'about:blank' })
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
     service.attachPou(POU_URI, POU_NAME, [], 'x = 1\n')
     service.notifyBodyChange(POU_URI, 'x = 2\n')
     service.notifyBodyChange(POU_URI, 'x = 3\n')
@@ -245,7 +245,7 @@ describe('notifyBodyChange', () => {
   it('uses an empty preamble for URIs that were never attached', () => {
     const { service: mockService } = installMockSharedService()
 
-    const service = startPythonLsp({ workerUrlOverride: 'about:blank' })
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
     service.notifyBodyChange(POU_URI, 'x = 1\n')
 
     const [, changedText] = mockService.changeDocument.mock.calls[0]
@@ -257,7 +257,7 @@ describe('notifyVariablesChange', () => {
   it('regenerates the preamble and re-records the offset', () => {
     const { service: mockService } = installMockSharedService()
 
-    const service = startPythonLsp({ workerUrlOverride: 'about:blank' })
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
     service.attachPou(POU_URI, POU_NAME, [makeBoolVar('a', 'input')], 'a = True\n')
     const firstOffset = setBodyLineOffset.mock.calls[0][1]
 
@@ -277,7 +277,7 @@ describe('detachPou', () => {
   it('closes the document and clears registry entries', () => {
     const { service: mockService } = installMockSharedService()
 
-    const service = startPythonLsp({ workerUrlOverride: 'about:blank' })
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
     service.attachPou(POU_URI, POU_NAME, [makeBoolVar('x', 'input')], 'x = True\n')
     service.detachPou(POU_URI)
 
@@ -288,7 +288,7 @@ describe('detachPou', () => {
   it('sends pyright/deleteFile after closing the document', () => {
     const { service: mockService, sendNotification } = installMockSharedService()
 
-    const service = startPythonLsp({ workerUrlOverride: 'about:blank' })
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
     service.attachPou(POU_URI, POU_NAME, [makeBoolVar('x', 'input')], 'x = True\n')
     sendNotification.mockClear()
     service.detachPou(POU_URI)
@@ -306,7 +306,7 @@ describe('detachPou', () => {
   it('does not throw when called on a never-attached URI', () => {
     installMockSharedService()
 
-    const service = startPythonLsp({ workerUrlOverride: 'about:blank' })
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
     expect(() => service.detachPou(POU_URI)).not.toThrow()
   })
 })
@@ -315,7 +315,7 @@ describe('dispose', () => {
   it('disposes the underlying shared service', () => {
     const { service: mockService } = installMockSharedService()
 
-    const service = startPythonLsp({ workerUrlOverride: 'about:blank' })
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
     service.dispose()
 
     expect(mockService.dispose).toHaveBeenCalledTimes(1)

--- a/src/frontend/services/python-lsp/index.ts
+++ b/src/frontend/services/python-lsp/index.ts
@@ -52,18 +52,8 @@ const EMPTY_PREAMBLE: PythonLspPreamble = {
   variableNameByPreambleLine: new Map(),
 }
 
-export function startPythonLsp(opts: PythonLspStartOptions = {}): PythonLspService {
-  const { monaco: monacoApi, workerUrlOverride, onCrash } = opts
-
-  // Resolve the worker URL.  The require lives inside the function
-  // so the bundler probe never runs under test (jsdom test envs
-  // don't ship the worker asset).
-  let workerUrl = workerUrlOverride
-  if (!workerUrl) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const moduleExports = require('browser-basedpyright/dist/pyright.worker.js?url') as { default: string } | string
-    workerUrl = typeof moduleExports === 'string' ? moduleExports : moduleExports.default
-  }
+export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
+  const { workerUrl, monaco: monacoApi, onCrash } = opts
 
   // Captured from `beforeListen` so attachPou / detachPou can send
   // `pyright/createFile` / `pyright/deleteFile` alongside didOpen /

--- a/src/frontend/services/python-lsp/types.ts
+++ b/src/frontend/services/python-lsp/types.ts
@@ -10,17 +10,24 @@ import type { PLCVariable } from '../../../middleware/shared/ports/types'
 
 export interface PythonLspStartOptions {
   /**
+   * URL of basedpyright's worker bundle.  Required — there is no
+   * in-module fallback: a bare `require('…/pyright.worker.js?url')`
+   * works under webpack's resource-loader rule but Vite emits the
+   * literal `require` call into the bundle, which crashes at
+   * runtime with `Can't find variable: require`.  Each host
+   * resolves the URL with its own bundler (`?url` import on Vite,
+   * the same on webpack 5 with `asset/resource`) and passes the
+   * resolved string in.  Tests pass `'about:blank'` (or any other
+   * placeholder) to bypass worker creation entirely.
+   */
+  workerUrl: string
+  /**
    * Monaco namespace.  Required for any provider registration to
    * happen.  Omit from the boot path that runs before Monaco loads
    * — the service still wires the protocol-level handlers, just
    * with no UI surface.
    */
   monaco?: typeof monaco
-  /**
-   * Override the worker URL.  Used by tests (Blob URL or
-   * `'about:blank'` stub) to bypass the default bundler probe.
-   */
-  workerUrlOverride?: string
   /**
    * Post-`initialize` worker crash callback.  Surfaces in the UI
    * as a one-shot toast.  Pre-init crashes don't go through this


### PR DESCRIPTION
Companion to [openplc-web fix](https://github.com/Autonomy-Logic/openplc-web/pull/new/fix/python-lsp-worker-url). Hotfix for the basedpyright migration — web users hit \`Can't find variable: require\` at boot because Vite emitted the shared \`startPythonLsp\`'s inline \`require('browser-basedpyright/dist/pyright.worker.js?url')\` as a literal \`require\` call.

## Fix

- \`services/python-lsp/index.ts\`: drop the inline require, require \`workerUrl\` as an option. Each platform's \`App.tsx\` resolves the URL through its own bundler (matches the ST pattern).
- \`monaco/python-lsp/index.ts\`: add \`setPythonLspWorkerUrl(...)\` so \`App.tsx\` can register the bundler-resolved URL. \`initPythonLSP\` reads it on first Monaco mount.
- \`App.tsx\`: import \`browser-basedpyright/dist/pyright.worker.js?url\` (webpack's \`asset/resource\` rule with \`resourceQuery: /^\\?url$/\` already handles this) and call the setter before any Python POU opens.
- \`frontend/env.d.ts\`: add \`declare module '*?url'\` for top-level \`?url\` imports.

## Test plan

- [x] \`npx jest src/frontend/services/python-lsp --no-coverage\` — 25/25 pass.
- [x] \`npx tsc --noEmit\` — clean.
- [ ] Manual: editor renderer hover/autocomplete/diagnostics still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Python language server now starts reliably the first time you open a Python file, improving availability of completions, diagnostics, and other editor features.

* **Refactor**
  * Streamlined Python LSP initialization to make worker loading more predictable and stable, reducing intermittent startup issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->