### PR TITLE
fix(variables): allow clearing the location of an orphaned-alias variable

### DIFF
--- a/src/frontend/components/_atoms/generic-table-inputs/generic-combobox-cell.tsx
+++ b/src/frontend/components/_atoms/generic-table-inputs/generic-combobox-cell.tsx
@@ -25,6 +25,7 @@ export const GenericComboboxCell = ({
   selected = true,
   openOnSelectedOption = false,
   canAddACustomOption = false,
+  allowClearWhenEmpty = false,
   displayLabel,
 }: {
   value: string
@@ -33,6 +34,11 @@ export const GenericComboboxCell = ({
   selected?: boolean
   openOnSelectedOption?: boolean
   canAddACustomOption?: boolean
+  /** Keep the "Clear" affordance enabled even when `value` is empty.
+   *  Used by the variable location cell for orphaned aliases: sync blanks
+   *  the location (so it's empty) but a stale alias label remains, and the
+   *  user must still be able to clear it — sending '' drops the stale alias. */
+  allowClearWhenEmpty?: boolean
   /** Visible text in the closed-state trigger. When omitted, the
    *  trigger shows `value` verbatim (the original behavior). Used by
    *  variable cells to render `alias (address)` so the bound alias
@@ -87,7 +93,7 @@ export const GenericComboboxCell = ({
         : item.value === inputValue.trim(),
     )
 
-  const isClearButtonDisabled = !value.trim()
+  const isClearButtonDisabled = !value.trim() && !allowClearWhenEmpty
 
   const handleOnOpenChange = (open: boolean) => {
     setSelectIsOpen(open)

--- a/src/frontend/components/_molecules/variables-table/editable-cell.tsx
+++ b/src/frontend/components/_molecules/variables-table/editable-cell.tsx
@@ -560,6 +560,10 @@ const EditableLocationCell = ({
       selected={selected}
       openOnSelectedOption
       canAddACustomOption
+      // Orphaned/mismatched aliases blank the location (sync clears it for
+      // compilation) but leave a stale alias label. Keep "Clear" enabled even
+      // when the location is empty so the user can drop the stale alias.
+      allowClearWhenEmpty={id === 'location' && (isOrphaned || isMismatched)}
     />
   ) : (
     <div

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -791,7 +791,9 @@ describe('createProjectSlice', () => {
       store.getState().projectActions.createVariable({ scope: 'global', data: makeVariable('gx', 'global') })
       store.getState().projectActions.updateVariable({ scope: 'global', variableId: 'gx', data: { location: '%QW0' } })
       // Attach a stale alias (no producer declares it).
-      store.getState().projectActions.updateVariable({ scope: 'global', variableId: 'gx', data: { alias: 'StaleAlias' } })
+      store
+        .getState()
+        .projectActions.updateVariable({ scope: 'global', variableId: 'gx', data: { alias: 'StaleAlias' } })
       let v = store.getState().project.data.configurations.resource.globalVariables[0]
       expect(v.location).toBe('%QW0')
       expect(v.alias).toBe('StaleAlias')

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -782,6 +782,30 @@ describe('createProjectSlice', () => {
       })
       expect(result.ok).toBe(false)
     })
+
+    it('clearing the location drops a stale alias', () => {
+      // Reproduces the orphaned-alias case: a variable that carries a
+      // location plus an alias no longer backed by any producer (target
+      // changed / device removed). Clearing the location (location: '')
+      // must succeed AND drop the stale alias.
+      store.getState().projectActions.createVariable({ scope: 'global', data: makeVariable('gx', 'global') })
+      store.getState().projectActions.updateVariable({ scope: 'global', variableId: 'gx', data: { location: '%QW0' } })
+      // Attach a stale alias (no producer declares it).
+      store.getState().projectActions.updateVariable({ scope: 'global', variableId: 'gx', data: { alias: 'StaleAlias' } })
+      let v = store.getState().project.data.configurations.resource.globalVariables[0]
+      expect(v.location).toBe('%QW0')
+      expect(v.alias).toBe('StaleAlias')
+
+      const result = store.getState().projectActions.updateVariable({
+        scope: 'global',
+        variableId: 'gx',
+        data: { location: '' },
+      })
+      expect(result.ok).toBe(true)
+      v = store.getState().project.data.configurations.resource.globalVariables[0]
+      expect(v.location).toBe('')
+      expect(v.alias ?? '').toBe('')
+    })
   })
 
   describe('getVariable', () => {


### PR DESCRIPTION
### What
When a variable carries an **orphaned/mismatched alias** (an alias no longer backed by any producer — e.g. the target changed or a device was removed), alias-sync blanks the variable's **location** for compilation but leaves a stale alias label behind. The location cell's "Clear" affordance was disabled whenever the value was empty, so the user had no way to drop the stale alias.

This adds an opt-in `allowClearWhenEmpty` prop to `GenericComboboxCell` and enables it on the variable **location** cell only for orphaned/mismatched aliases, so clearing sends `''` and drops the stale alias. Covered by a new store test (`clearing the location drops a stale alias`).

### Files
- `_atoms/generic-table-inputs/generic-combobox-cell.tsx` — new `allowClearWhenEmpty` prop (keeps Clear enabled on empty value).
- `_molecules/variables-table/editable-cell.tsx` — enable it for the location cell on orphaned/mismatched aliases.
- `store/__tests__/project-slice.test.ts` — regression test.

### Notes
- The branch was cut before PR #876 (RTU persistence) merged; I merged `development` in so this PR shows only the 3 alias-clearing files and merges cleanly (no revert of #876 — verified).
- All 3 files are shared surface; a **matching openplc-web PR** accompanies this one. The cross-repo sync check stays red until both land on their `development` branches (merge web first, then editor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing the clearing of empty alias states in variable location fields, enabling users to properly remove orphaned or stale aliases from their variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->