### PR TITLE
fix(debug+library): library block help + per-transport debug poll rates

### DIFF
--- a/src/frontend/components/_organisms/explorer/index.tsx
+++ b/src/frontend/components/_organisms/explorer/index.tsx
@@ -1,7 +1,9 @@
-import { LegacyRef, ReactElement, useState } from 'react'
+import { LegacyRef, ReactElement, useMemo, useState } from 'react'
 import { ImperativePanelHandle } from 'react-resizable-panels'
 
 import { useOpenPLCStore } from '../../../store'
+import type { BlockVariant } from '../../_atoms/graphical-editor/types/block'
+import { getBlockDocumentation } from '../../_atoms/graphical-editor/utils'
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '../panel'
 import { Info } from './info'
 import { Library } from './library'
@@ -64,10 +66,34 @@ const Explorer = ({ collapse, defaultSize = 16 }: ExplorerProps): ReactElement =
       : library.pous.some((pou) => pou.name.toLowerCase().includes(filterText)),
   )
 
-  const selectedPouDocumentation =
-    system
-      .flatMap((library: { pous: { name: string; documentation?: string }[] }) => library.pous)
-      .find((pou) => pou.name === selectedFileKey)?.documentation || null
+  // Help text for the selected library block — rendered in the bottom
+  // Info panel.  Mirrors the graphical-editor tooltip exactly by routing
+  // through `getBlockDocumentation` (documentation + INPUT/OUTPUT list),
+  // so a block with no prose doc still shows its I/O signature instead of
+  // falling back to "No file selected".  System library blocks carry
+  // their own `variables`; user-library blocks are project POUs, so we
+  // resolve those from `pous` (interface variables + documentation).
+  const selectedPouDocumentation = useMemo<string | null>(() => {
+    if (!selectedFileKey) return null
+
+    const systemPou = system.flatMap((library) => library.pous).find((pou) => pou.name === selectedFileKey)
+    if (systemPou) {
+      return getBlockDocumentation({
+        documentation: systemPou.documentation,
+        variables: systemPou.variables,
+      } as unknown as BlockVariant)
+    }
+
+    const projectPou = pous.find((pou) => pou.name === selectedFileKey)
+    if (projectPou) {
+      return getBlockDocumentation({
+        documentation: projectPou.documentation ?? '',
+        variables: projectPou.interface?.variables ?? [],
+      } as unknown as BlockVariant)
+    }
+
+    return null
+  }, [selectedFileKey, system, pous])
 
   return (
     <ResizablePanel

--- a/src/frontend/hooks/useDebugPolling.ts
+++ b/src/frontend/hooks/useDebugPolling.ts
@@ -18,14 +18,17 @@
  *   since the editor is read-only during debug
  *
  * Polling intervals:
- * - Modbus RTU / simulator: 50ms  (serial frame timing)
- * - Modbus TCP / WebSocket: 200ms (general purpose)
+ * - Modbus RTU / simulator: 50ms   (no network; keep the UI snappy)
+ * - Web HTTP fallback:      1000ms  (WebRTC failed; each poll is a slow
+ *                                    orchestrator round-trip, so back off)
+ * - Everything else:        200ms   (general purpose — TCP / WebSocket /
+ *                                    web WebRTC data channel)
  */
 
 import { useCallback, useEffect, useRef } from 'react'
 
 import type { DebugConnectionType, DebugTreeNode } from '../../middleware/shared/ports/types'
-import { useDebugger } from '../../middleware/shared/providers'
+import { useCapabilities, useDebugger } from '../../middleware/shared/providers'
 import { openPLCStoreBase, useOpenPLCStore } from '../store'
 import { buildActiveIndexSet } from '../utils/debug-polling-filter'
 import { applySwapToVariableBytes } from '../utils/endian'
@@ -35,6 +38,10 @@ import { getTypeSizeByName, parseValueByTypeName } from '../utils/variable-sizes
 const RTU_POLL_INTERVAL_MS = 50
 /** Polling interval for higher-bandwidth transports (TCP / WebSocket). */
 const DEFAULT_POLL_INTERVAL_MS = 200
+/** Polling interval for the web HTTP fallback (WebRTC unavailable): each
+ *  poll is a full orchestrator `run_command` round-trip, so we slow right
+ *  down to avoid hammering the edge API / runtime. */
+const HTTP_FALLBACK_POLL_INTERVAL_MS = 1000
 
 // Batch size is transport-dependent. The wire request packs 3 bytes per
 // variable (arr:u8 + elem:u16); the response packs raw type-sized values
@@ -111,8 +118,16 @@ export interface UseDebugPollingOptions {
 
 export function useDebugPolling({ debugTreesRef }: UseDebugPollingOptions): void {
   const debuggerPort = useDebugger()
+  const capabilities = useCapabilities()
   const isDebuggerVisible = useOpenPLCStore((state) => state.workspace.isDebuggerVisible)
   const { workspaceActions, consoleActions } = useOpenPLCStore()
+  // Web-only: which transport the debug session is actually running over.
+  // 'http' means WebRTC is unavailable and every poll is a slow
+  // orchestrator round-trip — so we back the cadence off (see below).
+  // On the desktop editor this is the unused 'http' default; the
+  // `!isNativeApplication` guard keeps the editor's real TCP/WebSocket
+  // transports on the standard 200ms regardless.
+  const sessionDebugTransport = useOpenPLCStore((state) => state.session.debugTransport)
 
   // Targeted selectors for active-index cache invalidation.
   // These only change on user interaction (not every poll cycle).
@@ -381,7 +396,17 @@ export function useDebugPolling({ debugTreesRef }: UseDebugPollingOptions): void
       // RTU framing also covers the simulator's virtual serial port —
       // both need the tighter cadence to keep up with toggling state.
       const usesRtuFraming = debugConnectionType === 'rtu' || debugConnectionType === 'simulator'
-      const pollIntervalMs = usesRtuFraming ? RTU_POLL_INTERVAL_MS : DEFAULT_POLL_INTERVAL_MS
+      // Web HTTP fallback: WebRTC unavailable, so reads go over the
+      // orchestrator proxy (high latency) — slow the cadence right down.
+      // Gated on `!isNativeApplication` so the desktop editor's real
+      // TCP/WebSocket transports never hit this branch (their
+      // `session.debugTransport` is an unused 'http' default).
+      const usesHttpFallback = !capabilities.isNativeApplication && sessionDebugTransport === 'http'
+      const pollIntervalMs = usesRtuFraming
+        ? RTU_POLL_INTERVAL_MS
+        : usesHttpFallback
+          ? HTTP_FALLBACK_POLL_INTERVAL_MS
+          : DEFAULT_POLL_INTERVAL_MS
 
       // Fire first poll immediately, then schedule at fixed rate
       // Skip tick if previous poll is still in progress (isPolling guard)
@@ -429,7 +454,17 @@ export function useDebugPolling({ debugTreesRef }: UseDebugPollingOptions): void
       visibleVarsCacheRef.current = null
       batchOffsetRef.current = 0
     }
-  }, [isDebuggerVisible, debugConnectionType, workspaceActions])
+    // `sessionDebugTransport` + `capabilities.isNativeApplication` are
+    // in the deps so the cadence re-evaluates if WebRTC drops to the HTTP
+    // fallback (or recovers) mid-session — the effect tears down the old
+    // interval and restarts at the new rate.
+  }, [
+    isDebuggerVisible,
+    debugConnectionType,
+    sessionDebugTransport,
+    capabilities.isNativeApplication,
+    workspaceActions,
+  ])
 
   // Clean up on unmount
   useEffect(() => {

--- a/src/frontend/hooks/useDebugSession.ts
+++ b/src/frontend/hooks/useDebugSession.ts
@@ -173,6 +173,16 @@ export function useDebugSession(): UseDebugSessionReturn {
           wsActions.setDebuggerTargetIp(debugConfig.connectionParams.ipAddress)
         }
 
+        // Record the active transport so useDebugPolling picks the right
+        // poll cadence + batch size.  Set on EVERY start path (runtime
+        // targets also set it earlier in handleMd5Verification; this
+        // additionally covers the simulator path, which doesn't go
+        // through MD5 verification — without it the simulator stayed at
+        // the default 200ms instead of its intended 50ms).  Must be set
+        // before `setDebuggerVisible(true)`, which is what triggers the
+        // polling effect.
+        wsActions.setDebugConnectionType(debugConfig.connectionType)
+
         wsActions.setDebuggerVisible(true)
         logActions.addLog({
           id: crypto.randomUUID(),


### PR DESCRIPTION
Fixes two reported bugs (shared frontend; mirrored byte-identical to openplc-web).

## 1. Library panel shows "No file selected" instead of block help
The bottom Info panel rendered only raw `pou.documentation`, which is empty for most `.stlib` blocks → "No file selected", even though the graphical **tooltip** shows help. The panel now routes through the same `getBlockDocumentation` the tooltip uses (documentation + INPUT/OUTPUT signature), resolving the selected block from **system libraries** first, then **project POUs** (user-library blocks). A block with no prose doc now shows its I/O signature instead of the empty fallback.

## 2. All debug sessions polled at the same rate (~200ms)
- **Simulator** stayed at the 200ms default because `setDebugConnectionType` was only called on the runtime (MD5-verify) path, never the simulator path. Now set in `useDebugSession.connectAndStart` (every start path) → **simulator = 50ms**.
- **Web HTTP fallback** (WebRTC unavailable) polled at 200ms, hammering the orchestrator. `useDebugPolling` now backs off to **1000ms** when on web (`!isNativeApplication`) and `session.debugTransport === 'http'`, and re-evaluates if WebRTC drops/recovers mid-session.
- Default stays **200ms** for all other protocols (TCP / WebSocket / web WebRTC). Editor's native transports unaffected.

No change to the build/debug **connection** flow — only the renderer poll cadence, batch sizing, and the help-text source.

## Test plan
- [x] `tsc`, eslint (0 errors), prettier clean on all 3 files
- [x] explorer `info` test passes; store includes the `session` slice (no undefined-access risk on editor)
- [ ] Manual: hover-vs-panel help parity; simulator polls fast (50ms), web debug over HTTP fallback polls every 1s, WebRTC/TCP/WebSocket at 200ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug session handling with enhanced HTTP fallback support when WebRTC is unavailable.
  * Fixed debug polling cadence to correctly adapt based on the selected transport method.

* **New Features**
  * Enhanced documentation display for library blocks to include INPUT/OUTPUT variable signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->