### PR TITLE
chore(deps): bump strucpp v0.5.2 → v0.5.3 (debugger STRING/WSTRING fix)

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.5.2",
+    "version": "v0.5.3",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }


### PR DESCRIPTION
## Summary

Bump strucpp to v0.5.3, which carries the debugger STRING / WSTRING read/write/force/unforce implementation (strucpp PR #162). Before this, the editor's debug watch panel showed "-" for every STRING / WSTRING variable because the runtime's `read_string_stub` returned zero bytes.

### Wire path (already wired editor-side)

- `frontend/utils/variable-sizes.ts::decodeWireValue` already has `case 'len8-utf8'` + `case 'len8-utf16le'` arms.
- `strucpp/libs/iec-types.json` already advertises STRING / WSTRING with the matching `wireFormat`.
- The only missing piece was the runtime impl, which lands in v0.5.3.

### Test plan

- [ ] CI green.
- [ ] After merge + production: open a project with a STRING variable, add to debug watch, confirm the value renders instead of "-".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated strucpp binary to v0.5.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->