### PR TITLE
fix(alias): repair alias↔location architecture (v4.2.0 forum bugs)

### DIFF
--- a/src/frontend/components/_atoms/graphical-editor/autocomplete/index.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/autocomplete/index.tsx
@@ -96,6 +96,33 @@ export const GraphicalEditorAutocomplete = forwardRef<HTMLDivElement, GraphicalE
       submit({ variable })
     }
 
+    /**
+     * Resolve what to submit when the user presses Enter/Tab without
+     * arrowing down to a row.  Previously this always sent the "Add
+     * variable" option, so typing the exact name of an existing
+     * variable and hitting Return would create a brand-new variable
+     * with a name-collision-resolved suffix (forum bug, v4.2.0).
+     *
+     * Exact case-insensitive match against the visible `variables`
+     * list takes precedence — the dropdown was already showing that
+     * variable, so the user clearly meant to bind to it.  Only when
+     * no match exists do we fall through to "Add variable".
+     */
+    const resolveImplicitSubmitOption = () => {
+      const trimmed = searchValue.trim().toLowerCase()
+      if (trimmed) {
+        const exactMatch = variables?.find((v) => v.name.toLowerCase() === trimmed)
+        if (exactMatch) {
+          return {
+            id: exactMatch.id ?? '',
+            name: exactMatch.name,
+          }
+        }
+      }
+      const addVariableOption = selectableValues.find((item) => item.type === 'add')
+      return addVariableOption ? addVariableOption.variable : null
+    }
+
     // @ts-expect-error - not all properties are used
     useImperativeHandle(ref, () => {
       return {
@@ -111,9 +138,9 @@ export const GraphicalEditorAutocomplete = forwardRef<HTMLDivElement, GraphicalE
          */
         triggerSubmit: () => {
           if (selectedVariable.positionInArray === -1) {
-            const addVariableOption = selectableValues.find((item) => item.type === 'add')
-            if (addVariableOption) {
-              submitAutocompletion({ variable: addVariableOption.variable })
+            const implicit = resolveImplicitSubmitOption()
+            if (implicit) {
+              submitAutocompletion({ variable: implicit })
             } else {
               closeModal()
             }
@@ -122,7 +149,7 @@ export const GraphicalEditorAutocomplete = forwardRef<HTMLDivElement, GraphicalE
           }
         },
       }
-    }, [selectedVariable, selectableValues, popoverRef, autocompleteFocus, submitAutocompletion, closeModal])
+    }, [selectedVariable, selectableValues, variables, searchValue, popoverRef, autocompleteFocus, submitAutocompletion, closeModal])
 
     useEffect(() => {
       switch (keyDown) {
@@ -152,13 +179,13 @@ export const GraphicalEditorAutocomplete = forwardRef<HTMLDivElement, GraphicalE
           break
         case 'Tab':
         case 'Enter':
-          // If nothing is selected (positionInArray === -1), find the "Add variable" option
           if (selectedVariable.positionInArray === -1) {
-            const addVariableOption = selectableValues.find((item) => item.type === 'add')
-            if (addVariableOption) {
-              submitAutocompletion({ variable: addVariableOption.variable })
+            const implicit = resolveImplicitSubmitOption()
+            if (implicit) {
+              submitAutocompletion({ variable: implicit })
             } else {
-              // No 'add' option available; close the autocomplete to provide clear feedback
+              // Nothing matched and no 'add' option available; close
+              // the autocomplete to give the user clear feedback.
               closeModal()
             }
           } else {

--- a/src/frontend/components/_atoms/graphical-editor/autocomplete/index.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/autocomplete/index.tsx
@@ -149,7 +149,16 @@ export const GraphicalEditorAutocomplete = forwardRef<HTMLDivElement, GraphicalE
           }
         },
       }
-    }, [selectedVariable, selectableValues, variables, searchValue, popoverRef, autocompleteFocus, submitAutocompletion, closeModal])
+    }, [
+      selectedVariable,
+      selectableValues,
+      variables,
+      searchValue,
+      popoverRef,
+      autocompleteFocus,
+      submitAutocompletion,
+      closeModal,
+    ])
 
     useEffect(() => {
       switch (keyDown) {

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/components/pin-mapping-table.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/components/pin-mapping-table.tsx
@@ -1,6 +1,14 @@
+import { toast } from '@root/frontend/components/_features/[app]/toast/use-toast'
 import { pinSelectors } from '@root/frontend/hooks/use-store-selectors'
 import { useOpenPLCStore } from '@root/frontend/store'
 import type { DevicePin } from '@root/middleware/shared/ports/types'
+import {
+  buildAddressPool,
+  buildAliasRegistry,
+  describeSource,
+  validateAliasEdit,
+} from '@root/middleware/shared/utils/iec-address'
+import { resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 import { createColumnHelper } from '@tanstack/react-table'
 
 import { GenericTable } from '../../../../../../_atoms/generic-table'
@@ -39,6 +47,54 @@ const PinMappingTable = ({ pins, selectedRowId, handleRowClick }: PinMappingTabl
   const updatePin = pinSelectors.useUpdatePin()
 
   const handleUpdateDataRequest = (_rowIndex: number, columnId: string, value: unknown) => {
+    // Phase 1 — write-time alias-uniqueness gate (global, across all
+    // producers).  `checkIfPinAliasIsValid` inside the slice's
+    // `updatePin` already enforces uniqueness *within* the active
+    // board's pin list; this additional check covers the cross-
+    // producer case where a pin alias collides with a VPP channel
+    // alias, a Modbus point alias, or an EtherCAT channel alias.
+    if (columnId === 'alias' && typeof value === 'string') {
+      const state = useOpenPLCStore.getState()
+      const board = state.deviceDefinitions.configuration.deviceBoard
+      const currentPins = state.deviceDefinitions.pinMapping.pinsByBoard[board] ?? []
+      const currentPin = currentPins[state.deviceDefinitions.pinMapping.currentSelectedPinTableRow]
+      const sourceRef = { kind: 'pin-mapping' as const, ref: currentPin?.address ?? '' }
+      const boardInfo = state.deviceAvailableOptions.availableBoards.get(board ?? '')
+      const ioMapping =
+        (
+          state.deviceDefinitions.configuration.vendorScreenData?.['io-mapping'] as
+            | { entries?: Array<{ iecAddress: string; alias?: string; slot: number; channelName: string }> }
+            | undefined
+        )?.entries ?? []
+      const pool = buildAddressPool(
+        {
+          pinMapping: { pins: currentPins },
+          vendorIoMapping: { entries: ioMapping },
+          remoteDevices: state.project.data.remoteDevices,
+        },
+        resolveTargetCapabilities(boardInfo),
+      )
+      const registry = buildAliasRegistry(pool)
+      const validation = validateAliasEdit(registry, value, sourceRef)
+      if (!validation.ok) {
+        toast({
+          title: 'Alias already in use',
+          description: `"${value}" is already assigned to ${describeSource(validation.conflict.source)} (${validation.conflict.address}). Alias names must be unique across all I/O channels.`,
+          variant: 'fail',
+        })
+        return { ok: false, title: 'Alias already in use', message: 'Pin alias collides with another producer.' }
+      }
+
+      // Phase 2 — cascade rename onto bound variables BEFORE
+      // mutating the pin, so the subsequent `syncVariableAliases()`
+      // sees variables pointing at the new alias and refreshes
+      // locations rather than orphaning them.
+      const oldAlias = currentPin?.alias ?? ''
+      if (oldAlias) {
+        useOpenPLCStore.getState().projectActions.renameAlias(oldAlias, value)
+      }
+    }
+
     const res = updatePin({
       [columnId as keyof DevicePin]: value,
     })

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/io-table-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/io-table-layout.tsx
@@ -1,8 +1,15 @@
+import { toast } from '@root/frontend/components/_features/[app]/toast/use-toast'
 import { useOpenPLCStore } from '@root/frontend/store'
 import { getSectionPersistenceKey } from '@root/frontend/utils/vpp/persistence-keys'
 import { resolveModuleChannels, type ResolverModuleDef } from '@root/frontend/utils/vpp/resolve-module-channels'
 import type { IoMappingEntry, VendorIoMapping } from '@root/middleware/shared/ports/types'
-import { buildAddressPool, nextFreeAddress } from '@root/middleware/shared/utils/iec-address'
+import {
+  buildAddressPool,
+  buildAliasRegistry,
+  describeSource,
+  nextFreeAddress,
+  validateAliasEdit,
+} from '@root/middleware/shared/utils/iec-address'
 import { resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
@@ -144,11 +151,53 @@ function IoTableLayout({ section, moduleSystem }: IoTableLayoutProps) {
   }, [slots, formatSelectionKey])
 
   const handleAliasChange = (index: number, alias: string) => {
+    const target = entries[index]
+    if (!target) return
+    const sourceRef = { kind: 'vpp-io' as const, ref: `slot-${target.slot}:${target.channelName}` }
+
+    // Phase 1 — write-time uniqueness gate.  See
+    // `module-slots-layout.tsx::handleAliasChange` for the full
+    // rationale; same pattern, scoped to this layout's `entries`
+    // array as the VPP-IO source.
+    const state = useOpenPLCStore.getState()
+    const boardInfo = state.deviceAvailableOptions.availableBoards.get(
+      state.deviceDefinitions.configuration.deviceBoard ?? '',
+    )
+    const pool = buildAddressPool(
+      {
+        pinMapping: {
+          pins: state.deviceDefinitions.pinMapping.pinsByBoard[state.deviceDefinitions.configuration.deviceBoard] ?? [],
+        },
+        vendorIoMapping: { entries },
+        remoteDevices: state.project.data.remoteDevices,
+      },
+      resolveTargetCapabilities(boardInfo),
+    )
+    const registry = buildAliasRegistry(pool)
+    const validation = validateAliasEdit(registry, alias, sourceRef)
+    if (!validation.ok) {
+      toast({
+        title: 'Alias already in use',
+        description: `"${alias}" is already assigned to ${describeSource(validation.conflict.source)} (${validation.conflict.address}). Alias names must be unique across all I/O channels.`,
+        variant: 'fail',
+      })
+      return
+    }
+
+    // Phase 2 — cascade rename onto bound variables BEFORE writing
+    // so the subsequent `syncVariableAliases()` sees variables
+    // pointing at the new alias and takes the refresh path instead
+    // of orphan.
+    const oldAlias = target.alias ?? ''
+    if (oldAlias) {
+      useOpenPLCStore.getState().projectActions.renameAlias(oldAlias, alias)
+    }
+
     const updated = [...entries]
     updated[index] = { ...updated[index], alias }
     setEntries(updated)
     setVendorScreenData(persistenceKey, { entries: updated })
-    // Alias name changed on a single entry — refresh.
+    // Refresh variables against any allocator-driven address shifts.
     useOpenPLCStore.getState().projectActions.syncVariableAliases()
   }
 

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
@@ -6,6 +6,7 @@ import { Checkbox } from '@root/frontend/components/_atoms/checkbox'
 import { Label } from '@root/frontend/components/_atoms/label'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@root/frontend/components/_atoms/select'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@root/frontend/components/_atoms/tooltip'
+import { toast } from '@root/frontend/components/_features/[app]/toast/use-toast'
 import { Modal, ModalContent, ModalTitle } from '@root/frontend/components/_molecules/modal'
 import { boardSelectors } from '@root/frontend/hooks/use-store-selectors'
 import { useOpenPLCStore } from '@root/frontend/store'
@@ -14,7 +15,13 @@ import { getSectionPersistenceKey } from '@root/frontend/utils/vpp/persistence-k
 import { resolveModuleChannels, type ResolverModuleDef } from '@root/frontend/utils/vpp/resolve-module-channels'
 import type { IoMappingEntry } from '@root/middleware/shared/ports/types'
 import { useDevice } from '@root/middleware/shared/providers/platform-context'
-import { buildAddressPool, nextFreeAddress } from '@root/middleware/shared/utils/iec-address'
+import {
+  buildAddressPool,
+  buildAliasRegistry,
+  describeSource,
+  nextFreeAddress,
+  validateAliasEdit,
+} from '@root/middleware/shared/utils/iec-address'
 import { resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
@@ -569,11 +576,55 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
   const handleAliasChange = (slot: number, channelName: string, alias: string) => {
     const state = useOpenPLCStore.getState()
     const vsd = state.deviceDefinitions.configuration.vendorScreenData
-    const entries = ((vsd?.['io-mapping'] as { entries?: IoMappingEntry[] } | undefined)?.entries ?? []).map((e) =>
-      e.slot === slot && e.channelName === channelName ? { ...e, alias } : e,
+    const sourceRef = { kind: 'vpp-io' as const, ref: `slot-${slot}:${channelName}` }
+
+    // Phase 1 — write-time uniqueness gate.  Build a fresh registry
+    // from the live state (including the entry being edited, scoped
+    // to the active board's capabilities) and reject the edit if the
+    // new alias is already claimed by a different channel.  Without
+    // this gate, the pool's silent first-wins reservation would
+    // cause every variable that the user later binds to the losing
+    // entry to collapse to the winner's address through
+    // `syncVariableAliases`'s refresh path.
+    const boardInfo = state.deviceAvailableOptions.availableBoards.get(
+      state.deviceDefinitions.configuration.deviceBoard ?? '',
     )
+    const currentEntries = (vsd?.['io-mapping'] as { entries?: IoMappingEntry[] } | undefined)?.entries ?? []
+    const pool = buildAddressPool(
+      {
+        pinMapping: {
+          pins: state.deviceDefinitions.pinMapping.pinsByBoard[state.deviceDefinitions.configuration.deviceBoard] ?? [],
+        },
+        vendorIoMapping: { entries: currentEntries },
+        remoteDevices: state.project.data.remoteDevices,
+      },
+      resolveTargetCapabilities(boardInfo),
+    )
+    const registry = buildAliasRegistry(pool)
+    const validation = validateAliasEdit(registry, alias, sourceRef)
+    if (!validation.ok) {
+      toast({
+        title: 'Alias already in use',
+        description: `"${alias}" is already assigned to ${describeSource(validation.conflict.source)} (${validation.conflict.address}). Alias names must be unique across all I/O channels.`,
+        variant: 'fail',
+      })
+      return
+    }
+
+    // Phase 2 — cascade rename onto bound variables BEFORE writing
+    // the new entries, so the subsequent `syncVariableAliases()`
+    // call sees variables already pointing at the new alias name and
+    // takes the refresh path (location follows alias) instead of the
+    // orphan path (location cleared, warning glyph rendered).
+    const oldAlias = currentEntries.find((e) => e.slot === slot && e.channelName === channelName)?.alias ?? ''
+    if (oldAlias) {
+      useOpenPLCStore.getState().projectActions.renameAlias(oldAlias, alias)
+    }
+
+    const entries = currentEntries.map((e) => (e.slot === slot && e.channelName === channelName ? { ...e, alias } : e))
     setVendorScreenData('io-mapping', { entries })
-    // Alias name changed — refresh variables bound to the old name.
+    // Refresh variables bound to the (now-renamed) alias against
+    // any address shifts produced by the change.
     useOpenPLCStore.getState().projectActions.syncVariableAliases()
   }
 

--- a/src/frontend/components/_molecules/global-variables-table/editable-cell.tsx
+++ b/src/frontend/components/_molecules/global-variables-table/editable-cell.tsx
@@ -291,22 +291,25 @@ const EditableLocationCell = ({
 
   const [cellValue, setCellValue] = useState(initialValue ?? '')
 
-  // Alias staleness check.  Lifted above `onBlur` so the short-circuit
-  // can take it into account — when the user's previously-bound alias
-  // has been renamed/removed upstream, re-picking the same address
-  // from the dropdown should still refresh the variable's stored
-  // alias.  Mirrors the local-table variant of this cell.
+  // Alias staleness checks.  See the local variables-table cell
+  // (`_molecules/variables-table/editable-cell.tsx`) for the longer
+  // explanation — same two flavours of staleness, same exception
+  // semantics on the location-column short-circuit.
   const variableAlias = original?.alias
+  const variableLocation = original?.location ?? ''
   const aliasRegistry = useAliasRegistry()
   const isOrphaned = !!variableAlias && !aliasRegistry.byAlias.has(variableAlias)
+  const isMismatched =
+    !!variableAlias && aliasRegistry.byAlias.has(variableAlias)
+      ? aliasRegistry.byAlias.get(variableAlias)?.address !== variableLocation
+      : false
 
   const onBlur = (value: string) => {
-    // Same short-circuit semantics as the local variables-table cell:
-    // skip unchanged-value blurs unless the variable's alias is
-    // orphaned, in which case the user re-picking the same address
-    // is their signal to refresh the alias.  `updateVariable`'s
-    // auto-adopt path re-resolves against the live alias registry.
-    if (value === initialValue && !isOrphaned) return
+    // Short-circuit unchanged-value blurs unless the variable's alias
+    // is orphaned or mismatched (alias points at a different address
+    // than the variable's location) — in either case re-picking the
+    // same address is the user's signal to refresh the alias.
+    if (value === initialValue && !(isOrphaned || isMismatched)) return
     const res = table.options.meta?.updateData(index, id, value)
     if (res?.ok) {
       setCellValue(value)

--- a/src/frontend/components/_molecules/variables-table/editable-cell.tsx
+++ b/src/frontend/components/_molecules/variables-table/editable-cell.tsx
@@ -471,26 +471,37 @@ const EditableLocationCell = ({
 
   const isEditable = useCallback(isCellEditable, [id, variable, isDebuggerVisible])
 
-  // Alias staleness check.  Lifted above `onBlur` so the short-circuit
-  // can take it into account — when the user's previously-bound alias
-  // has been renamed/removed upstream (pin mapping, backplane, etc.),
-  // re-picking the same address from the dropdown should refresh the
-  // variable's stored alias.  Without this hoist `isOrphaned` was
-  // only used for the rendered warning glyph below.
+  // Alias staleness checks.  Lifted above `onBlur` so the short-
+  // circuit can take them into account.  Two flavours of staleness
+  // both demand that the location-pick re-fires `updateVariable`
+  // even when the picked value matches the cell's current address:
+  //
+  //   - `isOrphaned`: the variable's stored alias is no longer in the
+  //     registry's `byAlias` (producer renamed/removed it).
+  //     Re-picking the same address re-runs the auto-adopt and
+  //     refreshes the alias against the live registry.
+  //   - `isMismatched`: the variable carries an alias that points at
+  //     a *different* address than its current location.  Happens when
+  //     legacy projects authored before `createVariable`'s auto-adopt
+  //     fix carried a stale alias from one row to the next through the
+  //     "+ button" template spread.  Without this exception, clicking
+  //     on the right alias for the current address would no-op because
+  //     the address itself isn't changing — the user would have to
+  //     pick a DIFFERENT alias first, then return to the desired one,
+  //     to force the alias write through.
   const aliasRegistry = useAliasRegistry()
   const isOrphaned = !!variable?.alias && !aliasRegistry.byAlias.has(variable.alias)
+  const isMismatched =
+    !!variable?.alias && aliasRegistry.byAlias.has(variable.alias)
+      ? aliasRegistry.byAlias.get(variable.alias)?.address !== variable.location
+      : false
 
   // When the input is blurred, we'll call our table meta's updateData function
   const onBlur = (value: string) => {
     // Short-circuit unchanged-value blurs so re-focus doesn't fire a
-    // gratuitous state update.  Exception: when the user re-picks the
-    // SAME location for a variable whose stored alias is now orphaned
-    // (the producer renamed it), force the update through so
-    // `updateVariable`'s auto-adopt path re-resolves the address
-    // against the live alias registry and refreshes the variable's
-    // alias field.  Otherwise the orphan warning would persist
-    // forever and the only workaround would be Clear → re-pick.
-    if (value === initialValue && !(id === 'location' && isOrphaned)) return
+    // gratuitous state update.  Exceptions for the location column,
+    // see the `isOrphaned` / `isMismatched` block above.
+    if (value === initialValue && !(id === 'location' && (isOrphaned || isMismatched))) return
     const res = table.options.meta?.updateData(index, id, value)
     if (res?.ok) {
       setCellValue(value)

--- a/src/frontend/components/_organisms/global-variables-editor/index.tsx
+++ b/src/frontend/components/_organisms/global-variables-editor/index.tsx
@@ -236,7 +236,11 @@ const GlobalVariablesEditor = () => {
       selectedRow === ROWS_NOT_SELECTED ? variables[variables.length - 1] : variables[selectedRow]
     ) as PLCGlobalVariable
 
-    const newVarData = { ...variable, documentation: '' }
+    // Don't carry the previous variable's `alias` into the new row.
+    // See variables-editor/index.tsx for the longer explanation —
+    // tl;dr: `createVariable` auto-increments `location`, and keeping
+    // the stale alias would break the alias-↔-location invariant.
+    const newVarData = { ...variable, alias: undefined, documentation: '' }
 
     if (selectedRow === ROWS_NOT_SELECTED) {
       createVariable({ scope: 'global', data: newVarData })

--- a/src/frontend/components/_organisms/variables-editor/index.tsx
+++ b/src/frontend/components/_organisms/variables-editor/index.tsx
@@ -424,8 +424,17 @@ const VariablesEditor = ({ name: propName, isActive: _isActive = true }: Variabl
     const variable: PLCVariable =
       selectedRow === ROWS_NOT_SELECTED ? variables[variables.length - 1] : variables[selectedRow]
 
+    // Don't carry the previous variable's `alias` into the new row.
+    // The slice's `createVariable` auto-increments `location`; if we
+    // kept the old alias attached, the new variable would claim the
+    // OLD channel's alias while pointing at the NEW address —
+    // breaking the alias-↔-location invariant.  `createVariable`'s
+    // auto-adopt path resolves the right alias for the new location
+    // against the live registry (matching whichever producer-channel
+    // owns the auto-incremented address).
     const newVarData = {
       ...variable,
+      alias: undefined,
       class: defaultClass,
       type:
         variable.type.definition === 'derived'

--- a/src/frontend/hooks/use-device-configuration.ts
+++ b/src/frontend/hooks/use-device-configuration.ts
@@ -1,6 +1,8 @@
 import { enrichDeviceData } from '@root/backend/shared/ethercat/enrich-device-data'
 import { generateDefaultChannelMappings, pdoToChannels } from '@root/backend/shared/ethercat/esi-parser'
 import { extractDefaultSdoConfigurations } from '@root/backend/shared/ethercat/sdo-config-defaults'
+import { toast } from '@root/frontend/components/_features/[app]/toast/use-toast'
+import { useOpenPLCStore } from '@root/frontend/store'
 import type {
   ConfiguredEtherCATDevice,
   EnrichDeviceData,
@@ -10,6 +12,13 @@ import type {
   EtherCATSlaveConfig,
 } from '@root/middleware/shared/ports/esi-types'
 import { useEsi } from '@root/middleware/shared/providers/platform-context'
+import {
+  buildAddressPool,
+  buildAliasRegistry,
+  describeSource,
+  validateAliasEdit,
+} from '@root/middleware/shared/utils/iec-address'
+import { resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 type UseDeviceConfigurationParams = {
@@ -106,10 +115,65 @@ export function useDeviceConfiguration({
   const handleAliasChange = useCallback(
     (channelId: string, alias: string) => {
       if (!device) return
+
+      // Resolve the bus owning this slave so we can construct a
+      // `SourceRef` whose `ref` matches the format used by the
+      // address pool (`${busName}:${slaveName}:${channelId}` — see
+      // `address-pool.ts:243`).  Without this, `validateAliasEdit`'s
+      // "ignoring" comparison wouldn't recognise a no-op self-rename
+      // and would spuriously reject it.
+      const state = useOpenPLCStore.getState()
+      const owningBus = state.project.data.remoteDevices?.find((d) =>
+        d.ethercatConfig?.devices?.some((s) => s.name === device.name),
+      )
+      const busName = owningBus?.name ?? ''
+      const sourceRef = { kind: 'ethercat' as const, ref: `${busName}:${device.name}:${channelId}` }
+
+      // Phase 1 — write-time uniqueness gate (global across all
+      // producers).  Build a fresh registry from the live state and
+      // reject the edit on collision.  See
+      // `module-slots-layout.tsx::handleAliasChange` for the longer
+      // rationale.
+      const board = state.deviceDefinitions.configuration.deviceBoard ?? ''
+      const boardInfo = state.deviceAvailableOptions.availableBoards.get(board)
+      const ioMapping =
+        (
+          state.deviceDefinitions.configuration.vendorScreenData?.['io-mapping'] as
+            | { entries?: Array<{ iecAddress: string; alias?: string; slot: number; channelName: string }> }
+            | undefined
+        )?.entries ?? []
+      const pool = buildAddressPool(
+        {
+          pinMapping: { pins: state.deviceDefinitions.pinMapping.pinsByBoard[board] ?? [] },
+          vendorIoMapping: { entries: ioMapping },
+          remoteDevices: state.project.data.remoteDevices,
+        },
+        resolveTargetCapabilities(boardInfo),
+      )
+      const registry = buildAliasRegistry(pool)
+      const validation = validateAliasEdit(registry, alias, sourceRef)
+      if (!validation.ok) {
+        toast({
+          title: 'Alias already in use',
+          description: `"${alias}" is already assigned to ${describeSource(validation.conflict.source)} (${validation.conflict.address}). Alias names must be unique across all I/O channels.`,
+          variant: 'fail',
+        })
+        return
+      }
+
+      // Phase 2 — cascade rename onto bound variables BEFORE
+      // writing the new alias so the downstream sync sees variables
+      // pointing at the new name and refreshes locations rather
+      // than orphaning them.
+      const oldAlias = device.channelMappings.find((m) => m.channelId === channelId)?.alias ?? ''
+      if (oldAlias) {
+        useOpenPLCStore.getState().projectActions.renameAlias(oldAlias, alias)
+      }
+
       const updated = device.channelMappings.map((m) => (m.channelId === channelId ? { ...m, alias } : m))
       onUpdateChannelMappingsRef.current(updated)
     },
-    [device?.channelMappings],
+    [device?.channelMappings, device?.name],
   )
 
   const updateConfig = useCallback(

--- a/src/frontend/store/__tests__/project-validation-variables.test.ts
+++ b/src/frontend/store/__tests__/project-validation-variables.test.ts
@@ -340,6 +340,54 @@ describe('createVariableValidation', () => {
     expect(result.location).toBe('%MD0')
   })
 
+  // -- Multi-collision walk (regression for forum bug: contiguous "+" clicks
+  //    across a row with a variable already further down) --
+  it('walks past intervening claimed locations until it finds a free slot (BOOL)', () => {
+    // Existing rows occupy %IX0.0..%IX0.4 and %IX0.5 — user "+"-clicks the row
+    // at %IX0.4.  Single-step increment would land on %IX0.5 and collide; the
+    // validator must walk to %IX0.6.
+    const existing = [
+      makeVariable('I1', 'BOOL', '%IX0.0'),
+      makeVariable('I1_0', 'BOOL', '%IX0.1'),
+      makeVariable('I1_1', 'BOOL', '%IX0.2'),
+      makeVariable('I1_2', 'BOOL', '%IX0.3'),
+      makeVariable('I1_3', 'BOOL', '%IX0.4'),
+      makeVariable('I2', 'BOOL', '%IX0.5'),
+    ]
+    const variable = makeVariable('NewVar', 'BOOL', '%IX0.4')
+    const result = createVariableValidation(existing, variable)
+    expect(result.location).toBe('%IX0.6')
+  })
+
+  it('walks past multiple consecutive claimed locations (WORD)', () => {
+    const existing = [
+      makeVariable('A', 'INT', '%QW5'),
+      makeVariable('B', 'INT', '%QW6'),
+      makeVariable('C', 'INT', '%QW7'),
+    ]
+    const variable = makeVariable('NewVar', 'INT', '%QW5')
+    const result = createVariableValidation(existing, variable)
+    expect(result.location).toBe('%QW8')
+  })
+
+  it('wraps past a full BOOL byte when every bit and the next byte are taken', () => {
+    // %QX0.0..%QX0.7 claimed plus %QX1.0 — must land at %QX1.1.
+    const existing = [
+      makeVariable('B0', 'BOOL', '%QX0.0'),
+      makeVariable('B1', 'BOOL', '%QX0.1'),
+      makeVariable('B2', 'BOOL', '%QX0.2'),
+      makeVariable('B3', 'BOOL', '%QX0.3'),
+      makeVariable('B4', 'BOOL', '%QX0.4'),
+      makeVariable('B5', 'BOOL', '%QX0.5'),
+      makeVariable('B6', 'BOOL', '%QX0.6'),
+      makeVariable('B7', 'BOOL', '%QX0.7'),
+      makeVariable('B8', 'BOOL', '%QX1.0'),
+    ]
+    const variable = makeVariable('NewVar', 'BOOL', '%QX0.0')
+    const result = createVariableValidation(existing, variable)
+    expect(result.location).toBe('%QX1.1')
+  })
+
   // -- Edge case: location exists but not found in variables (defensive) --
   it('returns unchanged when location exists but variable not found in list', () => {
     // This covers the `if (!variableFound) return response` branch

--- a/src/frontend/store/__tests__/sync-variable-aliases-action.test.ts
+++ b/src/frontend/store/__tests__/sync-variable-aliases-action.test.ts
@@ -163,7 +163,7 @@ describe('projectActions.syncVariableAliases (store integration)', () => {
     expect(vars[0].alias).toBe('conveyor_motor')
   })
 
-  it('reports orphans when the producer no longer exposes the alias', () => {
+  it('reports orphans and clears their stale location when the producer no longer exposes the alias', () => {
     const store = makeStore()
     seedBoard(store, 'SLM-RP4', VPP_V4)
     seedVendorScreenData(store, withVppEntries([])) // no VPP entries at all
@@ -172,10 +172,13 @@ describe('projectActions.syncVariableAliases (store integration)', () => {
     const report = store.getState().projectActions.syncVariableAliases()
     expect(report.orphaned).toBe(1)
 
-    // Variable kept as-is so the user can re-bind manually.
+    // Phase 3 contract: orphans keep the alias name (so the UI can
+    // render the warning glyph + tooltip) but their stale location
+    // is cleared so the ST / XML emitters don't bake an `AT %…` into
+    // the compile for an alias whose producer is no longer active.
     const vars = store.getState().project.data.pous[0].interface!.variables
     expect(vars[0].alias).toBe('conveyor_motor')
-    expect(vars[0].location).toBe('%QX0.0')
+    expect(vars[0].location).toBe('')
   })
 
   it('honours target capabilities: switching to an arduino board orphans VPP-bound aliases', () => {

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -14,8 +14,10 @@ import type {
 import {
   buildAddressPool,
   buildAliasRegistry,
+  describeSource,
   nextFreeAddress,
   syncVariableAliases as syncVariablesPure,
+  validateAliasEdit,
 } from '../../../../middleware/shared/utils/iec-address'
 import { resolveTargetCapabilities } from '../../../../middleware/shared/utils/target-capabilities'
 import { parseIecStringToVariables } from '../../../utils/generate-iec-string-to-variables'
@@ -765,6 +767,23 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
           message: `Address pool reports ${pool.conflicts.length} conflicting claim(s): ${sample}${overflow}. The first source wins; later ones lose their address binding.`,
         })
       }
+      // Same migration warning, alias side: projects authored before
+      // the write-time `validateAliasEdit` gate landed may have
+      // duplicate alias names across producers.  The registry
+      // first-wins on `byAlias`, but every variable bound to the
+      // losing entry gets quietly collapsed to the winner's address
+      // through the sync's refresh path.  Surface this loudly so the
+      // user can resolve it (rename one of the duplicates) instead
+      // of silently inheriting a broken state.
+      if (registry.duplicateAliases.length > 0) {
+        const sample = registry.duplicateAliases.slice(0, 5).join(', ')
+        const overflow = registry.duplicateAliases.length > 5 ? ` (+${registry.duplicateAliases.length - 5} more)` : ''
+        live.consoleActions.addLog({
+          id: crypto.randomUUID(),
+          level: 'warning',
+          message: `Alias registry reports ${registry.duplicateAliases.length} duplicate alias name(s): ${sample}${overflow}. Each alias must be unique across all I/O channels — rename the duplicates in the IO mapping screens. Until then, variables bound to the losing entries will resolve to the winning entry's address.`,
+        })
+      }
 
       let adopted = 0
       let refreshed = 0
@@ -801,6 +820,63 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       )
 
       return { adopted, refreshed, orphaned }
+    },
+
+    /**
+     * Cascade-rename every variable's `.alias` from `oldAlias` to
+     * `newAlias`.  See the type doc in `project/types.ts` for the
+     * full contract — short version: when the user renames the
+     * alias on a producer channel (pin mapping, VPP module, Modbus
+     * TCP, EtherCAT), the bound variables follow so they don't drop
+     * into the orphan path.  Case-insensitive match.  A subsequent
+     * `syncVariableAliases()` then refreshes the variables'
+     * `.location` against the now-renamed alias's address.
+     */
+    renameAlias: (oldAlias, newAlias) => {
+      const trimmedOld = oldAlias?.trim() ?? ''
+      const trimmedNew = newAlias?.trim() ?? ''
+      // No-op when there's nothing to rename FROM.  Caller is the IO
+      // mapping screen on first-time alias write where there's no
+      // prior text to cascade.
+      if (trimmedOld.length === 0) return { renamed: 0 }
+      // No-op when the rename is a pure case change or an actual
+      // no-op — saves a render pass and avoids spurious mutation.
+      if (trimmedOld.toLowerCase() === trimmedNew.toLowerCase()) return { renamed: 0 }
+
+      let renamed = 0
+      const cascade = (variable: PLCVariable): PLCVariable => {
+        if (!variable.alias) return variable
+        if (variable.alias.toLowerCase() !== trimmedOld.toLowerCase()) return variable
+        renamed += 1
+        // When the user clears the alias on the producer side, the
+        // bound variables should also drop their alias — the next
+        // `syncVariableAliases()` will then re-evaluate them against
+        // the live registry (auto-adopt by raw location if the same
+        // address is still claimed by some other producer, or leave
+        // them alias-less otherwise).  `undefined` rather than ''
+        // matches the rest of the codebase's "no alias" convention.
+        return { ...variable, alias: trimmedNew.length > 0 ? trimmedNew : undefined }
+      }
+
+      setState(
+        produce((slice: ProjectSlice) => {
+          for (const pou of slice.project.data.pous) {
+            /* istanbul ignore if -- schema guarantees `interface.variables`; defensive */
+            if (!pou.interface?.variables) continue
+            for (let i = 0; i < pou.interface.variables.length; i++) {
+              pou.interface.variables[i] = cascade(pou.interface.variables[i])
+            }
+          }
+          const globals = slice.project.data.configurations.resource.globalVariables
+          if (globals) {
+            for (let i = 0; i < globals.length; i++) {
+              globals[i] = cascade(globals[i])
+            }
+          }
+        }),
+      )
+
+      return { renamed }
     },
 
     // -----------------------------------------------------------------------
@@ -1421,6 +1497,58 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       return ok()
     },
     updateIOPointAlias: (deviceName, groupId, pointId, alias) => {
+      // Phase 1 — write-time alias-uniqueness gate (global, across
+      // all producers).  Build a fresh registry from the live state
+      // and reject the edit on collision.  See
+      // `module-slots-layout.tsx::handleAliasChange` for the longer
+      // rationale.
+      const live = getState()
+      const sourceRef = { kind: 'modbus-tcp-remote' as const, ref: `${deviceName}:${pointId}` }
+      const boardInfo = live.deviceAvailableOptions?.availableBoards?.get(
+        live.deviceDefinitions?.configuration?.deviceBoard ?? '',
+      )
+      const ioMapping =
+        (
+          live.deviceDefinitions?.configuration?.vendorScreenData?.['io-mapping'] as
+            | { entries?: Array<{ iecAddress: string; alias?: string; slot: number; channelName: string }> }
+            | undefined
+        )?.entries ?? []
+      const pool = buildAddressPool(
+        {
+          pinMapping: {
+            pins:
+              live.deviceDefinitions?.pinMapping?.pinsByBoard[
+                live.deviceDefinitions?.configuration?.deviceBoard ?? ''
+              ] ?? [],
+          },
+          vendorIoMapping: { entries: ioMapping },
+          remoteDevices: live.project.data.remoteDevices,
+        },
+        resolveTargetCapabilities(boardInfo),
+      )
+      const registry = buildAliasRegistry(pool)
+      const validation = validateAliasEdit(registry, alias, sourceRef)
+      if (!validation.ok) {
+        return {
+          ok: false,
+          title: 'Alias already in use',
+          message: `"${alias}" is already assigned to ${describeSource(validation.conflict.source)} (${validation.conflict.address}). Alias names must be unique across all I/O channels.`,
+        }
+      }
+
+      // Phase 2 — capture the old alias and cascade rename onto
+      // bound variables BEFORE writing the new alias so the
+      // downstream sync sees variables pointing at the new name and
+      // refreshes locations rather than orphaning them.
+      const oldAlias =
+        live.project.data.remoteDevices
+          ?.find((d) => d.name === deviceName)
+          ?.modbusTcpConfig?.ioGroups?.find((g) => g.id === groupId)
+          ?.ioPoints?.find((p) => p.id === pointId)?.alias ?? ''
+      if (oldAlias) {
+        getState().projectActions.renameAlias(oldAlias, alias)
+      }
+
       setState(
         produce((slice: ProjectSlice) => {
           const device = slice.project.data.remoteDevices?.find((d) => d.name === deviceName)

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -172,6 +172,57 @@ function generateIOPoints(
 }
 
 // ---------------------------------------------------------------------------
+// Alias auto-adopt
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the canonical alias that a variable should carry for its
+ * current `location`.  Builds a fresh pool + registry from the live
+ * store state, scoped to the active target's capabilities, then
+ * returns whatever alias the registry attaches to that address (or
+ * `undefined` when the address isn't aliased, or `location` is empty).
+ *
+ * Used by both `createVariable` and `updateVariable` to enforce the
+ * alias-↔-location invariant: a variable's `alias` field MUST point
+ * at the same producer-channel its `location` points at.  Without
+ * this, the "+" button (which auto-increments the location of a
+ * spread-from-previous variable) leaves the OLD alias attached to a
+ * NEW address — `syncVariableAliases` then collapses every such
+ * variable back to the OLD alias's canonical address on the next
+ * refresh pass, producing the duplicate-address compile errors
+ * reported in v4.2.0.
+ *
+ * Returns `undefined` for an empty / missing location so callers can
+ * distinguish "no alias because the address is unmapped" from "no
+ * alias because we didn't bother to look".
+ */
+function resolveAliasForLocation(getState: ProjectGetState, location: string | undefined): string | undefined {
+  if (!location) return undefined
+  const live = getState()
+  const boardInfo = live.deviceAvailableOptions.availableBoards.get(
+    live.deviceDefinitions.configuration.deviceBoard ?? '',
+  )
+  const ioMapping =
+    (
+      live.deviceDefinitions.configuration.vendorScreenData?.['io-mapping'] as
+        | { entries?: Array<{ iecAddress: string; alias?: string; slot: number; channelName: string }> }
+        | undefined
+    )?.entries ?? []
+  const pool = buildAddressPool(
+    {
+      pinMapping: {
+        pins: live.deviceDefinitions.pinMapping.pinsByBoard[live.deviceDefinitions.configuration.deviceBoard] ?? [],
+      },
+      vendorIoMapping: { entries: ioMapping },
+      remoteDevices: live.project.data.remoteDevices,
+    },
+    resolveTargetCapabilities(boardInfo),
+  )
+  const registry = buildAliasRegistry(pool)
+  return registry.byAddress.get(location)?.alias
+}
+
+// ---------------------------------------------------------------------------
 // Variables-text ⇄ variables-table reconcile helpers
 // ---------------------------------------------------------------------------
 
@@ -496,6 +547,24 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
         if (!reconcile.ok) return reconcile
       }
 
+      // Apply the validator's name + location auto-increment OUTSIDE
+      // produce so we can then re-resolve the alias against the live
+      // store state.  The new variable's `alias` MUST point at the
+      // channel its post-increment `location` points at — otherwise
+      // the "+ button" UI flow (which spreads the previous variable
+      // as a template) carries a stale alias from the previous row
+      // forward, breaking the alias-↔-location invariant.  The next
+      // `syncVariableAliases` refresh would then silently collapse
+      // the new variable back to the stale alias's canonical
+      // address, producing the duplicate-address compile errors
+      // reported in v4.2.0 (forum thread "openplc-420-teething-bugs").
+      const sourceVariables =
+        scope === 'local' && associatedPou
+          ? (getState().project.data.pous.find((p) => p.name === associatedPou)?.interface?.variables ?? [])
+          : getState().project.data.configurations.resource.globalVariables
+      const validated = createVariableValidation(sourceVariables, data)
+      data = { ...data, ...validated, alias: resolveAliasForLocation(getState, validated.location) }
+
       let response: ProjectResponse = { ok: true }
       setState(
         produce((slice: ProjectSlice) => {
@@ -511,9 +580,6 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
           } else {
             variables = slice.project.data.configurations.resource.globalVariables
           }
-
-          // Validate and auto-increment name/location
-          data = { ...data, ...createVariableValidation(variables, data) }
 
           // Insert or append
           if (rowToInsert !== undefined) {
@@ -557,40 +623,19 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
 
       let response: ProjectResponse = { ok: true }
 
-      // Auto-adopt path: whenever the location changes, look up the
-      // alias registry and patch updates.alias to match the new
-      // address. If the address has an alias, the variable adopts it
-      // (cell shows the alias name, Phase 4 sync will keep the
-      // location current as the alias moves). If not, the alias
+      // Auto-adopt path: whenever the location changes, re-resolve
+      // the alias against the live registry so the variable's alias
+      // always points at the producer-channel its location points at.
+      // If the address has an alias, the variable adopts it (cell
+      // shows the alias name; `syncVariableAliases` will keep the
+      // location current as the alias moves).  If not, the alias
       // clears — re-typing a now-orphaned location intentionally
-      // drops the stale alias label too. Done outside `produce` so
+      // drops the stale alias label too.  Done outside `produce` so
       // we read the live store state including pinMapping + caps.
-      let aliasOverride: { alias: string | undefined } | undefined
-      if (typeof updates.location === 'string') {
-        const live = getState()
-        const boardInfo = live.deviceAvailableOptions.availableBoards.get(
-          live.deviceDefinitions.configuration.deviceBoard ?? '',
-        )
-        const ioMapping =
-          (
-            live.deviceDefinitions.configuration.vendorScreenData?.['io-mapping'] as
-              | { entries?: Array<{ iecAddress: string; alias?: string; slot: number; channelName: string }> }
-              | undefined
-          )?.entries ?? []
-        const pool = buildAddressPool(
-          {
-            pinMapping: {
-              pins:
-                live.deviceDefinitions.pinMapping.pinsByBoard[live.deviceDefinitions.configuration.deviceBoard] ?? [],
-            },
-            vendorIoMapping: { entries: ioMapping },
-            remoteDevices: live.project.data.remoteDevices,
-          },
-          resolveTargetCapabilities(boardInfo),
-        )
-        const registry = buildAliasRegistry(pool)
-        aliasOverride = { alias: registry.byAddress.get(updates.location)?.alias }
-      }
+      const aliasOverride: { alias: string | undefined } | undefined =
+        typeof updates.location === 'string'
+          ? { alias: resolveAliasForLocation(getState, updates.location) }
+          : undefined
 
       setState(
         produce((slice: ProjectSlice) => {

--- a/src/frontend/store/slices/project/types.ts
+++ b/src/frontend/store/slices/project/types.ts
@@ -165,6 +165,29 @@ export type ProjectActions = {
     orphaned: number
   }
 
+  /**
+   * Cascade-rename every variable's `.alias` field from `oldAlias` to
+   * `newAlias` across all POU-local and global variables.  Used by
+   * the IO-mapping screens (pin-mapping, VPP modules, VPP io-table,
+   * Modbus TCP remote, EtherCAT) when the user renames the alias on
+   * a producer channel — the rename cascades to bound variables so
+   * they don't become orphaned just because the alias text moved.
+   *
+   * Empty `oldAlias` (channel previously had no alias) is a no-op.
+   * Empty `newAlias` (user clearing the alias) causes the matching
+   * variables to drop their alias too; `syncVariableAliases` will
+   * then re-evaluate them against the live registry (auto-adopt by
+   * raw location when applicable, otherwise alias-less binding).
+   *
+   * Case-insensitive matching to align with the rest of the IEC
+   * identifier handling.  Callers should follow this with a
+   * `syncVariableAliases()` to refresh `.location` against the now-
+   * renamed alias's address.
+   *
+   * Returns the number of variables actually mutated.
+   */
+  renameAlias: (oldAlias: string, newAlias: string) => { renamed: number }
+
   // Data types
   createDatatype: (dto: DataTypeDTO & { rowToInsert?: number }) => ProjectResponse
   deleteDatatype: (name: string) => void

--- a/src/frontend/store/slices/project/validation/variables.ts
+++ b/src/frontend/store/slices/project/validation/variables.ts
@@ -212,6 +212,92 @@ const checkVariableName = (variables: PLCVariable[], variableName: string) => {
  * This is a validation to check if it is needed changing the name of a variable at creation.
  * If the variable exists change the variable name.
  **/
+/**
+ * Increment an IEC 61131-3 address by one slot, respecting the
+ * width of the variable's underlying type.  For BOOL addresses
+ * (`%IX/%QX<byte>.<bit>`) the bit field wraps from .7 back to .0
+ * with the byte index bumping by one; for word / dword / lword
+ * forms the numeric index after the prefix increments by one.
+ *
+ * Returns `null` when the type isn't recognised — the caller stops
+ * the auto-increment loop and falls back to whatever location it
+ * currently holds, so an unknown future IEC type can't produce an
+ * infinite loop here.
+ */
+const incrementLocationByOne = (location: string, typeValue: string): string | null => {
+  switch (typeValue.toUpperCase()) {
+    case 'BOOL': {
+      const stringWithNoPrefix = location
+        .replace(PLC_ADDRESS_PREFIX.BOOL_OUTPUT, '')
+        .replace(PLC_ADDRESS_PREFIX.BOOL_INPUT, '')
+      const position = parseInt(stringWithNoPrefix.split('.')[0])
+      const dotPosition = parseInt(stringWithNoPrefix.split('.')[1])
+      const prefix = location.startsWith(PLC_ADDRESS_PREFIX.BOOL_OUTPUT)
+        ? PLC_ADDRESS_PREFIX.BOOL_OUTPUT
+        : PLC_ADDRESS_PREFIX.BOOL_INPUT
+      return `${prefix}${dotPosition === 7 ? position + 1 : position}.${dotPosition === 7 ? 0 : dotPosition + 1}`
+    }
+    case 'INT':
+    case 'UINT':
+    case 'WORD': {
+      const stringWithNoPrefix = location
+        .replace(PLC_ADDRESS_PREFIX.WORD_OUTPUT, '')
+        .replace(PLC_ADDRESS_PREFIX.WORD_INPUT, '')
+        .replace(PLC_ADDRESS_PREFIX.WORD_MEMORY, '')
+      const position = parseInt(stringWithNoPrefix)
+      const prefix = location.startsWith(PLC_ADDRESS_PREFIX.WORD_OUTPUT)
+        ? PLC_ADDRESS_PREFIX.WORD_OUTPUT
+        : location.startsWith(PLC_ADDRESS_PREFIX.WORD_INPUT)
+          ? PLC_ADDRESS_PREFIX.WORD_INPUT
+          : PLC_ADDRESS_PREFIX.WORD_MEMORY
+      return `${prefix}${position + 1}`
+    }
+    case 'DINT':
+    case 'UDINT':
+    case 'REAL':
+    case 'DWORD': {
+      const stringWithNoPrefix = location
+        .replace(PLC_ADDRESS_PREFIX.DWORD_OUTPUT, '')
+        .replace(PLC_ADDRESS_PREFIX.DWORD_INPUT, '')
+        .replace(PLC_ADDRESS_PREFIX.DWORD_MEMORY, '')
+      const position = parseInt(stringWithNoPrefix)
+      const prefix = location.startsWith(PLC_ADDRESS_PREFIX.DWORD_OUTPUT)
+        ? PLC_ADDRESS_PREFIX.DWORD_OUTPUT
+        : location.startsWith(PLC_ADDRESS_PREFIX.DWORD_INPUT)
+          ? PLC_ADDRESS_PREFIX.DWORD_INPUT
+          : PLC_ADDRESS_PREFIX.DWORD_MEMORY
+      return `${prefix}${position + 1}`
+    }
+    case 'LINT':
+    case 'ULINT':
+    case 'LREAL':
+    case 'LWORD': {
+      const stringWithNoPrefix = location
+        .replace(PLC_ADDRESS_PREFIX.LWORD_OUTPUT, '')
+        .replace(PLC_ADDRESS_PREFIX.LWORD_INPUT, '')
+        .replace(PLC_ADDRESS_PREFIX.LWORD_MEMORY, '')
+      const position = parseInt(stringWithNoPrefix)
+      const prefix = location.startsWith(PLC_ADDRESS_PREFIX.LWORD_OUTPUT)
+        ? PLC_ADDRESS_PREFIX.LWORD_OUTPUT
+        : location.startsWith(PLC_ADDRESS_PREFIX.LWORD_INPUT)
+          ? PLC_ADDRESS_PREFIX.LWORD_INPUT
+          : PLC_ADDRESS_PREFIX.LWORD_MEMORY
+      return `${prefix}${position + 1}`
+    }
+    default:
+      return null
+  }
+}
+
+/** Safety bound on the auto-increment loop in `createVariableValidation`.
+ *  Picked well above any realistic project size (8 bits × N bytes =
+ *  N×8 BOOLs; this lets us scan ~1000 bytes / words / dwords / lwords
+ *  before we give up).  The loop normally terminates after at most
+ *  a handful of iterations — the bound only matters if the table is
+ *  pathologically dense or an unknown IEC type slipped past
+ *  `incrementLocationByOne`'s switch. */
+const MAX_AUTO_INCREMENT_ITERATIONS = 8192
+
 const createVariableValidation = (
   variables: PLCVariable[],
   variable: PLCVariable,
@@ -224,84 +310,25 @@ const createVariableValidation = (
     response.name = `${variableNameWithoutNumber}${number}`
   }
 
-  if (checkIfLocationExists(variables, variableLocation)) {
-    if (variableLocation === '') return response
-
-    const variableFound = variables.find((variable) => variable.location === variableLocation)
-    /* istanbul ignore next -- defensive: find() uses same predicate as checkIfLocationExists above */
-    if (!variableFound) return response
-
-    switch (variable.type.value.toUpperCase()) {
-      case 'BOOL': {
-        const stringWithNoPrefix = variableFound.location
-          .replace(PLC_ADDRESS_PREFIX.BOOL_OUTPUT, '')
-          .replace(PLC_ADDRESS_PREFIX.BOOL_INPUT, '')
-        const position = parseInt(stringWithNoPrefix.split('.')[0])
-        const dotPosition = parseInt(stringWithNoPrefix.split('.')[1])
-
-        const prefix = variableFound?.location.startsWith(PLC_ADDRESS_PREFIX.BOOL_OUTPUT)
-          ? PLC_ADDRESS_PREFIX.BOOL_OUTPUT
-          : PLC_ADDRESS_PREFIX.BOOL_INPUT
-        response.location = `${prefix}${dotPosition === 7 ? position + 1 : position}.${dotPosition === 7 ? 0 : dotPosition + 1}`
-        break
-      }
-
-      case 'INT':
-      case 'UINT':
-      case 'WORD': {
-        const stringWithNoPrefix = variableFound.location
-          .replace(PLC_ADDRESS_PREFIX.WORD_OUTPUT, '')
-          .replace(PLC_ADDRESS_PREFIX.WORD_INPUT, '')
-          .replace(PLC_ADDRESS_PREFIX.WORD_MEMORY, '')
-        const position = parseInt(stringWithNoPrefix)
-        const prefix = variableFound?.location.startsWith(PLC_ADDRESS_PREFIX.WORD_OUTPUT)
-          ? PLC_ADDRESS_PREFIX.WORD_OUTPUT
-          : variableFound?.location.startsWith(PLC_ADDRESS_PREFIX.WORD_INPUT)
-            ? PLC_ADDRESS_PREFIX.WORD_INPUT
-            : PLC_ADDRESS_PREFIX.WORD_MEMORY
-        response.location = `${prefix}${position + 1}`
-        break
-      }
-
-      case 'DINT':
-      case 'UDINT':
-      case 'REAL':
-      case 'DWORD': {
-        const stringWithNoPrefix = variableFound.location
-          .replace(PLC_ADDRESS_PREFIX.DWORD_OUTPUT, '')
-          .replace(PLC_ADDRESS_PREFIX.DWORD_INPUT, '')
-          .replace(PLC_ADDRESS_PREFIX.DWORD_MEMORY, '')
-        const position = parseInt(stringWithNoPrefix)
-        const prefix = variableFound?.location.startsWith(PLC_ADDRESS_PREFIX.DWORD_OUTPUT)
-          ? PLC_ADDRESS_PREFIX.DWORD_OUTPUT
-          : variableFound?.location.startsWith(PLC_ADDRESS_PREFIX.DWORD_INPUT)
-            ? PLC_ADDRESS_PREFIX.DWORD_INPUT
-            : PLC_ADDRESS_PREFIX.DWORD_MEMORY
-        response.location = `${prefix}${position + 1}`
-        break
-      }
-
-      case 'LINT':
-      case 'ULINT':
-      case 'LREAL':
-      case 'LWORD': {
-        const stringWithNoPrefix = variableFound.location
-          .replace(PLC_ADDRESS_PREFIX.LWORD_OUTPUT, '')
-          .replace(PLC_ADDRESS_PREFIX.LWORD_INPUT, '')
-          .replace(PLC_ADDRESS_PREFIX.LWORD_MEMORY, '')
-        const position = parseInt(stringWithNoPrefix)
-        const prefix = variableFound?.location.startsWith(PLC_ADDRESS_PREFIX.LWORD_OUTPUT)
-          ? PLC_ADDRESS_PREFIX.LWORD_OUTPUT
-          : variableFound?.location.startsWith(PLC_ADDRESS_PREFIX.LWORD_INPUT)
-            ? PLC_ADDRESS_PREFIX.LWORD_INPUT
-            : PLC_ADDRESS_PREFIX.LWORD_MEMORY
-        response.location = `${prefix}${position + 1}`
-        break
-      }
-
-      default:
-        break
+  if (checkIfLocationExists(variables, variableLocation) && variableLocation !== '') {
+    // Scan forward through the address space until we find a slot
+    // that no other variable in this table holds.  Single-increment
+    // wasn't enough: when the user kept clicking "+" through a row
+    // of contiguous variables, the increment would eventually land
+    // ON another already-bound row and silently produce a duplicate-
+    // location collision that only the compiler caught (forum
+    // thread, v4.2.0 follow-up).  An `inUse` set keeps the inner
+    // check O(1) so the loop is linear in the number of variables.
+    const inUse = new Set(variables.map((v) => v.location))
+    let candidate = variableLocation
+    let iterations = 0
+    while (inUse.has(candidate) && iterations < MAX_AUTO_INCREMENT_ITERATIONS) {
+      const next = incrementLocationByOne(candidate, variable.type.value)
+      if (!next || next === candidate) break // unknown type / no progress — bail
+      candidate = next
+      iterations += 1
     }
+    response.location = candidate
   }
   return response
 }

--- a/src/frontend/utils/__tests__/remote-device-options.test.ts
+++ b/src/frontend/utils/__tests__/remote-device-options.test.ts
@@ -42,10 +42,14 @@ describe('buildRemoteDeviceOptionGroups', () => {
   })
 
   it('groups points by device name', () => {
+    // Each address must be distinct — the production address pool
+    // enforces one-claim-per-address, and the builder dedupes
+    // defensively against legacy projects that drifted before that
+    // enforcement landed.
     const points = [
-      makeIOPoint({ deviceName: 'DevA', ioPointId: 'a1', alias: 'A1' }),
-      makeIOPoint({ deviceName: 'DevB', ioPointId: 'b1', alias: 'B1' }),
-      makeIOPoint({ deviceName: 'DevA', ioPointId: 'a2', alias: 'A2' }),
+      makeIOPoint({ deviceName: 'DevA', ioPointId: 'a1', iecLocation: '%IX0.0', alias: 'A1' }),
+      makeIOPoint({ deviceName: 'DevB', ioPointId: 'b1', iecLocation: '%IX0.1', alias: 'B1' }),
+      makeIOPoint({ deviceName: 'DevA', ioPointId: 'a2', iecLocation: '%IX0.2', alias: 'A2' }),
     ]
     const result = buildRemoteDeviceOptionGroups('c', points)
     expect(result).toHaveLength(2)
@@ -57,13 +61,30 @@ describe('buildRemoteDeviceOptionGroups', () => {
 
   it('mixes aliased and non-aliased points, keeping only aliased', () => {
     const points = [
-      makeIOPoint({ ioPointId: 'p1', alias: 'Yes' }),
-      makeIOPoint({ ioPointId: 'p2', alias: undefined }),
-      makeIOPoint({ ioPointId: 'p3', alias: 'Also' }),
+      makeIOPoint({ ioPointId: 'p1', iecLocation: '%IX0.0', alias: 'Yes' }),
+      makeIOPoint({ ioPointId: 'p2', iecLocation: '%IX0.1', alias: undefined }),
+      makeIOPoint({ ioPointId: 'p3', iecLocation: '%IX0.2', alias: 'Also' }),
     ]
     const result = buildRemoteDeviceOptionGroups('x', points)
     expect(result).toHaveLength(1)
     expect(result[0].options).toHaveLength(2)
+  })
+
+  it('dedupes by IEC address (defensive against legacy projects with duplicate-address entries)', () => {
+    // Production never produces this state (the address pool enforces
+    // uniqueness at write time), but legacy projects may have drifted
+    // into it before the gate existed.  First-iterated wins, matching
+    // the pool's reservation order.
+    const points = [
+      makeIOPoint({ ioPointId: 'first', iecLocation: '%IX0.0', alias: 'A_first' }),
+      makeIOPoint({ ioPointId: 'second', iecLocation: '%IX0.0', alias: 'A_second' }),
+      makeIOPoint({ ioPointId: 'third', iecLocation: '%IX0.1', alias: 'B_unique' }),
+    ]
+    const result = buildRemoteDeviceOptionGroups('x', points)
+    expect(result).toHaveLength(1)
+    expect(result[0].options).toHaveLength(2)
+    expect(result[0].options[0].label).toBe('%IX0.0 (A_first)')
+    expect(result[0].options[1].label).toBe('%IX0.1 (B_unique)')
   })
 
   it('uses cellId in option IDs', () => {

--- a/src/frontend/utils/location-dropdown-options.ts
+++ b/src/frontend/utils/location-dropdown-options.ts
@@ -11,6 +11,29 @@
  * the dropdown would offer addresses from producers the active target
  * has deactivated — e.g. an SLM-RP4 slot 1 entry still showing while
  * the user is targeting an Arduino Mega.
+ *
+ * Pin-mapping vs. VPP/remote-device dropdown asymmetry — by design:
+ *   - Pin-mapping options below (`pinGroup`) list **every pin**,
+ *     aliased or not.  Pin addresses on Arduino-style targets are
+ *     stable hardware facts (pin 13 = `%QX0.3` on Arduino Uno,
+ *     always), so addressing by raw IEC location stays meaningful
+ *     even without a user-supplied alias.  An empty `(alias)` suffix
+ *     just means the user hasn't given the pin a friendly name yet.
+ *   - VPP/module + remote-device options (`buildVendorIoOptionGroups` /
+ *     `buildRemoteDeviceOptionGroups` in `remote-device-options.ts`)
+ *     list only **aliased entries**.  Their IEC addresses are
+ *     allocator-assigned and can shift when the user changes slot
+ *     layout, adds modules, etc.  Variables that bind to an alias
+ *     survive those shifts (`syncVariableAliases` refreshes their
+ *     `location` via the registry); variables that bound to a raw
+ *     address would silently break.  Requiring an alias makes the
+ *     rebind-on-shift contract explicit.
+ *
+ * Do not "fix" the inconsistency by filtering the pin-mapping branch
+ * to aliased pins only — it would force users to write an alias
+ * before they can bind any variable to a pin, regressing the
+ * Arduino-style "bind by raw `%IX0.0`" workflow that pre-dates the
+ * alias machinery.
  */
 
 import type { DevicePin, IoMappingEntry } from '../../middleware/shared/ports/types'

--- a/src/frontend/utils/remote-device-options.ts
+++ b/src/frontend/utils/remote-device-options.ts
@@ -1,6 +1,30 @@
 /**
  * Utility functions for building remote device and vendor module IO point options.
  * Used in location dropdowns for variable tables.
+ *
+ * Dropdown asymmetry — by design:
+ *   - Pin-mapping options (see `location-dropdown-options.ts`) list
+ *     **every pin**, aliased or not.  Pin addresses on Arduino-style
+ *     targets are stable (pin 13 = `%QX0.3` on Arduino Uno, always),
+ *     so addressing by raw IEC location stays meaningful even without
+ *     a user-supplied alias.
+ *   - VPP module + remote-device options (this file) list **only
+ *     aliased entries**.  Their IEC addresses are allocator-assigned
+ *     and can shift when the user changes slot layout, adds modules,
+ *     etc.  Variables that bind to an alias survive those shifts
+ *     (the sync engine refreshes their `location` via the registry);
+ *     variables that bound to a raw address would silently break.
+ *     Requiring an alias makes the rebind-on-shift contract explicit.
+ *
+ * Dedupe contract: each address can appear at most once across all
+ * options this file produces.  The address pool enforces one-claim-
+ * per-address at registry-build time, so authoring through the live
+ * UI never produces duplicates.  Legacy projects authored before the
+ * write-time `validateAliasEdit` check existed may have drifted into
+ * a state where two entries claim the same `iecAddress` — for those,
+ * we skip later occurrences (first-iterated wins, matching the
+ * pool's first-wins reservation order) so the picker can never offer
+ * an ambiguous pick.
  */
 
 import type { IoMappingEntry } from '../../middleware/shared/ports/types'
@@ -36,9 +60,12 @@ type DropdownGroup = {
  */
 export function buildRemoteDeviceOptionGroups(cellId: string, remoteIOPoints: RemoteDeviceIOPoint[]): DropdownGroup[] {
   const groupsByDevice = new Map<string, DropdownOption[]>()
+  const seenAddresses = new Set<string>() // see file-level "Dedupe contract"
 
   for (const ioPoint of remoteIOPoints) {
     if (!ioPoint.alias) continue // Only show points with aliases
+    if (seenAddresses.has(ioPoint.iecLocation)) continue
+    seenAddresses.add(ioPoint.iecLocation)
 
     let deviceGroup = groupsByDevice.get(ioPoint.deviceName)
     if (!deviceGroup) {
@@ -69,9 +96,12 @@ export function buildRemoteDeviceOptionGroups(cellId: string, remoteIOPoints: Re
  */
 export function buildVendorIoOptionGroups(cellId: string, entries: IoMappingEntry[]): DropdownGroup[] {
   const groupsBySlot = new Map<string, DropdownOption[]>()
+  const seenAddresses = new Set<string>() // see file-level "Dedupe contract"
 
   for (const entry of entries) {
     if (!entry.alias) continue
+    if (seenAddresses.has(entry.iecAddress)) continue
+    seenAddresses.add(entry.iecAddress)
 
     const groupKey = `Slot ${entry.slot}: ${entry.moduleName}`
     let group = groupsBySlot.get(groupKey)

--- a/src/middleware/shared/utils/iec-address/__tests__/alias-registry.test.ts
+++ b/src/middleware/shared/utils/iec-address/__tests__/alias-registry.test.ts
@@ -1,6 +1,12 @@
 import { ARDUINO_CLI_CAPABILITIES, RUNTIME_V4_CAPABILITIES } from '../../target-capabilities'
 import { buildAddressPool } from '../address-pool'
-import { aliasForAddress, buildAliasRegistry, isAliasNameAvailable, resolveAlias } from '../alias-registry'
+import {
+  aliasForAddress,
+  buildAliasRegistry,
+  isAliasNameAvailable,
+  resolveAlias,
+  validateAliasEdit,
+} from '../alias-registry'
 
 const v4 = RUNTIME_V4_CAPABILITIES
 const arduino = ARDUINO_CLI_CAPABILITIES
@@ -190,5 +196,46 @@ describe('isAliasNameAvailable', () => {
 
   it('returns false when ignoring a different source', () => {
     expect(isAliasNameAvailable(reg, 'tank', { kind: 'modbus-tcp-remote', ref: 'd:p' })).toBe(false)
+  })
+})
+
+describe('validateAliasEdit', () => {
+  const pool = buildAddressPool(
+    {
+      vendorIoMapping: {
+        entries: [{ iecAddress: '%IW0', alias: 'tank', slot: 1, channelName: 'AI1' }],
+      },
+    },
+    v4WithVpp,
+  )
+  const reg = buildAliasRegistry(pool)
+
+  it('accepts an empty alias (user clearing the field)', () => {
+    expect(validateAliasEdit(reg, '', { kind: 'vpp-io', ref: 'slot-2:AI1' })).toEqual({ ok: true })
+    expect(validateAliasEdit(reg, '   ', { kind: 'vpp-io', ref: 'slot-2:AI1' })).toEqual({ ok: true })
+    expect(validateAliasEdit(reg, undefined, { kind: 'vpp-io', ref: 'slot-2:AI1' })).toEqual({ ok: true })
+  })
+
+  it('accepts a brand-new alias name', () => {
+    expect(validateAliasEdit(reg, 'pressure', { kind: 'vpp-io', ref: 'slot-2:AI1' })).toEqual({ ok: true })
+  })
+
+  it('accepts a no-op rename (same alias, same source)', () => {
+    expect(validateAliasEdit(reg, 'tank', { kind: 'vpp-io', ref: 'slot-1:AI1' })).toEqual({ ok: true })
+  })
+
+  it('rejects a collision with another channel and returns the conflicting entry', () => {
+    const result = validateAliasEdit(reg, 'tank', { kind: 'vpp-io', ref: 'slot-2:AI1' })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.conflict.alias).toBe('tank')
+      expect(result.conflict.address).toBe('%IW0')
+      expect(result.conflict.source).toEqual({ kind: 'vpp-io', ref: 'slot-1:AI1' })
+    }
+  })
+
+  it('rejects a collision across producers (pin-mapping vs VPP)', () => {
+    const result = validateAliasEdit(reg, 'tank', { kind: 'pin-mapping', ref: '%QX0.0' })
+    expect(result.ok).toBe(false)
   })
 })

--- a/src/middleware/shared/utils/iec-address/__tests__/sync-variable-aliases.test.ts
+++ b/src/middleware/shared/utils/iec-address/__tests__/sync-variable-aliases.test.ts
@@ -61,12 +61,16 @@ describe('syncVariableAliases', () => {
     expect(result.report.refreshed).toEqual([])
   })
 
-  it('reports orphaned variables when the alias no longer exists in the registry', () => {
+  it('orphans clear the stale location but keep the alias for the UI warning glyph', () => {
     const registry = buildRegistryFromVpp([])
     const vars = [VAR({ name: 'ghost', location: '%QX2.0', alias: 'removed_module' })]
     const result = syncVariableAliases(vars, registry)
-    // Variable kept as-is so the user can re-bind manually.
-    expect(result.variables[0].location).toBe('%QX2.0')
+    // `location` is cleared so the ST / XML emitters don't bake an
+    // `AT %QX2.0` for an alias whose producer is no longer active.
+    // `alias` is kept so the variable cell renders the orphan glyph
+    // and tooltip; the previous address is preserved in the report's
+    // `lastKnownAddress` field for the tooltip + undo affordance.
+    expect(result.variables[0].location).toBe('')
     expect(result.variables[0].alias).toBe('removed_module')
     expect(result.report.orphaned).toEqual([{ varName: 'ghost', alias: 'removed_module', lastKnownAddress: '%QX2.0' }])
     expect(result.report.adopted).toEqual([])
@@ -87,7 +91,10 @@ describe('syncVariableAliases', () => {
     const result = syncVariableAliases(vars, registry)
     expect(result.variables[0]).toMatchObject({ name: 'adopted', alias: 'pressure', location: '%IW1' })
     expect(result.variables[1]).toMatchObject({ name: 'refreshed', alias: 'valve_open', location: '%QX3.2' })
-    expect(result.variables[2]).toMatchObject({ name: 'orphaned', alias: 'gone', location: '%QW9' })
+    // Orphaned variables retain their alias (for the UI warning) but
+    // get their location cleared — see the "orphans clear the stale
+    // location" case above for the standalone version of this rule.
+    expect(result.variables[2]).toMatchObject({ name: 'orphaned', alias: 'gone', location: '' })
     expect(result.variables[3]).toMatchObject({ name: 'untouched', location: '%MW100' })
 
     expect(result.report.adopted).toHaveLength(1)

--- a/src/middleware/shared/utils/iec-address/alias-registry.ts
+++ b/src/middleware/shared/utils/iec-address/alias-registry.ts
@@ -90,3 +90,99 @@ export function isAliasNameAvailable(registry: AliasRegistry, alias: string, ign
   if (!ignoring) return false
   return entry.source.kind === ignoring.kind && entry.source.ref === ignoring.ref
 }
+
+/** Outcome of `validateAliasEdit`.  When `ok` is false, `conflict`
+ *  carries the in-registry entry that already owns the alias, so
+ *  callers can render a precise error message (e.g.  "alias 'relay_1'
+ *  is already used by slot 2 channel O3").
+ */
+export type AliasEditValidation = { ok: true } | { ok: false; conflict: AliasEntry }
+
+/**
+ * Human-readable description of a `SourceRef`, for use inside error
+ * toasts / inline validation messages.  Centralised here so every
+ * producer's alias-edit screen renders the same wording when the
+ * uniqueness check rejects an edit.
+ *
+ * Format examples:
+ *   - `pin-mapping` ref="%QX0.0"            → "pin mapping (%QX0.0)"
+ *   - `vpp-io` ref="slot-2:O3"              → "VPP slot 2 channel O3"
+ *   - `modbus-tcp-remote` ref="d1:point17"  → "Modbus device d1 point point17"
+ *   - `ethercat` ref="bus0:slave2:ch5"      → "EtherCAT bus0 slave2 channel ch5"
+ *
+ * Unknown formats fall back to a verbatim `${kind} ${ref}` rendering
+ * so future producer kinds at least show something useful before this
+ * helper is updated.
+ */
+export function describeSource(source: SourceRef): string {
+  switch (source.kind) {
+    case 'pin-mapping':
+      return `pin mapping (${source.ref})`
+    case 'vpp-io': {
+      // ref shape "slot-<n>:<channelName>" — see address-pool.ts:218.
+      const match = /^slot-(\d+):(.+)$/.exec(source.ref)
+      if (match) return `VPP slot ${match[1]} channel ${match[2]}`
+      return `VPP I/O (${source.ref})`
+    }
+    case 'modbus-tcp-remote': {
+      // ref shape "<deviceName>:<pointId>" — see address-pool.ts:228.
+      const idx = source.ref.indexOf(':')
+      if (idx > 0) {
+        const device = source.ref.slice(0, idx)
+        const point = source.ref.slice(idx + 1)
+        return `Modbus device ${device} point ${point}`
+      }
+      return `Modbus TCP (${source.ref})`
+    }
+    case 'ethercat': {
+      // ref shape "<deviceName>:<slaveRef>:<channelId>" — see address-pool.ts:243.
+      const parts = source.ref.split(':')
+      if (parts.length === 3) return `EtherCAT ${parts[0]} slave ${parts[1]} channel ${parts[2]}`
+      return `EtherCAT (${source.ref})`
+    }
+    default:
+      // Exhaustive-fallback.  TypeScript narrows `source` to `never`
+      // here when every `SourceKind` above is covered, so this branch
+      // only executes when a future `SourceKind` lands without
+      // updating this helper.  We stringify defensively rather than
+      // dereferencing `source.kind` / `source.ref` (which TS would
+      // reject on the narrowed `never`).
+      return JSON.stringify(source)
+  }
+}
+
+/**
+ * Validate an alias-edit at write time.  Wraps `isAliasNameAvailable`
+ * and returns the conflicting entry so the calling UI can produce a
+ * helpful toast / inline error instead of a generic "already in use".
+ *
+ * Semantics:
+ *   - Empty / whitespace-only `alias` is always OK (user clearing the
+ *     alias is the normal way to detach a channel from its variables).
+ *   - When the alias is already claimed by **the same channel** that's
+ *     being edited (`ignoring` matches the in-registry source), the
+ *     edit is OK — this lets the UI commit no-op writes without
+ *     spuriously failing.
+ *   - When the alias is already claimed by **a different channel**,
+ *     the edit is rejected and `conflict` carries the surviving entry.
+ *
+ * Every IO-mapping screen / pin-mapping table / remote-device editor
+ * MUST call this before persisting a new alias, otherwise the registry
+ * silently first-wins on duplicates and the variables bound to the
+ * losing entry are subsequently collapsed by `syncVariableAliases` to
+ * the winner's address.  See the architectural notes at the top of
+ * `address-pool.ts` for the full reservation chain.
+ */
+export function validateAliasEdit(
+  registry: AliasRegistry,
+  alias: string | undefined,
+  ignoring: SourceRef,
+): AliasEditValidation {
+  if (!alias || alias.trim().length === 0) return { ok: true }
+  const entry = registry.byAlias.get(alias)
+  if (!entry) return { ok: true }
+  if (entry.source.kind === ignoring.kind && entry.source.ref === ignoring.ref) {
+    return { ok: true }
+  }
+  return { ok: false, conflict: entry }
+}

--- a/src/middleware/shared/utils/iec-address/index.ts
+++ b/src/middleware/shared/utils/iec-address/index.ts
@@ -15,12 +15,15 @@ export {
   type SourceRef,
 } from './address-pool'
 export {
+  type AliasEditValidation,
   type AliasEntry,
   aliasForAddress,
   type AliasRegistry,
   buildAliasRegistry,
+  describeSource,
   isAliasNameAvailable,
   resolveAlias,
+  validateAliasEdit,
 } from './alias-registry'
 export {
   type SyncableVariable,

--- a/src/middleware/shared/utils/iec-address/sync-variable-aliases.ts
+++ b/src/middleware/shared/utils/iec-address/sync-variable-aliases.ts
@@ -15,9 +15,14 @@
  *                    reallocates its addresses.
  *   - **orphaned**:  variable has an alias the registry no longer
  *                    knows about (its producer was removed, or
- *                    target-switched away). Keeps `location` and
- *                    `alias` so the user can decide; reported so
- *                    the UI can flag the cell.
+ *                    target-switched away).  Keeps `alias` so the
+ *                    UI can show the orphan warning + tooltip, but
+ *                    **clears `location`** so the ST / XML emitters
+ *                    don't bake the stale `AT %…` into the compile.
+ *                    The user can re-bind via the picker; the
+ *                    previous address is preserved in the report's
+ *                    `lastKnownAddress` field for an undo / tooltip
+ *                    affordance.
  *
  * Pure function: same inputs always produce the same outputs.
  * Safe to call from any context — store actions, the pre-compile
@@ -65,7 +70,14 @@ export function syncVariableAliases<V extends SyncableVariable>(
           alias: variable.alias,
           lastKnownAddress: variable.location,
         })
-        next.push(variable)
+        // Clear the stale location so the compile step (ST + XML
+        // emitters) doesn't bake an `AT %…` for an address whose
+        // producer is no longer active.  The alias name is retained
+        // so the variable cell can render the orphan warning and the
+        // tooltip can surface the last-known address from the report.
+        // When the user re-binds, `updateVariable`'s auto-adopt path
+        // re-attaches the alias against the live registry.
+        next.push({ ...variable, location: '' })
         continue
       }
       if (entry.address !== variable.location) {


### PR DESCRIPTION
## Summary

Repairs the alias↔location architecture in the variables / IEC address allocator and the graphical-editor variable picker.  All four commits address user-reported bugs from the v4.2.0 forum thread *openplc-420-teething-bugs*.

The driving model (per the maintainer's clarification): the mapping registry allocates one unique IEC address per I/O channel; the **alias** is a shortcut to that channel, NOT to the address.  Each commit closes a specific gap where the previous code either let the alias drift away from its channel or accidentally created/renamed/destroyed bindings the user did not request.

- **`fix(alias): enforce unique aliases at write time + cascade rename + clear orphaned locations`** (8001308c9)
  Five phases — write-time uniqueness gate on every alias-edit screen, alias-rename cascade to bound variables, orphan branch clears `variable.location` so the ST/XML compiler stops emitting stale `AT %…` clauses, doc notes on the pin-mapping vs VPP/remote dropdown asymmetry, and defensive dedupe-by-address in the dropdown builders.
- **`fix(alias): enforce alias-↔-location invariant on createVariable + same-address re-pick`** (cbd87180c)
  "+" button on the variables table no longer carries the previous row's alias forward to the new auto-incremented address.  `createVariable` now auto-adopts via a new `resolveAliasForLocation` helper; both "+" callsites drop the stale alias in their spreads; `editable-cell` short-circuit grows an `isMismatched` exception so legacy projects repair with one click.
- **`fix(alias): walk past intervening claims when auto-incrementing IEC location`** (247346c97)
  `createVariableValidation` previously incremented by one and returned without re-checking.  Now extracts `incrementLocationByOne` and loops the check-and-increment until the candidate is free of other variables in the same table, with an 8192-iteration safety bound.
- **`fix(graphical-editor): bind to exact-match variable on Enter instead of creating duplicate`** (5c0e88512)
  Typing the exact name of an existing variable in a ladder contact / coil or an FBD input/output variable and pressing Return no longer creates a renamed duplicate.  `GraphicalEditorAutocomplete` now resolves an exact case-insensitive match against the visible list before falling through to "Add variable".

## Shared-surface note

Every code path lives under `frontend/` or `middleware/shared/`, both byte-identical between openplc-editor and openplc-web.  A matching PR on openplc-web will mirror the same diff.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm jest --no-coverage` — 217 suites / 4875 tests pass
- [x] Manual ladder rename: type exact name of existing variable, hit Return → binds instead of creating duplicate (confirmed by reporter)
- [x] Manual variable "+" chain past existing addresses → walks to next free slot (confirmed by reporter)
- [ ] Cross-check FBD input/output-variable rename (same atom path; trace verified)
- [ ] Run on Opta target to confirm the original *Variable picker shows wrong alias* / *outputs collapse to %QX0.0* symptoms are gone end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autocomplete: Enter/Tab now implicitly submits exact variable-name matches.
  * Picker options: IEC addresses deduplicated; remote/vendor lists only show alias-backed entries.

* **Bug Fixes / Improvements**
  * Alias uniqueness enforced with user-facing error toasts on conflicts.
  * Alias renames now cascade reliably to bound variables.
  * Creating variables no longer carries stale aliases; orphaned aliases keep their name but clear stale locations.
  * Re-blurring unchanged alias/location can now refresh bindings when stale/mismatched.

* **Tests**
  * Added/updated tests for auto-increment, orphan handling, and alias validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->