### PR TITLE
fix(monaco): stop xyflow from eating Space in EditContext-based editors

### DIFF
--- a/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
@@ -859,45 +859,6 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
     focusDisposables.current.onFocus?.dispose()
     focusDisposables.current.onBlur?.dispose()
 
-    // ST POU body editors silently lose plain-Space keystrokes after
-    // the STruC++ LSP completion provider became active in the v4.2.0
-    // RC line.  Symptom: with the suggest widget mounted (visible OR
-    // just tracking — the "active suggest model" state), `onKeyDown`
-    // for Space fires, `defaultPrevented` is false, no built-in
-    // Space binding exists in the editor surface (only Ctrl+Space /
-    // Cmd+Space for trigger-suggest), yet `onDidType(" ")` never
-    // fires and the model stays unchanged.  The break only shows up
-    // when the LSP provider is registered; every other Monaco editor
-    // surface in the app (IL, Python, C++) types space fine because
-    // no LSP provider attaches.  Reproduced cleanly with `if<Space>`
-    // (widget filtering on the keyword list) and inside snippet
-    // placeholders after Tab-accepting a suggestion.
-    //
-    // The fix is byte-equivalent to what Monaco's default Space
-    // dispatch *should* do: invoke the `type` core command with a
-    // single space, and dismiss the suggest widget so it doesn't
-    // dangle.  Binding via `addCommand(KeyCode.Space, …)` registers
-    // an editor-scoped keybinding at the highest user-priority slot;
-    // it never collides with built-in shortcuts because Monaco
-    // reserves Space only with modifiers (Ctrl/Cmd) and only for
-    // trigger-suggest, which still works because that binding lives
-    // at a different chord.  See `node_modules/monaco-editor/esm/vs/
-    // editor/contrib/suggest/browser/suggestController.js:676` for
-    // the only Space-key registration in editor scope.
-    //
-    // Root cause of the upstream interference between the LSP
-    // semantic-tokens / completion-model flow and Monaco's default
-    // type pipeline is still open — left for an upstream Monaco /
-    // strucpp-LSP investigation since the regression sits below the
-    // surface our converters touch (items carry no commitCharacters
-    // and no itemDefaults; the suggestModel just stops dispatching
-    // type for Space).  This binding restores the expected typing
-    // behaviour with zero side effects on other editors.
-    editorInstance.addCommand(monacoInstance.KeyCode.Space, () => {
-      editorInstance.trigger('keyboard', 'type', { text: ' ' })
-      editorInstance.trigger('keyboard', 'hideSuggestWidget', {})
-    })
-
     focusDisposables.current.onFocus = editorInstance.onDidFocusEditorText(() => {
       openPLCStoreBase.getState().editorActions.setMonacoFocused(true)
     })
