### PR TITLE
feat(firmware): iec_runtime_fault glue + strucpp v0.5.8

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.5.7",
+    "version": "v0.5.8",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }

--- a/resources/sources/arduino/arduino_runtime_glue.cpp
+++ b/resources/sources/arduino/arduino_runtime_glue.cpp
@@ -20,6 +20,21 @@
 #include "debug_dispatch.hpp"
 
 // ---------------------------------------------------------------------------
+// Runtime fault hook
+// ---------------------------------------------------------------------------
+// Weak default for strucpp::iec_runtime_fault (declared in iec_fault.hpp).
+// On MCU firmware (compiled -fno-exceptions) the runtime calls this instead
+// of throwing on an unrecoverable fault (null deref, array OOB, bad located
+// address). Default behaviour: halt. A VPP HAL may provide a STRONG override
+// to signal the fault its own way — blink a status LED, sound an alarm,
+// reboot, etc. Kept free of <Arduino.h> so this TU stays macro-clean.
+__attribute__((weak)) void strucpp::iec_runtime_fault(strucpp::IecFault /*reason*/,
+                                                       const char* /*context*/) noexcept {
+    for (;;) {
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Storage
 // ---------------------------------------------------------------------------
 strucpp::Configuration_CONFIG0 g_config;


### PR DESCRIPTION
Adopts strucpp **v0.5.8** (target-aware runtime fault path).

- **arduino_runtime_glue.cpp**: weak default `strucpp::iec_runtime_fault` (halt) for MCU targets compiled `-fno-exceptions`. VPP HALs may override (P1AM blinks its LED).
- **binary-versions.json**: strucpp `v0.5.7` → `v0.5.8`.

No `-fexceptions` change here — the editor never hardcoded it (it came from VPP `cxx_flags`, removed in openplc-packages). Matching openplc-web PR opened with byte-identical firmware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated strucpp binary to version 0.5.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->