### PR TITLE
feat(ethercat): surface dedup-after-retry ESI uploads in the UI

### DIFF
--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/__tests__/esi-upload.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/__tests__/esi-upload.test.tsx
@@ -1,10 +1,19 @@
 import type { ESIRepositoryItemLight } from '@root/middleware/shared/ports/esi-types'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 
-// Mocked EsiPort surface — the two methods the upload flow touches. The
-// `mock`-prefixed name is referenced lazily inside the factory (only when
-// `useEsi()` is called at render time), so this works under both Vitest and
-// the editor's Jest+vi shim — without `vi.hoisted`, which the shim lacks.
+// Mocked EsiPort surface — the two methods the upload flow touches.
+//
+// Cross-runner compatibility relies on two independent mechanisms:
+//   - Under Vitest, `vi.mock` is hoisted above imports, so the factory runs
+//     before `import { ESIUpload }`. A hoisted factory may only reference names
+//     that survive hoisting — hence the `mock`-prefixed `mockEsi`, read lazily
+//     when `useEsi()` is called at render time (not at factory-eval time).
+//   - Under the editor's Jest+vi shim, `vi.mock` is NOT hoisted (ts-jest's
+//     transformer only hoists `jest.mock`). It works because the
+//     `import { ESIUpload }` below is deliberately placed AFTER this `vi.mock`
+//     call. That import position is load-bearing: do NOT move it into the top
+//     import block, or ESIUpload binds to the real platform-context module
+//     before the mock is registered.
 const mockEsi = {
   parseAndSaveFile: vi.fn(),
   loadRepositoryLight: vi.fn(),
@@ -82,6 +91,19 @@ describe('ESIUpload — dedupAfterRetry handling', () => {
     expect(mockEsi.loadRepositoryLight).toHaveBeenCalledTimes(1)
     // No new item was returned, so the fallback keeps the existing repository.
     expect(onFilesLoaded).toHaveBeenCalledWith(existing, undefined)
+  })
+
+  it('dedups a recovered add that already exists in the repository', async () => {
+    // dedupAfterRetry recovery: the retry hit the backend dedup against a row
+    // that was already present in `repository`, and the adapter returns that
+    // same row as `item`. The merged list must not contain it twice.
+    mockEsi.parseAndSaveFile.mockResolvedValueOnce({ success: true, item: SAMPLE_ITEM, dedupAfterRetry: true })
+
+    const { onFilesLoaded } = uploadFile([SAMPLE_ITEM])
+
+    await waitFor(() => expect(onFilesLoaded).toHaveBeenCalled())
+    expect(onFilesLoaded).toHaveBeenCalledWith([SAMPLE_ITEM], undefined)
+    expect(mockEsi.loadRepositoryLight).not.toHaveBeenCalled()
   })
 
   it('skips a real duplicate silently without re-listing', async () => {

--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/__tests__/esi-upload.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/__tests__/esi-upload.test.tsx
@@ -1,0 +1,96 @@
+import type { ESIRepositoryItemLight } from '@root/middleware/shared/ports/esi-types'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+
+// Mocked EsiPort surface — the two methods the upload flow touches. The
+// `mock`-prefixed name is referenced lazily inside the factory (only when
+// `useEsi()` is called at render time), so this works under both Vitest and
+// the editor's Jest+vi shim — without `vi.hoisted`, which the shim lacks.
+const mockEsi = {
+  parseAndSaveFile: vi.fn(),
+  loadRepositoryLight: vi.fn(),
+}
+
+vi.mock('@root/middleware/shared/providers/platform-context', () => ({
+  useEsi: () => mockEsi,
+}))
+
+import { ESIUpload } from '../esi-upload'
+
+const SAMPLE_ITEM: ESIRepositoryItemLight = {
+  id: 'item-1',
+  filename: 'Beckhoff.xml',
+  vendor: { id: '0x0002', name: 'Beckhoff' },
+  devices: [],
+  loadedAt: '2026-01-01T00:00:00.000Z',
+}
+
+/** Build an XML File whose `.text()` resolves regardless of jsdom version. */
+function xmlFile(name = 'Beckhoff.xml', content = '<xml />'): File {
+  const file = new File([content], name, { type: 'text/xml' })
+  Object.defineProperty(file, 'text', { value: () => Promise.resolve(content) })
+  return file
+}
+
+/** Render the component and drive a single-file upload through the input. */
+function uploadFile(repository: ESIRepositoryItemLight[] = []) {
+  const onFilesLoaded = vi.fn()
+  const { container } = render(<ESIUpload onFilesLoaded={onFilesLoaded} repository={repository} />)
+  const input = container.querySelector('input[type="file"]') as HTMLInputElement
+  fireEvent.change(input, { target: { files: [xmlFile()] } })
+  return { onFilesLoaded }
+}
+
+describe('ESIUpload — dedupAfterRetry handling', () => {
+  beforeEach(() => {
+    mockEsi.parseAndSaveFile.mockReset()
+    mockEsi.loadRepositoryLight.mockReset()
+  })
+
+  it('appends a newly added item without re-listing the repository', async () => {
+    mockEsi.parseAndSaveFile.mockResolvedValueOnce({ success: true, item: SAMPLE_ITEM })
+
+    const { onFilesLoaded } = uploadFile()
+
+    await waitFor(() => expect(onFilesLoaded).toHaveBeenCalled())
+    expect(onFilesLoaded).toHaveBeenCalledWith([SAMPLE_ITEM], undefined)
+    expect(mockEsi.loadRepositoryLight).not.toHaveBeenCalled()
+  })
+
+  it('re-lists the repository when a dedupAfterRetry lands without an item', async () => {
+    mockEsi.parseAndSaveFile.mockResolvedValueOnce({ success: true, dedupAfterRetry: true })
+    mockEsi.loadRepositoryLight.mockResolvedValueOnce({ success: true, items: [SAMPLE_ITEM] })
+
+    const { onFilesLoaded } = uploadFile()
+
+    await waitFor(() => expect(onFilesLoaded).toHaveBeenCalled())
+    expect(mockEsi.loadRepositoryLight).toHaveBeenCalledTimes(1)
+    // The refreshed list is authoritative — the recovered row appears here.
+    expect(onFilesLoaded).toHaveBeenCalledWith([SAMPLE_ITEM], undefined)
+  })
+
+  it('falls back to the local list when the refresh itself fails', async () => {
+    const existing: ESIRepositoryItemLight[] = [{ ...SAMPLE_ITEM, id: 'old', filename: 'Old.xml' }]
+    mockEsi.parseAndSaveFile.mockResolvedValueOnce({ success: true, dedupAfterRetry: true })
+    mockEsi.loadRepositoryLight.mockResolvedValueOnce({ success: false, error: 'list failed' })
+
+    const onFilesLoaded = vi.fn()
+    const { container } = render(<ESIUpload onFilesLoaded={onFilesLoaded} repository={existing} />)
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, { target: { files: [xmlFile()] } })
+
+    await waitFor(() => expect(onFilesLoaded).toHaveBeenCalled())
+    expect(mockEsi.loadRepositoryLight).toHaveBeenCalledTimes(1)
+    // No new item was returned, so the fallback keeps the existing repository.
+    expect(onFilesLoaded).toHaveBeenCalledWith(existing, undefined)
+  })
+
+  it('skips a real duplicate silently without re-listing', async () => {
+    mockEsi.parseAndSaveFile.mockResolvedValueOnce({ success: true, duplicate: true })
+
+    const { onFilesLoaded } = uploadFile()
+
+    await waitFor(() => expect(onFilesLoaded).toHaveBeenCalled())
+    expect(onFilesLoaded).toHaveBeenCalledWith([], undefined)
+    expect(mockEsi.loadRepositoryLight).not.toHaveBeenCalled()
+  })
+})

--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
@@ -124,7 +124,17 @@ const ESIUpload = ({ onFilesLoaded, repository, isLoading = false }: ESIUploadPr
         }
       }
 
-      onFilesLoaded([...repository, ...newItems], errors.length > 0 ? errors : undefined)
+      // A recovered add (item + dedupAfterRetry) can return a row that already
+      // exists in `repository` — the retry hit the backend dedup against a
+      // pre-existing entry. Dedup the merged list by id (repository wins) so the
+      // same row isn't rendered twice or assigned a duplicate React key.
+      const mergedById = new Map<ESIRepositoryItemLight['id'], ESIRepositoryItemLight>()
+      for (const item of [...repository, ...newItems]) {
+        if (!mergedById.has(item.id)) {
+          mergedById.set(item.id, item)
+        }
+      }
+      onFilesLoaded([...mergedById.values()], errors.length > 0 ? errors : undefined)
     },
     [onFilesLoaded, repository, esi],
   )

