### PR TITLE
feat(vpp): bake per-module config bytes into vpp_config.h for Arduino targets

### DIFF
--- a/resources/sources/Baremetal/ModbusSlave.cpp
+++ b/resources/sources/Baremetal/ModbusSlave.cpp
@@ -1342,11 +1342,18 @@ void debugGetMd5(void * /*endianness*/)
         mb_frame[md5_len + 3] = md5[md5_len];
     }
 
-    // Native-order store of the endianness sentinel.  The reinterpret_cast
-    // is intentional: it preserves the target's byte ordering in the
-    // emitted bytes, which is exactly the signal the editor uses to choose
-    // its swap behaviour.
-    *reinterpret_cast<uint16_t *>(&mb_frame[md5_len + 3]) = 0xDEAD;
+    // Native-order store of the endianness sentinel.  Written byte-wise
+    // (not via `*reinterpret_cast<uint16_t*>`) because `md5_len + 3` is an
+    // odd offset for a 32-char MD5, and a typed 16-bit store there is an
+    // unaligned access that HardFaults on Cortex-M0+ (SAMD21: MKR Zero /
+    // P1AM-100) — hanging the device on the first debugger request. Copying
+    // the two bytes of a native-order uint16_t preserves the target's byte
+    // ordering (the signal the editor uses to choose its swap behaviour)
+    // while keeping every access byte-aligned.
+    const uint16_t endian_sentinel = 0xDEAD;
+    const uint8_t *sentinel_bytes = reinterpret_cast<const uint8_t *>(&endian_sentinel);
+    mb_frame[md5_len + 3] = sentinel_bytes[0];
+    mb_frame[md5_len + 4] = sentinel_bytes[1];
     mb_frame_len = md5_len + 5;
 }
 

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -100,7 +100,10 @@ import {
 } from '@root/backend/shared/utils/cpp/generateCBlocksHeader'
 import { validatePathId } from '@root/backend/shared/utils/path-safety'
 import { XmlGenerator } from '@root/backend/shared/utils/PLC/xml-generator'
-import { buildModuleConfigEntries, generateVendorPluginConfig } from '@root/backend/shared/utils/vpp/generate-vendor-plugin-config'
+import {
+  buildModuleConfigEntries,
+  generateVendorPluginConfig,
+} from '@root/backend/shared/utils/vpp/generate-vendor-plugin-config'
 import { getErrorMessage } from '@root/frontend/utils/get-error-message'
 import { app as electronApp, dialog, MessageChannelMain } from 'electron'
 import type { MessagePortMain } from 'electron/main'

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -100,7 +100,7 @@ import {
 } from '@root/backend/shared/utils/cpp/generateCBlocksHeader'
 import { validatePathId } from '@root/backend/shared/utils/path-safety'
 import { XmlGenerator } from '@root/backend/shared/utils/PLC/xml-generator'
-import { generateVendorPluginConfig } from '@root/backend/shared/utils/vpp/generate-vendor-plugin-config'
+import { buildModuleConfigEntries, generateVendorPluginConfig } from '@root/backend/shared/utils/vpp/generate-vendor-plugin-config'
 import { getErrorMessage } from '@root/frontend/utils/get-error-message'
 import { app as electronApp, dialog, MessageChannelMain } from 'electron'
 import type { MessagePortMain } from 'electron/main'
