### PR TITLE
chore(deps): bump strucpp to v0.5.6

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.5.5",
+    "version": "v0.5.6",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }


### PR DESCRIPTION
Pins the STruC++ compiler binary to the newly released **v0.5.6** (Autonomy-Logic/STruCpp). Verified the `strucpp-0.5.6.tgz` asset downloads + installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated strucpp dependency to v0.5.6

<!-- end of auto-generated comment: release notes by coderabbit.ai -->