### PR TITLE
fix(editor): accept POINTER TO <T> on ULINT block pins

### DIFF
--- a/src/frontend/utils/PLC/__tests__/validate-variable-type.test.ts
+++ b/src/frontend/utils/PLC/__tests__/validate-variable-type.test.ts
@@ -81,6 +81,31 @@ describe('validateVariableType', () => {
     })
   })
 
+  describe('pointer / address-word compatibility (ADR block)', () => {
+    // ADR() returns a pointer-width address typed as ULINT (CODESYS __XWORD).
+    // A POINTER TO <T> variable holds such an address, so the two must be
+    // interchangeable at a block pin, independently of <T> and direction.
+    it('accepts a POINTER TO <T> variable on a ULINT pin', () => {
+      expect(validateVariableType('POINTER TO INT', 'ULINT').isValid).toBe(true)
+      expect(validateVariableType('POINTER TO REAL', 'ULINT').isValid).toBe(true)
+      expect(validateVariableType('pointer to int', 'ulint').isValid).toBe(true)
+    })
+
+    it('accepts a ULINT variable on a POINTER TO <T> pin (reverse direction)', () => {
+      expect(validateVariableType('ULINT', 'POINTER TO INT').isValid).toBe(true)
+    })
+
+    it('does not treat other integer words as pointer-compatible', () => {
+      expect(validateVariableType('POINTER TO INT', 'UDINT').isValid).toBe(false)
+      expect(validateVariableType('POINTER TO INT', 'DWORD').isValid).toBe(false)
+      expect(validateVariableType('POINTER TO INT', 'INT').isValid).toBe(false)
+    })
+
+    it('still rejects a plain INT on a ULINT pin', () => {
+      expect(validateVariableType('INT', 'ULINT').isValid).toBe(false)
+    })
+  })
+
   it('returns a non-empty error message when validation fails', () => {
     const result = validateVariableType('BOOL', 'ANY_REAL')
     expect(result.isValid).toBe(false)

--- a/src/frontend/utils/PLC/validate-variable-type.ts
+++ b/src/frontend/utils/PLC/validate-variable-type.ts
@@ -58,6 +58,25 @@ function flattenGenericToBaseTypes(genericName: string, visited: Set<string> = n
   return out
 }
 
+/**
+ * An address produced by `ADR()` is pointer-width and is represented as
+ * `ULINT` (this mirrors CODESYS's `__XWORD` on a 64-bit target).  A
+ * `POINTER TO <T>` variable holds exactly such an address, so the two are
+ * interchangeable at a block pin — independently of `<T>`:
+ *
+ *   - `ADR`'s `OUT : ULINT` must accept a `POINTER TO INT` sink variable.
+ *   - a `POINTER TO <T>` pin must accept a `ULINT` address source.
+ *
+ * Checked in both directions so the rule fixes every pointer-using block,
+ * not just `ADR`.
+ */
+const POINTER_PREFIX = 'POINTER TO '
+const isAddressPointerPair = (a: string, b: string): boolean => {
+  const isPointer = (t: string) => t.startsWith(POINTER_PREFIX)
+  const isAddressWord = (t: string) => t === 'ULINT'
+  return (isPointer(a) && isAddressWord(b)) || (isAddressWord(a) && isPointer(b))
+}
+
 export const validateVariableType = (
   selectedType: string,
   expectedType: string,
@@ -66,6 +85,15 @@ export const validateVariableType = (
   const upperExpectedType = expectedType.toUpperCase()
 
   if (upperExpectedType === 'ANY') {
+    return {
+      isValid: true,
+      error: undefined,
+    }
+  }
+
+  // A POINTER TO <T> variable and a ULINT address word are interchangeable
+  // at a block pin (e.g. connecting POINTER TO INT to ADR's ULINT OUT pin).
+  if (isAddressPointerPair(upperSelectedType, upperExpectedType)) {
     return {
       isValid: true,
       error: undefined,

--- a/src/frontend/utils/graphical/__tests__/sync-nodes-with-variables.test.ts
+++ b/src/frontend/utils/graphical/__tests__/sync-nodes-with-variables.test.ts
@@ -82,6 +82,28 @@ describe('syncNodesWithVariables', () => {
     expect(updateNode).not.toHaveBeenCalled()
   })
 
+  it('treats a POINTER TO <T> variable as compatible with a ULINT expected type', () => {
+    // The sync path now delegates to the shared validateVariableType, so a
+    // POINTER TO INT variable on a ULINT-typed block pin (e.g. ADR output)
+    // must NOT be flagged as wrong.
+    const updateNode = vi.fn()
+    const variable = makeVariable('myPtr', 'POINTER TO INT', 'user-data-type')
+    const node = makeNode('n1', 'block', { name: 'myPtr' } as Partial<PLCVariable>, {
+      variant: { name: 'ULINT' },
+    })
+
+    const ladderFlows = [
+      {
+        name: 'editor1',
+        rungs: [{ id: 'r1', nodes: [node], edges: [] }],
+      },
+    ] as unknown as Parameters<typeof syncNodesWithVariables>[1]
+
+    syncNodesWithVariables([variable], ladderFlows, updateNode)
+    // Types are considered compatible and wrongVariable is not set, so no update.
+    expect(updateNode).not.toHaveBeenCalled()
+  })
+
   it('does not update when node has no variable', () => {
     const updateNode = vi.fn()
     const node = makeNode('n1', 'contact')

--- a/src/frontend/utils/graphical/sync-nodes-with-variables.ts
+++ b/src/frontend/utils/graphical/sync-nodes-with-variables.ts
@@ -1,6 +1,7 @@
 import { Node } from '@xyflow/react'
 
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import { validateVariableType } from '../PLC/validate-variable-type'
 
 type UpdateLadderNodeFn = (params: {
   editorName: string
@@ -29,8 +30,12 @@ const getBlockExpectedType = (node: Node): string => {
   return ''
 }
 
+// Delegate to the shared PLC validator so this re-sync path agrees with
+// connection-time validation: it understands ANY/ANY_* generics and treats
+// a POINTER TO <T> variable as compatible with the ULINT address word
+// (e.g. ADR's output), instead of a naive string-equality compare.
 const sameType = (firstType: string, secondType: string) =>
-  firstType.toString().trim().toLowerCase() === secondType.toString().trim().toLowerCase()
+  validateVariableType(firstType.toString().trim(), secondType.toString().trim()).isValid
 
 export const syncNodesWithVariables = (
   newVars: PLCVariable[],


### PR DESCRIPTION
## Summary

The Ladder/FBD type checker rejected connecting a `POINTER TO <T>` variable to a `ULINT` block pin (e.g. `ADR`'s `OUT` pin), flagging it as `wrongVariable`. The comparison was a strict type-name equality, but `ADR` returns a pointer-width address typed as `ULINT` (mirroring CODESYS `__XWORD`), and a `POINTER TO <T>` variable holds exactly such an address — so the two are interchangeable at a pin.

## Changes

- **`validateVariableType`** (the shared validator every connection/type-change path funnels through): treat `POINTER TO <T>` ⇆ `ULINT` as compatible in both directions, independent of `<T>`. Scoped to `ULINT` only, so other integer words (`UDINT`/`DWORD`/`INT`) are still rejected.
- **`sync-nodes-with-variables`**: route the rename/retype re-sync `sameType` check through the shared `validateVariableType` so it agrees with connection-time validation (and gains `ANY`/`ANY_*` generic awareness) instead of a naive string-equality compare.

## Tests

- `validate-variable-type`: pointer-on-ULINT (both directions) accepted; `UDINT`/`DWORD`/`INT` still rejected; plain `INT` on `ULINT` still rejected.
- `sync-nodes-with-variables`: a `POINTER TO INT` variable on a `ULINT` expected type is no longer flagged.
- All affected suites green (16 + 28 + 21).

## Result

Fixes the spurious `wrongVariable` flag on `ADR → POINTER TO INT` connections in Ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved block pin type compatibility validation. POINTER TO types are now correctly recognized as interchangeable with ULINT address-word pins in both directions, enabling more flexible variable assignments while maintaining type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->