### PR TITLE
fix(menu): wire File → Open's picker result through to handleOpenProjectResponse

### DIFF
--- a/src/frontend/components/_templates/accelerator-handler.tsx
+++ b/src/frontend/components/_templates/accelerator-handler.tsx
@@ -108,13 +108,26 @@ const AcceleratorHandler = () => {
 
   /**
    * Open project via file picker
+   *
+   * Mirrors the start-screen's `handleOpenProject` flow: the picker
+   * returns `{ success, data }` and the renderer must dispatch
+   * `handleOpenProjectResponse(data)` to actually load the project
+   * into the store.  Discarding the promise (`void
+   * projectPort.openProject()`) opened the picker but threw the
+   * result on the floor, so File → Open silently no-op'd after the
+   * user picked a folder — only the start-screen shortcut worked.
    */
   useEffect(() => {
     const unsub = accelerator.onOpenProject(() => {
       switch (editingState) {
         case 'saved':
         case 'initial-state':
-          void projectPort.openProject()
+          void (async () => {
+            const result = await projectPort.openProject()
+            if (result.success && result.data) {
+              handleOpenProjectResponse(result.data)
+            }
+          })()
           break
         case 'unsaved':
           openModal('save-changes-project', {
@@ -133,7 +146,7 @@ const AcceleratorHandler = () => {
       }
     })
     return unsub
-  }, [editingState, accelerator, openModal, projectPort])
+  }, [editingState, accelerator, openModal, projectPort, handleOpenProjectResponse])
 
   /**
    * Open recent project (editor-specific — data passed via IPC accelerator)


### PR DESCRIPTION
## Summary

The renderer-side \`accelerator.onOpenProject\` handler in \`accelerator-handler.tsx\` discarded the picker's return value with \`void projectPort.openProject()\`.  The file picker opened, the user selected a project folder, the main process read it and returned \`{ success, data }\` — and the renderer threw the result on the floor.  Only the start-screen "Open folder" shortcut worked.

Mirrored start-screen's pattern in the accelerator handler's 'saved' / 'initial-state' branch.  \`handleOpenProjectResponse\` was already destructured from the store at the top of the component, so the only wiring needed was awaiting the promise, dispatching the response, and adding \`handleOpenProjectResponse\` to the useEffect dep array.

## Cross-platform

Verified with a grep + sed on \`src/main/menu.ts\`: both the Linux/Windows submenu (line 197) and the macOS submenu (line 467) wire \`click: () => this.sendOpenRequest()\`, both emit the same IPC channel (\`project:open-project-request\`), and both land in this renderer handler.  Linux fix confirmed by the user; macOS + Windows are mechanically identical.

## Test plan

- [x] Linux: verified by user — File → Open now opens the picked project
- [ ] Paired sync PR on openplc-web (\`fix/file-open-menu-action\`) — required for \`Shared Surface Sync\` CI on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project opening behavior via accelerator handler to properly load projects into the application, ensuring consistent behavior across all project opening methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->