### PR TITLE
feat(theme): platform-owned theme handling synced with openplc-web

### DIFF
--- a/src/frontend/components/_molecules/menu-bar/menus/display.tsx
+++ b/src/frontend/components/_molecules/menu-bar/menus/display.tsx
@@ -1,6 +1,7 @@
 import * as MenuPrimitive from '@radix-ui/react-menubar'
 import { useEffect, useState } from 'react'
 
+import { useTheme } from '../../../../../middleware/shared/providers'
 import { i18n } from '../../../../locales/i18n'
 import { useOpenPLCStore } from '../../../../store'
 import { MenuClasses } from '../constants'
@@ -16,12 +17,6 @@ type ThemeChoice = 'light' | 'dark' | 'nineties'
 const THEME_ORDER: readonly ThemeChoice[] = ['light', 'dark', 'nineties']
 const THEME_LABEL: Record<ThemeChoice, string> = { light: 'light', dark: 'dark', nineties: "90's" }
 
-function getThemePreference(): ThemeChoice {
-  const stored = localStorage.getItem('theme')
-  if (stored === 'dark' || stored === 'light' || stored === 'nineties') return stored
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-}
-
 export const DisplayMenu = () => {
   const {
     workspaceActions: { setSystemConfigs, toggleCollapse },
@@ -29,18 +24,21 @@ export const DisplayMenu = () => {
 
   const { TRIGGER, CONTENT, ITEM, ACCELERATOR, SEPARATOR } = MenuClasses
 
-  const [theme, setTheme] = useState(getThemePreference())
+  // The theme port owns persistence (localStorage, the cross-app cookie and
+  // the backend preference) and the DOM class; this component only mirrors
+  // the current value for the menu label and the Monaco light/dark flag.
+  const themePort = useTheme()
+  const [theme, setTheme] = useState<ThemeChoice>(themePort.getCurrentTheme())
+
+  useEffect(() => themePort.onThemeChanged(setTheme), [themePort])
 
   useEffect(() => {
-    document.documentElement.classList.remove('dark', 'light', 'nineties')
-    document.documentElement.classList.add(theme)
     setSystemConfigs({ shouldUseDarkMode: theme === 'dark' })
   }, [theme, setSystemConfigs])
 
   const cycleTheme = () => {
     const newTheme = THEME_ORDER[(THEME_ORDER.indexOf(theme) + 1) % THEME_ORDER.length] ?? 'light'
-    setTheme(newTheme)
-    localStorage.setItem('theme', newTheme)
+    themePort.setTheme(newTheme)
     // The desktop bridge only understands the OS-level light/dark themes; the
     // retro skin is a web/UI-only flavour, so don't push it over IPC.
     if ((newTheme === 'light' || newTheme === 'dark') && 'bridge' in window) {

--- a/src/frontend/components/_templates/accelerator-handler.tsx
+++ b/src/frontend/components/_templates/accelerator-handler.tsx
@@ -302,15 +302,14 @@ const AcceleratorHandler = () => {
   }, [editingState, accelerator, openModal])
 
   /**
-   * Theme update from main process
+   * Theme changes (user toggle, OS preference, or cross-app cookie sync).
+   * The theme adapter owns the DOM class and persistence; here we only
+   * mirror the Monaco light/dark flag (set explicitly from the theme —
+   * toggling drifts when cycling through the 90's skin, and the retro
+   * theme uses light Monaco).
    */
   useEffect(() => {
     const unsub = themePort.onThemeChanged((newTheme) => {
-      document.documentElement.classList.remove('dark', 'light')
-      document.documentElement.classList.add(newTheme)
-      localStorage.setItem('theme', newTheme)
-      // Set the Monaco light/dark flag explicitly from the theme (toggling drifts
-      // when cycling through the 90's skin); the retro theme uses light Monaco.
       setSystemConfigs({ shouldUseDarkMode: newTheme === 'dark' })
     })
     return unsub

--- a/src/frontend/components/_templates/app-layout.tsx
+++ b/src/frontend/components/_templates/app-layout.tsx
@@ -1,6 +1,6 @@
 import { ComponentPropsWithoutRef, ReactNode, useCallback, useEffect, useState } from 'react'
 
-import { useCapabilities, useProject, useSystem } from '../../../middleware/shared/providers'
+import { useCapabilities, useProject, useSystem, useTheme } from '../../../middleware/shared/providers'
 import { useOpenPLCStore } from '../../store'
 import type { RungLadderState } from '../../store/slices/ladder'
 import { cn } from '../../utils/cn'
@@ -36,21 +36,14 @@ const AppLayout = ({ children, ...rest }: AppLayoutProps): ReactNode => {
   const OS = useOpenPLCStore(useCallback((s) => s.workspace.systemConfigs.OS, []))
   const { setSystemConfigs, setRecent } = useOpenPLCStore(useCallback((s) => s.workspaceActions, []))
 
-  // Theme initialization - applies the theme class before DisplayMenu mounts.
-  // Supports the retro 'nineties' skin alongside light/dark; it is light-based,
-  // so shouldUseDarkMode (which drives Monaco) stays false for it.
+  // Theme initialization - the theme port adapter owns reading the stored
+  // preference (cross-app cookie → localStorage → OS) and applying the
+  // <html> class; here we only seed the Monaco light/dark flag. The retro
+  // 'nineties' skin is light-based, so shouldUseDarkMode stays false for it.
+  const themePort = useTheme()
   useEffect(() => {
-    const stored = localStorage.getItem('theme')
-    const theme =
-      stored === 'dark' || stored === 'light' || stored === 'nineties'
-        ? stored
-        : window.matchMedia('(prefers-color-scheme: dark)').matches
-          ? 'dark'
-          : 'light'
-    document.documentElement.classList.remove('dark', 'light', 'nineties')
-    document.documentElement.classList.add(theme)
-    setSystemConfigs({ shouldUseDarkMode: theme === 'dark' })
-  }, [setSystemConfigs])
+    setSystemConfigs({ shouldUseDarkMode: themePort.getCurrentTheme() === 'dark' })
+  }, [themePort, setSystemConfigs])
 
   // System initialization
   useEffect(() => {

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -799,6 +799,7 @@ class MainProcessBridge implements MainIpcModule {
 
     // Theme and store handlers
     this.ipcMain.on('system:update-theme', this.mainIpcEventHandlers.handleUpdateTheme)
+    this.ipcMain.handle('system:get-theme', this.mainIpcEventHandlers.handleGetTheme)
     // this.ipcMain.handle('app:store-get', this.mainIpcEventHandlers.getStoreValue)
 
     // ===================== COMPILER SERVICE =====================
@@ -2187,11 +2188,20 @@ class MainProcessBridge implements MainIpcModule {
 
   // ===================== EVENT HANDLERS =====================
   mainIpcEventHandlers = {
-    handleUpdateTheme: (_event: unknown, theme?: 'light' | 'dark') => {
+    handleUpdateTheme: (_event: unknown, theme?: 'light' | 'dark' | 'nineties') => {
       const newTheme = theme ?? (nativeTheme.shouldUseDarkColors ? 'light' : 'dark')
-      nativeTheme.themeSource = newTheme
+      // nativeTheme only models light/dark; the 90's skin is UI-only and rides
+      // on a light base (mirrors MenuBuilder.updateAppTheme). The store keeps
+      // the full preference — it is the desktop's durable source of truth,
+      // analogous to the edge backend's user preference on the web app.
+      nativeTheme.themeSource = newTheme === 'dark' ? 'dark' : 'light'
       const appStore = this.store as unknown as { set: (key: string, value: string) => void }
       appStore.set('theme', newTheme)
+    },
+    handleGetTheme: (): 'light' | 'dark' | 'nineties' | null => {
+      const appStore = this.store as unknown as { get: (key: string) => unknown }
+      const stored = appStore.get('theme')
+      return stored === 'light' || stored === 'dark' || stored === 'nineties' ? stored : null
     },
     createPou: () => this.mainWindow?.webContents.send('pou:createPou', { ok: true }),
   }

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -189,7 +189,8 @@ const rendererProcessBridge = {
 
   // ===================== THEME =====================
   handleUpdateTheme: (callback: IpcRendererCallbacks) => ipcRenderer.on('system:update-theme', callback),
-  winHandleUpdateTheme: (theme?: 'light' | 'dark') => ipcRenderer.send('system:update-theme', theme),
+  winHandleUpdateTheme: (theme?: 'light' | 'dark' | 'nineties') => ipcRenderer.send('system:update-theme', theme),
+  winGetTheme: (): Promise<'light' | 'dark' | 'nineties' | null> => ipcRenderer.invoke('system:get-theme'),
 
   // ===================== COMPILER/BUILD METHODS =====================
   // !! Deprecated: This method is an outdated implementation and should be substituted.

--- a/src/middleware/adapters/editor/__tests__/theme-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/theme-adapter.test.ts
@@ -2,10 +2,12 @@ import type { ThemePort } from '../../../shared/ports/theme-port'
 import { createEditorThemeAdapter } from '../theme-adapter'
 
 let adapter: ThemePort
-let themeChangeHandler: ((_event: unknown) => void) | null
+let themeChangeHandler: ((_event: unknown, ...args: unknown[]) => void) | null
 
 beforeEach(() => {
   themeChangeHandler = null
+  localStorage.clear()
+  document.documentElement.classList.remove('dark', 'light', 'nineties')
 
   // Default: matchMedia says dark mode
   Object.defineProperty(window, 'matchMedia', {
@@ -15,7 +17,7 @@ beforeEach(() => {
 
   window.bridge = {
     winHandleUpdateTheme: jest.fn(),
-    handleUpdateTheme: jest.fn().mockImplementation((handler: (_event: unknown) => void) => {
+    handleUpdateTheme: jest.fn().mockImplementation((handler: (_event: unknown, ...args: unknown[]) => void) => {
       themeChangeHandler = handler
     }),
   } as unknown as typeof window.bridge
@@ -34,14 +36,42 @@ describe('getCurrentTheme', () => {
 
     expect(adapter.getCurrentTheme()).toBe('light')
   })
+
+  it('prefers the stored explicit theme over matchMedia', () => {
+    localStorage.setItem('theme', 'nineties')
+    adapter = createEditorThemeAdapter()
+
+    expect(adapter.getCurrentTheme()).toBe('nineties')
+    expect(document.documentElement.classList.contains('nineties')).toBe(true)
+  })
 })
 
 describe('setTheme', () => {
-  it('updates the current theme and calls bridge', () => {
+  it('updates the theme, applies the DOM class, persists, and drives nativeTheme', () => {
     adapter.setTheme('light')
 
     expect(adapter.getCurrentTheme()).toBe('light')
-    expect(window.bridge.winHandleUpdateTheme).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem('theme')).toBe('light')
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    expect(window.bridge.winHandleUpdateTheme).toHaveBeenCalledWith('light')
+  })
+
+  it('notifies subscribers', () => {
+    const cb = jest.fn()
+    adapter.onThemeChanged(cb)
+
+    adapter.setTheme('light')
+
+    expect(cb).toHaveBeenCalledWith('light')
+  })
+
+  it('does not drive nativeTheme for the UI-only nineties skin', () => {
+    adapter.setTheme('nineties')
+
+    expect(adapter.getCurrentTheme()).toBe('nineties')
+    expect(document.documentElement.classList.contains('nineties')).toBe(true)
+    expect(window.bridge.winHandleUpdateTheme).not.toHaveBeenCalled()
   })
 })
 
@@ -52,7 +82,7 @@ describe('toggleTheme', () => {
     adapter.toggleTheme()
 
     expect(adapter.getCurrentTheme()).toBe('light')
-    expect(window.bridge.winHandleUpdateTheme).toHaveBeenCalledTimes(1)
+    expect(window.bridge.winHandleUpdateTheme).toHaveBeenCalledWith('light')
   })
 
   it('toggles from light to dark', () => {
@@ -64,18 +94,34 @@ describe('toggleTheme', () => {
   })
 })
 
-describe('onThemeChanged', () => {
-  it('registers a bridge listener and toggles theme on event', () => {
+describe('main process theme events', () => {
+  it('registers the bridge listener once at creation', () => {
+    expect(window.bridge.handleUpdateTheme).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies an explicit theme from the native menu without echoing IPC', () => {
     const cb = jest.fn()
     adapter.onThemeChanged(cb)
 
-    expect(window.bridge.handleUpdateTheme).toHaveBeenCalledTimes(1)
+    themeChangeHandler!({}, 'nineties')
+
+    expect(adapter.getCurrentTheme()).toBe('nineties')
+    expect(localStorage.getItem('theme')).toBe('nineties')
+    expect(document.documentElement.classList.contains('nineties')).toBe(true)
+    expect(cb).toHaveBeenCalledWith('nineties')
+    expect(window.bridge.winHandleUpdateTheme).not.toHaveBeenCalled()
+  })
+
+  it('toggles theme on a payload-less (OS-level) event without persisting', () => {
+    const cb = jest.fn()
+    adapter.onThemeChanged(cb)
 
     // Theme starts as dark, so handler should toggle to light
     themeChangeHandler!({})
 
     expect(cb).toHaveBeenCalledWith('light')
     expect(adapter.getCurrentTheme()).toBe('light')
+    expect(localStorage.getItem('theme')).toBeNull()
   })
 
   it('toggles back on second event', () => {
@@ -90,6 +136,19 @@ describe('onThemeChanged', () => {
     expect(adapter.getCurrentTheme()).toBe('dark')
   })
 
+  it('does not flip off the retro skin on a payload-less event', () => {
+    const cb = jest.fn()
+    adapter.setTheme('nineties')
+    adapter.onThemeChanged(cb)
+
+    themeChangeHandler!({})
+
+    expect(adapter.getCurrentTheme()).toBe('nineties')
+    expect(cb).not.toHaveBeenCalled()
+  })
+})
+
+describe('onThemeChanged', () => {
   it('returns an unsubscribe function that deactivates the callback', () => {
     const cb = jest.fn()
     const unsub = adapter.onThemeChanged(cb)

--- a/src/middleware/adapters/editor/__tests__/theme-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/theme-adapter.test.ts
@@ -4,6 +4,22 @@ import { createEditorThemeAdapter } from '../theme-adapter'
 let adapter: ThemePort
 let themeChangeHandler: ((_event: unknown, ...args: unknown[]) => void) | null
 
+function flushPromises() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function mockBridge(storedTheme: 'light' | 'dark' | 'nineties' | null = null) {
+  window.bridge = {
+    winHandleUpdateTheme: jest.fn(),
+    // System store (electron-store on the main process) — the desktop's
+    // durable source of truth, analogous to the edge backend on web.
+    winGetTheme: jest.fn().mockResolvedValue(storedTheme),
+    handleUpdateTheme: jest.fn().mockImplementation((handler: (_event: unknown, ...args: unknown[]) => void) => {
+      themeChangeHandler = handler
+    }),
+  } as unknown as typeof window.bridge
+}
+
 beforeEach(() => {
   themeChangeHandler = null
   localStorage.clear()
@@ -15,12 +31,7 @@ beforeEach(() => {
     value: jest.fn().mockReturnValue({ matches: true }),
   })
 
-  window.bridge = {
-    winHandleUpdateTheme: jest.fn(),
-    handleUpdateTheme: jest.fn().mockImplementation((handler: (_event: unknown, ...args: unknown[]) => void) => {
-      themeChangeHandler = handler
-    }),
-  } as unknown as typeof window.bridge
+  mockBridge()
 
   adapter = createEditorThemeAdapter()
 })
@@ -66,12 +77,14 @@ describe('setTheme', () => {
     expect(cb).toHaveBeenCalledWith('light')
   })
 
-  it('does not drive nativeTheme for the UI-only nineties skin', () => {
+  it('persists the UI-only nineties skin to the system store too', () => {
     adapter.setTheme('nineties')
 
     expect(adapter.getCurrentTheme()).toBe('nineties')
     expect(document.documentElement.classList.contains('nineties')).toBe(true)
-    expect(window.bridge.winHandleUpdateTheme).not.toHaveBeenCalled()
+    // The main process maps 'nineties' onto a light nativeTheme but keeps
+    // the full preference in its store.
+    expect(window.bridge.winHandleUpdateTheme).toHaveBeenCalledWith('nineties')
   })
 })
 
@@ -91,6 +104,44 @@ describe('toggleTheme', () => {
 
     expect(adapter.getCurrentTheme()).toBe('dark')
     expect(window.bridge.winHandleUpdateTheme).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('system store boot reconcile', () => {
+  it('applies the stored theme over the renderer localStorage cache', async () => {
+    localStorage.setItem('theme', 'dark')
+    mockBridge('nineties')
+
+    adapter = createEditorThemeAdapter()
+    await flushPromises()
+
+    expect(adapter.getCurrentTheme()).toBe('nineties')
+    expect(localStorage.getItem('theme')).toBe('nineties')
+    expect(document.documentElement.classList.contains('nineties')).toBe(true)
+    // The value came FROM the store — no echo IPC.
+    expect(window.bridge.winHandleUpdateTheme).not.toHaveBeenCalled()
+  })
+
+  it('seeds the system store from the renderer preference when the store has none', async () => {
+    localStorage.setItem('theme', 'nineties')
+    mockBridge(null)
+
+    adapter = createEditorThemeAdapter()
+    await flushPromises()
+
+    expect(adapter.getCurrentTheme()).toBe('nineties')
+    expect(window.bridge.winHandleUpdateTheme).toHaveBeenCalledWith('nineties')
+  })
+
+  it('does nothing when neither layer has an explicit preference', async () => {
+    mockBridge(null)
+
+    adapter = createEditorThemeAdapter()
+    await flushPromises()
+
+    expect(adapter.getCurrentTheme()).toBe('dark') // matchMedia fallback
+    expect(window.bridge.winHandleUpdateTheme).not.toHaveBeenCalled()
+    expect(localStorage.getItem('theme')).toBeNull()
   })
 })
 

--- a/src/middleware/adapters/editor/theme-adapter.ts
+++ b/src/middleware/adapters/editor/theme-adapter.ts
@@ -3,23 +3,28 @@
  *
  * The shared frontend surface (display menu, app-layout, accelerator
  * handler) no longer touches localStorage or the <html> classes directly —
- * the platform's theme adapter owns persistence and DOM application (the
- * web adapter additionally syncs a cross-subdomain cookie and the edge
- * backend; on desktop neither applies). This adapter therefore:
+ * the platform's theme adapter owns persistence and DOM application. The
+ * layering mirrors the web adapter so the logic stays aligned across repos:
  *
- *   - reads the stored preference (localStorage `theme`) at creation and
- *     applies the <html> class before the UI mounts
- *   - applies + persists explicit changes from `setTheme`/`toggleTheme`,
- *     driving Electron's nativeTheme for light/dark via IPC
- *   - listens for theme events from the main process (native menu) and
- *     mirrors them into the DOM and subscribers
+ *   1. localStorage `theme` + the <html> class — renderer cache (what you
+ *      see; same role as the web app's per-origin localStorage)
+ *   2. electron-store `theme` on the main process — the desktop's durable
+ *      source of truth, analogous to the edge backend's user preference
+ *      on the web app (read via winGetTheme, written via
+ *      winHandleUpdateTheme)
+ *
+ * Conflict policy (same as web): the system store wins once per launch at
+ * boot; after that, explicit `setTheme`/`toggleTheme` changes write
+ * through to every layer. Native-menu theme events from the main process
+ * are mirrored into the DOM and subscribers without echoing IPC back.
  *
  * IPC flow:
  *   Renderer → winHandleUpdateTheme(theme) → main sets nativeTheme + store
+ *   Renderer → winGetTheme() → main returns the stored preference
  *   Main (native menu) → handleUpdateTheme() → renderer applies + notifies
  *
  * 'nineties' is a UI-only retro skin: it has no OS-level counterpart, so
- * it never drives nativeTheme and is light-based for Monaco purposes.
+ * it rides on a light nativeTheme and is light-based for Monaco purposes.
  */
 
 import type { ThemePort, ThemeVariant } from '../../shared/ports/theme-port'
@@ -70,6 +75,24 @@ export function createEditorThemeAdapter(): ThemePort {
     notifyListeners()
   }
 
+  // Boot reconcile: the system store (electron-store on the main process)
+  // is the desktop's durable source of truth — a theme stored there wins
+  // over the renderer's localStorage cache (e.g. after a cleared renderer
+  // session, or when the native menu changed it while no window listened).
+  // If the store has no theme yet but the renderer does (pre-feature
+  // users), seed the store from the local value instead.
+  void window.bridge
+    .winGetTheme?.()
+    .then((stored) => {
+      if (stored === 'light' || stored === 'dark' || stored === 'nineties') {
+        // The value came FROM the store — apply locally without echoing IPC.
+        applyExplicitTheme(stored)
+      } else if (explicitPreference) {
+        window.bridge.winHandleUpdateTheme(explicitPreference)
+      }
+    })
+    .catch(() => undefined)
+
   // Theme events from the main process (native menu picks, OS changes).
   window.bridge.handleUpdateTheme((_event: unknown, ...args: unknown[]) => {
     const theme = args[0]
@@ -95,11 +118,11 @@ export function createEditorThemeAdapter(): ThemePort {
 
     setTheme(theme: ThemeVariant): void {
       applyExplicitTheme(theme)
-      // Passing the theme explicitly makes the IPC idempotent (no toggle
-      // semantics), so the display menu's own bridge push is harmless.
-      if (theme === 'light' || theme === 'dark') {
-        window.bridge.winHandleUpdateTheme(theme)
-      }
+      // Persist every theme (including 'nineties') to the system store —
+      // the main process maps it onto nativeTheme as needed. Passing the
+      // theme explicitly makes the IPC idempotent (no toggle semantics),
+      // so the display menu's own bridge push is harmless.
+      window.bridge.winHandleUpdateTheme(theme)
     },
 
     toggleTheme(): void {

--- a/src/middleware/adapters/editor/theme-adapter.ts
+++ b/src/middleware/adapters/editor/theme-adapter.ts
@@ -1,22 +1,92 @@
 /**
- * Editor ThemePort adapter — delegates to Electron IPC bridge.
+ * Editor ThemePort adapter — owns theme state for the desktop app.
  *
- * Uses nativeTheme on the main process side (via `window.bridge`)
- * for OS-level theme detection and persistence via electron-store.
+ * The shared frontend surface (display menu, app-layout, accelerator
+ * handler) no longer touches localStorage or the <html> classes directly —
+ * the platform's theme adapter owns persistence and DOM application (the
+ * web adapter additionally syncs a cross-subdomain cookie and the edge
+ * backend; on desktop neither applies). This adapter therefore:
  *
- * Initial theme is read synchronously from matchMedia, which in Electron
- * reflects the nativeTheme state set by the main process on startup.
+ *   - reads the stored preference (localStorage `theme`) at creation and
+ *     applies the <html> class before the UI mounts
+ *   - applies + persists explicit changes from `setTheme`/`toggleTheme`,
+ *     driving Electron's nativeTheme for light/dark via IPC
+ *   - listens for theme events from the main process (native menu) and
+ *     mirrors them into the DOM and subscribers
  *
  * IPC flow:
- *   Renderer → winHandleUpdateTheme() → main toggles nativeTheme
- *   Main → handleUpdateTheme() → renderer updates local state
+ *   Renderer → winHandleUpdateTheme(theme) → main sets nativeTheme + store
+ *   Main (native menu) → handleUpdateTheme() → renderer applies + notifies
+ *
+ * 'nineties' is a UI-only retro skin: it has no OS-level counterpart, so
+ * it never drives nativeTheme and is light-based for Monaco purposes.
  */
 
 import type { ThemePort, ThemeVariant } from '../../shared/ports/theme-port'
 import type { Unsubscribe } from '../../shared/ports/types'
 
+const STORAGE_KEY = 'theme'
+
+function getSystemThemePreference(): ThemeVariant {
+  // In Electron this reflects nativeTheme, which the main process restored
+  // from electron-store at startup.
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function readExplicitPreference(): ThemeVariant | null {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  return stored === 'dark' || stored === 'light' || stored === 'nineties' ? stored : null
+}
+
+function applyThemeToDOM(theme: ThemeVariant): void {
+  const root = document.documentElement
+  // Mutually-exclusive theme classes — clear all three, then set the active
+  // one. 'nineties' is a light-based retro skin, so it never carries 'dark'.
+  root.classList.remove('dark', 'light', 'nineties')
+  root.classList.add(theme)
+  root.style.colorScheme = theme === 'dark' ? 'dark' : 'light'
+}
+
 export function createEditorThemeAdapter(): ThemePort {
-  let currentTheme: ThemeVariant = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  let explicitPreference: ThemeVariant | null = readExplicitPreference()
+  let currentTheme: ThemeVariant = explicitPreference ?? getSystemThemePreference()
+  const listeners = new Set<(theme: ThemeVariant) => void>()
+
+  applyThemeToDOM(currentTheme)
+
+  function notifyListeners(): void {
+    for (const cb of listeners) {
+      cb(currentTheme)
+    }
+  }
+
+  /** Record an explicit theme locally (state, DOM, localStorage) and notify. */
+  function applyExplicitTheme(theme: ThemeVariant): void {
+    explicitPreference = theme
+    localStorage.setItem(STORAGE_KEY, theme)
+    if (theme === currentTheme) return
+    currentTheme = theme
+    applyThemeToDOM(theme)
+    notifyListeners()
+  }
+
+  // Theme events from the main process (native menu picks, OS changes).
+  window.bridge.handleUpdateTheme((_event: unknown, ...args: unknown[]) => {
+    const theme = args[0]
+    if (theme === 'light' || theme === 'dark' || theme === 'nineties') {
+      // Explicit pick from the native menu — main already updated
+      // nativeTheme + its store, so only mirror it locally (no echo IPC).
+      applyExplicitTheme(theme)
+      return
+    }
+
+    // No payload = an OS-level light/dark flip; don't flip off the retro
+    // skin, and don't persist — it is not an explicit user choice.
+    if (currentTheme === 'nineties') return
+    currentTheme = currentTheme === 'dark' ? 'light' : 'dark'
+    applyThemeToDOM(currentTheme)
+    notifyListeners()
+  })
 
   return {
     getCurrentTheme(): ThemeVariant {
@@ -24,47 +94,24 @@ export function createEditorThemeAdapter(): ThemePort {
     },
 
     setTheme(theme: ThemeVariant): void {
-      currentTheme = theme
-      // 'nineties' is a UI-only retro skin (handled by the shared app-layout /
-      // display menu via the `.nineties` class + localStorage); it has no
-      // OS-level counterpart, so don't drive nativeTheme for it.
+      applyExplicitTheme(theme)
+      // Passing the theme explicitly makes the IPC idempotent (no toggle
+      // semantics), so the display menu's own bridge push is harmless.
       if (theme === 'light' || theme === 'dark') {
-        window.bridge.winHandleUpdateTheme()
+        window.bridge.winHandleUpdateTheme(theme)
       }
     },
 
     toggleTheme(): void {
-      currentTheme = currentTheme === 'dark' ? 'light' : 'dark'
-      window.bridge.winHandleUpdateTheme()
+      const next: ThemeVariant = currentTheme === 'dark' ? 'light' : 'dark'
+      applyExplicitTheme(next)
+      window.bridge.winHandleUpdateTheme(next)
     },
 
     onThemeChanged(callback: (theme: ThemeVariant) => void): Unsubscribe {
-      let active = true
-
-      const handler = (_event: unknown, ...args: unknown[]) => {
-        if (!active) return
-
-        // Explicit theme from the native menu (light / dark / 90's). The shared
-        // applier only clears `dark`/`light`, so clear the retro class here to
-        // avoid it sticking when switching away from the 90's skin.
-        const theme = args[0]
-        if (theme === 'light' || theme === 'dark' || theme === 'nineties') {
-          document.documentElement.classList.remove('nineties')
-          currentTheme = theme
-          callback(theme)
-          return
-        }
-
-        // No payload = an OS-level light/dark change; don't flip off the retro skin.
-        if (currentTheme === 'nineties') return
-        currentTheme = currentTheme === 'dark' ? 'light' : 'dark'
-        callback(currentTheme)
-      }
-
-      window.bridge.handleUpdateTheme(handler)
-
+      listeners.add(callback)
       return () => {
-        active = false
+        listeners.delete(callback)
       }
     },
   }


### PR DESCRIPTION
## Summary

Matching PR for Autonomy-Logic/openplc-web's `feat/theme-sync` branch — keeps the shared frontend surface byte-identical (verified with `compare-surfaces.py`: 0 diffs across `frontend/`, `middleware/shared/`, `backend/shared/`, `__architecture__/`).

The cross-app theme sync work (edge.autonomylogic.com ↔ editor.autonomylogic.com) moves theme persistence + DOM application out of the shared components and into each platform's `ThemePort` adapter:

- **Shared surface (byte-identical with openplc-web):** `display.tsx` cycles themes through `themePort.setTheme()`; `app-layout.tsx` and `accelerator-handler.tsx` only mirror the Monaco light/dark flag — no more direct localStorage/`<html>` class writes.
- **Editor adapter (desktop-specific):** now owns reading the stored preference at creation, applying the `<html>` classes, persisting explicit choices, and driving `nativeTheme` over IPC with an explicit payload (idempotent — avoids toggle double-fire with the display menu's legacy bridge push). Native-menu theme events are mirrored locally without echoing IPC; OS-level flips are not persisted and no longer stomp an explicit user choice.

Desktop behavior is unchanged from the user's perspective; the web platform gains cross-subdomain + backend theme sync in the openplc-web PR.

## Tests

- `theme-adapter.test.ts` rewritten for the new contract — 14/14 pass
- `tsc --noEmit` clean
- Full jest suite: only pre-existing failures (vitest-import suites synced from web, unrelated compiler-port types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit support for a "nineties" retro skin and unified theme control across the app, including a system-query endpoint for the current theme.

* **Bug Fixes**
  * Centralized theme persistence and DOM handling to reduce inconsistencies and avoid unwanted theme flips during OS changes.
  * Improved idempotent updates between app and OS-level theme.

* **Tests**
  * Expanded theme tests to cover persistence, OS events, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->