### PR TITLE
feat(ai-chat): add rate_limit_exceeded variant to exhaustion modal (mirror of web #464)

### DIFF
--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/AcuExhaustionModal.tsx
@@ -1,6 +1,18 @@
 import type { BillingErrorPayload } from '../../../../../middleware/shared/ports/types'
 import { Modal, ModalContent, ModalHeader, ModalTitle } from '../../../_molecules/modal'
 
+/**
+ * Format the `rate_limit_exceeded` reset timestamp into a locale-aware
+ * date+time string, or `null` when there's nothing valid to show (the
+ * backend sends `null`/omits it when it can't compute a reset point).
+ */
+function formatResetTime(resetsAt?: string | null): string | null {
+  if (!resetsAt) return null
+  const ms = Date.parse(resetsAt)
+  if (Number.isNaN(ms)) return null
+  return new Date(ms).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
 export type AcuExhaustionModalProps = {
   /** Pulled from `ai.billingError`. Modal renders when non-null. */
   billingError: BillingErrorPayload | null
@@ -42,19 +54,24 @@ export const AcuExhaustionModal = ({
   if (!billingError) return null
 
   const isInactive = billingError.code === 'subscription_inactive'
+  const isRateLimit = billingError.code === 'rate_limit_exceeded'
+  const resetLabel = isRateLimit ? formatResetTime(billingError.resetsAt) : null
 
-  const title = isInactive ? 'Subscription required' : "You're out of ACU"
+  const title = isRateLimit ? 'AI usage limit reached' : isInactive ? 'Subscription required' : "You're out of ACU"
   // Frontend-controlled copy: the backend `CreditGuard` message is geared
   // toward operators/logs and still references the (now-descoped) Haiku
   // model quick-switch from DOPE-288. We pull only the structured fields
-  // (subscriptionStatus, monthlyLimit) and compose user-facing text here.
-  const description = isInactive
-    ? `Your subscription is ${billingError.subscriptionStatus ?? 'inactive'}. Reactivate it to keep using AI features.`
-    : billingError.monthlyLimit != null
-      ? `You've used all ${Math.round(billingError.monthlyLimit)} ACU for this billing period. Buy more ACU or upgrade your plan to keep going.`
-      : "You're out of ACU for this billing period. Buy more ACU or upgrade your plan to keep going."
+  // (subscriptionStatus, monthlyLimit, resetsAt) and compose user-facing
+  // text here.
+  const description = isRateLimit
+    ? 'You’ve reached the AI usage limit for the current window. Wait until it resets, or upgrade your plan for a higher limit and a larger context window.'
+    : isInactive
+      ? `Your subscription is ${billingError.subscriptionStatus ?? 'inactive'}. Reactivate it to keep using AI features.`
+      : billingError.monthlyLimit != null
+        ? `You've used all ${Math.round(billingError.monthlyLimit)} ACU for this billing period. Buy more ACU or upgrade your plan to keep going.`
+        : "You're out of ACU for this billing period. Buy more ACU or upgrade your plan to keep going."
   const ctaLabel = isInactive ? 'Reactivate subscription' : 'Upgrade plan'
-  // subscription_inactive carries its own reactivation URL; insufficient_acu doesn't.
+  // subscription_inactive carries its own reactivation URL; the other variants don't.
   const ctaUrl = isInactive && billingError.reactivateUrl ? billingError.reactivateUrl : upgradeUrl
 
   return (
@@ -80,6 +97,11 @@ export const AcuExhaustionModal = ({
               remaining.
             </p>
           )}
+        {isRateLimit && resetLabel && (
+          <p className='text-[12px] text-neutral-500 dark:text-neutral-400'>
+            Your usage window resets on {resetLabel}.
+          </p>
+        )}
         <div className='mt-2 flex items-center justify-end gap-2'>
           <button
             type='button'

--- a/src/frontend/components/_features/[workspace]/ai-settings-panel/__tests__/AcuExhaustionModal.test.tsx
+++ b/src/frontend/components/_features/[workspace]/ai-settings-panel/__tests__/AcuExhaustionModal.test.tsx
@@ -141,6 +141,44 @@ describe('AcuExhaustionModal', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1)
   })
 
+  it('renders the rate-limit variant with reset time + upgrade CTA', () => {
+    const rateLimited: BillingErrorPayload = {
+      code: 'rate_limit_exceeded',
+      message: 'Too many AI requests in the recent window. Try again shortly.',
+      resetsAt: '2026-06-01T18:30:00.000Z',
+    }
+    render(<AcuExhaustionModal billingError={rateLimited} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
+    expect(screen.getByText('AI usage limit reached')).toBeTruthy()
+    expect(screen.getByText(/reached the AI usage limit.*upgrade your plan for a higher limit/i)).toBeTruthy()
+    // The reset line renders a locale-formatted timestamp; assert the prefix
+    // (the exact date/time string is locale/timezone dependent).
+    expect(screen.getByText(/Your usage window resets on /)).toBeTruthy()
+    const cta = screen.getByTestId('acu-exhaustion-cta') as HTMLAnchorElement
+    expect(cta.textContent).toBe('Upgrade plan')
+    expect(cta.href).toBe(TEST_UPGRADE_URL)
+  })
+
+  it('omits the reset line for a rate-limit block with null resetsAt', () => {
+    const rateLimited: BillingErrorPayload = {
+      code: 'rate_limit_exceeded',
+      message: 'Too many AI requests in the recent window. Try again shortly.',
+      resetsAt: null,
+    }
+    render(<AcuExhaustionModal billingError={rateLimited} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
+    expect(screen.getByText('AI usage limit reached')).toBeTruthy()
+    expect(screen.queryByText(/Your usage window resets on/)).toBeNull()
+  })
+
+  it('omits the reset line when the rate-limit resetsAt is an unparseable string', () => {
+    const rateLimited: BillingErrorPayload = {
+      code: 'rate_limit_exceeded',
+      message: 'Too many AI requests in the recent window. Try again shortly.',
+      resetsAt: 'not-a-date',
+    }
+    render(<AcuExhaustionModal billingError={rateLimited} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
+    expect(screen.queryByText(/Your usage window resets on/)).toBeNull()
+  })
+
   it('uses dialog ARIA semantics (Radix Dialog)', () => {
     render(<AcuExhaustionModal billingError={insufficientAcu} onDismiss={vi.fn()} upgradeUrl={TEST_UPGRADE_URL} />)
     const dialog = screen.getByRole('dialog')

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -1219,16 +1219,19 @@ export interface AIUsage {
 }
 
 /**
- * Structured 402 payload from `/ai/chat` and `/ai/complete`. The backend
- * `CreditGuard` (autonomy-edge `presentation/guards/credit.guard.ts`) throws
- * one of two variants depending on whether the user is out of ACU
- * (`insufficient_acu`) or has a non-active Paddle subscription
- * (`subscription_inactive`). Surfaced via `AIRequestError.billing` in the
- * web adapter and stored on `AISlice` as `billingError` for the exhaustion-
- * modal consumer (DOPE-285).
+ * Structured billing/limit payload from `/ai/chat` and `/ai/complete`. The
+ * backend `CreditGuard` (autonomy-edge `presentation/guards/credit.guard.ts`)
+ * throws one of these variants:
+ *  - `insufficient_acu` (HTTP 402) — user is out of monthly ACU.
+ *  - `subscription_inactive` (HTTP 402) — non-active Paddle subscription.
+ *  - `rate_limit_exceeded` (HTTP 429) — the rolling usage window (default 6h,
+ *    capped at a percentage of the monthly ACU) is spent. Carries `resetsAt`
+ *    so the UI can tell the user when the window frees up.
+ * Surfaced via `AIRequestError.billing` in the web adapter and stored on
+ * `AISlice` as `billingError` for the exhaustion-modal consumer (DOPE-285).
  */
 export type BillingErrorPayload = {
-  code: 'insufficient_acu' | 'subscription_inactive'
+  code: 'insufficient_acu' | 'subscription_inactive' | 'rate_limit_exceeded'
   message: string
   /** Set when `code === 'insufficient_acu'`. ACU remaining in the period. */
   remaining?: number
@@ -1240,6 +1243,12 @@ export type BillingErrorPayload = {
   subscriptionStatus?: SubscriptionStatus
   /** Optional deep-link to the autonomy-edge billing portal. */
   reactivateUrl?: string
+  /**
+   * Set when `code === 'rate_limit_exceeded'`. ISO-8601 timestamp at which the
+   * rolling usage window resets and AI requests are allowed again. `null` when
+   * the backend couldn't compute it (no prior reservations in the window).
+   */
+  resetsAt?: string | null
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Mirror of openplc-web PR Autonomy-Logic/openplc-web#464 — keeps the shared frontend/ports surface byte-identical between the two IDEs (required by the `sync / Shared Surface Sync` gate).

This PR carries only the **shared-surface** files:
- `src/middleware/shared/ports/types.ts` — `BillingErrorPayload` gains `code: 'rate_limit_exceeded'` + `resetsAt` (HTTP 429 from the backend's rolling 6h usage-window guard).
- `src/frontend/.../ai-settings-panel/AcuExhaustionModal.tsx` — third modal variant ("AI usage limit reached") showing the window reset time + upgrade CTA.
- `src/frontend/.../ai-settings-panel/__tests__/AcuExhaustionModal.test.tsx` — coverage for the new variant.

The rest of the feature (429 parsing in `api-client`, chat-panel wiring, telemetry, the subscription tier badge, and hiding the WIP attach/mention buttons) is web-adapter-specific and lives only in the web PR.

Mirror of Autonomy-Logic/openplc-web#464

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added rate-limit exceeded error handling that displays when your usage window resets
* Enhanced billing error notifications with distinct messaging for rate-limit exceeded, insufficient credits, and inactive subscription scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->