@@ -2353,6 +2353,71 @@ class CompilerModule {
   }
 
   /**
+   * Compute per-slot module-configuration bytes for an Arduino VPP
+   * target with a modular backplane.
+   *
+   * Microcontroller boards have no runtime JSON, so per-module config
+   * (analog ranges, thermocouple types, ...) must be baked into the
+   * firmware. This resolves the installed VPP device for `boardTarget`,
+   * loads each module's configScreen, and encodes the same bytes the
+   * runtime-v4 plugin path would — keyed by 1-based slot. The caller
+   * injects them into `vendorScreenData` under a synthetic
+   * `module-config` key so the `vpp_config.h` generator emits
+   * `VPP_MODULE_CONFIG_ENTRIES_*` macros for the HAL.
+   *
+   * Returns [] for non-modular / non-VPP boards. Never throws.
+   */
+  async buildVppArduinoModuleConfig(
+    boardTarget: string,
+    vendorScreenData: Record<string, unknown>,
+  ): Promise<Array<{ slot: number; bytes: number[] }>> {
+    try {
+      const packageManager = new PackageManagerModule()
+      const installed = packageManager.listInstalled()
+
+      let matchingPackagePath: string | null = null
+      let matchingDevice: PackageManifest['devices'][number] | null = null
+      for (const pkg of installed) {
+        const manifest = packageManager.getInstalledPackageManifest(pkg.packageId)
+        if (!manifest) continue
+        const device = manifest.devices.find((d) => d.name === boardTarget)
+        if (device) {
+          matchingPackagePath = pkg.path
+          matchingDevice = device
+          break
+        }
+      }
+
+      const rawModules = matchingDevice?.moduleSystem?.modules
+      if (!matchingDevice || !matchingPackagePath || !rawModules || rawModules.length === 0) return []
+
+      const pkgPath = matchingPackagePath
+      const modules = await Promise.all(
+        rawModules.map(async (m) => {
+          let configScreenDefinition: unknown
+          const rel = (m as { configScreen?: string }).configScreen
+          if (rel) {
+            try {
+              const raw = await readFile(join(pkgPath, rel), 'utf-8')
+              configScreenDefinition = JSON.parse(raw)
+            } catch {
+              // Missing/invalid configScreen — module contributes no bytes.
+            }
+          }
+          return { ...m, configScreenDefinition }
+        }),
+      )
+
+      return buildModuleConfigEntries(
+        vendorScreenData as Parameters<typeof buildModuleConfigEntries>[0],
+        modules as Parameters<typeof buildModuleConfigEntries>[1],
+      )
+    } catch {
+      return []
+    }
+  }
+
+  /**
    * Main compile entry point.  Drives the full Step 0-13 flow
    * through the shared `runCompilePipeline` orchestrator
    * (`backend/shared/compile/pipeline.ts`); platform-specific bits
@@ -2660,6 +2725,20 @@ class CompilerModule {
       }
     }
 
+    // For Arduino VPP targets with a modular backplane, bake the
+    // per-slot module-configuration bytes into vpp_config.h (the MCU
+    // has no runtime JSON to load them from). The synthetic
+    // `module-config` key flows through the generic vpp_config.h walker
+    // as VPP_MODULE_CONFIG_ENTRIES_* macros. No-op for non-modular /
+    // non-VPP / runtime-v4 / simulator targets.
+    let effectiveVendorScreenData = vendorScreenData
+    if (!isRuntimeV4 && !isSimulator) {
+      const moduleConfigEntries = await this.buildVppArduinoModuleConfig(boardTarget, vendorScreenData ?? {})
+      if (moduleConfigEntries.length > 0) {
+        effectiveVendorScreenData = { ...(vendorScreenData ?? {}), 'module-config': { entries: moduleConfigEntries } }
+      }
+    }
+
     // --- Run the shared pipeline ---
     const result = await runCompilePipeline(
       {
@@ -2685,7 +2764,7 @@ class CompilerModule {
         deviceContext,
         communicationPort: communicationPort ?? undefined,
         ...(vppModbusState ? { vppModbusState } : {}),
-        vendorScreenData,
+        vendorScreenData: effectiveVendorScreenData,
       },
       platformPort,
       (event) => {

--- a/src/backend/shared/utils/vpp/__tests__/generate-vendor-plugin-config.test.ts
+++ b/src/backend/shared/utils/vpp/__tests__/generate-vendor-plugin-config.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildModuleConfigEntries,
   generateVendorPluginConfig,
   type VendorScreenData,
   type VppModuleDefinition,
@@ -737,5 +738,46 @@ describe('generateVendorPluginConfig — pins[] (GPIO pin-mapping)', () => {
     )
     expect(result.slots).toEqual([])
     expect(result.pins).toEqual([{ pin: 11, direction: 'output', byte: 0, bit: 0 }])
+  })
+})
+
+describe('buildModuleConfigEntries', () => {
+  const modules: VppModuleDefinition[] = [moduleDi8, moduleThm4]
+
+  it('encodes per-slot config bytes for a configurable module, keyed by 1-based slot', () => {
+    const vsd = {
+      'module-configuration': {
+        slots: [null, 'thm-4'], // slot 2 holds the THM-4
+        slotsConfig: { '2': { ch1_type: '0x5' } }, // override CH1 -> Type T
+      },
+    } as unknown as VendorScreenData
+    const entries = buildModuleConfigEntries(vsd, modules)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].slot).toBe(2)
+    // 20-byte buffer: 0x4003, 0x6005 defaults, ch1 = 0x2100 | 0x5 = 0x2105
+    expect(entries[0].bytes).toHaveLength(20)
+    expect(entries[0].bytes.slice(0, 6)).toEqual([0x40, 0x03, 0x60, 0x05, 0x21, 0x05])
+  })
+
+  it('falls back to field defaults when the user set no values', () => {
+    const vsd = {
+      'module-configuration': { slots: ['thm-4'] },
+    } as unknown as VendorScreenData
+    const entries = buildModuleConfigEntries(vsd, modules)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].slot).toBe(1)
+    // ch1 defaults to 0x0 -> 0x2100 | 0x0 = 0x2100
+    expect(entries[0].bytes.slice(0, 6)).toEqual([0x40, 0x03, 0x60, 0x05, 0x21, 0x00])
+  })
+
+  it('omits modules with no configScreen and unknown/empty slots', () => {
+    const vsd = {
+      'module-configuration': { slots: ['di-8', null, 'not-a-module'] },
+    } as unknown as VendorScreenData
+    expect(buildModuleConfigEntries(vsd, modules)).toEqual([])
+  })
+
+  it('returns [] when there is no module-configuration', () => {
+    expect(buildModuleConfigEntries({} as VendorScreenData, modules)).toEqual([])
   })
 })

--- a/src/backend/shared/utils/vpp/generate-vendor-plugin-config.ts
+++ b/src/backend/shared/utils/vpp/generate-vendor-plugin-config.ts
@@ -301,6 +301,44 @@ function buildSlots(vendorScreenData: VendorScreenData, modules: VppModuleDefini
 }
 
 /**
+ * Build the per-slot module-configuration byte entries for an Arduino
+ * (microcontroller) VPP target.
+ *
+ * The runtime-v4 path serialises module config bytes into the plugin's
+ * JSON (see `buildSlots` -> `module_config`). Arduino targets have no
+ * runtime JSON: every byte must be baked into flash through
+ * `vpp_config.h`. This helper produces the same encoded bytes, keyed by
+ * 1-based slot, so the caller can inject them into `vendorScreenData`
+ * under a synthetic `module-config` key — the generic `vpp_config.h`
+ * walker then emits them as `VPP_MODULE_CONFIG_ENTRIES_*` macros that
+ * the HAL feeds to `P1.configureModule()` (or equivalent) at boot.
+ *
+ * Only slots whose module declared a configScreen and resolved to a
+ * non-empty byte array are returned; everything else is omitted (the
+ * module library's factory defaults apply).
+ */
+export function buildModuleConfigEntries(
+  vendorScreenData: VendorScreenData,
+  modules: VppModuleDefinition[],
+): Array<{ slot: number; bytes: number[] }> {
+  const moduleConfig = (vendorScreenData['module-configuration'] as ModuleConfiguration | undefined) ?? {}
+  const slotAssignments = moduleConfig.slots ?? []
+  const slotsConfigBag = moduleConfig.slotsConfig ?? {}
+
+  const entries: Array<{ slot: number; bytes: number[] }> = []
+  for (let slotIndex = 0; slotIndex < slotAssignments.length; slotIndex++) {
+    const moduleId = slotAssignments[slotIndex]
+    if (!moduleId) continue
+    const moduleDef = modules.find((m) => m.id === moduleId)
+    if (!moduleDef) continue
+    const slotNumber = slotIndex + 1
+    const bytes = encodeModuleConfig(moduleDef.configScreenDefinition, slotsConfigBag[String(slotNumber)] ?? {})
+    if (bytes && bytes.length > 0) entries.push({ slot: slotNumber, bytes })
+  }
+  return entries
+}
+
+/**
  * Build the `pins` array for a pin-based plugin from the editor's GPIO
  * pin-mapping table.
  *


### PR DESCRIPTION
### What
Microcontroller VPP targets (e.g. AutomationDirect P1AM) have no runtime JSON to load per-module configuration from, the way runtime-v4 plugins do. So per-module config authored on the Backplane Configuration screen (analog ranges, thermocouple/RTD/thermistor types) never reached an Arduino HAL — only the raw, un-encoded field values did.

This computes the same encoded config-byte buffer the runtime-v4 path produces (reusing `encodeModuleConfig`) and injects it into `vendorScreenData` under a synthetic `module-config` key before the `vpp_config.h` generator runs. The generic JSON→`#define` walker then emits `VPP_MODULE_CONFIG_ENTRIES_{COUNT,<i>_SLOT,<i>_BYTES,FOREACH}`, which the HAL feeds to `P1.configureModule()` (or equivalent) at boot.

### Files
- `backend/shared/utils/vpp/generate-vendor-plugin-config.ts` — new exported `buildModuleConfigEntries()` (slot iteration mirrors `buildSlots`, reuses `encodeModuleConfig`). **Shared surface.**
- `backend/shared/utils/vpp/__tests__/…` — tests for `buildModuleConfigEntries` (encode, defaults, omit, empty). **Shared surface.**
- `backend/editor/compiler/compiler-module.ts` — `buildVppArduinoModuleConfig()` resolves the installed VPP device, encodes each module's config, injects bytes for non-runtime-v4 / non-simulator targets. **Editor-only.**

### Notes
- Branch was cut before recent `development` work merged; I merged `development` in so the PR shows only its own files and merges cleanly.
- The 2 shared `vpp` files have a **matching openplc-web PR**; the `compiler-module.ts` change is editor-specific (web wires the shared helper through its own adapter separately). Cross-repo sync goes green once both shared changes land on their `development` branches (web first, then editor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-slot module configuration on Arduino VPP boards with modular backplane. The compiler now processes and injects module configuration data into the compilation pipeline.

* **Tests**
  * Added test suite verifying module configuration encoding, including handling of user overrides and default values for configurable modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->