### PR TITLE
feat(vpp): package prebuilt-object plugins for upload

### DIFF
--- a/src/backend/editor/compiler/__tests__/handle-vendor-plugin-packaging.test.ts
+++ b/src/backend/editor/compiler/__tests__/handle-vendor-plugin-packaging.test.ts
@@ -1,0 +1,159 @@
+/**
+ * `CompilerModule.handleVendorPluginPackaging` — prebuilt vs source
+ * provisioning branch.
+ *
+ * The packager treats `hal.pluginEntry` differently depending on
+ * `hal.provisioning`:
+ *   - "prebuilt": pluginEntry IS the directory holding the precompiled
+ *     `.o` objects + link-only Makefile — copied verbatim.
+ *   - source (default / absent): pluginEntry is the entry source FILE,
+ *     so the directory to copy is its parent.
+ *
+ * We drive the real method against a temp filesystem, mocking only the
+ * package manager (which board/manifest it sees) and electron (so the
+ * module import doesn't try to reach the Electron app at load time).
+ * The method doesn't touch `this`, so we invoke it via the prototype
+ * and skip the constructor entirely.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// The module calls `electronApp.getPath(...)` in its constructor; we never
+// construct it here, but the top-level `import electron` still has to resolve.
+jest.mock('electron', () => ({
+  app: { getPath: () => tmpdir() },
+  dialog: {},
+  MessageChannelMain: class {},
+}))
+
+const listInstalled = jest.fn()
+const getInstalledPackageManifest = jest.fn()
+jest.mock('../../package-manager', () => ({
+  PackageManagerModule: jest.fn().mockImplementation(() => ({
+    listInstalled,
+    getInstalledPackageManifest,
+  })),
+}))
+
+// eslint-disable-next-line import/first
+import { CompilerModule } from '../compiler-module'
+
+type LogEntry = { message: string; level: string }
+
+const BOARD = 'Raspberry Pi (prebuilt test)'
+
+const handler = CompilerModule.prototype.handleVendorPluginPackaging
+
+function makeManifest(hal: Record<string, unknown>) {
+  return {
+    devices: [
+      {
+        name: BOARD,
+        target: { type: 'runtime-v4' },
+        hal,
+        moduleSystem: undefined,
+      },
+    ],
+  }
+}
+
+/** Writes a plugin directory with two payload files + an excluded one. */
+function writePluginDir(pkgDir: string): string {
+  const pluginDir = join(pkgDir, 'hal', 'runtime-v4', 'plugin')
+  mkdirSync(pluginDir, { recursive: true })
+  writeFileSync(join(pluginDir, 'rpi_plugin.o'), 'OBJECT-BYTES')
+  writeFileSync(join(pluginDir, 'Makefile'), 'all:\n\techo link\n')
+  // Excluded by the packager — must not be copied into vpp_plugin/.
+  writeFileSync(join(pluginDir, 'config_template.json'), JSON.stringify({ plugin_name: 'rpi_gpio', pins: [] }))
+  return pluginDir
+}
+
+describe('handleVendorPluginPackaging — provisioning branch', () => {
+  let pkgDir: string
+  let projectDir: string
+  let targetDir: string
+  let logs: LogEntry[]
+
+  const runFor = (hal: Record<string, unknown>) => {
+    listInstalled.mockReturnValue([{ packageId: 'com.openplc.rpi', path: pkgDir }])
+    getInstalledPackageManifest.mockReturnValue(makeManifest(hal))
+    return handler.call(
+      {} as CompilerModule,
+      BOARD,
+      projectDir,
+      targetDir,
+      (message: string | Buffer, level?: string) => {
+        logs.push({ message: String(message), level: level ?? '' })
+      },
+    )
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    pkgDir = mkdtempSync(join(tmpdir(), 'vpp-pkg-'))
+    projectDir = mkdtempSync(join(tmpdir(), 'vpp-proj-'))
+    targetDir = mkdtempSync(join(tmpdir(), 'vpp-target-'))
+    logs = []
+    writePluginDir(pkgDir)
+  })
+
+  afterEach(() => {
+    for (const dir of [pkgDir, projectDir, targetDir]) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('treats pluginEntry as a directory when provisioning is "prebuilt"', async () => {
+    await runFor({
+      type: 'runtime-v4-plugin',
+      pluginType: 'native',
+      provisioning: 'prebuilt',
+      pluginEntry: 'hal/runtime-v4/plugin',
+      configTemplate: 'hal/runtime-v4/plugin/config_template.json',
+    })
+
+    const dest = join(targetDir, 'vpp_plugin')
+    expect(existsSync(join(dest, 'rpi_plugin.o'))).toBe(true)
+    expect(existsSync(join(dest, 'Makefile'))).toBe(true)
+    // Excluded file is never copied.
+    expect(existsSync(join(dest, 'config_template.json'))).toBe(false)
+    // Deterministic integrity checksum is emitted.
+    expect(existsSync(join(dest, 'checksum.sha256'))).toBe(true)
+    // The summary log distinguishes the prebuilt path.
+    expect(logs.some((l) => /prebuilt file\(s\)/.test(l.message))).toBe(true)
+  })
+
+  it('treats pluginEntry as a file and copies its parent dir in source mode (provisioning absent)', async () => {
+    // Source-mode pluginEntry points at the entry FILE; the directory to copy
+    // is its parent — the same plugin dir, reached via dirname().
+    writeFileSync(join(pkgDir, 'hal', 'runtime-v4', 'plugin', 'rpi_plugin.c'), 'int main(){}')
+
+    await runFor({
+      type: 'runtime-v4-plugin',
+      pluginType: 'native',
+      pluginEntry: 'hal/runtime-v4/plugin/rpi_plugin.c',
+      configTemplate: 'hal/runtime-v4/plugin/config_template.json',
+    })
+
+    const dest = join(targetDir, 'vpp_plugin')
+    expect(existsSync(join(dest, 'rpi_plugin.c'))).toBe(true)
+    expect(existsSync(join(dest, 'Makefile'))).toBe(true)
+    expect(existsSync(join(dest, 'config_template.json'))).toBe(false)
+    expect(logs.some((l) => /source file\(s\)/.test(l.message))).toBe(true)
+  })
+
+  it('copies the payload byte-for-byte (prebuilt object content preserved)', async () => {
+    await runFor({
+      type: 'runtime-v4-plugin',
+      pluginType: 'native',
+      provisioning: 'prebuilt',
+      pluginEntry: 'hal/runtime-v4/plugin',
+      configTemplate: 'hal/runtime-v4/plugin/config_template.json',
+    })
+
+    const copied = readFileSync(join(targetDir, 'vpp_plugin', 'rpi_plugin.o'), 'utf-8')
+    expect(copied).toBe('OBJECT-BYTES')
+  })
+})

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -2240,19 +2240,24 @@ class CompilerModule {
         handleOutputData('VPP board has no HAL configTemplate, skipping plugin config generation', 'info')
       }
 
-      // --- Step 2: Copy plugin source + generate checksum ---
+      // --- Step 2: Copy plugin payload + generate checksum ---
       const pluginEntryRelPath = matchingDevice.hal?.pluginEntry
       if (!pluginEntryRelPath) {
         handleOutputData('VPP board has no HAL pluginEntry, skipping plugin source upload', 'info')
         return
       }
 
-      // The plugin source directory is the parent directory of pluginEntry.
+      // Resolve the plugin directory. In "source" mode (default) pluginEntry is
+      // the entry source file, so the dir is its parent. In "prebuilt" mode
+      // (provisioning === 'prebuilt') pluginEntry is the directory itself,
+      // holding the precompiled .o objects plus the link-only Makefile.
       // pluginEntryRelPath is supplied by the package manifest; without
       // containment, an entry like `../../../etc` would resolve outside
       // matchingPackagePath and the recursive-copy below would slurp
       // arbitrary host files into the build's vpp_plugin directory.
-      const pluginSourceDir = join(matchingPackagePath, path.dirname(pluginEntryRelPath))
+      const isPrebuilt = matchingDevice.hal?.provisioning === 'prebuilt'
+      const pluginDirRelPath = isPrebuilt ? pluginEntryRelPath : path.dirname(pluginEntryRelPath)
+      const pluginSourceDir = join(matchingPackagePath, pluginDirRelPath)
       try {
         assertPathContained(matchingPackagePath, pluginSourceDir, 'matchingDevice.hal.pluginEntry')
       } catch (err) {
@@ -2343,7 +2348,7 @@ class CompilerModule {
       await writeFile(join(destPluginDir, 'checksum.sha256'), combinedHash + '\n', 'utf-8')
 
       handleOutputData(
-        `Copied ${copiedFiles.length} VPP plugin source file(s) to vpp_plugin/ (checksum: ${combinedHash.slice(0, 12)}...)`,
+        `Copied ${copiedFiles.length} VPP plugin ${isPrebuilt ? 'prebuilt' : 'source'} file(s) to vpp_plugin/ (checksum: ${combinedHash.slice(0, 12)}...)`,
         'info',
       )
     } catch (error) {

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -743,8 +743,17 @@ export interface PackageManifest {
     hal: {
       type: string
       pluginType?: string
+      /**
+       * Native runtime-v4 plugin provisioning. "source" (default when absent):
+       * pluginEntry is the entry source file and its directory is compiled on
+       * the runtime. "prebuilt": pluginEntry is the directory holding the
+       * precompiled .o objects plus a link-only Makefile; the runtime only links.
+       */
+      provisioning?: string
       pluginEntry?: string
       configTemplate?: string
+      /** Minimum runtime version the prebuilt objects are ABI-compatible with. */
+      minRuntimeVersion?: string
       requirements?: string
       source?: string
       compilerFlags?: {

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -752,8 +752,6 @@ export interface PackageManifest {
       provisioning?: string
       pluginEntry?: string
       configTemplate?: string
-      /** Minimum runtime version the prebuilt objects are ABI-compatible with. */
-      minRuntimeVersion?: string
       requirements?: string
       source?: string
       compilerFlags?: {


### PR DESCRIPTION
## Resumo

Adiciona suporte a VPPs (Vendor Plugin Packages) nativos do tipo **prebuilt-object**: em vez de carregar os sources C/C++ no corpo do pacote (modo `source`), o VPP pode distribuir objetos `.o` relocáveis pré-compilados + um Makefile link-only. No empacotamento, `hal.pluginEntry` passa a ser tratado como **diretório** quando `hal.provisioning === 'prebuilt'` (vs arquivo no modo source). Testado de ponta a ponta numa Raspberry Pi: o runtime recebeu o VPP, linkou os objects e resolveu os símbolos do plugin.

## Mudanças

- `compiler-module.ts` (`handleVendorPluginPackaging`): branching prebuilt vs source na resolução do diretório do plugin, preservando path-containment, rejeição de symlinks e checksum SHA-256 nos dois modos (commit `a0b602adf`).
- `ports/types.ts`: campo `provisioning?` em `PackageManifest.hal` (parte do shared surface, byte-identical com openplc-web).
- Removido o campo `minRuntimeVersion` (a implementação não exigiu mudança no runtime, então o gate de versão era desnecessário).
- Teste direto do branch prebuilt vs source em `handleVendorPluginPackaging`.

## Verificação

- `handle-vendor-plugin-packaging.test.ts` — 3 testes passando (prebuilt=diretório, source=arquivo→dirname, exclusão de arquivos editor-only, cópia byte-a-byte, checksum).
- Lint limpo nos arquivos alterados.

> Shared surface sincronizado byte-identical com `openplc-web` (PR irmão) e `openplc-packages` (schema/validação).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple plugin provisioning modes, enabling flexible deployment of both prebuilt and source-based plugins with automatic payload selection and checksum generation for integrity verification.

* **Tests**
  * Introduced comprehensive test coverage for plugin packaging workflows, validating proper handling across different provisioning configurations and payload types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->