### PR TITLE
chore: bump version to 4.2.4 (shared APP_VERSION mirror)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-plc-editor",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "license": "GPL-3.0",
   "author": {
     "name": "Autonomy Logic"

--- a/src/frontend/data/constants/app-version.ts
+++ b/src/frontend/data/constants/app-version.ts
@@ -18,4 +18,4 @@
  * compares a per-deploy `BUILD_ID` (git commit SHA), not this version, so a
  * stale tab is detected on every deploy even without a version bump.
  */
-export const APP_VERSION = '4.2.3'
+export const APP_VERSION = '4.2.4'


### PR DESCRIPTION
## Summary
Byte-identical `APP_VERSION` bump to **4.2.4** mirroring openplc-web's v4.2.4 release (PWA removal / reliable-update fix). No functional editor change — the desktop app has no service worker; the version constant must stay in sync across both repos for the shared-surface gate. Also bumps `package.json` to match (release.yml keeps them equal).

Pairs with openplc-web PR for v4.2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Application version updated to 4.2.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->