### PR TITLE
chore(deps): bump xml2st to v4.0.6

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -1,6 +1,6 @@
 {
   "xml2st": {
-    "version": "v4.0.5",
+    "version": "v4.0.6",
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {


### PR DESCRIPTION
Bumps the bundled **xml2st** binary from v4.0.5 → v4.0.6.

### Why
xml2st cancelled (skipped) any function whose only input is `EN` — e.g. `CURRENT_DT` and other nullary functions — while still emitting references to its `_TMP_<type><id>_ENO` / `_TMP_<type><id>_OUT` temps. The generated ST then referenced undeclared variables and STruC++ rejected it:

```
main.st:1:6: error: Undeclared variable '_TMP_CURRENT_DT..._ENO'
main.st:2:16: error: Undeclared variable '_TMP_CURRENT_DT..._OUT'
```

v4.0.6 ([Autonomy-Logic/xml2st](https://github.com/Autonomy-Logic/xml2st)) treats functions with no data inputs as eligible for emission, so the call and its output temps are generated correctly.

### Note
This is a shared-surface change — the identical bump is being made on openplc-web in a parallel PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated xml2st package to the latest version (4.0.6).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->