@@ -1449,7 +1410,27 @@ void loop()
 
   return (
     <>
-      <div id='editor drop handler' className='oplc-monaco-wrapper relative h-full w-full' onDrop={handleDrop}>
+      {/* `nokey` opts every keystroke inside this Monaco editor out of
+       *  @xyflow/react's global window-level `keydown` listener
+       *  (`downHandler` in @xyflow_react.js — tracks Space as a
+       *  pan-modifier for the diagram canvas and `preventDefault`s
+       *  it).  xyflow's `isInputDOMNode` guard bails out for
+       *  `<input>` / `<textarea>` / `[contenteditable]` targets, but
+       *  Monaco's new EditContext-API surface renders as a plain
+       *  `<div class="native-edit-context">` with NO `contenteditable`
+       *  attribute (the EditContext API replaces the legacy textarea
+       *  entirely), so xyflow doesn't recognise it as input —
+       *  preventDefault then swallows Space before the browser can
+       *  commit text to the EditContext, and `onWillType` /
+       *  `onDidType` never fire.  The `.nokey` class is xyflow's
+       *  documented escape hatch (`target.closest(".nokey")` in the
+       *  same guard); marking this wrapper opts every keystroke
+       *  inside the editor out cleanly, without leaking a global
+       *  keybinding into other Monaco instances on the page.  See
+       *  @xyflow/react `node_modules/.vite/deps/@xyflow_react.js`
+       *  around the `downHandler` definition (currently ~line 6080)
+       *  and `isInputDOMNode` (~line 3759). */}
+      <div id='editor drop handler' className='oplc-monaco-wrapper nokey relative h-full w-full' onDrop={handleDrop}>
         <PrimitiveEditor
           key={capabilities.hasLocalFilesystem ? undefined : editorModelPath}
           options={monacoEditorUserOptions}

--- a/src/frontend/components/_organisms/variables-code-editor/index.tsx
+++ b/src/frontend/components/_organisms/variables-code-editor/index.tsx
@@ -129,10 +129,17 @@ const VariablesCodeEditor = ({
   }, [cursorPosition, editorMounted])
 
   return (
+    // `nokey` opts keystrokes inside this Monaco instance out of
+    // @xyflow/react's global Space pan-modifier listener.  See the
+    // long comment on the body Monaco wrapper (`oplc-monaco-wrapper`
+    // in `editor/monaco/index.tsx`) for the full diagnosis.  Without
+    // this opt-out, switching the variables table to text mode
+    // silently drops every typed Space (xyflow `preventDefault`s the
+    // keystroke before Monaco's new EditContext can commit it).
     <div
       ref={containerRef}
       aria-label='Variable Code Editor Container'
-      className='h-full w-full'
+      className='nokey h-full w-full'
       style={{ overflow: 'hidden' }}
     >
       <Editor


### PR DESCRIPTION
## Summary

**Bug**: typing Space in any Monaco editor (body or variables-text-mode) silently dropped the character whenever a graphical POU (FBD/LD/SFC — which mounts @xyflow/react) was open anywhere on the page. Letters/numbers worked fine — Space was uniquely affected. Also: spaces would sometimes leak from the variables-text editor into a body editor in another tab.

**Root cause**: @xyflow/react installs a global window-level `keydown` listener (`downHandler` in `@xyflow_react.js` ~line 6080) that calls `event.preventDefault()` on Space — it tracks Space as the pan-modifier for the diagram canvas. Its `isInputDOMNode` guard (~line 3759) bails out for `<input>` / `<textarea>` / `[contenteditable]` targets, but Monaco's new **EditContext API** editor renders the input surface as a plain `<div class="native-edit-context">` with **no `contenteditable` attribute** (the EditContext API replaces the legacy textarea entirely). So xyflow doesn't recognise it as input, preventDefault eats Space, and the browser never commits text to the EditContext — `onWillType` / `onDidType` never fire, model stays unchanged.

**Why cross-tab leakage happened**: the prior workaround was `editorInstance.addCommand(KeyCode.Space, () => editor.trigger('keyboard', 'type', { text: ' ' }))` in the body editor's mount. `addCommand` registers against Monaco's **singleton** `StandaloneKeybindingService` with no `when` clause, so the binding is global across every Monaco instance on the page. Multi-mount keeps every open text-POU's body editor alive even when a graphical POU is active — so a Space typed in the variables-text editor (or any other Monaco surface) would fire the handler that explicitly types ' ' into the body editor it was registered against. Hence "spaces leak into another tab's body editor".

## Fix

Add @xyflow/react's documented escape-hatch class **`nokey`** to the wrappers of every Monaco surface in the app:
- `editor/monaco/index.tsx:1413` — body editor wrapper (`oplc-monaco-wrapper`)
- `variables-code-editor/index.tsx:131` — variables-text-mode editor wrapper

xyflow's guard does `target.closest(".nokey")` and bails out if truthy. The opt-out is per-wrapper scoped: outside the editor (diagram canvas itself), Space still pans the diagram as expected.

The old `addCommand(KeyCode.Space, …)` workaround and its 35-line "open root cause" comment are obsolete and removed.

## How it was diagnosed

Reproduced live in `pnpm dev:local` against the dev project — opened an ST POU, instrumented `Event.prototype.preventDefault`, observed `downHandler` (line 6089) calling preventDefault on Space. Confirmed `editContext.textupdate` never fires for Space (and DOES fire for letters). Verified the fix by adding `nokey` and re-typing — `total_chars` went from "no space delta" to "every space typed".

## Test plan

- [ ] Reviewer: open a project with both a graphical POU (FBD/LD) and a text-based POU (ST/IL/Python). Type Space in:
  - [ ] ST/IL/Python body editor — should work
  - [ ] Variables-table text mode — should work
  - [ ] Multiple text POUs simultaneously open — no cross-instance interference
- [ ] CI green on this PR (architecture, build-check, format, lint, sync x4, complete-build x3).

## Cross-repo

Both files are **shared surface** (`frontend/`). A byte-identical mirror PR on `openplc-web` follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Space key input handling in the code editor to ensure proper functionality
  * Resolved Space key behavior in the variables editor when switching between different editing modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->