### PR TITLE
chore(release): bump version to 4.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-plc-editor",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "license": "GPL-3.0",
   "author": {
     "name": "Autonomy Logic"

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-plc-editor",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
   "license": "MIT",
   "author": {

--- a/src/frontend/data/constants/app-version.ts
+++ b/src/frontend/data/constants/app-version.ts
@@ -18,4 +18,4 @@
  * compares a per-deploy `BUILD_ID` (git commit SHA), not this version, so a
  * stale tab is detected on every deploy even without a version bump.
  */
-export const APP_VERSION = '4.2.1'
+export const APP_VERSION = '4.2.2'


### PR DESCRIPTION
Three-file version bump: 4.2.1 → 4.2.2.

- `package.json` (root)
- `release/app/package.json` (electron-builder installer metadata)
- `src/frontend/data/constants/app-version.ts` (shared with openplc-web, displayed at runtime)

Tags the editor development line for the v4.2.2 release.  Content of 4.2.2 since v4.2.1:

- **#850** alias-architecture (this was already in 4.2.1's diff but never tagged — first time it ships under a version)
- **#852** web-app-versioning (shared APP_VERSION wiring)
- **#853** feat(transpiler): build-time toggle, ships with legacy xml2st as default
- **#854** fix(transpiler): polymorphic `TO_<TYPE>` conversions resolve to concrete output types (no-op while toggle stays default-off)

The matching web bump is at openplc-web PR #505 (`release/app-version-4.2.2` → development).  The two need to land together to keep the shared-surface byte-identity check happy on both repos.

After this lands on development, the next step is `development` → `main` and tag `v4.2.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 4.2.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->