### PR TITLE
fix(debug): runtime v4 debug without configured IP; bump v4.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-plc-editor",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "license": "GPL-3.0",
   "author": {
     "name": "Autonomy Logic"

--- a/src/backend/shared/firmware/hals.json
+++ b/src/backend/shared/firmware/hals.json
@@ -108,8 +108,7 @@
           "enabledWhen": true,
           "params": {
             "ipAddress": {
-              "$ref": "configuration.runtimeIpAddress",
-              "required": "Runtime IP address is not configured."
+              "$ref": "configuration.runtimeIpAddress"
             },
             "jwtToken": {
               "$ref": "runtimeConnection.jwtToken",

--- a/src/backend/shared/hardware/__tests__/debug-spec.test.ts
+++ b/src/backend/shared/hardware/__tests__/debug-spec.test.ts
@@ -553,5 +553,48 @@ describe('resolveDebugConnection', () => {
         })
       }
     })
+
+    // Regression (openplc-web vPLC debug): the v4 websocket `ipAddress`
+    // param is an OPTIONAL `$ref` — no `required` annotation — so a
+    // platform that routes by orchestrator device context instead of a
+    // direct IP (web) resolves to `config` with the param simply
+    // dropped, rather than erroring with "Runtime IP address is not
+    // configured."  The desktop still gets a real IP because its
+    // `runtimeConnected` precondition can't pass without one.
+    it('Runtime v4: websocket resolves to config when runtimeIpAddress is absent (orchestrator-routed)', () => {
+      const spec: DebugSpec = {
+        preconditions: ['runtimeConnected', 'jwtToken'],
+        channels: [
+          {
+            label: 'WebSocket',
+            channel: 'websocket',
+            enabledWhen: true,
+            params: {
+              ipAddress: { $ref: 'configuration.runtimeIpAddress' },
+              jwtToken: { $ref: 'runtimeConnection.jwtToken' },
+            },
+          },
+        ],
+      }
+      const result = resolveDebugConnection(
+        spec,
+        makeContext({
+          // No runtimeIpAddress — web vPLC targets route through the orchestrator.
+          state: {
+            configuration: { deviceBoard: 'OpenPLC Runtime v4' },
+            runtimeConnection: { jwtToken: 'abc.def.ghi' },
+          },
+          capabilities: { runtimeConnected: true, jwtToken: true },
+        }),
+      )
+      expect(result.kind).toBe('config')
+      if (result.kind === 'config') {
+        // ipAddress dropped (undefined ref, not required); jwt still present.
+        expect(result.config).toEqual({
+          connectionType: 'websocket',
+          connectionParams: { jwtToken: 'abc.def.ghi' },
+        })
+      }
+    })
   })
 })

--- a/src/frontend/data/constants/app-version.ts
+++ b/src/frontend/data/constants/app-version.ts
@@ -18,4 +18,4 @@
  * compares a per-deploy `BUILD_ID` (git commit SHA), not this version, so a
  * stale tab is detected on every deploy even without a version bump.
  */
-export const APP_VERSION = '4.2.2'
+export const APP_VERSION = '4.2.3'


### PR DESCRIPTION
## Summary
Drops the `required` annotation on the v4 websocket debug channel's `ipAddress` param in the shared `hals.json`, fixing the **"Runtime IP address is not configured"** modal that blocked debugging vPLC (Runtime v4) targets on openplc-web.

- Web vPLC targets route through the orchestrator (agentId/deviceId) and never set `configuration.runtimeIpAddress`, so the shared resolver errored before a session could start.
- Desktop is unaffected: the `runtimeConnected` precondition already cannot pass without an IP (editor `isReadyForDebug()` requires it), and the editor websocket transport still reads the resolved `ipAddress`. The annotation was redundant on desktop.
- On web the ref resolves to `undefined`, is dropped, and the transport routes via the selected device — same model the runtime-v4 upload path already uses.

Bumps shared `APP_VERSION` and editor `package.json` to **4.2.3**.

Coordinated byte-identical mirror with openplc-web (same-named branch/PR).

## Test plan
- [x] `debug-spec.test.ts` — 29 pass incl. new regression (v4 websocket resolves to `config` when `runtimeIpAddress` absent)
- [x] hardware/compile/device suites — 190 pass
- [x] `hals.json`, `debug-spec.test.ts`, `app-version.ts` verified byte-identical across both repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  * Bumped version to 4.2.3

* **Bug Fixes**
  * Fixed WebSocket debug configuration for OpenPLC Runtime v4 to properly handle optional runtime IP address in orchestrator-routed contexts, eliminating incorrect validation errors.

* **Tests**
  * Added regression test for debug connection resolution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->