### PR TITLE
chore(deps): bump strucpp v0.5.3 → v0.5.4 (debug-table STRING/WSTRING emission)

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.5.3",
+    "version": "v0.5.4",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }


### PR DESCRIPTION
## Summary

Bump strucpp to v0.5.4, the other half of the debugger STRING/WSTRING fix. v0.5.3 shipped the runtime read impl; v0.5.4 fixes the emitter — `addLeaf` in `debug-table-gen.ts` was explicitly skipping STRING/WSTRING (Phase-4a guard) so they were never in the debug table, making the runtime read unreachable.

End-to-end verified locally before tagging: simulator runs the Irrigation Controller dev project with a `test_string : STRING := 'hello world'` in Manual_Override; editor's polling loop receives the correct length-prefixed UTF-8 bytes and decodes them as `"hello world"` instead of `-`.

### Test plan

- [ ] CI green.
- [ ] After merge + prod: STRING / WSTRING values render in the debug watch panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated strucpp binary version to v0.5.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->