### PR TITLE
fix(st-lsp): keep open editor's model alive during project reload

### DIFF
--- a/src/backend/shared/compile/steps/compose-firmware-bundle.ts
+++ b/src/backend/shared/compile/steps/compose-firmware-bundle.ts
@@ -198,7 +198,7 @@ export function composeFirmwareBundle(input: ComposeFirmwareBundleInput): Record
   // intentionally empty.
   files['src/OpenPLCUserLib.h'] = [
     '// Auto-generated stub for OpenPLCUserLib.',
-    '// Resolves Baremetal.ino\'s `#include <OpenPLCUserLib.h>` in the',
+    "// Resolves Baremetal.ino's `#include <OpenPLCUserLib.h>` in the",
     '// strucpp pipeline.  Real declarations come via',
     '// arduino_runtime_glue.h (already in src/).',
     '#pragma once',

--- a/src/frontend/services/st-lsp/__tests__/monaco-model-sync.test.ts
+++ b/src/frontend/services/st-lsp/__tests__/monaco-model-sync.test.ts
@@ -132,13 +132,36 @@ describe('attachMonacoModelSync', () => {
   })
 
   it('disposes the model when its POU is removed', () => {
-    setProjectPous([makeStPou('Doomed')])
+    // Genuine single-POU removal: another POU survives, so the list is
+    // non-empty and the disappeared-POU sweep runs.
+    setProjectPous([makeStPou('Doomed'), makeStPou('Keeper')])
     const stub = makeMonacoStub()
     const handle = attachMonacoModelSync(stub as unknown as typeof import('monaco-editor'))
     expect(stub.__models.has('inmemory://pou/Doomed.st')).toBe(true)
 
-    setProjectPous([])
+    setProjectPous([makeStPou('Keeper')])
     expect(stub.__models.has('inmemory://pou/Doomed.st')).toBe(false)
+    expect(stub.__models.has('inmemory://pou/Keeper.st')).toBe(true)
+    handle.dispose()
+  })
+
+  it('does NOT dispose models on the transient empty-pous clear (stash reload guard)', () => {
+    // `handleOpenProjectResponse` sets `pous = []` before repopulating on every
+    // project reload (e.g. after a stash apply/pop).  The owned models must
+    // survive that transient so the open editor keeps its (still-attached)
+    // model — otherwise @monaco-editor/react crashes on a null getModel().
+    setProjectPous([makeStPou('Main', 'a := 1;')])
+    const stub = makeMonacoStub()
+    const handle = attachMonacoModelSync(stub as unknown as typeof import('monaco-editor'))
+    expect(stub.__models.has('inmemory://pou/Main.st')).toBe(true)
+
+    // Transient clear — model must NOT be disposed.
+    setProjectPous([])
+    expect(stub.__models.get('inmemory://pou/Main.st')!.disposed).toBe(false)
+
+    // Repopulate with updated body — same model is reused and synced.
+    setProjectPous([makeStPou('Main', 'a := 2;')])
+    expect(stub.__models.get('inmemory://pou/Main.st')!.value).toBe('a := 2;')
     handle.dispose()
   })
 

--- a/src/frontend/services/st-lsp/monaco-model-sync.ts
+++ b/src/frontend/services/st-lsp/monaco-model-sync.ts
@@ -74,6 +74,18 @@ export function attachMonacoModelSync(monacoApi: typeof monaco): MonacoModelSync
 
   function reconcile(pous: PLCPou[]): void {
     if (disposed) return
+    // Skip the transient empty state.  `handleOpenProjectResponse` clears the
+    // store (`pous = []`) before repopulating it on every project (re)load —
+    // e.g. the reload after a stash apply/pop.  Our store subscription fires
+    // synchronously on that empty list; without this guard the disappeared-POU
+    // sweep below would dispose EVERY owned model, including the one the
+    // currently-open `<Editor>` is bound to.  Monaco then detaches the disposed
+    // model, leaving `editorRef.current.getModel()` null, and
+    // `@monaco-editor/react`'s value-sync effect crashes with
+    // "null is not an object (evaluating 'getModel().getFullModelRange')".
+    // A real project always has at least one POU; genuine full teardown goes
+    // through `dispose()`, so an empty list here is never a real deletion.
+    if (pous.length === 0) return
     const seen = new Set<string>()
     for (const pou of pous) {
       // ST POUs live at pou://; everything else at stub://.  Matches


### PR DESCRIPTION
## Why

Mirror of the matching **openplc-web** change so the shared surfaces stay byte-identical (ci-sync was failing with `hash_mismatch` on these three files).

## The bug

Applying/popping a stash (or any project reload) could crash the open code editor with:

> `null is not an object (evaluating 't.current.getModel().getFullModelRange')`

### Root cause

1. Stash apply/pop → `reloadProject()` → `handleOpenProjectResponse()`, which first calls `clearStatesOnCloseProject()` → `clearProjects()`, setting `project.data.pous = []`, then repopulates.
2. The ST LSP model-sync subscribes to `project.data.pous` and fires **synchronously** on that empty list. Its disappeared-POU sweep then disposed **every** owned Monaco model — including the one the currently-open `<Editor>` was bound to.
3. Monaco detaches the disposed model, so `editorRef.current.getModel()` returns `null`. On the next render the `value` prop changes and `@monaco-editor/react`'s value-sync effect runs `getModel().getFullModelRange()` → crash.

This only reproduced with a **ST/IL** tab active during the reload (graphical / device / server tabs have no Monaco model to dispose), which is why it looked intermittent and pattern-less.

## The fix

`reconcile` now skips an empty POU list — that state is always the transient clear during reload (a real project always has ≥1 POU; genuine teardown goes through `dispose()`). Genuine single-POU removal (with other POUs present) still disposes as before.

Also folds in a pre-existing Prettier fix in `compose-firmware-bundle.ts` so the shared surface matches openplc-web.

## Tests

- Updated `monaco-model-sync.test.ts`: the single-POU-removal test now keeps another POU present.
- Added a regression test asserting the transient empty-pous clear does **not** dispose models.

Passes in openplc-web (vitest) and Prettier `--check` in both repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur when reloading projects in the editor by preventing improper disposal of editor models during project state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->