### PR TITLE
feat(xml-generator): embed used library-block signatures for xml2st

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -1,10 +1,10 @@
 {
   "xml2st": {
-    "version": "v4.0.6",
+    "version": "v4.0.7",
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.5.7",
+    "version": "v0.5.9",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-plc-editor",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-plc-editor",
-      "version": "4.2.5",
+      "version": "4.2.6",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-plc-editor",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "license": "GPL-3.0",
   "author": {
     "name": "Autonomy Logic"

--- a/src/backend/shared/utils/PLC/__tests__/collect-library-blocks.test.ts
+++ b/src/backend/shared/utils/PLC/__tests__/collect-library-blocks.test.ts
@@ -33,6 +33,25 @@ function fbdProject(nodes: unknown[], extraPous: unknown[] = []): PLCProjectData
   } as unknown as PLCProjectData
 }
 
+/** Build a project with a single Ladder program; blocks live in rungs[].nodes. */
+function ldProject(nodesByRung: unknown[][]): PLCProjectData {
+  return {
+    dataTypes: [],
+    pous: [
+      {
+        type: 'program',
+        data: {
+          name: 'main',
+          language: 'ld',
+          variables: [],
+          documentation: '',
+          body: { language: 'ld', value: { name: 'main', rungs: nodesByRung.map((nodes) => ({ nodes })) } },
+        },
+      },
+    ],
+  } as unknown as PLCProjectData
+}
+
 describe('collectLibraryBlocks', () => {
   it('returns null when there are no graphical blocks', () => {
     const project = {
@@ -133,5 +152,34 @@ describe('collectLibraryBlocks', () => {
 
     const pous = (collectLibraryBlocks(project) as any).data.libraryBlocks.pou
     expect(pous.map((p: any) => p['@name'])).toEqual(['ADD'])
+  })
+
+  it('collects blocks from Ladder rungs (the common case)', () => {
+    const project = ldProject([
+      [
+        blockNode({
+          name: 'TON',
+          type: 'function-block',
+          variables: [
+            { name: 'IN', class: 'input', type: baseType('BOOL') },
+            { name: 'PT', class: 'input', type: baseType('TIME') },
+            { name: 'Q', class: 'output', type: baseType('BOOL') },
+          ],
+        }),
+      ],
+      [
+        blockNode({
+          name: 'CURRENT_DT',
+          type: 'function',
+          variables: [{ name: 'OUT', class: 'output', type: baseType('DT') }],
+        }),
+      ],
+    ])
+
+    const pous = (collectLibraryBlocks(project) as any).data.libraryBlocks.pou
+    // blocks gathered across both rungs, sorted by name
+    expect(pous.map((p: any) => p['@name'])).toEqual(['CURRENT_DT', 'TON'])
+    expect(pous.find((p: any) => p['@name'] === 'TON')['@pouType']).toBe('functionBlock')
+    expect(pous.find((p: any) => p['@name'] === 'CURRENT_DT').interface.returnType).toEqual({ DT: '' })
   })
 })

--- a/src/backend/shared/utils/PLC/__tests__/collect-library-blocks.test.ts
+++ b/src/backend/shared/utils/PLC/__tests__/collect-library-blocks.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for collectLibraryBlocks — the pure project→<addData> collector that
+ * embeds used library-block signatures for the xml2st transpiler.
+ */
+
+import type { PLCProjectData } from '@root/middleware/shared/ports/open-plc-types'
+
+import { collectLibraryBlocks } from '../collect-library-blocks'
+
+const baseType = (value: string) => ({ definition: 'base-type' as const, value })
+const genericType = (value: string) => ({ definition: 'generic-type' as const, value })
+
+const blockNode = (variant: unknown) => ({ type: 'block', data: { variant } })
+
+/** Build a project with a single FBD program containing the given block nodes. */
+function fbdProject(nodes: unknown[], extraPous: unknown[] = []): PLCProjectData {
+  return {
+    dataTypes: [],
+    pous: [
+      {
+        type: 'program',
+        data: {
+          name: 'main',
+          language: 'fbd',
+          variables: [],
+          documentation: '',
+          body: { language: 'fbd', value: { name: 'main', rung: { nodes } } },
+        },
+      },
+      ...extraPous,
+    ],
+    // configuration etc. are unused by the collector
+  } as unknown as PLCProjectData
+}
+
+describe('collectLibraryBlocks', () => {
+  it('returns null when there are no graphical blocks', () => {
+    const project = {
+      dataTypes: [],
+      pous: [{ type: 'program', data: { name: 'main', body: { language: 'st', value: '' } } }],
+    } as unknown as PLCProjectData
+    expect(collectLibraryBlocks(project)).toBeNull()
+  })
+
+  it('emits a nullary function as a returnType-only pou', () => {
+    const project = fbdProject([
+      blockNode({
+        name: 'CURRENT_DT',
+        type: 'function',
+        variables: [
+          { name: 'EN', class: 'input', type: baseType('BOOL') },
+          { name: 'ENO', class: 'output', type: baseType('BOOL') },
+          { name: 'OUT', class: 'output', type: baseType('DT') },
+        ],
+      }),
+    ])
+
+    const result = collectLibraryBlocks(project) as any
+    expect(result.data['@name']).toBe('openplc.org/xml2st/library-blocks')
+    const pous = result.data.libraryBlocks.pou
+    expect(pous).toHaveLength(1)
+    expect(pous[0]).toMatchObject({
+      '@name': 'CURRENT_DT',
+      '@pouType': 'function',
+      interface: { returnType: { DT: '' } },
+    })
+    // EN/ENO are dropped; no spurious inputVars/outputVars
+    expect(pous[0].interface.inputVars).toBeUndefined()
+    expect(pous[0].interface.outputVars).toBeUndefined()
+    expect(pous[0]['@extensible']).toBeUndefined()
+  })
+
+  it('preserves generic types and the extensible flag for variadic functions', () => {
+    const project = fbdProject([
+      blockNode({
+        name: 'ADD',
+        type: 'function',
+        extensible: true,
+        variables: [
+          { name: 'EN', class: 'input', type: baseType('BOOL') },
+          { name: 'IN1', class: 'input', type: genericType('ANY_NUM') },
+          { name: 'IN2', class: 'input', type: genericType('ANY_NUM') },
+          { name: 'OUT', class: 'output', type: genericType('ANY_NUM') },
+        ],
+      }),
+    ])
+
+    const pou = (collectLibraryBlocks(project) as any).data.libraryBlocks.pou[0]
+    expect(pou['@extensible']).toBe(true)
+    expect(pou.interface.returnType).toEqual({ ANY_NUM: '' })
+    expect(pou.interface.inputVars.variable).toEqual([
+      { '@name': 'IN1', type: { ANY_NUM: '' } },
+      { '@name': 'IN2', type: { ANY_NUM: '' } },
+    ])
+  })
+
+  it('emits function blocks with outputVars (no returnType)', () => {
+    const project = fbdProject([
+      blockNode({
+        name: 'TON',
+        type: 'function-block',
+        variables: [
+          { name: 'IN', class: 'input', type: baseType('BOOL') },
+          { name: 'PT', class: 'input', type: baseType('TIME') },
+          { name: 'Q', class: 'output', type: baseType('BOOL') },
+          { name: 'ET', class: 'output', type: baseType('TIME') },
+        ],
+      }),
+    ])
+
+    const pou = (collectLibraryBlocks(project) as any).data.libraryBlocks.pou[0]
+    expect(pou['@pouType']).toBe('functionBlock')
+    expect(pou.interface.returnType).toBeUndefined()
+    expect(pou.interface.outputVars.variable).toEqual([
+      { '@name': 'Q', type: { BOOL: '' } },
+      { '@name': 'ET', type: { TIME: '' } },
+    ])
+  })
+
+  it('dedupes by name and skips user-defined POUs', () => {
+    const userFb = {
+      type: 'function-block',
+      data: { name: 'MyFB', body: { language: 'st', value: '' } },
+    }
+    const project = fbdProject(
+      [
+        blockNode({ name: 'ADD', type: 'function', variables: [{ name: 'OUT', class: 'output', type: genericType('ANY_NUM') }] }),
+        blockNode({ name: 'ADD', type: 'function', variables: [{ name: 'OUT', class: 'output', type: genericType('ANY_NUM') }] }),
+        blockNode({ name: 'MyFB', type: 'function-block', variables: [] }),
+      ],
+      [userFb],
+    )
+
+    const pous = (collectLibraryBlocks(project) as any).data.libraryBlocks.pou
+    expect(pous.map((p: any) => p['@name'])).toEqual(['ADD'])
+  })
+})

--- a/src/backend/shared/utils/PLC/collect-library-blocks.ts
+++ b/src/backend/shared/utils/PLC/collect-library-blocks.ts
@@ -1,0 +1,137 @@
+import type { PLCProjectData } from '@root/middleware/shared/ports/open-plc-types'
+
+/**
+ * Collect the signatures of every *library* block a project uses and emit them
+ * as a PLCopen `<addData>` payload that the xml2st transpiler reads.
+ *
+ * Why: xml2st emits a local temporary per FUNCTION output and must declare it
+ * with a concrete type. It infers that type from the wired connections, but
+ * cannot when a function has no typed pin to borrow from (e.g. a nullary
+ * `CURRENT_DT` whose output is unconnected) — it then falls back to the illegal
+ * type `ANY`, which STruC++ rejects. Rather than make xml2st carry a block
+ * library (which would diverge from the real STruC++ library), we hand it the
+ * exact signatures the project uses, embedded in the project file itself.
+ *
+ * Every graphical block instance already carries its full typed signature in
+ * `node.data.variant` (the editor stamps it from the library on placement), so
+ * this is a pure function over the project model — no I/O, no library archives,
+ * no platform specifics. It therefore lives on the shared surface and is
+ * identical across the desktop and web builds.
+ *
+ * Output shape feeds xmlbuilder2 (see XmlGenerator); it is inserted as
+ * `<project>/<addData>` after `<instances>`. Contract: xml2st/docs/library-blocks.md.
+ */
+
+const DATA_NAME = 'openplc.org/xml2st/library-blocks'
+
+type XmlElement = Record<string, unknown>
+
+// Minimal view of a block variant's variable; the full schema lives in
+// middleware/shared/ports/block-types.ts (blockVariantVariableSchema).
+type VariantVariable = {
+  name: string
+  class: 'input' | 'output' | 'local' | 'inOut'
+  type: { definition: 'base-type' | 'generic-type'; value: string }
+}
+
+type BlockVariant = {
+  name: string
+  type: 'function' | 'function-block' | 'generic'
+  extensible?: boolean
+  variables: VariantVariable[]
+}
+
+/** `<INT/>`, `<ANY_NUM/>`, ... — xml2st reads the (upper-cased) tag name. */
+const typeElement = (variable: VariantVariable): XmlElement => ({ [variable.type.value]: '' })
+
+const variableElement = (variable: VariantVariable): XmlElement => ({
+  '@name': variable.name,
+  type: typeElement(variable),
+})
+
+/** Walk every graphical POU body and yield each block instance's variant. */
+const collectBlockVariants = (project: PLCProjectData): BlockVariant[] => {
+  const variants: BlockVariant[] = []
+
+  const visitNodes = (nodes: unknown) => {
+    if (!Array.isArray(nodes)) return
+    for (const node of nodes) {
+      const n = node as { type?: string; data?: { variant?: BlockVariant } }
+      if (n?.type === 'block' && n.data?.variant?.name) variants.push(n.data.variant)
+    }
+  }
+
+  for (const pou of project.pous) {
+    const body = pou.data?.body as { language?: string; value?: unknown } | undefined
+    if (!body) continue
+    if (body.language === 'fbd') {
+      const value = body.value as { rung?: { nodes?: unknown } } | undefined
+      visitNodes(value?.rung?.nodes)
+    } else if (body.language === 'ld') {
+      const value = body.value as { rungs?: Array<{ nodes?: unknown }> } | undefined
+      for (const rung of value?.rungs ?? []) visitNodes(rung?.nodes)
+    }
+  }
+
+  return variants
+}
+
+const variantToPou = (variant: BlockVariant): XmlElement => {
+  const isFunctionBlock = variant.type === 'function-block'
+  // EN/ENO are implicit control pins; xml2st adds them itself.
+  const vars = variant.variables.filter((v) => v.name !== 'EN' && v.name !== 'ENO')
+  const inputs = vars.filter((v) => v.class === 'input')
+  const inouts = vars.filter((v) => v.class === 'inOut')
+  const outputs = vars.filter((v) => v.class === 'output')
+
+  const iface: XmlElement = {}
+
+  if (!isFunctionBlock) {
+    // A function returns a single value; model its primary output (OUT) as the
+    // return type, any extra outputs as VAR_OUTPUT.
+    const ret = outputs.find((v) => v.name === 'OUT') ?? outputs[0]
+    if (ret) iface.returnType = typeElement(ret)
+    const extraOutputs = outputs.filter((v) => v !== ret)
+    if (extraOutputs.length) iface.outputVars = { variable: extraOutputs.map(variableElement) }
+  } else if (outputs.length) {
+    iface.outputVars = { variable: outputs.map(variableElement) }
+  }
+
+  if (inputs.length) iface.inputVars = { variable: inputs.map(variableElement) }
+  if (inouts.length) iface.inOutVars = { variable: inouts.map(variableElement) }
+
+  return {
+    '@name': variant.name,
+    '@pouType': isFunctionBlock ? 'functionBlock' : 'function',
+    ...(variant.extensible ? { '@extensible': true } : {}),
+    interface: iface,
+  }
+}
+
+/**
+ * Build the `<addData>` library-blocks payload for a project, or `null` when the
+ * project references no library blocks (e.g. text-only POUs).
+ *
+ * User-defined POUs are excluded: their definitions already travel in
+ * `<types><pous>` and xml2st resolves them directly.
+ */
+export const collectLibraryBlocks = (project: PLCProjectData): XmlElement | null => {
+  const userPouNames = new Set(project.pous.map((pou) => pou.data?.name))
+
+  const byName = new Map<string, BlockVariant>()
+  for (const variant of collectBlockVariants(project)) {
+    if (userPouNames.has(variant.name)) continue
+    if (!byName.has(variant.name)) byName.set(variant.name, variant)
+  }
+  if (byName.size === 0) return null
+
+  const pous = [...byName.values()].sort((a, b) => a.name.localeCompare(b.name)).map(variantToPou)
+
+  return {
+    data: {
+      '@name': DATA_NAME,
+      '@handleUnknown': 'discard',
+      libraryBlocks: { pou: pous },
+    },
+  }
+}

--- a/src/backend/shared/utils/PLC/xml-generator.ts
+++ b/src/backend/shared/utils/PLC/xml-generator.ts
@@ -3,7 +3,6 @@ import { BaseXml as codeSysBaseXml } from '@root/middleware/shared/ports/xml-typ
 import { BaseXml as oldBaseXml } from '@root/middleware/shared/ports/xml-types/old-editor'
 import { create } from 'xmlbuilder2'
 
-import { collectLibraryBlocks } from './collect-library-blocks'
 import {
   codeSysInstanceToXml,
   codeSysParseDataTypesToXML,
@@ -16,6 +15,7 @@ import {
   oldEditorParseDataTypesToXML,
   oldEditorParsePousToXML,
 } from '../../../../frontend/utils/PLC/xml-generator/old-editor'
+import { collectLibraryBlocks } from './collect-library-blocks'
 
 const XmlGenerator = (
   projectToGenerateXML: PLCProjectData,

--- a/src/backend/shared/utils/PLC/xml-generator.ts
+++ b/src/backend/shared/utils/PLC/xml-generator.ts
@@ -3,6 +3,7 @@ import { BaseXml as codeSysBaseXml } from '@root/middleware/shared/ports/xml-typ
 import { BaseXml as oldBaseXml } from '@root/middleware/shared/ports/xml-types/old-editor'
 import { create } from 'xmlbuilder2'
 
+import { collectLibraryBlocks } from './collect-library-blocks'
 import {
   codeSysInstanceToXml,
   codeSysParseDataTypesToXML,
@@ -67,6 +68,17 @@ const XmlGenerator = (
      */
     const configuration = projectToGenerateXML.configuration
     xmlResult = codeSysInstanceToXml(csXml, configuration)
+  }
+
+  /**
+   * Embed the signatures of every library block the project uses, so xml2st
+   * can type the temporaries it generates for FUNCTION outputs without
+   * carrying a block library of its own.  Added last so it serialises after
+   * <instances>, as the PLCopen schema requires for <addData>.
+   */
+  const libraryBlocks = collectLibraryBlocks(projectToGenerateXML)
+  if (libraryBlocks) {
+    ;(xmlResult as unknown as { project: Record<string, unknown> }).project.addData = libraryBlocks
   }
 
   const doc = create(xmlResult)

--- a/src/frontend/data/constants/app-version.ts
+++ b/src/frontend/data/constants/app-version.ts
@@ -18,4 +18,4 @@
  * compares a per-deploy `BUILD_ID` (git commit SHA), not this version, so a
  * stale tab is detected on every deploy even without a version bump.
  */
-export const APP_VERSION = '4.2.5'
+export const APP_VERSION = '4.2.6'

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -5,6 +5,7 @@ import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 import { parseIecStringToVariables } from '../../../utils/generate-iec-string-to-variables'
 import { generateIecVariablesToString } from '../../../utils/generate-iec-variables-to-string'
 import { syncNodesWithVariables, syncNodesWithVariablesFBD } from '../../../utils/graphical/sync-nodes-with-variables'
+import { restampFlowLibraryVariants } from '../../../utils/PLC/restamp-library-variants'
 import { collectAllSlaveNames } from '../../../utils/unique-slave-name'
 import type { FBDFlowType } from '../fbd'
 import type { FileSliceDataObject } from '../file'
@@ -565,16 +566,38 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       // path see no change in behaviour; projects with the legacy
       // drift auto-recover on first open.
       const pous = data.projectData.pous
+
+      // Refresh placed library-block variant types from the current libraries
+      // before the flows enter the store, so existing projects pick up library
+      // type changes (e.g. ADR: ULINT -> __XWORD). Blocks backed by a
+      // user-defined POU are skipped — the project owns their interface. A
+      // no-op when the libraries haven't loaded yet or nothing is stale.
+      const systemLibraries = getState().libraries.system
+      const userPouNames = pous.filter((pou) => pou.pouType !== 'program').map((pou) => pou.name)
+      let restampedCount = 0
+
       pous.forEach((pou) => {
         if (pou.body.language === 'ld') {
-          const bodyValue = pou.body.value as LadderFlowType
+          // The loaded project data is frozen, so clone before re-stamping
+          // (which mutates variant types in place) and hand the store the copy.
+          const bodyValue = structuredClone(pou.body.value) as LadderFlowType
+          restampedCount += restampFlowLibraryVariants([bodyValue], systemLibraries, userPouNames)
           getState().ladderFlowActions.addLadderFlow({ ...bodyValue, name: pou.name })
         }
         if (pou.body.language === 'fbd') {
-          const bodyValue = pou.body.value as FBDFlowType
+          const bodyValue = structuredClone(pou.body.value) as FBDFlowType
+          restampedCount += restampFlowLibraryVariants([bodyValue], systemLibraries, userPouNames)
           getState().fbdFlowActions.addFBDFlow({ ...bodyValue, name: pou.name })
         }
       })
+
+      if (restampedCount > 0) {
+        getState().consoleActions.addLog({
+          id: crypto.randomUUID(),
+          level: 'info',
+          message: `Refreshed ${restampedCount} library block pin type(s) from the current library definitions.`,
+        })
+      }
 
       // Register user-defined functions/function-blocks in the library
       pous.forEach((pou) => {

--- a/src/frontend/utils/PLC/__tests__/restamp-library-variants.test.ts
+++ b/src/frontend/utils/PLC/__tests__/restamp-library-variants.test.ts
@@ -1,0 +1,118 @@
+import type { SystemLibrary } from '../../../../middleware/shared/ports/library-types'
+import { restampFlowLibraryVariants } from '../restamp-library-variants'
+
+// ---------------------------------------------------------------------------
+// Factory helpers
+// ---------------------------------------------------------------------------
+
+/** A system library whose ADR function now returns __XWORD (was ULINT). */
+function makeSystemLibraries(): SystemLibrary[] {
+  return [
+    {
+      name: 'STANDARD_FUNCTIONS',
+      pous: [
+        {
+          name: 'ADR',
+          type: 'function',
+          language: 'st',
+          body: '',
+          documentation: '',
+          variables: [
+            { name: 'OUT', class: 'output', type: { definition: 'base-type', value: '__XWORD' } },
+            { name: 'IN', class: 'input', type: { definition: 'generic-type', value: 'ANY' } },
+          ],
+        },
+      ],
+    },
+  ] as unknown as SystemLibrary[]
+}
+
+/** A block node whose ADR variant is still stamped with the old ULINT return. */
+function makeStaleAdrNode() {
+  return {
+    id: 'block-1',
+    type: 'block',
+    data: {
+      variant: {
+        name: 'ADR',
+        type: 'function',
+        language: 'st',
+        body: '',
+        documentation: '',
+        variables: [
+          { name: 'OUT', class: 'output', type: { definition: 'base-type', value: 'ULINT' } },
+          { name: 'IN', class: 'input', type: { definition: 'generic-type', value: 'ANY' } },
+        ],
+      },
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('restampFlowLibraryVariants', () => {
+  it('refreshes a stale library block return type (ADR ULINT -> __XWORD)', () => {
+    const node = makeStaleAdrNode()
+    const flow = { rung: { nodes: [node] } }
+
+    const changed = restampFlowLibraryVariants([flow], makeSystemLibraries(), [])
+
+    expect(changed).toBe(1)
+    expect(node.data.variant.variables.find((v) => v.name === 'OUT')!.type.value).toBe('__XWORD')
+  })
+
+  it('walks every rung of a ladder flow', () => {
+    const node = makeStaleAdrNode()
+    const flow = { rungs: [{ nodes: [] }, { nodes: [node] }] }
+
+    const changed = restampFlowLibraryVariants([flow], makeSystemLibraries(), [])
+
+    expect(changed).toBe(1)
+    expect(node.data.variant.variables[0].type.value).toBe('__XWORD')
+  })
+
+  it('skips blocks backed by a user-defined POU', () => {
+    // A user POU named "ADR" (contrived) must NOT be re-stamped even though a
+    // library entry of the same name exists.
+    const node = makeStaleAdrNode()
+    const flow = { rung: { nodes: [node] } }
+
+    const changed = restampFlowLibraryVariants([flow], makeSystemLibraries(), ['ADR'])
+
+    expect(changed).toBe(0)
+    expect(node.data.variant.variables[0].type.value).toBe('ULINT')
+  })
+
+  it('leaves up-to-date variants untouched (no spurious changes)', () => {
+    const node = makeStaleAdrNode()
+    node.data.variant.variables[0].type.value = '__XWORD'
+    const flow = { rung: { nodes: [node] } }
+
+    const changed = restampFlowLibraryVariants([flow], makeSystemLibraries(), [])
+
+    expect(changed).toBe(0)
+  })
+
+  it('ignores blocks not present in any library (user blocks, unknown types)', () => {
+    const node = makeStaleAdrNode()
+    node.data.variant.name = 'MY_CUSTOM_FB'
+    const flow = { rung: { nodes: [node] } }
+
+    const changed = restampFlowLibraryVariants([flow], makeSystemLibraries(), [])
+
+    expect(changed).toBe(0)
+    expect(node.data.variant.variables[0].type.value).toBe('ULINT')
+  })
+
+  it('is a no-op when no libraries are loaded yet', () => {
+    const node = makeStaleAdrNode()
+    const flow = { rung: { nodes: [node] } }
+
+    const changed = restampFlowLibraryVariants([flow], [], [])
+
+    expect(changed).toBe(0)
+    expect(node.data.variant.variables[0].type.value).toBe('ULINT')
+  })
+})

--- a/src/frontend/utils/PLC/restamp-library-variants.ts
+++ b/src/frontend/utils/PLC/restamp-library-variants.ts
@@ -1,0 +1,117 @@
+import type { BlockVariant } from '@root/middleware/shared/ports/block-types'
+import type { SystemLibrary } from '@root/middleware/shared/ports/library-types'
+
+/**
+ * Refresh the *types* carried by placed graphical block variants from the
+ * current library definitions.
+ *
+ * A block's signature is copied into `node.data.variant` once, when the block
+ * is dropped on the canvas (see the FBD/LD `handleAddElementByDropping`), and
+ * then frozen in the saved project. When a library updates a block's pin or
+ * return type — e.g. `ADR` moving from `ULINT` to the platform-width `__XWORD`
+ * — already-placed blocks keep the stale type and the transpiler (which reads
+ * `node.data.variant` via `collect-library-blocks`) emits the old type.
+ *
+ * On project load we re-stamp the variable types of every block that resolves
+ * to a **library** definition (the bundled / system libraries in
+ * `libraries.system`). Blocks backed by a **user-defined POU** (a function or
+ * function-block authored in this project) are skipped — their interface lives
+ * in the project, not the library, so the project is the source of truth.
+ *
+ * The refresh is intentionally type-only: it matches variables by name and
+ * copies the library's `type`, leaving the pin set, ids, handles and wiring
+ * untouched. That keeps extensible (variadic) blocks and existing connections
+ * intact while still propagating type changes.
+ */
+
+type VariantVariable = BlockVariant['variables'][number]
+
+/** Index every library POU by name → its variables, for O(1) lookup. */
+function indexLibraryPous(systemLibraries: SystemLibrary[]): Map<string, SystemLibrary['pous'][number]> {
+  const byName = new Map<string, SystemLibrary['pous'][number]>()
+  for (const library of systemLibraries) {
+    for (const pou of library.pous) {
+      // First definition wins; bundled libraries don't collide on name.
+      if (!byName.has(pou.name)) byName.set(pou.name, pou)
+    }
+  }
+  return byName
+}
+
+/** A minimal block-bearing node shape; both FBD and LD nodes satisfy it. */
+type BlockBearingNode = { type?: string; data?: { variant?: BlockVariant } }
+
+/**
+ * Re-stamp variable types in place for every library-backed block node.
+ *
+ * @param nodes            the flow's nodes (FBD `rung.nodes` or an LD
+ *                         `rung.nodes`)
+ * @param libraryPousByName library POUs indexed by name
+ * @param userPouNames     names of user-defined POUs to skip (uppercased)
+ * @returns the number of variables actually changed (for logging/tests)
+ */
+function restampNodes(
+  nodes: BlockBearingNode[],
+  libraryPousByName: Map<string, SystemLibrary['pous'][number]>,
+  userPouNames: Set<string>,
+): number {
+  let changed = 0
+  for (const node of nodes) {
+    if (node?.type !== 'block') continue
+    const variant = node.data?.variant
+    const name = variant?.name
+    if (!variant || !name) continue
+
+    // Skip blocks backed by a user-defined POU — the project owns their shape.
+    if (userPouNames.has(name.toUpperCase())) continue
+
+    const libPou = libraryPousByName.get(name)
+    if (!libPou) continue
+
+    // Index the library's variables by name for matching.
+    const libVarByName = new Map(libPou.variables.map((v) => [v.name, v]))
+
+    for (const variable of variant.variables) {
+      const libVar = libVarByName.get(variable.name)
+      if (!libVar) continue
+      const next = libVar.type
+      const current = variable.type
+      if (current.definition === next.definition && current.value === next.value) continue
+      // The block-variant type union only admits 'base-type' / 'generic-type';
+      // library `typeRef()` emits exactly those, so the shape is compatible.
+      variable.type = { definition: next.definition, value: next.value } as VariantVariable['type']
+      changed += 1
+    }
+  }
+  return changed
+}
+
+/**
+ * Re-stamp every block in the given flows from the current system libraries.
+ * Mutates the flow objects in place. Returns the total number of variable
+ * types changed (0 when nothing was stale).
+ *
+ * `flows` accepts both FBD flows (single `rung`) and LD flows (`rungs[]`); the
+ * shape is duck-typed so the helper stays language-agnostic and on the shared
+ * surface.
+ */
+export function restampFlowLibraryVariants(
+  flows: Array<{ rung?: { nodes?: unknown }; rungs?: Array<{ nodes?: unknown }> }>,
+  systemLibraries: SystemLibrary[],
+  userPouNames: Iterable<string>,
+): number {
+  const libraryPousByName = indexLibraryPous(systemLibraries)
+  if (libraryPousByName.size === 0) return 0
+  const skip = new Set<string>()
+  for (const n of userPouNames) skip.add(n.toUpperCase())
+
+  let changed = 0
+  for (const flow of flows) {
+    const rungs = flow.rungs ?? (flow.rung ? [flow.rung] : [])
+    for (const rung of rungs) {
+      const nodes = rung?.nodes
+      if (Array.isArray(nodes)) changed += restampNodes(nodes as BlockBearingNode[], libraryPousByName, skip)
+    }
+  }
+  return changed
+}

--- a/src/frontend/utils/keywords.ts
+++ b/src/frontend/utils/keywords.ts
@@ -116,6 +116,7 @@ const keywords = [
   'WORD',
   'DWORD',
   'LWORD',
+  '__XWORD',
   'REAL',
   'LREAL',
   'TIME',

--- a/src/frontend/utils/pou-helpers.ts
+++ b/src/frontend/utils/pou-helpers.ts
@@ -53,6 +53,7 @@ const BASE_TYPES = [
   'WORD',
   'DWORD',
   'LWORD',
+  '__XWORD',
 ]
 
 /**

--- a/src/frontend/utils/python/generatePythonLspPreamble.ts
+++ b/src/frontend/utils/python/generatePythonLspPreamble.ts
@@ -69,7 +69,8 @@ function mapIecBaseTypeToPython(value: string): string | null {
     upper === 'BYTE' ||
     upper === 'WORD' ||
     upper === 'DWORD' ||
-    upper === 'LWORD'
+    upper === 'LWORD' ||
+    upper === '__XWORD'
   ) {
     return 'int'
   }

--- a/src/frontend/utils/stlib-to-system-library.ts
+++ b/src/frontend/utils/stlib-to-system-library.ts
@@ -66,6 +66,7 @@ const BASE_TYPE_NAMES = new Set([
   'WORD',
   'DWORD',
   'LWORD',
+  '__XWORD',
   'SINT',
   'INT',
   'DINT',

--- a/src/middleware/shared/ports/plc-schemas.ts
+++ b/src/middleware/shared/ports/plc-schemas.ts
@@ -49,7 +49,7 @@ const genericTypeSchema = z.object({
     z.literal('ANY_ELEMENTARY'),
   ]),
   ANY_INT: baseTypeEnum.extract(['SINT', 'INT', 'DINT', 'LINT', 'USINT', 'UINT', 'UDINT', 'ULINT']),
-  ANY_BIT: baseTypeEnum.extract(['BOOL', 'BYTE', 'WORD', 'DWORD', 'LWORD']),
+  ANY_BIT: baseTypeEnum.extract(['BOOL', 'BYTE', 'WORD', 'DWORD', 'LWORD', '__XWORD']),
   ANY_STRING: baseTypeEnum.extract(['STRING']),
   ANY_REAL: baseTypeEnum.extract(['REAL', 'LREAL']),
   ANY_DATE: baseTypeEnum.extract(['TIME', 'DATE', 'TOD', 'DT']),


### PR DESCRIPTION
## What & why

The new xml2st (Autonomy-Logic/xml2st#26) is library-agnostic: it types the `_TMP` temporaries it generates for FUNCTION outputs from block signatures embedded in the project XML, instead of a bundled library that diverges from STruC++.

Every graphical block instance already carries its full typed signature in `node.data.variant` (stamped from the library on placement), so we collect the signatures of every library block a project uses and embed them as a project-level `<addData>` payload that xml2st reads.

This fixes the `ANY`-typed-temp compile failures (e.g. nullary `CURRENT_DT`) and removes the transpiler/library divergence.

## Changes (shared surface — pure logic, no I/O)
- `src/backend/shared/utils/PLC/collect-library-blocks.ts`: pure `projectData`→`<addData>` collector. Walks FBD/LD bodies, dedupes by name, skips user POUs, keeps IEC generics (`ANY_NUM`) and the `extensible` flag for variadic functions.
- `src/backend/shared/utils/PLC/xml-generator.ts`: append the payload after `<instances>`.
- Tests for nullary / variadic / function-block / dedupe.

Format contract: see `docs/library-blocks.md` in Autonomy-Logic/xml2st#26.

## Pairing ⚠️
Byte-identical shared-surface change — paired with the openplc-web mirror (`feat/embed-library-blocks-xml`). Merge together to satisfy `ci-sync`.

## Follow-ups (not in this PR)
- SFC action/transition bodies aren't traversed yet (FBD/LD covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features / Improvements**
  * PLC XML generation now collects the concrete signatures of used library block variants and embeds them into the generated XML payload (deduplicated by variant name and avoiding conflicts with user-defined POUs).
  * When opening/loading a project, library-backed block variant pin types are refreshed to stay in sync with current system libraries.
  * Updated PLC type handling to treat `__XWORD` consistently across identifier rules, base-type traversal, Python mapping, stlib conversion, and `ANY_BIT` generic schemas.

* **Tests**
  * Added Jest coverage for library block collection across FBD and Ladder, and for variant-pin restamping behavior.

* **Chores**
  * Updated tooling versions (xml2st, strucpp).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->