### PR TITLE
fix(transpiler): resolve polymorphic TO_<TYPE> conversions in JSON→ST emitter

### DIFF
--- a/src/backend/shared/transpilers/st-transpiler/emit/pou-graphical.ts
+++ b/src/backend/shared/transpilers/st-transpiler/emit/pou-graphical.ts
@@ -35,9 +35,27 @@ interface InterfaceEntry {
  * polymorphic conversion target.
  */
 const TO_CONVERSION_TARGETS: ReadonlySet<string> = new Set([
-  'BCD', 'BOOL', 'BYTE', 'DATE', 'DINT', 'DT', 'DWORD', 'INT',
-  'LINT', 'LREAL', 'LWORD', 'REAL', 'SINT', 'STRING', 'TIME',
-  'TOD', 'UDINT', 'UINT', 'ULINT', 'USINT', 'WORD',
+  'BCD',
+  'BOOL',
+  'BYTE',
+  'DATE',
+  'DINT',
+  'DT',
+  'DWORD',
+  'INT',
+  'LINT',
+  'LREAL',
+  'LWORD',
+  'REAL',
+  'SINT',
+  'STRING',
+  'TIME',
+  'TOD',
+  'UDINT',
+  'UINT',
+  'ULINT',
+  'USINT',
+  'WORD',
 ])
 
 /* ─────────────────────────── public entry ───────────────────────────────── */

--- a/src/backend/shared/transpilers/st-transpiler/emit/pou-graphical.ts
+++ b/src/backend/shared/transpilers/st-transpiler/emit/pou-graphical.ts
@@ -26,6 +26,20 @@ interface InterfaceEntry {
   vars: TranspileVariable[]
 }
 
+/**
+ * Destination types of the IEC 61131-3 polymorphic conversion family
+ * (`TO_BOOL`, `TO_INT`, `TO_UINT`, …).  Hard-coded here rather than
+ * derived at runtime from the catalog so any future addition is visible
+ * in code review.  Kept in sync with `data/std_block_catalog.json` — any
+ * `<SRC>_TO_<X>` entry in the catalog implies `TO_<X>` is a valid
+ * polymorphic conversion target.
+ */
+const TO_CONVERSION_TARGETS: ReadonlySet<string> = new Set([
+  'BCD', 'BOOL', 'BYTE', 'DATE', 'DINT', 'DT', 'DWORD', 'INT',
+  'LINT', 'LREAL', 'LWORD', 'REAL', 'SINT', 'STRING', 'TIME',
+  'TOD', 'UDINT', 'UINT', 'ULINT', 'USINT', 'WORD',
+])
+
 /* ─────────────────────────── public entry ───────────────────────────────── */
 
 /**
@@ -68,6 +82,15 @@ export function generateGraphicalPou(pou: TranspilePou, project: TranspileProjec
   //      …) collapse to `BOOL`, which matches the corpus where these
   //      operators are always Boolean rung logic.  A future
   //      computeConnectionTypes port will narrow these properly.
+  //   3. Polymorphic IEC 61131-3 type-conversion functions of the
+  //      form `TO_<TYPE>` (TO_INT, TO_UINT, TO_REAL, …) — the
+  //      catalog enumerates the source-specific variants
+  //      (`BOOL_TO_UINT`, `INT_TO_UINT`, …) but NOT the generic
+  //      `TO_<TYPE>` family, so resolveBlockType returns null for
+  //      them.  Without this case the synthetic var stayed at
+  //      `ANY` and strucpp rejected the program with
+  //      "Undefined type 'ANY' in PROGRAM" — fixed here by reading
+  //      the destination type directly from the function name.
   const resolvedSyntheticVars = emitted.syntheticVars.map<SyntheticVar>((sv) => {
     if (sv.type !== 'ANY' || sv.originBlockTypeName === undefined) return sv
     const referenced = project.pous.find((p) => p.name === sv.originBlockTypeName)
@@ -81,6 +104,10 @@ export function generateGraphicalPou(pou: TranspilePou, project: TranspileProjec
         const collapsed = outPort.type.startsWith('ANY') ? 'BOOL' : outPort.type
         return { ...sv, type: collapsed }
       }
+    }
+    const polymorphicMatch = sv.originBlockTypeName.match(/^TO_([A-Z]+)$/)
+    if (polymorphicMatch && TO_CONVERSION_TARGETS.has(polymorphicMatch[1])) {
+      return { ...sv, type: polymorphicMatch[1] }
     }
     return sv
   })


### PR DESCRIPTION
## Summary

User-reported regression: a project that compiles fine on the web editor failed on the desktop editor with:

```
main.st:15:30: error: Undefined type 'ANY' in PROGRAM 'MAIN'
  15 |     _TMP_TO_UINT874561_OUT : ANY;
```

The bug is in the new JSON→ST transpiler from PR #843 — synthetic output temps for polymorphic IEC type-conversion functions (`TO_INT`, `TO_UINT`, `TO_REAL`, …) were left at `ANY` because the catalog only enumerates source-specific variants (`BOOL_TO_UINT`, `INT_TO_UINT`, …), never the polymorphic shortcuts.  STruC++ correctly rejects `ANY` as a variable declaration type — it's a generic placeholder, not a concrete type.

Web compiled the same project because it's still on xml2st in a worker (different compiler, different code path).

## Fix

Single file (`src/backend/shared/transpilers/st-transpiler/emit/pou-graphical.ts`), 27 lines added.  After the catalog lookup fails, the resolver now matches `^TO_([A-Z]+)$` against the block name and, if the suffix is one of the 21 known IEC destination types (BOOL/INT/UINT/REAL/DINT/LREAL/BYTE/WORD/DWORD/LWORD/SINT/USINT/LINT/ULINT/UDINT/BCD/TIME/DATE/TOD/DT/STRING), uses the suffix as the output type.  Unknown block names still fall through to `ANY` so STruC++ produces the same clear error for truly-unknown blocks — no regression on the unhappy path.

## Why this is essentially a no-op today

With PR #853 just merged, the editor ships with `OPENPLC_USE_NEW_TRANSPILER` defaulting to OFF — the new JSON→ST transpiler is only exercised when an operator explicitly opts in.  Production projects still flow through legacy xml2st.  This fix lands the moment-someone-flips-the-toggle behavior we want, without changing default compilation.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Manual: with `OPENPLC_USE_NEW_TRANSPILER=1`, compile `~/Downloads/Blink Demo Multilanguage` (two `TO_UINT` blocks at numericId `874561` and `9788614`) — should now emit `: UINT` instead of `: ANY` and pass STruC++

## Shared-surface mirror

`emit/pou-graphical.ts` is part of the byte-identical shared surface.  A matching commit on openplc-web is required (will be opened in tandem so the sync check passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resolution of type-conversion results so temporary "any" types are correctly assigned their destination type for IEC 61131-3-style conversions, preventing unresolved types and incorrect type propagation in graphical diagrams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->