--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
@@ -55,6 +55,12 @@ const ESIUpload = ({ onFilesLoaded, repository, isLoading = false }: ESIUploadPr
 
       const newItems: ESIRepositoryItemLight[] = []
       const errors: Array<{ filename: string; error: string }> = []
+      // A dedup-after-retry result means the file was persisted on the backend
+      // but its row was missing from the upload response (and the adapter's own
+      // recovery lookup also failed). Honor the EsiPort contract by re-listing
+      // the repository after the batch so the file appears instead of silently
+      // vanishing — see EsiPort.parseAndSaveFile (`dedupAfterRetry`).
+      let needsRepositoryRefresh = false
 
       const MAX_FILE_SIZE = 100 * 1024 * 1024 // 100MB
 
@@ -84,8 +90,13 @@ const ESIUpload = ({ onFilesLoaded, repository, isLoading = false }: ESIUploadPr
 
           if (result.success && result.item) {
             newItems.push(result.item)
+          } else if (result.success && result.dedupAfterRetry) {
+            // Uploaded but absent from the response: a transient-failure retry
+            // hit the backend dedup and the adapter couldn't recover the row.
+            // Flag a repository refresh so the file surfaces after the batch.
+            needsRepositoryRefresh = true
           } else if (result.success) {
-            // Duplicate content already in the repository — skip silently.
+            // Real duplicate — content already in the repository. Skip silently.
             // See EsiPort.parseAndSaveFile for the duplicate-handling contract.
           } else {
             errors.push({ filename: file.name, error: result.error ?? 'Parse failed' })
@@ -101,6 +112,17 @@ const ESIUpload = ({ onFilesLoaded, repository, isLoading = false }: ESIUploadPr
         totalFiles: 0,
         percentage: 100,
       })
+
+      // A recovered-but-unlisted upload (dedupAfterRetry) is on the backend yet
+      // missing from `newItems`. Re-list the repository so it shows up; fall
+      // back to the locally accumulated list if the refresh itself fails.
+      if (needsRepositoryRefresh) {
+        const refreshed = await esi!.loadRepositoryLight()
+        if (refreshed.success && refreshed.items) {
+          onFilesLoaded(refreshed.items, errors.length > 0 ? errors : undefined)
+          return
+        }
+      }
 
       onFilesLoaded([...repository, ...newItems], errors.length > 0 ? errors : undefined)
     },

--- a/src/middleware/shared/ports/esi-port.ts
+++ b/src/middleware/shared/ports/esi-port.ts
@@ -48,13 +48,13 @@ export interface EsiPort {
    * transient-failure retry — the first attempt likely persisted the file but
    * its response was lost. It can accompany any of three result shapes (only
    * the web adapter ever sets it; the editor's local IPC adapter never does):
-   *   - `item` + `dedupAfterRetry`: recovered add — the adapter relocated the
-   *     persisted row and returns it. Treat as a normal add, but note the row
-   *     may already be present in the caller's list, so dedup by `id` when
+   *   - `item` + `dedupAfterRetry`: recovered add — the backend returned the
+   *     matched row in the dedup response. Treat as a normal add, but note the
+   *     row may already be present in the caller's list, so dedup by `id` when
    *     merging into an existing repository view.
-   *   - `duplicate` + `dedupAfterRetry`: persisted but unlisted — the row could
-   *     not be recovered. Callers should refresh the repository so the file
-   *     surfaces instead of silently skipping it.
+   *   - `duplicate` + `dedupAfterRetry`: persisted but unlisted — the matched
+   *     row wasn't echoed back (e.g. an older backend). Callers should refresh
+   *     the repository so the file surfaces instead of silently skipping it.
    *   - `duplicate` alone: a real duplicate — content already in the
    *     repository. Safe to skip silently.
    */

--- a/src/middleware/shared/ports/esi-port.ts
+++ b/src/middleware/shared/ports/esi-port.ts
@@ -39,11 +39,17 @@ export interface EsiPort {
    * Dedup is filename-based: reimporting the same bytes under a different name
    * will add a new entry, and replacing a file's contents without renaming it
    * is reported as a duplicate.
+   *
+   * `dedupAfterRetry: true` indicates the duplicate response landed after a
+   * transient-failure retry — the first attempt likely persisted the file and
+   * its response was lost. Callers should treat this as "uploaded but absent
+   * from the response" rather than silently skipping, since the user expects
+   * the file to appear in the repository.
    */
   parseAndSaveFile(
     filename: string,
     content: string,
-  ): Promise<Result<{ item?: ESIRepositoryItemLight; duplicate?: boolean }>>
+  ): Promise<Result<{ item?: ESIRepositoryItemLight; duplicate?: boolean; dedupAfterRetry?: boolean }>>
 
   /**
    * Delete a single repository item and its associated XML file.

--- a/src/middleware/shared/ports/esi-port.ts
+++ b/src/middleware/shared/ports/esi-port.ts
@@ -34,17 +34,29 @@ export interface EsiPort {
    * The filename and raw XML content are provided; parsing happens on the backend.
    *
    * On success, `item` is present when the file was newly added, and omitted
-   * with `duplicate: true` when a repository entry with the same filename
-   * already exists — letting callers distinguish a real add from a silent skip.
-   * Dedup is filename-based: reimporting the same bytes under a different name
-   * will add a new entry, and replacing a file's contents without renaming it
-   * is reported as a duplicate.
+   * with `duplicate: true` when the file is considered a duplicate — letting
+   * callers distinguish a real add from a silent skip.
    *
-   * `dedupAfterRetry: true` indicates the duplicate response landed after a
-   * transient-failure retry — the first attempt likely persisted the file and
-   * its response was lost. Callers should treat this as "uploaded but absent
-   * from the response" rather than silently skipping, since the user expects
-   * the file to appear in the repository.
+   * Dedup semantics are adapter-defined and differ by platform:
+   *   - Editor adapter: filename-based. Reimporting the same bytes under a
+   *     different name adds a new entry; replacing a file's contents without
+   *     renaming it is reported as a duplicate.
+   *   - Web adapter: SHA-256 content-hash-based. Identical bytes are a
+   *     duplicate regardless of filename.
+   *
+   * `dedupAfterRetry: true` marks a response that landed after a
+   * transient-failure retry — the first attempt likely persisted the file but
+   * its response was lost. It can accompany any of three result shapes (only
+   * the web adapter ever sets it; the editor's local IPC adapter never does):
+   *   - `item` + `dedupAfterRetry`: recovered add — the adapter relocated the
+   *     persisted row and returns it. Treat as a normal add, but note the row
+   *     may already be present in the caller's list, so dedup by `id` when
+   *     merging into an existing repository view.
+   *   - `duplicate` + `dedupAfterRetry`: persisted but unlisted — the row could
+   *     not be recovered. Callers should refresh the repository so the file
+   *     surfaces instead of silently skipping it.
+   *   - `duplicate` alone: a real duplicate — content already in the
+   *     repository. Safe to skip silently.
    */
   parseAndSaveFile(
     filename: string,


### PR DESCRIPTION
## What

Shared-surface sync with openplc-web PR Autonomy-Logic/openplc-web#494.

Mirrors, byte-identical, the three shared-surface files from that PR:
- `middleware/shared/ports/esi-port.ts` — the `dedupAfterRetry` contract field on `parseAndSaveFile`.
- `frontend/.../ethercat/components/esi-upload.tsx` — the `ESIUpload` consumer that re-lists the repository when an upload is recovered after a transient-failure retry but comes back without an item, so the file surfaces instead of silently vanishing.
- `frontend/.../components/__tests__/esi-upload.test.tsx` — the four-branch test (normal add, dedup-after-retry refetch, refetch-failure fallback, real duplicate). Runner-agnostic mock, runs under Jest here and Vitest on web.

## Why

Keeps the shared surface in lockstep with openplc-web (enforced by the cross-repo surface-sync CI). The retry/adapter internals are web-only and intentionally not ported — the editor's main-process ESI adapter doesn't retry, and the new `dedupAfterRetry` field is optional, so this is backward compatible.

## Tests

`esi-upload.test.tsx` passes under the editor's Jest (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate EtherCAT ESI uploads: successful-but-unlisted uploads now trigger a repository refresh to return authoritative results; when refresh fails, a safe fallback combines local and new items while avoiding duplicates.
* **Tests**
  * Added tests covering upload deduplication, retry handling, refresh/fallback behavior, and duplicate suppression across outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->