### PR TITLE
chore: bump strucpp to v0.5.7, release 4.2.5

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.5.6",
+    "version": "v0.5.7",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-plc-editor",
-  "version": "4.1.4",
+  "version": "4.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-plc-editor",
-      "version": "4.1.4",
+      "version": "4.2.5",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-plc-editor",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "license": "GPL-3.0",
   "author": {
     "name": "Autonomy Logic"

--- a/src/frontend/data/constants/app-version.ts
+++ b/src/frontend/data/constants/app-version.ts
@@ -18,4 +18,4 @@
  * compares a per-deploy `BUILD_ID` (git commit SHA), not this version, so a
  * stale tab is detected on every deploy even without a version bump.
  */
-export const APP_VERSION = '4.2.4'
+export const APP_VERSION = '4.2.5'


### PR DESCRIPTION
Bumps the bundled **strucpp** compiler **v0.5.6 → v0.5.7** and the app version **4.2.4 → 4.2.5**.

strucpp v0.5.7 carries important compiler fixes: CoDeSys V2.3 `.lib` import (length-prefixed records), date-literal + chained-assignment language support, cross-library FB-member type resolution, library global-variable export (additive), struct field-type export, and the OSCAT-building ST→C++→binary codegen/runtime gaps.

- `binary-versions.json`: strucpp `v0.5.6` → `v0.5.7`
- `package.json` / `package-lock.json` / `app-version.ts`: `4.2.4` → `4.2.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 4.2.5
  * Updated core binary dependency to v0.5.7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->