### PR TITLE
Release v4.2.3

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -1,6 +1,6 @@
 {
   "xml2st": {
-    "version": "v4.0.5",
+    "version": "v4.0.6",
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {

--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.5.5",
+    "version": "v0.5.6",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }

--- a/src/backend/shared/compile/__tests__/pipeline-runtime-v3.test.ts
+++ b/src/backend/shared/compile/__tests__/pipeline-runtime-v3.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Focused tests for the Runtime v3 branch of the shared compile pipeline.
+ *
+ * v3 is the legacy target that ingests a single `program.st` (not a v4
+ * zip) and recompiles it on-device with MatIEC.  The pipeline must
+ * therefore short-circuit to `uploadRuntimeV3` BEFORE any arduino-cli
+ * step (core/lib install, firmware bundle, compile) — a regression
+ * where the v3 branch sat after `installArduinoCore` made every v3
+ * build die with "invalid empty core argument" (v3 has no Arduino
+ * core).  These tests lock that ordering in.
+ *
+ * Kept in a separate file from `pipeline.test.ts` (which is stale from
+ * the xml2st→JSON-transpiler migration and references the removed
+ * `transpileXmlToSt` port method) so the v3 coverage compiles + runs
+ * against the current `transpileToSt` contract.
+ */
+
+import type { DevicePin } from '../../types/PLC/devices'
+import type { PLCProjectData } from '../../types/PLC/open-plc'
+import type {
+  CompilerPlatformPort,
+  PlatformDeviceContext,
+} from '../../../../middleware/shared/ports/compiler-platform-port'
+
+jest.mock('../../utils/PLC/xml-generator', () => ({ XmlGenerator: jest.fn() }))
+jest.mock('../../library/program-build-pipeline', () => ({ runProgramBuildPipeline: jest.fn() }))
+jest.mock('../../library/program-build-helpers', () => ({
+  buildKnownPous: jest.fn(() => []),
+  emitCompileErrorEvents: jest.fn(),
+}))
+jest.mock('../../firmware/build-arduino-cli-args', () => ({
+  buildArduinoCliCompileArgs: jest.fn(() => ['compile', '-b', 'arduino:avr:mega']),
+}))
+jest.mock('../../firmware/runtime-version-gate', () => ({
+  isStrucppCompatibleRuntime: jest.fn(() => true),
+  describeIncompatibleRuntime: jest.fn((v: string | null) => `Runtime ${String(v)} too old`),
+}))
+jest.mock('../steps/generate-confs', () => ({
+  generateRuntimeConfs: jest.fn(() => ({ modbusSlave: '', modbusMaster: '', s7Comm: '', opcUa: null, ethercat: '' })),
+}))
+
+import { runProgramBuildPipeline } from '../../library/program-build-pipeline'
+import { type PipelineProgressEvent, runCompilePipeline, type RunCompilePipelineArgs } from '../pipeline'
+
+const mockedStrucpp = runProgramBuildPipeline as jest.MockedFunction<typeof runProgramBuildPipeline>
+
+function makePort(overrides: Partial<CompilerPlatformPort> = {}): jest.Mocked<CompilerPlatformPort> {
+  return {
+    computeMd5: jest.fn().mockResolvedValue('a'.repeat(32)),
+    transpileToSt: jest.fn().mockResolvedValue({ ok: true, programSt: 'PROGRAM main\nEND_PROGRAM' }),
+    installArduinoCore: jest.fn().mockResolvedValue({ ok: true }),
+    installArduinoLib: jest.fn().mockResolvedValue({ ok: true }),
+    compileArduino: jest.fn().mockResolvedValue({ ok: true, binary: new Uint8Array([1]) }),
+    uploadRuntimeV4: jest.fn().mockResolvedValue({ ok: true }),
+    uploadArduinoBoard: jest.fn().mockResolvedValue({ ok: true }),
+    uploadRuntimeV3: jest.fn().mockResolvedValue({ ok: true }),
+    checkRuntimeVersion: jest.fn().mockResolvedValue({ ok: true, version: '3.0' }),
+    packageVppPlugin: jest.fn().mockResolvedValue({ files: {} }),
+    ...overrides,
+  } as unknown as jest.Mocked<CompilerPlatformPort>
+}
+
+const deviceContext: PlatformDeviceContext = { kind: 'editor-https', ip: '192.168.1.199', jwt: 'jwt' }
+
+function makeArgs(overrides: Partial<RunCompilePipelineArgs> = {}): RunCompilePipelineArgs {
+  return {
+    projectData: {
+      pous: [],
+      dataTypes: [],
+      configuration: { resource: { tasks: [], instances: [], globalVariables: [] } },
+      servers: [],
+      remoteDevices: [],
+    } as unknown as PLCProjectData,
+    boardTarget: 'OpenPLC Runtime v3',
+    boardRuntime: 'openplc-runtime',
+    boardEntry: { platform: '', core: '', define: [] },
+    devicePinMapping: [] as DevicePin[],
+    isSimulator: false,
+    isRuntimeV4: false,
+    isRuntimeV3: true,
+    compileOnly: false,
+    libraryArchives: [],
+    missingLibraries: [],
+    firmwareSkeleton: {},
+    strucppRuntimeHeaders: {},
+    avrLibStdCppInclude: '',
+    arduinoCliParallel: false,
+    deviceContext,
+    ...overrides,
+  }
+}
+
+function captureEvents() {
+  const events: PipelineProgressEvent[] = []
+  return { events, emit: (e: PipelineProgressEvent) => events.push(e) }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockedStrucpp.mockReturnValue({
+    success: true,
+    files: [{ name: 'debug-map.json', content: '{}' }],
+    errors: [],
+    warnings: [],
+    md5Hash: 'a'.repeat(32),
+    splitterFallbackMessage: null,
+    debugMapSummary: null,
+  })
+})
+
+describe('runCompilePipeline — Runtime v3 branch', () => {
+  it('uploads program.st via uploadRuntimeV3 WITHOUT touching any arduino-cli step', async () => {
+    const port = makePort()
+    const { events, emit } = captureEvents()
+
+    const result = await runCompilePipeline(makeArgs(), port, emit)
+
+    expect(result).toEqual({ success: true, md5: 'a'.repeat(32), uploaded: true })
+    // The regression guard: v3 must never reach the Arduino path.
+    expect(port.installArduinoCore).not.toHaveBeenCalled()
+    expect(port.installArduinoLib).not.toHaveBeenCalled()
+    expect(port.compileArduino).not.toHaveBeenCalled()
+    expect(port.uploadRuntimeV4).not.toHaveBeenCalled()
+    // Strucpp still runs as an error-check before upload.
+    expect(mockedStrucpp).toHaveBeenCalledTimes(1)
+    expect(port.uploadRuntimeV3).toHaveBeenCalledTimes(1)
+    expect(events.map((e) => e.stage)).toContain('done')
+  })
+
+  it('passes the plain program.st (no FILE markers) when there are no C/C++ POUs', async () => {
+    const port = makePort()
+    const { emit } = captureEvents()
+
+    await runCompilePipeline(makeArgs(), port, emit)
+
+    const [uploadArg] = port.uploadRuntimeV3.mock.calls[0]
+    expect(uploadArg.programSt).toBe('PROGRAM main\nEND_PROGRAM')
+    expect(uploadArg.programSt).not.toContain('(*FILE:')
+  })
+
+  it('skips upload in compileOnly mode', async () => {
+    const port = makePort()
+    const { emit } = captureEvents()
+
+    const result = await runCompilePipeline(makeArgs({ compileOnly: true }), port, emit)
+
+    expect(result).toEqual({ success: true, md5: 'a'.repeat(32), uploaded: false })
+    expect(port.uploadRuntimeV3).not.toHaveBeenCalled()
+    expect(port.installArduinoCore).not.toHaveBeenCalled()
+  })
+
+  it('warns and skips upload when no device context is configured', async () => {
+    const port = makePort()
+    const { events, emit } = captureEvents()
+
+    const result = await runCompilePipeline(makeArgs({ deviceContext: undefined }), port, emit)
+
+    expect(result.uploaded).toBe(false)
+    expect(port.uploadRuntimeV3).not.toHaveBeenCalled()
+    expect(events.some((e) => e.level === 'warning' && /v3 not configured/i.test(e.message))).toBe(true)
+  })
+
+  it('bails when uploadRuntimeV3 reports failure', async () => {
+    const port = makePort({ uploadRuntimeV3: jest.fn().mockResolvedValue({ ok: false }) })
+    const { emit } = captureEvents()
+
+    const result = await runCompilePipeline(makeArgs(), port, emit)
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/backend/shared/compile/pipeline.ts
+++ b/src/backend/shared/compile/pipeline.ts
@@ -591,7 +591,53 @@ async function runCompilePipelineInner(
   }
 
   // ---------------------------------------------------------------------
-  // Step 4b: Arduino / Simulator path — install core + lib (no-op on
+  // Step 4b: Runtime v3 branch — legacy target that ingests a single
+  // `program.st` (not a zip).  v3's on-device MatIEC recompiles the ST
+  // itself, so this MUST short-circuit BEFORE the arduino-cli path
+  // (core/lib install, firmware bundle, compile) — none of which apply
+  // to v3.  (Placing it after `installArduinoCore` was the bug: v3 has
+  // no Arduino core, so the install ran with an empty FQBN and aborted
+  // the build before the upload was ever reached.)
+  //
+  // Strucpp already ran above purely as a correctness check; a strucpp
+  // error bails before we get here, which is the desired behaviour
+  // (catch user code errors without an on-device round-trip).
+  //
+  // C/C++ and Python function blocks are NOT supported on v3 — they
+  // lower to strucpp `{external ...}` inline-C that v3's MatIEC can't
+  // parse — and are rejected up front by the editor compile adapter
+  // before this pipeline runs (see `createEditorCompilerAdapter`).  So
+  // the ST that reaches here is plain IEC that MatIEC accepts; we just
+  // upload it verbatim.
+  // ---------------------------------------------------------------------
+  if (isRuntimeV3) {
+    if (compileOnly) {
+      emit({ stage: 'done', message: 'Compile only mode — skipping upload to runtime v3.', level: 'info' })
+      return { success: true, md5, uploaded: false }
+    }
+    if (!deviceContext) {
+      emit({
+        stage: 'upload',
+        message: 'Runtime v3 not configured. Skipping upload.',
+        level: 'warning',
+      })
+      return { success: true, md5, uploaded: false }
+    }
+
+    emit({ stage: 'upload', message: 'Uploading program.st to Runtime v3...', level: 'info' })
+    const uploadResult = await port.uploadRuntimeV3(
+      { programSt, context: deviceContext },
+      makePlatformLog(emit, 'upload'),
+    )
+    if (!uploadResult.ok) {
+      return bailError(emit, 'upload', 'Failed to upload to Runtime v3.', uploadResult.errors)
+    }
+    emit({ stage: 'done', message: 'Runtime v3 upload complete.', level: 'info' })
+    return { success: true, md5, uploaded: true }
+  }
+
+  // ---------------------------------------------------------------------
+  // Step 4c: Arduino / Simulator path — install core + lib (no-op on
   // web), generate defines.h, compose firmware bundle, compile via
   // arduino-cli.
   // ---------------------------------------------------------------------
@@ -676,40 +722,6 @@ async function runCompilePipelineInner(
     avrLibStdCppInclude,
     parallel: arduinoCliParallel,
   })
-
-  // ---------------------------------------------------------------------
-  // Step 4b (cont.): Runtime v3 branch is a sub-case that runs BEFORE
-  // the arduino-cli compile — it embeds C blocks into program.st and
-  // uploads the merged ST file directly to the device.
-  // ---------------------------------------------------------------------
-  if (isRuntimeV3) {
-    if (compileOnly) {
-      emit({ stage: 'done', message: 'Compile only mode — skipping upload to runtime v3.', level: 'info' })
-      return { success: true, md5, uploaded: false }
-    }
-    if (!deviceContext) {
-      emit({
-        stage: 'upload',
-        message: 'Runtime v3 not configured. Skipping upload.',
-        level: 'warning',
-      })
-      return { success: true, md5, uploaded: false }
-    }
-    emit({ stage: 'embed-c-blocks', message: 'Embedding C blocks into program.st...', level: 'info' })
-    // Editor's port implementation embeds c_blocks.h + c_blocks_code.cpp
-    // into program.st as (*FILE:...*) marked comments; web's port
-    // implementation no-ops (web doesn't target v3).  The pipeline
-    // delegates to the port so the embed details stay platform-specific.
-    const uploadResult = await port.uploadRuntimeV3(
-      { programSt, context: deviceContext },
-      makePlatformLog(emit, 'upload'),
-    )
-    if (!uploadResult.ok) {
-      return bailError(emit, 'upload', 'Failed to upload to Runtime v3.', uploadResult.errors)
-    }
-    emit({ stage: 'done', message: 'Runtime v3 upload complete.', level: 'info' })
-    return { success: true, md5, uploaded: true }
-  }
 
   // Run arduino-cli compile.  Editor: spawns the binary.  Web: HTTP
   // POST.  Both consume the same `files` map + `argv`.

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/board.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/board.tsx
@@ -74,6 +74,11 @@ const Board = memo(function () {
   const [previewImage, setPreviewImage] = useState('')
   const [formattedBoardState, setFormattedBoardState] = useState('')
   const [showPythonWarning, setShowPythonWarning] = useState(false)
+  // Human-readable label of the function-block kind(s) the target can't
+  // host (e.g. "Python", "C/C++", "C/C++ and Python") — drives the
+  // warning modal's copy so the same dialog serves Arduino (Python only)
+  // and Runtime v3 (neither C/C++ nor Python).
+  const [unsupportedBlocksLabel, setUnsupportedBlocksLabel] = useState('Python')
   const [showV4FeaturesWarning, setShowV4FeaturesWarning] = useState(false)
   const [v4FeaturesAffected, setV4FeaturesAffected] = useState<{ hasServers: boolean; hasRemoteDevices: boolean }>({
     hasServers: false,
@@ -286,8 +291,23 @@ const Board = memo(function () {
       const hasPythonFunctionBlocks = pous.some(
         (pou) => pou.pouType === 'function-block' && pou.body.language === 'python',
       )
+      const hasCppFunctionBlocks = pous.some((pou) => pou.pouType === 'function-block' && pou.body.language === 'cpp')
 
-      if (!targetCaps.pythonFunctionBlocks && hasPythonFunctionBlocks) {
+      // OpenPLC Runtime v3 can host neither C/C++ nor Python function
+      // blocks: both lower to strucpp `{external ...}` inline-C that v3's
+      // MatIEC toolchain can't compile.  Other targets are gated per
+      // capability (Arduino: no Python; v4 / simulator: both fine).  Warn
+      // on switch — same soft prompt Arduino shows for Python — and let
+      // the user proceed (compilation will fail on the device if they do).
+      const isRuntimeV3Target = normalizedBoard === 'OpenPLC Runtime v3'
+      const pythonUnsupported = (!targetCaps.pythonFunctionBlocks || isRuntimeV3Target) && hasPythonFunctionBlocks
+      const cppUnsupported = isRuntimeV3Target && hasCppFunctionBlocks
+
+      if (pythonUnsupported || cppUnsupported) {
+        const label = [cppUnsupported ? 'C/C++' : null, pythonUnsupported ? 'Python' : null]
+          .filter(Boolean)
+          .join(' and ')
+        setUnsupportedBlocksLabel(label)
         setPendingBoardChange({ board: normalizedBoard, formattedBoard: board })
         setShowPythonWarning(true)
         return
@@ -735,15 +755,17 @@ const Board = memo(function () {
       <Modal open={showPythonWarning} onOpenChange={setShowPythonWarning}>
         <ModalContent className='h-fit w-[500px]'>
           <ModalHeader>
-            <ModalTitle>Python Function Blocks Not Supported</ModalTitle>
+            <ModalTitle>{unsupportedBlocksLabel} Function Blocks Not Supported</ModalTitle>
           </ModalHeader>
           <div className='flex flex-col gap-4'>
             <p className='text-sm text-neutral-700 dark:text-neutral-300'>
-              The selected target ({pendingBoardChange?.formattedBoard}) does not support Python Function Blocks.
+              The selected target ({pendingBoardChange?.formattedBoard}) does not support {unsupportedBlocksLabel}{' '}
+              Function Blocks.
             </p>
             <p className='text-sm text-neutral-700 dark:text-neutral-300'>
-              Your project contains Python Function Blocks that will cause compilation to fail on this target. To use
-              this target, you must remove all Python Function Blocks from your project.
+              Your project contains {unsupportedBlocksLabel} Function Blocks that will cause compilation to fail on this
+              target. To use this target, you must remove all {unsupportedBlocksLabel} Function Blocks from your
+              project.
             </p>
           </div>
           <ModalFooter className='flex justify-end gap-2'>

--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/__tests__/esi-upload.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/__tests__/esi-upload.test.tsx
@@ -1,10 +1,19 @@
 import type { ESIRepositoryItemLight } from '@root/middleware/shared/ports/esi-types'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 
-// Mocked EsiPort surface — the two methods the upload flow touches. The
-// `mock`-prefixed name is referenced lazily inside the factory (only when
-// `useEsi()` is called at render time), so this works under both Vitest and
-// the editor's Jest+vi shim — without `vi.hoisted`, which the shim lacks.
+// Mocked EsiPort surface — the two methods the upload flow touches.
+//
+// Cross-runner compatibility relies on two independent mechanisms:
+//   - Under Vitest, `vi.mock` is hoisted above imports, so the factory runs
+//     before `import { ESIUpload }`. A hoisted factory may only reference names
+//     that survive hoisting — hence the `mock`-prefixed `mockEsi`, read lazily
+//     when `useEsi()` is called at render time (not at factory-eval time).
+//   - Under the editor's Jest+vi shim, `vi.mock` is NOT hoisted (ts-jest's
+//     transformer only hoists `jest.mock`). It works because the
+//     `import { ESIUpload }` below is deliberately placed AFTER this `vi.mock`
+//     call. That import position is load-bearing: do NOT move it into the top
+//     import block, or ESIUpload binds to the real platform-context module
+//     before the mock is registered.
 const mockEsi = {
   parseAndSaveFile: vi.fn(),
   loadRepositoryLight: vi.fn(),
@@ -82,6 +91,19 @@ describe('ESIUpload — dedupAfterRetry handling', () => {
     expect(mockEsi.loadRepositoryLight).toHaveBeenCalledTimes(1)
     // No new item was returned, so the fallback keeps the existing repository.
     expect(onFilesLoaded).toHaveBeenCalledWith(existing, undefined)
+  })
+
+  it('dedups a recovered add that already exists in the repository', async () => {
+    // dedupAfterRetry recovery: the retry hit the backend dedup against a row
+    // that was already present in `repository`, and the adapter returns that
+    // same row as `item`. The merged list must not contain it twice.
+    mockEsi.parseAndSaveFile.mockResolvedValueOnce({ success: true, item: SAMPLE_ITEM, dedupAfterRetry: true })
+
+    const { onFilesLoaded } = uploadFile([SAMPLE_ITEM])
+
+    await waitFor(() => expect(onFilesLoaded).toHaveBeenCalled())
+    expect(onFilesLoaded).toHaveBeenCalledWith([SAMPLE_ITEM], undefined)
+    expect(mockEsi.loadRepositoryLight).not.toHaveBeenCalled()
   })
 
   it('skips a real duplicate silently without re-listing', async () => {

--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/__tests__/esi-upload.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/__tests__/esi-upload.test.tsx
@@ -1,0 +1,96 @@
+import type { ESIRepositoryItemLight } from '@root/middleware/shared/ports/esi-types'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+
+// Mocked EsiPort surface — the two methods the upload flow touches. The
+// `mock`-prefixed name is referenced lazily inside the factory (only when
+// `useEsi()` is called at render time), so this works under both Vitest and
+// the editor's Jest+vi shim — without `vi.hoisted`, which the shim lacks.
+const mockEsi = {
+  parseAndSaveFile: vi.fn(),
+  loadRepositoryLight: vi.fn(),
+}
+
+vi.mock('@root/middleware/shared/providers/platform-context', () => ({
+  useEsi: () => mockEsi,
+}))
+
+import { ESIUpload } from '../esi-upload'
+
+const SAMPLE_ITEM: ESIRepositoryItemLight = {
+  id: 'item-1',
+  filename: 'Beckhoff.xml',
+  vendor: { id: '0x0002', name: 'Beckhoff' },
+  devices: [],
+  loadedAt: '2026-01-01T00:00:00.000Z',
+}
+
+/** Build an XML File whose `.text()` resolves regardless of jsdom version. */
+function xmlFile(name = 'Beckhoff.xml', content = '<xml />'): File {
+  const file = new File([content], name, { type: 'text/xml' })
+  Object.defineProperty(file, 'text', { value: () => Promise.resolve(content) })
+  return file
+}
+
+/** Render the component and drive a single-file upload through the input. */
+function uploadFile(repository: ESIRepositoryItemLight[] = []) {
+  const onFilesLoaded = vi.fn()
+  const { container } = render(<ESIUpload onFilesLoaded={onFilesLoaded} repository={repository} />)
+  const input = container.querySelector('input[type="file"]') as HTMLInputElement
+  fireEvent.change(input, { target: { files: [xmlFile()] } })
+  return { onFilesLoaded }
+}
+
+describe('ESIUpload — dedupAfterRetry handling', () => {
+  beforeEach(() => {
+    mockEsi.parseAndSaveFile.mockReset()
+    mockEsi.loadRepositoryLight.mockReset()
+  })
+
+  it('appends a newly added item without re-listing the repository', async () => {
+    mockEsi.parseAndSaveFile.mockResolvedValueOnce({ success: true, item: SAMPLE_ITEM })
+
+    const { onFilesLoaded } = uploadFile()
+
+    await waitFor(() => expect(onFilesLoaded).toHaveBeenCalled())
+    expect(onFilesLoaded).toHaveBeenCalledWith([SAMPLE_ITEM], undefined)
+    expect(mockEsi.loadRepositoryLight).not.toHaveBeenCalled()
+  })
+
+  it('re-lists the repository when a dedupAfterRetry lands without an item', async () => {
+    mockEsi.parseAndSaveFile.mockResolvedValueOnce({ success: true, dedupAfterRetry: true })
+    mockEsi.loadRepositoryLight.mockResolvedValueOnce({ success: true, items: [SAMPLE_ITEM] })
+
+    const { onFilesLoaded } = uploadFile()
+
+    await waitFor(() => expect(onFilesLoaded).toHaveBeenCalled())
+    expect(mockEsi.loadRepositoryLight).toHaveBeenCalledTimes(1)
+    // The refreshed list is authoritative — the recovered row appears here.
+    expect(onFilesLoaded).toHaveBeenCalledWith([SAMPLE_ITEM], undefined)
+  })
+
+  it('falls back to the local list when the refresh itself fails', async () => {
+    const existing: ESIRepositoryItemLight[] = [{ ...SAMPLE_ITEM, id: 'old', filename: 'Old.xml' }]
+    mockEsi.parseAndSaveFile.mockResolvedValueOnce({ success: true, dedupAfterRetry: true })
+    mockEsi.loadRepositoryLight.mockResolvedValueOnce({ success: false, error: 'list failed' })
+
+    const onFilesLoaded = vi.fn()
+    const { container } = render(<ESIUpload onFilesLoaded={onFilesLoaded} repository={existing} />)
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, { target: { files: [xmlFile()] } })
+
+    await waitFor(() => expect(onFilesLoaded).toHaveBeenCalled())
+    expect(mockEsi.loadRepositoryLight).toHaveBeenCalledTimes(1)
+    // No new item was returned, so the fallback keeps the existing repository.
+    expect(onFilesLoaded).toHaveBeenCalledWith(existing, undefined)
+  })
+
+  it('skips a real duplicate silently without re-listing', async () => {
+    mockEsi.parseAndSaveFile.mockResolvedValueOnce({ success: true, duplicate: true })
+
+    const { onFilesLoaded } = uploadFile()
+
+    await waitFor(() => expect(onFilesLoaded).toHaveBeenCalled())
+    expect(onFilesLoaded).toHaveBeenCalledWith([], undefined)
+    expect(mockEsi.loadRepositoryLight).not.toHaveBeenCalled()
+  })
+})

--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
@@ -124,7 +124,17 @@ const ESIUpload = ({ onFilesLoaded, repository, isLoading = false }: ESIUploadPr
         }
       }
 
-      onFilesLoaded([...repository, ...newItems], errors.length > 0 ? errors : undefined)
+      // A recovered add (item + dedupAfterRetry) can return a row that already
+      // exists in `repository` — the retry hit the backend dedup against a
+      // pre-existing entry. Dedup the merged list by id (repository wins) so the
+      // same row isn't rendered twice or assigned a duplicate React key.
+      const mergedById = new Map<ESIRepositoryItemLight['id'], ESIRepositoryItemLight>()
+      for (const item of [...repository, ...newItems]) {
+        if (!mergedById.has(item.id)) {
+          mergedById.set(item.id, item)
+        }
+      }
+      onFilesLoaded([...mergedById.values()], errors.length > 0 ? errors : undefined)
     },
     [onFilesLoaded, repository, esi],
   )

--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/esi-upload.tsx
@@ -55,6 +55,12 @@ const ESIUpload = ({ onFilesLoaded, repository, isLoading = false }: ESIUploadPr
 
       const newItems: ESIRepositoryItemLight[] = []
       const errors: Array<{ filename: string; error: string }> = []
+      // A dedup-after-retry result means the file was persisted on the backend
+      // but its row was missing from the upload response (and the adapter's own
+      // recovery lookup also failed). Honor the EsiPort contract by re-listing
+      // the repository after the batch so the file appears instead of silently
+      // vanishing — see EsiPort.parseAndSaveFile (`dedupAfterRetry`).
+      let needsRepositoryRefresh = false
 
       const MAX_FILE_SIZE = 100 * 1024 * 1024 // 100MB
 
@@ -84,8 +90,13 @@ const ESIUpload = ({ onFilesLoaded, repository, isLoading = false }: ESIUploadPr
 
           if (result.success && result.item) {
             newItems.push(result.item)
+          } else if (result.success && result.dedupAfterRetry) {
+            // Uploaded but absent from the response: a transient-failure retry
+            // hit the backend dedup and the adapter couldn't recover the row.
+            // Flag a repository refresh so the file surfaces after the batch.
+            needsRepositoryRefresh = true
           } else if (result.success) {
-            // Duplicate content already in the repository — skip silently.
+            // Real duplicate — content already in the repository. Skip silently.
             // See EsiPort.parseAndSaveFile for the duplicate-handling contract.
           } else {
             errors.push({ filename: file.name, error: result.error ?? 'Parse failed' })
@@ -101,6 +112,17 @@ const ESIUpload = ({ onFilesLoaded, repository, isLoading = false }: ESIUploadPr
         totalFiles: 0,
         percentage: 100,
       })
+
+      // A recovered-but-unlisted upload (dedupAfterRetry) is on the backend yet
+      // missing from `newItems`. Re-list the repository so it shows up; fall
+      // back to the locally accumulated list if the refresh itself fails.
+      if (needsRepositoryRefresh) {
+        const refreshed = await esi!.loadRepositoryLight()
+        if (refreshed.success && refreshed.items) {
+          onFilesLoaded(refreshed.items, errors.length > 0 ? errors : undefined)
+          return
+        }
+      }
 
       onFilesLoaded([...repository, ...newItems], errors.length > 0 ? errors : undefined)
     },

--- a/src/frontend/components/_organisms/explorer/index.tsx
+++ b/src/frontend/components/_organisms/explorer/index.tsx
@@ -1,7 +1,9 @@
-import { LegacyRef, ReactElement, useState } from 'react'
+import { LegacyRef, ReactElement, useMemo, useState } from 'react'
 import { ImperativePanelHandle } from 'react-resizable-panels'
 
 import { useOpenPLCStore } from '../../../store'
+import type { BlockVariant } from '../../_atoms/graphical-editor/types/block'
+import { getBlockDocumentation } from '../../_atoms/graphical-editor/utils'
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '../panel'
 import { Info } from './info'
 import { Library } from './library'
@@ -64,10 +66,34 @@ const Explorer = ({ collapse, defaultSize = 16 }: ExplorerProps): ReactElement =
       : library.pous.some((pou) => pou.name.toLowerCase().includes(filterText)),
   )
 
-  const selectedPouDocumentation =
-    system
-      .flatMap((library: { pous: { name: string; documentation?: string }[] }) => library.pous)
-      .find((pou) => pou.name === selectedFileKey)?.documentation || null
+  // Help text for the selected library block — rendered in the bottom
+  // Info panel.  Mirrors the graphical-editor tooltip exactly by routing
+  // through `getBlockDocumentation` (documentation + INPUT/OUTPUT list),
+  // so a block with no prose doc still shows its I/O signature instead of
+  // falling back to "No file selected".  System library blocks carry
+  // their own `variables`; user-library blocks are project POUs, so we
+  // resolve those from `pous` (interface variables + documentation).
+  const selectedPouDocumentation = useMemo<string | null>(() => {
+    if (!selectedFileKey) return null
+
+    const systemPou = system.flatMap((library) => library.pous).find((pou) => pou.name === selectedFileKey)
+    if (systemPou) {
+      return getBlockDocumentation({
+        documentation: systemPou.documentation,
+        variables: systemPou.variables,
+      } as unknown as BlockVariant)
+    }
+
+    const projectPou = pous.find((pou) => pou.name === selectedFileKey)
+    if (projectPou) {
+      return getBlockDocumentation({
+        documentation: projectPou.documentation ?? '',
+        variables: projectPou.interface?.variables ?? [],
+      } as unknown as BlockVariant)
+    }
+
+    return null
+  }, [selectedFileKey, system, pous])
 
   return (
     <ResizablePanel

--- a/src/frontend/hooks/useDebugPolling.ts
+++ b/src/frontend/hooks/useDebugPolling.ts
@@ -18,14 +18,17 @@
  *   since the editor is read-only during debug
  *
  * Polling intervals:
- * - Modbus RTU / simulator: 50ms  (serial frame timing)
- * - Modbus TCP / WebSocket: 200ms (general purpose)
+ * - Modbus RTU / simulator: 50ms   (no network; keep the UI snappy)
+ * - Web HTTP fallback:      1000ms  (WebRTC failed; each poll is a slow
+ *                                    orchestrator round-trip, so back off)
+ * - Everything else:        200ms   (general purpose — TCP / WebSocket /
+ *                                    web WebRTC data channel)
  */
 
 import { useCallback, useEffect, useRef } from 'react'
 
 import type { DebugConnectionType, DebugTreeNode } from '../../middleware/shared/ports/types'
-import { useDebugger } from '../../middleware/shared/providers'
+import { useCapabilities, useDebugger } from '../../middleware/shared/providers'
 import { openPLCStoreBase, useOpenPLCStore } from '../store'
 import { buildActiveIndexSet } from '../utils/debug-polling-filter'
 import { applySwapToVariableBytes } from '../utils/endian'
@@ -35,6 +38,10 @@ import { getTypeSizeByName, parseValueByTypeName } from '../utils/variable-sizes
 const RTU_POLL_INTERVAL_MS = 50
 /** Polling interval for higher-bandwidth transports (TCP / WebSocket). */
 const DEFAULT_POLL_INTERVAL_MS = 200
+/** Polling interval for the web HTTP fallback (WebRTC unavailable): each
+ *  poll is a full orchestrator `run_command` round-trip, so we slow right
+ *  down to avoid hammering the edge API / runtime. */
+const HTTP_FALLBACK_POLL_INTERVAL_MS = 1000
 
 // Batch size is transport-dependent. The wire request packs 3 bytes per
 // variable (arr:u8 + elem:u16); the response packs raw type-sized values
@@ -111,8 +118,16 @@ export interface UseDebugPollingOptions {
 
 export function useDebugPolling({ debugTreesRef }: UseDebugPollingOptions): void {
   const debuggerPort = useDebugger()
+  const capabilities = useCapabilities()
   const isDebuggerVisible = useOpenPLCStore((state) => state.workspace.isDebuggerVisible)
   const { workspaceActions, consoleActions } = useOpenPLCStore()
+  // Web-only: which transport the debug session is actually running over.
+  // 'http' means WebRTC is unavailable and every poll is a slow
+  // orchestrator round-trip — so we back the cadence off (see below).
+  // On the desktop editor this is the unused 'http' default; the
+  // `!isNativeApplication` guard keeps the editor's real TCP/WebSocket
+  // transports on the standard 200ms regardless.
+  const sessionDebugTransport = useOpenPLCStore((state) => state.session.debugTransport)
 
   // Targeted selectors for active-index cache invalidation.
   // These only change on user interaction (not every poll cycle).
@@ -381,7 +396,17 @@ export function useDebugPolling({ debugTreesRef }: UseDebugPollingOptions): void
       // RTU framing also covers the simulator's virtual serial port —
       // both need the tighter cadence to keep up with toggling state.
       const usesRtuFraming = debugConnectionType === 'rtu' || debugConnectionType === 'simulator'
-      const pollIntervalMs = usesRtuFraming ? RTU_POLL_INTERVAL_MS : DEFAULT_POLL_INTERVAL_MS
+      // Web HTTP fallback: WebRTC unavailable, so reads go over the
+      // orchestrator proxy (high latency) — slow the cadence right down.
+      // Gated on `!isNativeApplication` so the desktop editor's real
+      // TCP/WebSocket transports never hit this branch (their
+      // `session.debugTransport` is an unused 'http' default).
+      const usesHttpFallback = !capabilities.isNativeApplication && sessionDebugTransport === 'http'
+      const pollIntervalMs = usesRtuFraming
+        ? RTU_POLL_INTERVAL_MS
+        : usesHttpFallback
+          ? HTTP_FALLBACK_POLL_INTERVAL_MS
+          : DEFAULT_POLL_INTERVAL_MS
 
       // Fire first poll immediately, then schedule at fixed rate
       // Skip tick if previous poll is still in progress (isPolling guard)
@@ -429,7 +454,17 @@ export function useDebugPolling({ debugTreesRef }: UseDebugPollingOptions): void
       visibleVarsCacheRef.current = null
       batchOffsetRef.current = 0
     }
-  }, [isDebuggerVisible, debugConnectionType, workspaceActions])
+    // `sessionDebugTransport` + `capabilities.isNativeApplication` are
+    // in the deps so the cadence re-evaluates if WebRTC drops to the HTTP
+    // fallback (or recovers) mid-session — the effect tears down the old
+    // interval and restarts at the new rate.
+  }, [
+    isDebuggerVisible,
+    debugConnectionType,
+    sessionDebugTransport,
+    capabilities.isNativeApplication,
+    workspaceActions,
+  ])
 
   // Clean up on unmount
   useEffect(() => {

--- a/src/frontend/hooks/useDebugSession.ts
+++ b/src/frontend/hooks/useDebugSession.ts
@@ -173,6 +173,16 @@ export function useDebugSession(): UseDebugSessionReturn {
           wsActions.setDebuggerTargetIp(debugConfig.connectionParams.ipAddress)
         }
 
+        // Record the active transport so useDebugPolling picks the right
+        // poll cadence + batch size.  Set on EVERY start path (runtime
+        // targets also set it earlier in handleMd5Verification; this
+        // additionally covers the simulator path, which doesn't go
+        // through MD5 verification — without it the simulator stayed at
+        // the default 200ms instead of its intended 50ms).  Must be set
+        // before `setDebuggerVisible(true)`, which is what triggers the
+        // polling effect.
+        wsActions.setDebugConnectionType(debugConfig.connectionType)
+
         wsActions.setDebuggerVisible(true)
         logActions.addLog({
           id: crypto.randomUUID(),

--- a/src/frontend/utils/PLC/__tests__/validate-variable-type.test.ts
+++ b/src/frontend/utils/PLC/__tests__/validate-variable-type.test.ts
@@ -81,6 +81,31 @@ describe('validateVariableType', () => {
     })
   })
 
+  describe('pointer / address-word compatibility (ADR block)', () => {
+    // ADR() returns a pointer-width address typed as ULINT (CODESYS __XWORD).
+    // A POINTER TO <T> variable holds such an address, so the two must be
+    // interchangeable at a block pin, independently of <T> and direction.
+    it('accepts a POINTER TO <T> variable on a ULINT pin', () => {
+      expect(validateVariableType('POINTER TO INT', 'ULINT').isValid).toBe(true)
+      expect(validateVariableType('POINTER TO REAL', 'ULINT').isValid).toBe(true)
+      expect(validateVariableType('pointer to int', 'ulint').isValid).toBe(true)
+    })
+
+    it('accepts a ULINT variable on a POINTER TO <T> pin (reverse direction)', () => {
+      expect(validateVariableType('ULINT', 'POINTER TO INT').isValid).toBe(true)
+    })
+
+    it('does not treat other integer words as pointer-compatible', () => {
+      expect(validateVariableType('POINTER TO INT', 'UDINT').isValid).toBe(false)
+      expect(validateVariableType('POINTER TO INT', 'DWORD').isValid).toBe(false)
+      expect(validateVariableType('POINTER TO INT', 'INT').isValid).toBe(false)
+    })
+
+    it('still rejects a plain INT on a ULINT pin', () => {
+      expect(validateVariableType('INT', 'ULINT').isValid).toBe(false)
+    })
+  })
+
   it('returns a non-empty error message when validation fails', () => {
     const result = validateVariableType('BOOL', 'ANY_REAL')
     expect(result.isValid).toBe(false)

--- a/src/frontend/utils/PLC/validate-variable-type.ts
+++ b/src/frontend/utils/PLC/validate-variable-type.ts
@@ -58,6 +58,25 @@ function flattenGenericToBaseTypes(genericName: string, visited: Set<string> = n
   return out
 }
 
+/**
+ * An address produced by `ADR()` is pointer-width and is represented as
+ * `ULINT` (this mirrors CODESYS's `__XWORD` on a 64-bit target).  A
+ * `POINTER TO <T>` variable holds exactly such an address, so the two are
+ * interchangeable at a block pin — independently of `<T>`:
+ *
+ *   - `ADR`'s `OUT : ULINT` must accept a `POINTER TO INT` sink variable.
+ *   - a `POINTER TO <T>` pin must accept a `ULINT` address source.
+ *
+ * Checked in both directions so the rule fixes every pointer-using block,
+ * not just `ADR`.
+ */
+const POINTER_PREFIX = 'POINTER TO '
+const isAddressPointerPair = (a: string, b: string): boolean => {
+  const isPointer = (t: string) => t.startsWith(POINTER_PREFIX)
+  const isAddressWord = (t: string) => t === 'ULINT'
+  return (isPointer(a) && isAddressWord(b)) || (isAddressWord(a) && isPointer(b))
+}
+
 export const validateVariableType = (
   selectedType: string,
   expectedType: string,
@@ -66,6 +85,15 @@ export const validateVariableType = (
   const upperExpectedType = expectedType.toUpperCase()
 
   if (upperExpectedType === 'ANY') {
+    return {
+      isValid: true,
+      error: undefined,
+    }
+  }
+
+  // A POINTER TO <T> variable and a ULINT address word are interchangeable
+  // at a block pin (e.g. connecting POINTER TO INT to ADR's ULINT OUT pin).
+  if (isAddressPointerPair(upperSelectedType, upperExpectedType)) {
     return {
       isValid: true,
       error: undefined,

--- a/src/frontend/utils/graphical/__tests__/sync-nodes-with-variables.test.ts
+++ b/src/frontend/utils/graphical/__tests__/sync-nodes-with-variables.test.ts
@@ -82,6 +82,28 @@ describe('syncNodesWithVariables', () => {
     expect(updateNode).not.toHaveBeenCalled()
   })
 
+  it('treats a POINTER TO <T> variable as compatible with a ULINT expected type', () => {
+    // The sync path now delegates to the shared validateVariableType, so a
+    // POINTER TO INT variable on a ULINT-typed block pin (e.g. ADR output)
+    // must NOT be flagged as wrong.
+    const updateNode = vi.fn()
+    const variable = makeVariable('myPtr', 'POINTER TO INT', 'user-data-type')
+    const node = makeNode('n1', 'block', { name: 'myPtr' } as Partial<PLCVariable>, {
+      variant: { name: 'ULINT' },
+    })
+
+    const ladderFlows = [
+      {
+        name: 'editor1',
+        rungs: [{ id: 'r1', nodes: [node], edges: [] }],
+      },
+    ] as unknown as Parameters<typeof syncNodesWithVariables>[1]
+
+    syncNodesWithVariables([variable], ladderFlows, updateNode)
+    // Types are considered compatible and wrongVariable is not set, so no update.
+    expect(updateNode).not.toHaveBeenCalled()
+  })
+
   it('does not update when node has no variable', () => {
     const updateNode = vi.fn()
     const node = makeNode('n1', 'contact')

--- a/src/frontend/utils/graphical/sync-nodes-with-variables.ts
+++ b/src/frontend/utils/graphical/sync-nodes-with-variables.ts
@@ -1,6 +1,7 @@
 import { Node } from '@xyflow/react'
 
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import { validateVariableType } from '../PLC/validate-variable-type'
 
 type UpdateLadderNodeFn = (params: {
   editorName: string
@@ -29,8 +30,12 @@ const getBlockExpectedType = (node: Node): string => {
   return ''
 }
 
+// Delegate to the shared PLC validator so this re-sync path agrees with
+// connection-time validation: it understands ANY/ANY_* generics and treats
+// a POINTER TO <T> variable as compatible with the ULINT address word
+// (e.g. ADR's output), instead of a naive string-equality compare.
 const sameType = (firstType: string, secondType: string) =>
-  firstType.toString().trim().toLowerCase() === secondType.toString().trim().toLowerCase()
+  validateVariableType(firstType.toString().trim(), secondType.toString().trim()).isValid
 
 export const syncNodesWithVariables = (
   newVars: PLCVariable[],

--- a/src/middleware/shared/ports/esi-port.ts
+++ b/src/middleware/shared/ports/esi-port.ts
@@ -48,13 +48,13 @@ export interface EsiPort {
    * transient-failure retry — the first attempt likely persisted the file but
    * its response was lost. It can accompany any of three result shapes (only
    * the web adapter ever sets it; the editor's local IPC adapter never does):
-   *   - `item` + `dedupAfterRetry`: recovered add — the adapter relocated the
-   *     persisted row and returns it. Treat as a normal add, but note the row
-   *     may already be present in the caller's list, so dedup by `id` when
+   *   - `item` + `dedupAfterRetry`: recovered add — the backend returned the
+   *     matched row in the dedup response. Treat as a normal add, but note the
+   *     row may already be present in the caller's list, so dedup by `id` when
    *     merging into an existing repository view.
-   *   - `duplicate` + `dedupAfterRetry`: persisted but unlisted — the row could
-   *     not be recovered. Callers should refresh the repository so the file
-   *     surfaces instead of silently skipping it.
+   *   - `duplicate` + `dedupAfterRetry`: persisted but unlisted — the matched
+   *     row wasn't echoed back (e.g. an older backend). Callers should refresh
+   *     the repository so the file surfaces instead of silently skipping it.
    *   - `duplicate` alone: a real duplicate — content already in the
    *     repository. Safe to skip silently.
    */

--- a/src/middleware/shared/ports/esi-port.ts
+++ b/src/middleware/shared/ports/esi-port.ts
@@ -39,11 +39,17 @@ export interface EsiPort {
    * Dedup is filename-based: reimporting the same bytes under a different name
    * will add a new entry, and replacing a file's contents without renaming it
    * is reported as a duplicate.
+   *
+   * `dedupAfterRetry: true` indicates the duplicate response landed after a
+   * transient-failure retry — the first attempt likely persisted the file and
+   * its response was lost. Callers should treat this as "uploaded but absent
+   * from the response" rather than silently skipping, since the user expects
+   * the file to appear in the repository.
    */
   parseAndSaveFile(
     filename: string,
     content: string,
-  ): Promise<Result<{ item?: ESIRepositoryItemLight; duplicate?: boolean }>>
+  ): Promise<Result<{ item?: ESIRepositoryItemLight; duplicate?: boolean; dedupAfterRetry?: boolean }>>
 
   /**
    * Delete a single repository item and its associated XML file.

--- a/src/middleware/shared/ports/esi-port.ts
+++ b/src/middleware/shared/ports/esi-port.ts
@@ -34,17 +34,29 @@ export interface EsiPort {
    * The filename and raw XML content are provided; parsing happens on the backend.
    *
    * On success, `item` is present when the file was newly added, and omitted
-   * with `duplicate: true` when a repository entry with the same filename
-   * already exists — letting callers distinguish a real add from a silent skip.
-   * Dedup is filename-based: reimporting the same bytes under a different name
-   * will add a new entry, and replacing a file's contents without renaming it
-   * is reported as a duplicate.
+   * with `duplicate: true` when the file is considered a duplicate — letting
+   * callers distinguish a real add from a silent skip.
    *
-   * `dedupAfterRetry: true` indicates the duplicate response landed after a
-   * transient-failure retry — the first attempt likely persisted the file and
-   * its response was lost. Callers should treat this as "uploaded but absent
-   * from the response" rather than silently skipping, since the user expects
-   * the file to appear in the repository.
+   * Dedup semantics are adapter-defined and differ by platform:
+   *   - Editor adapter: filename-based. Reimporting the same bytes under a
+   *     different name adds a new entry; replacing a file's contents without
+   *     renaming it is reported as a duplicate.
+   *   - Web adapter: SHA-256 content-hash-based. Identical bytes are a
+   *     duplicate regardless of filename.
+   *
+   * `dedupAfterRetry: true` marks a response that landed after a
+   * transient-failure retry — the first attempt likely persisted the file but
+   * its response was lost. It can accompany any of three result shapes (only
+   * the web adapter ever sets it; the editor's local IPC adapter never does):
+   *   - `item` + `dedupAfterRetry`: recovered add — the adapter relocated the
+   *     persisted row and returns it. Treat as a normal add, but note the row
+   *     may already be present in the caller's list, so dedup by `id` when
+   *     merging into an existing repository view.
+   *   - `duplicate` + `dedupAfterRetry`: persisted but unlisted — the row could
+   *     not be recovered. Callers should refresh the repository so the file
+   *     surfaces instead of silently skipping it.
+   *   - `duplicate` alone: a real duplicate — content already in the
+   *     repository. Safe to skip silently.
    */
   parseAndSaveFile(
     filename: string,


### PR DESCRIPTION
Promotes `development` → `main` for the **v4.2.3** release.

Headline fix in this release: **xml2st v4.0.6** — functions whose only input is `EN` (e.g. `CURRENT_DT`) are now emitted instead of silently cancelled, fixing `Undeclared variable _TMP_<type><id>_OUT/_ENO` compile failures. Already shipped to openplc-web production.

Also includes accumulated development work since v4.2.2 (library/debug fixes, EtherCAT ESI upload retry, runtime v3 build fixes, strucpp v0.5.6, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)