### PR TITLE
fix(c-blocks): standardize STRING/WSTRING through strucpp wrappers

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.5.0",
+    "version": "v0.5.1",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }

--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.5.1",
+    "version": "v0.5.2",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
@@ -37,15 +37,22 @@ describe('generateCBlocksCode', () => {
     const code = 'void setup() { }\nvoid loop() { }'
     const result = generateCBlocksCode([{ name: 'B', code, variables }])
 
-    // Baseline: strucpp wrappers visible to the auto-generated struct.
+    // Baseline: strucpp wrappers visible to the auto-generated struct
+    // — covers numeric AND STRING pins now (every pin field qualifies
+    // as `strucpp::IEC_*`).
     expect(result).toContain('#include "iec_var.hpp"')
     expect(result).toContain('#include "iec_string.hpp"')
     // Baseline: raw file-scope typedefs for user-local variables.
     expect(result).toContain('typedef int16_t   IEC_INT;')
     expect(result).toContain('typedef float    IEC_REAL;')
-    // Baseline: raw STRING struct (`{ len; body[]; }`) shared with the
-    // auto-generated struct field type.
-    expect(result).toMatch(/typedef\s+struct\s+\{[\s\S]*?__strlen_t len;[\s\S]*?\}\s+IEC_STRING;/)
+    // STRING no longer has a raw POD typedef.  The historical
+    // `{ __strlen_t len; uint8_t body[]; }` struct is gone — STRING
+    // pins and locals both use `strucpp::IEC_STRING` (= IECStringVar
+    // <254>) from `iec_string.hpp`.  Pin the regression so a future
+    // edit can't quietly re-introduce the raw shape.
+    expect(result).not.toContain('__strlen_t')
+    expect(result).not.toContain('STR_MAX_LEN')
+    expect(result).not.toMatch(/typedef\s+struct\s+\{[\s\S]*?body\[[\s\S]*?\]\s*;[\s\S]*?\}\s+IEC_STRING;/)
   })
 
   it("undefines Arduino.h's min/max macros before pulling in strucpp/std headers", () => {
@@ -120,9 +127,8 @@ describe('generateCBlocksCode', () => {
 
     expect(result).toContain('typedef struct {')
     expect(result).toContain('} EMPTY_VARS;')
-    // No #define / #undef for variables (the baseline's STR_MAX_LEN /
-    // STR_LEN_TYPE defines and the Arduino min/max macro undefs are
-    // unrelated bookkeeping).
+    // No #define / #undef for variables (the only `#define`s in the
+    // baseline now are the Arduino min/max macro guards).
     expect(result).not.toMatch(/^#define\s+\w+\s+\(/m)
     // Strip the baseline's `#undef min` / `#undef max` (Arduino.h macro
     // scrubbing — see baseline) before asserting no per-variable undefs.

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
@@ -34,6 +34,17 @@ describe('generateCBlocksHeader', () => {
     expect(result).toContain('#endif // C_BLOCKS_H')
   })
 
+  it('pulls in the strucpp wrapper headers so `strucpp::IEC_*` qualifications resolve', () => {
+    // Every struct field this header emits is fully qualified as
+    // `strucpp::IEC_*` (numeric, bit-string, STRING, WSTRING). Without
+    // these includes, a TU that does `#include "c_blocks.h"` without
+    // first pulling in the strucpp runtime would fail with
+    // `'IEC_STRING' does not name a type`.
+    const result = generateCBlocksHeader([])
+    expect(result).toContain('#include "iec_var.hpp"')
+    expect(result).toContain('#include "iec_string.hpp"')
+  })
+
   it('generates struct and function declarations for a pou with scalar variables', () => {
     const variables: PLCVariable[] = [makeScalarVar('speed', 'input', 'INT'), makeScalarVar('result', 'output', 'REAL')]
 

--- a/src/backend/shared/utils/cpp/generateCBlocksCode.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksCode.ts
@@ -10,20 +10,30 @@ type CppPouData = {
 /**
  * Self-contained baseline for c_blocks_code.cpp. Carries:
  *
- *   - The strucpp runtime includes so the auto-generated struct fields
- *     (`strucpp::IEC_INT*` etc., emitted by `generateStructMember`)
- *     resolve to IECVar wrappers. Force semantics flow through
- *     `IECVar::operator=` on the user's writes.
+ *   - The strucpp runtime includes so the auto-generated POU struct
+ *     fields (`strucpp::IEC_INT*` / `strucpp::IEC_STRING*` etc.,
+ *     emitted by `generateStructMember`) resolve to IECVar /
+ *     IECStringVar wrappers.  Force semantics flow through
+ *     `IECVar::operator=` (and `IECStringVar::operator=`) on every
+ *     user write — uniform across numeric, bit-string, and string
+ *     pins.
  *
- *   - File-scope raw IEC_BOOL/INT/.../REAL typedefs preserved from the
- *     MatIEC era. These exist only for the user's *local* variables in
- *     setup() / loop() (e.g. `IEC_INT my_temp = 0;`). They never collide
- *     with the auto-generated struct because that uses `strucpp::IEC_*`.
+ *   - File-scope raw numeric typedefs (`IEC_BOOL` / `IEC_INT` /
+ *     `IEC_REAL` / etc.) preserved from the MatIEC era.  These exist
+ *     ONLY for the user's *local* variables inside `setup()` /
+ *     `loop()` (e.g. `IEC_INT my_temp = 0;`).  They never collide
+ *     with the auto-generated struct fields because the struct
+ *     fully qualifies as `strucpp::IEC_*`.
  *
- *   - Raw `IEC_STRING` / `IEC_WSTRING` structs (`{ len; body[]; }`)
- *     used by the auto-generated struct AND by the user's c_blocks
- *     code via `name.len` / `name.body[i]`. The C++ stub copies these
- *     in/out of strucpp's IECStringVar at scan boundaries.
+ *   - No raw `IEC_STRING` / `IEC_WSTRING` typedef.  STRING pins now
+ *     use the strucpp wrapper end-to-end (`strucpp::IEC_STRING =
+ *     IECStringVar<254>`), so user code interacts with them via
+ *     `name = "hello";` / `name.length()` / `name[i]` /
+ *     `name.c_str()` / `name == "stop"` — the same surface every
+ *     other pin already exposes.  Local STRING variables inside
+ *     setup() / loop() can also be declared as
+ *     `strucpp::IEC_STRING my_buf;` (or `using strucpp::IEC_STRING;`
+ *     at the top of the user's POU body, opt-in).
  */
 const C_BLOCKS_BASELINE = `#include <cstdint>
 #include <cstring>
@@ -41,15 +51,25 @@ const C_BLOCKS_BASELINE = `#include <cstdint>
 #undef max
 #endif
 
-// STruC++ runtime types — IECVar<T> wrappers under namespace strucpp.
-// The auto-generated POU struct refers to them as \`strucpp::IEC_*\`,
-// keeping force-aware semantics on the user's writes via operator=.
+// STruC++ runtime types — IECVar<T> / IECStringVar<N> wrappers under
+// namespace strucpp.  The auto-generated POU struct refers to them
+// as \`strucpp::IEC_*\` for every pin (numeric, bit-string, STRING,
+// WSTRING), keeping force-aware semantics on the user's writes via
+// the wrapper's operator=.
 #include "iec_var.hpp"
 #include "iec_string.hpp"
 
 /*********************/
 /*  IEC Types defs   */
 /*********************/
+//
+// File-scope raw typedefs for the user's LOCAL variables inside
+// setup() / loop() (e.g. \`IEC_INT my_temp = 0;\`).  The auto-
+// generated POU struct fields use the fully-qualified
+// \`strucpp::IEC_*\` wrappers and are unaffected by these aliases.
+// STRING / WSTRING are NOT defined as raw POD structs here — local
+// STRING variables should use \`strucpp::IEC_STRING\` directly
+// (\`IECStringVar<254>\`), matching the wrapper used on pin fields.
 
 typedef uint8_t  IEC_BOOL;
 
@@ -70,24 +90,6 @@ typedef uint64_t   IEC_LWORD;
 
 typedef float    IEC_REAL;
 typedef double   IEC_LREAL;
-
-#ifndef STR_MAX_LEN
-#define STR_MAX_LEN 126
-#endif
-
-#ifndef STR_LEN_TYPE
-#define STR_LEN_TYPE int8_t
-#endif
-
-typedef STR_LEN_TYPE __strlen_t;
-// Raw STRING/WSTRING layout used by both the auto-generated POU
-// struct and the user's c_blocks code. The C++ stub copies between
-// this raw struct and strucpp::IECStringVar at the scan boundary.
-typedef struct {
-    __strlen_t len;
-    uint8_t body[STR_MAX_LEN];
-} IEC_STRING;
-typedef IEC_STRING IEC_WSTRING;
 
 `
 

--- a/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
@@ -10,6 +10,14 @@ const generateCBlocksHeader = (cppPous: CppPouData[]): string => {
   let headerContent = `#ifndef C_BLOCKS_H
 #define C_BLOCKS_H
 
+// The user-visible struct fields are fully qualified as
+// \`strucpp::IEC_*\` (numeric, bit-string, STRING, WSTRING — every pin
+// is an \`IECVar<T>\` / \`IECStringVar<N>\` wrapper).  Pull the runtime
+// headers in here so any TU that includes this header gets the
+// wrappers in scope without depending on include order.
+#include "iec_var.hpp"
+#include "iec_string.hpp"
+
 `
 
   cppPous.forEach((pou) => {

--- a/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
@@ -758,12 +758,14 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
 
         const code = model.getValue()
         const variableSuggestions = parseCppVariables(code, range)
+        const tableVariableSuggestions = tableVariablesCompletion({ range, variables: pouVariables }).suggestions
 
         const suggestions: monaco.languages.CompletionItem[] = [
           ...stdLibSuggestions,
           ...snippetSuggestions,
           ...arduinoSuggestions,
           ...variableSuggestions,
+          ...tableVariableSuggestions,
         ]
 
         return { suggestions }
@@ -776,7 +778,7 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
       completionDisposable.dispose()
       signatureHelpDisposable.dispose()
     }
-  }, [language, deviceBoard])
+  }, [language, deviceBoard, pouVariables])
 
   // -----------------------------------------------------------------------
   // AI inline completion provider (gated by hasAIAssistant)

--- a/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
+++ b/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
@@ -285,12 +285,12 @@ describe('generateStructMember', () => {
     expect(result).toBe('  strucpp::IEC_REAL *SENSORS;\n')
   })
 
-  // STRING/WSTRING stay unqualified so they bind to the file-scope raw
-  // struct typedef in c_blocks_code.cpp (`{ len; body[]; }`). The C++
-  // stub copies between this raw struct and strucpp::IECStringVar at
-  // the scan boundary.
-  it('generates an unqualified pointer member for STRING (binds to raw c_blocks typedef)', () => {
+  // STRING / WSTRING use the same `strucpp::` qualification as every
+  // other elementary type — the field is a pointer to
+  // `IECStringVar<254>`, identical to the wrapper every numeric pin
+  // uses.  No raw POD shape, no scan-boundary stub.
+  it('generates a strucpp-qualified pointer member for STRING', () => {
     const result = generateStructMember(makeScalarVar('msg', 'string'))
-    expect(result).toBe('  IEC_STRING *MSG;\n')
+    expect(result).toBe('  strucpp::IEC_STRING *MSG;\n')
   })
 })

--- a/src/frontend/utils/PLC/array-codegen-helpers.ts
+++ b/src/frontend/utils/PLC/array-codegen-helpers.ts
@@ -92,22 +92,26 @@ const getArrayStartIndex = (variable: PLCVariable): number => {
  * - Scalars: pointer to the single value
  * - Arrays: pointer to the first element of the table
  *
- * Type qualification:
- * - STRING / WSTRING resolve to the file-scope raw struct typedef in
- *   c_blocks_code.cpp (`{ len; body[]; }`). The C++ stub copies these
- *   in/out of strucpp's IECStringVar at the boundary, preserving the
- *   historical `name.len` / `name.body[i]` user syntax.
- * - Every other base type (BOOL/INT/REAL/TIME/...) resolves to the
- *   strucpp IECVar wrapper (e.g. `strucpp::IEC_INT = IECVar<INT_t>`).
- *   That gives the user's `*name = 5` write force-aware semantics
- *   via `IECVar::operator=` while keeping the raw-pointer feel.
+ * Every base type — including STRING / WSTRING — resolves to the
+ * strucpp IECVar / IECStringVar wrapper (e.g. `strucpp::IEC_INT =
+ * IECVar<INT_t>`, `strucpp::IEC_STRING = IECStringVar<254>`).  The
+ * single, uniform qualification keeps the c_blocks.h ↔ strucpp
+ * runtime ABI byte-identical for every elementary type — no parallel
+ * raw POD shape, no copy-in/copy-out stub at scan boundaries.
+ *
+ * User-syntax consequence for STRING / WSTRING: the historical
+ * `name.len` / `name.body[i]` pattern is replaced by `name.length()`
+ * / `name[i]` (read-only — returns by value) / `name.c_str()` /
+ * `name = "literal";` — exposed by `IECStringVar`.  Byte-level
+ * mutation goes through `auto raw = name.get(); raw[i] = '…';
+ * name.set(raw);`.  See `generateCBlocksCode.ts` for the file-scope
+ * numeric raw typedefs that still cover the user's local-variable
+ * declarations inside `setup()` / `loop()`.
  */
 const generateStructMember = (variable: PLCVariable): string => {
   const iecType = getVariableIECType(variable)
   const name = variable.name.toUpperCase()
-  const isStringType = iecType === 'IEC_STRING' || iecType === 'IEC_WSTRING'
-  const qualifiedType = isStringType ? iecType : `strucpp::${iecType}`
-  return `  ${qualifiedType} *${name};\n`
+  return `  strucpp::${iecType} *${name};\n`
 }
 
 export {

--- a/src/frontend/utils/cpp/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/cpp/__tests__/generateSTCode.test.ts
@@ -92,31 +92,32 @@ describe('generateSTCode (cpp)', () => {
     expect(result).not.toContain('for (int __i')
   })
 
-  it('stages STRING variables through a flat raw struct and writes back via IECStringVar', () => {
+  it('passes STRING variables by direct IECStringVar pointer — no staging, no boundary copy', () => {
     const result = generateSTCode({
       pouName: 'StrBlock',
       allVariables: [makeScalarVar('inMsg', 'input', 'string'), makeScalarVar('outMsg', 'output', 'string')],
     })
 
-    // Stage both strings — user keeps name.len / name.body[] syntax.
-    expect(result).toContain('IEC_STRING __INMSG_stage;')
-    expect(result).toContain('IEC_STRING __OUTMSG_stage;')
+    // Strings are now `strucpp::IEC_STRING = IECStringVar<254>` on
+    // both sides — c_blocks.h struct field is `strucpp::IEC_STRING *`
+    // and the strucpp program member is `IECStringVar<254>`.  `&NAME`
+    // matches the field type exactly, so we point directly and let
+    // user writes (`name = "hi"`) route through `IECStringVar::
+    // operator=` for force-respecting semantics — identical to how
+    // numeric scalars are wired.
+    expect(result).toContain('vars.INMSG = &INMSG;')
+    expect(result).toContain('vars.OUTMSG = &OUTMSG;')
 
-    // Input copy: read through .get() to honour forcing.
-    expect(result).toContain('auto __s = INMSG.get();')
-    expect(result).toContain('__INMSG_stage.len = (__strlen_t)__s.length();')
-    expect(result).toContain('std::memcpy(__INMSG_stage.body, __s.c_str(), STR_MAX_LEN);')
-
-    // Pointer in struct points at the staging copy, NOT the IECStringVar.
-    expect(result).toContain('vars.INMSG = &__INMSG_stage;')
-    expect(result).toContain('vars.OUTMSG = &__OUTMSG_stage;')
-
-    // Writeback for outputs only — input strings are read-only from
-    // the IEC side after copy-in.
-    expect(result).toContain(
-      'OUTMSG = strucpp::IECString<254>(reinterpret_cast<const char*>(__OUTMSG_stage.body), __OUTMSG_stage.len);',
-    )
-    expect(result).not.toContain('INMSG = strucpp::IECString<254>')
+    // Regression guards: the historical flat-staging path is GONE.
+    // Re-introducing it would re-break user POU compilation against
+    // the strucpp wrapper (`.len` / `.body` / `__strlen_t` /
+    // `STR_MAX_LEN` do not exist on `IECStringVar`).
+    expect(result).not.toContain('__INMSG_stage')
+    expect(result).not.toContain('__OUTMSG_stage')
+    expect(result).not.toContain('__strlen_t')
+    expect(result).not.toContain('STR_MAX_LEN')
+    expect(result).not.toContain('std::memcpy')
+    expect(result).not.toContain('IECString<254>(reinterpret_cast')
   })
 
   it('handles no variables', () => {
@@ -144,7 +145,10 @@ describe('generateSTCode (cpp)', () => {
 
     expect(result).toContain('vars.A = &A;')
     expect(result).toContain('vars.B = &B[0] - 0;')
-    expect(result).toContain('vars.MSG = &__MSG_stage;')
+    // STRING uses the same direct-pointer path as every other scalar
+    // (no `&__MSG_stage` boundary copy).
+    expect(result).toContain('vars.MSG = &MSG;')
+    expect(result).not.toContain('__MSG_stage')
     expect(result).toContain('vars.C = &C;')
     expect(result).toContain('vars.D = &D[0] - 0;')
   })

--- a/src/frontend/utils/cpp/generateSTCode.ts
+++ b/src/frontend/utils/cpp/generateSTCode.ts
@@ -1,5 +1,5 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
-import { getArrayStartIndex, getVariableIECType, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { getArrayStartIndex, isArrayVariable } from '../PLC/array-codegen-helpers'
 
 type STCodeGenerationParams = {
   pouName: string
@@ -7,86 +7,26 @@ type STCodeGenerationParams = {
 }
 
 /**
- * Detect a STRING / WSTRING base-type variable. The C++ stub copies these
- * through a flat raw struct (matching c_blocks_code.cpp's typedef) so the
- * user keeps the `name.len` / `name.body[i]` syntax. Every other base type
- * (and arrays of base types) is passed by direct IECVar pointer.
- */
-const isStringVariable = (variable: PLCVariable): boolean => {
-  if (variable.type.definition !== 'base-type') return false
-  const v = variable.type.value.toLowerCase()
-  return v === 'string' || v === 'wstring'
-}
-
-/**
- * Per-string flat staging structs the user code reads/writes through. The
- * struct mirrors c_blocks_code.cpp's raw `IEC_STRING` typedef. We allocate
- * one per STRING/WSTRING variable on the stack of the program method, fill
- * it from the strucpp IECStringVar before the user runs, and write back
- * after.
- */
-const generateStringStaging = (stringVariables: PLCVariable[]): string => {
-  if (stringVariables.length === 0) return ''
-  let code = ''
-  for (const variable of stringVariables) {
-    const iecType = getVariableIECType(variable) // IEC_STRING / IEC_WSTRING
-    const name = variable.name.toUpperCase()
-    code += `${iecType} __${name}_stage;\n`
-  }
-  return code
-}
-
-const generateStringCopyIn = (stringVariables: PLCVariable[]): string => {
-  let code = ''
-  for (const variable of stringVariables) {
-    const name = variable.name.toUpperCase()
-    code += `{ auto __s = ${name}.get();\n`
-    code += `  __${name}_stage.len = (__strlen_t)__s.length();\n`
-    code += `  std::memcpy(__${name}_stage.body, __s.c_str(), STR_MAX_LEN); }\n`
-  }
-  return code
-}
-
-const generateStringCopyOut = (stringVariables: PLCVariable[]): string => {
-  let code = ''
-  for (const variable of stringVariables) {
-    const name = variable.name.toUpperCase()
-    const iecType = getVariableIECType(variable)
-    // strucpp::IEC_STRING is IECStringVar<254>; build an IECString<254>
-    // from the staged bytes and assign — operator= → set() respects
-    // forcing on the IEC side, so a forced output's user write is a
-    // no-op for IEC reads (matching how scalar/array writes behave).
-    const innerType = iecType === 'IEC_WSTRING' ? 'strucpp::IECWString<254>' : 'strucpp::IECString<254>'
-    code += `${name} = ${innerType}(reinterpret_cast<const char*>(__${name}_stage.body), __${name}_stage.len);\n`
-  }
-  return code
-}
-
-/**
  * Pointer assignment for the user-visible struct.
  *
- * - Scalars: `vars.NAME = &NAME` — `&NAME` is `IECVar<T>*`, struct field
- *   is `strucpp::IEC_T*`, types match. The user's `*name = 5` then
- *   routes through `IECVar::operator=`, which respects forcing.
+ * - Scalars (including STRING / WSTRING): `vars.NAME = &NAME` — every
+ *   base type, strings included, is an `IECVar<T>` / `IECStringVar<N>`
+ *   on the strucpp side, and the struct field is the matching
+ *   `strucpp::IEC_T*` / `strucpp::IEC_STRING*` pointer. The user's
+ *   `*name = 5` / `name = "hi"` routes through the wrapper's
+ *   `operator=`, which respects forcing.
  *
  * - Base-type arrays: `vars.NAME = &NAME[lower] - lower`. `Array1D<T>`
- *   stores `std::array<IECVar<T>, N>`; element 0 of that std::array
- *   sits at `&NAME[lower]`. Subtracting `lower` shifts the pointer so
- *   `vars->NAME[iec_idx]` works for any IEC index in the declared
- *   range. Per-element forcing is preserved.
- *
- * - Strings: `vars.NAME = &__NAME_stage` — point at the flat staging
- *   struct, NOT the IECStringVar. The boundary copy in/out happens
- *   around the user's setup/loop calls.
+ *   stores `std::array<IECVar<T>, N>`; element 0 sits at `&NAME[lower]`.
+ *   Subtracting `lower` shifts the pointer so `vars->NAME[iec_idx]`
+ *   works for any IEC index in the declared range. Per-element forcing
+ *   is preserved.
  */
 const generateVariableAssignment = (variable: PLCVariable): string => {
   const name = variable.name.toUpperCase()
   if (isArrayVariable(variable)) {
     const startIndex = getArrayStartIndex(variable)
     return `vars.${name} = &${name}[${startIndex}] - ${startIndex};\n`
-  }
-  if (isStringVariable(variable)) {
-    return `vars.${name} = &__${name}_stage;\n`
   }
   return `vars.${name} = &${name};\n`
 }
@@ -101,27 +41,20 @@ const generateSTCode = (params: STCodeGenerationParams): string => {
   const setupFunctionName = `${pouName.toLowerCase()}_setup`
   const loopFunctionName = `${pouName.toLowerCase()}_loop`
 
-  // Strings need flat staging on the program method's stack — see
-  // generateStringStaging for the reasoning.
-  const inputStrings = inputVariables.filter(isStringVariable)
-  const outputStrings = outputVariables.filter(isStringVariable)
-  const allStrings = [...inputStrings, ...outputStrings]
-
-  const stringStaging = generateStringStaging(allStrings)
-  const stringCopyIn = generateStringCopyIn(allStrings)
-  const stringCopyOut = generateStringCopyOut(outputStrings)
-
   let variableAssignments = ''
   for (const variable of inputVariables) variableAssignments += generateVariableAssignment(variable)
   for (const variable of outputVariables) variableAssignments += generateVariableAssignment(variable)
 
-  // Header `{external}` block: declare the user-visible struct, stage
-  // strings, fill the pointer fields. STruC++ emits this body verbatim
-  // into the program's run() method, so unqualified UPPERCASE names
-  // resolve to class members (the program's IEC variables).
-  let stCode = `{external
+  // Header `{external}` block: declare the user-visible struct, fill
+  // the pointer fields. STruC++ emits this body verbatim into the
+  // program's run() method, so unqualified UPPERCASE names resolve to
+  // class members (the program's IEC variables). No boundary copy is
+  // needed — every pin (numeric, bit-string, STRING, WSTRING) is a
+  // `strucpp::IEC_*` wrapper on both sides of the call, so taking its
+  // address is type-compatible with the struct field.
+  return `{external
 ${structName} vars;
-${stringStaging}${stringCopyIn}${variableAssignments}}
+${variableAssignments}}
 if hasBeenInitialized = False then
 {external
 ${setupFunctionName}(&vars);
@@ -131,16 +64,6 @@ end_if;
 {external
 ${loopFunctionName}(&vars);
 }`
-
-  // Writeback for output strings — base-type scalars and arrays write
-  // through the IECVar pointer directly inside the user's loop, so no
-  // extra copy is needed for them.
-  if (stringCopyOut) {
-    stCode += `\n{external
-${stringCopyOut}}`
-  }
-
-  return stCode
 }
 
 export { generateSTCode, type STCodeGenerationParams }


### PR DESCRIPTION
## Summary

Replace the legacy `{ __strlen_t len; uint8_t body[STR_MAX_LEN]; }` POD shape with `strucpp::IEC_STRING` / `strucpp::IEC_WSTRING` (= `IECStringVar<254>` / `IECWStringVar<254>`) end-to-end across the c_blocks header, the c_blocks_code baseline, and the strucpp ST↔C++ bridge stub. Strings now flow through the same `strucpp::IEC_*` wrapper everywhere — same shape numeric pins already use — and the boundary-copy/staging path is gone.

### What changed

- **`generateCBlocksHeader`** emits `strucpp::IEC_*` for every struct field (numeric, bit-string, STRING, WSTRING) and pulls in `iec_var.hpp` + `iec_string.hpp` so the qualifications resolve regardless of include order.
- **`generateCBlocksCode`** baseline drops the raw POD typedef + `STR_MAX_LEN` / `__strlen_t` plumbing. Keeps the file-scope numeric typedefs (`IEC_INT`, `IEC_REAL`, ...) for user locals inside `setup()` / `loop()`.
- **`generateSTCode` (cpp variant)** drops the per-STRING staging copy entirely. Strings now use the same direct-pointer path as every other scalar: `vars.NAME = &NAME` — both sides are `IECStringVar<254>`, so the boundary copy is dead weight. No more `__INMSG_stage.len = ...; memcpy(__INMSG_stage.body, ...)`.
- **`array-codegen-helpers.generateStructMember`** now emits `strucpp::${iecType} *${name}` for every type, including STRING / WSTRING (no more special case).

### User-facing impact in C/C++ POU bodies

- Reads: `name.length()`, `name.c_str()`, `name[i]` (by value, read-only on the pin).
- Writes: `name = "literal";`, `name = other_string;`, `name = c_buffer;` — all force-respecting through `IECStringVar::operator=`.
- Mutation: `auto buf = name.get(); buf[3] = 'X'; name = buf;` for mid-string edits.
- Concat: `buf += "..."`, `buf += other.get()`, `buf.append('!')`.
- The full set of patterns is documented in **user-docs PR autonomy-logic/user-docs#12**.

### Bonus: Variables Table completion

Surfaces user-declared Variables Table entries in the Monaco C++ completion provider. Identifier completion in C++ POUs now picks up names declared in the table (e.g. typing `my_` after declaring `my_variable` suggests it). Mirrors the existing ST/IL behavior.

### Test plan

- [x] Unit tests green: `npx jest --testPathPatterns="(generateSTCode|generateCBlocksHeader|generateCBlocksCode|array-codegen-helpers)"` → 64/64 pass.
- [x] Manual verification: user's `test_str` POU compiles cleanly end-to-end on Arduino Mega target, including a `name = strucpp::IECString<254>("...") + other.get();` mutation.
- [ ] Reviewer: pick a STRING/WSTRING POU, build for Arduino Mega + Linux targets, confirm both compile clean.
- [ ] Reviewer: open a C++ POU, declare `my_variable` in the Variables Table, type `my_` in the editor, confirm completion lists it.

### Strucpp counterpart

This PR depends on strucpp 0.5.0's `IECStringVar` / `IECWStringVar` read-through proxy methods (`length`, `c_str`, `operator[]`) that route through `forced_ ? forced_value_ : value_` for force semantics. Those proxies land separately in strucpp; this PR consumes a strucpp 0.5.0 install with that delta.

### Mirror to openplc-web

The c_blocks pieces (header, code, ST stub, struct member generation, array-codegen-helpers) sit inside shared surface and need a byte-identical mirror PR on `openplc-web`. The Monaco completion edit is editor-only and does NOT mirror. Full file-by-file shared/editor-only breakdown to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autocomplete now includes PLC/POU variable suggestions in the C++ Monaco editor.

* **Improvements**
  * Unified and simplified STRING/WSTRING handling in generated C++ to use wrapper-based types end-to-end, removing prior staging/copy steps.
  * Generated headers now include and document wrapper support so consumers get correct type behavior.

* **Tests**
  * Unit tests updated to match the new string representation and generation behavior.

* **Chores**
  * Bumped strucpp runtime version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->