### PR TITLE
release: promote development to main (v4.2.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-plc-editor",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "license": "GPL-3.0",
   "author": {
     "name": "Autonomy Logic"

--- a/src/frontend/data/constants/app-version.ts
+++ b/src/frontend/data/constants/app-version.ts
@@ -18,4 +18,4 @@
  * compares a per-deploy `BUILD_ID` (git commit SHA), not this version, so a
  * stale tab is detected on every deploy even without a version bump.
  */
-export const APP_VERSION = '4.2.3'
+export const APP_VERSION = '4.2.4'


### PR DESCRIPTION
Promotes `development` → `main`.

Carries the shared **APP_VERSION 4.2.4** bump mirroring openplc-web's v4.2.4 release (PWA removal + debug-compile fix). No desktop release tag created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)