### PR TITLE
Release v4.2.1 — File → Open menu fix

### DIFF
--- a/src/frontend/components/_templates/accelerator-handler.tsx
+++ b/src/frontend/components/_templates/accelerator-handler.tsx
@@ -108,13 +108,26 @@ const AcceleratorHandler = () => {
 
   /**
    * Open project via file picker
+   *
+   * Mirrors the start-screen's `handleOpenProject` flow: the picker
+   * returns `{ success, data }` and the renderer must dispatch
+   * `handleOpenProjectResponse(data)` to actually load the project
+   * into the store.  Discarding the promise (`void
+   * projectPort.openProject()`) opened the picker but threw the
+   * result on the floor, so File → Open silently no-op'd after the
+   * user picked a folder — only the start-screen shortcut worked.
    */
   useEffect(() => {
     const unsub = accelerator.onOpenProject(() => {
       switch (editingState) {
         case 'saved':
         case 'initial-state':
-          void projectPort.openProject()
+          void (async () => {
+            const result = await projectPort.openProject()
+            if (result.success && result.data) {
+              handleOpenProjectResponse(result.data)
+            }
+          })()
           break
         case 'unsaved':
           openModal('save-changes-project', {
@@ -133,7 +146,7 @@ const AcceleratorHandler = () => {
       }
     })
     return unsub
-  }, [editingState, accelerator, openModal, projectPort])
+  }, [editingState, accelerator, openModal, projectPort, handleOpenProjectResponse])
 
   /**
    * Open recent project (editor-specific — data passed via IPC accelerator)


### PR DESCRIPTION
## Summary

Patch release containing the File → Open menu fix (#846 / openplc-web #492).

The renderer-side accelerator handler for the File → Open menu action discarded the picker's return value, so the picker opened, the user picked a folder, and the renderer threw the response on the floor.  Only the start-screen "Open folder" shortcut worked.  Fix mirrors the start-screen pattern: await the picker, dispatch the result through \`handleOpenProjectResponse\`.

Cross-platform: identical IPC chain on Linux, macOS, Windows — Linux verified by user; macOS / Windows mechanically identical (same \`sendOpenRequest()\` from both menu branches, same renderer handler).

## Test plan

- [x] Linux verified by user (File → Open opens picked project)
- [ ] After merge: tag v4.2.1 → CI release workflow publishes signed artefacts on all platforms