### PR TITLE
fix(build): exclude browser-basedpyright from the dev DLL entry list

### DIFF
--- a/configs/webpack/webpack.config.renderer.dev.dll.ts
+++ b/configs/webpack/webpack.config.renderer.dev.dll.ts
@@ -34,7 +34,14 @@ const configuration: webpack.Configuration = {
   module: require('./webpack.config.renderer.dev').default.module,
 
   entry: {
-    renderer: Object.keys(dependencies || {}),
+    // Pre-bundle every runtime dependency into the dev DLL for faster
+    // renderer rebuilds.  Exclude packages that have no resolvable
+    // top-level entry (`main`/`module`/`exports`) — webpack errors
+    // out trying to bundle them as renderer entries even though our
+    // source code only consumes them via subpath imports (e.g.
+    // `browser-basedpyright` ships only the worker bundle under
+    // `dist/` and is loaded through `?url`).
+    renderer: Object.keys(dependencies || {}).filter((name) => name !== 'browser-basedpyright'),
   },
 
   output: {


### PR DESCRIPTION
## Cause

The release build (\`Build and Release\` workflow) failed across all five platforms during \`npm run build:dll\` with:

\`\`\`
Module not found: Error: Can't resolve 'browser-basedpyright' in /…/openplc-editor
\`\`\`

\`configs/webpack/webpack.config.renderer.dev.dll.ts\` does:

\`\`\`ts
entry: { renderer: Object.keys(dependencies || {}) }
\`\`\`

Every runtime dep gets bundled into the DLL cache. \`browser-basedpyright\` is a worker-only package — its \`package.json#main\` points at a missing \`index.js\`, and the only entry we actually consume is the subpath \`dist/pyright.worker.js?url\`.

## Fix

Filter \`browser-basedpyright\` out of the entry list. The \`?url\` subpath import goes through normal module resolution (untouched by this change).

## Test plan

- [x] \`npm run build:dll\` exits 0 locally.
- [ ] \`Build and Release\` workflow runs on this branch (or on \`development\` after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development build configuration to improve development environment stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->