### PR TITLE
ci(release): pin Windows runners to windows-2025 (VS 2026 maxBuffer bug)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,13 @@ jobs:
   # Windows Build - x64
   # =============================================================================
   build-windows-x64:
-    runs-on: windows-latest
+    # Pinned alongside build-windows-arm64 (see the comment block on
+    # that job for the full story).  The Win-x64 build succeeded on
+    # `windows-latest = windows-2025-vs2026` for v4.2.2, but the
+    # underlying VS 2026 maxBuffer issue could trip x64 too on a
+    # future runner rotation.  Pinning both today is cheaper than
+    # debugging the same class of failure again in a few months.
+    runs-on: windows-2025
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -186,7 +192,22 @@ jobs:
   # Windows Build - ARM64
   # =============================================================================
   build-windows-arm64:
-    runs-on: windows-latest
+    # Pin to windows-2025 (NOT windows-latest): `windows-latest`
+    # rotated to the `windows-2025-vs2026` image variant between the
+    # v4.2.1 (Jun 7) and v4.2.2 (Jun 8) release runs.  v4.2.1's
+    # successful build ran on the base `windows-2025` image (VS 2022
+    # default); v4.2.2's failed build ran on `windows-2025-vs2026`
+    # (Visual Studio 2026).  VS 2026's `vswhere`/PowerShell
+    # enumeration emits enough metadata that node-gyp's child_process
+    # stdout read overflows with `RangeError
+    # [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]` — node-gyp then reports
+    # "Could not find any Visual Studio installation to use" and the
+    # ARM64 cross-compile of `@serialport/bindings-cpp` fails.
+    # Explicit pin to `windows-2025` (VS 2022 default) restores the
+    # environment that produced v4.2.0 / v4.2.1.  When node-gyp /
+    # electron-builder ship a fix for the VS 2026 maxBuffer issue
+    # we can revert to `windows-latest`.
+    runs-on: windows-2025
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fixes the v4.2.2 release build failure on Win-ARM64.  Pins both Windows jobs (x64 + arm64) to the `windows-2025` runner image (VS 2022), matching what produced the successful v4.2.0 / v4.2.1 releases.

`windows-latest` rotated to `windows-2025-vs2026` (VS 2026) between Jun 7 and Jun 8.  VS 2026's `vswhere`/PowerShell discovery output overflows node-gyp's child_process buffer when cross-compiling native modules for ARM64 — node-gyp then reports "Could not find any Visual Studio installation."  Reproducible on every retry; not a flake.  Full diagnosis in the commit message.

## Follow-up

The v4.2.2 tag currently points at a commit that doesn't have this fix.  Release workflow files are resolved at the tag's commit, so re-running the existing failed workflow would use the same broken definition.  After this lands, the v4.2.2 tag will be force-updated to the new merge commit, which will trigger a fresh release workflow run with the pinned runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)