### PR TITLE
release: development → main (v4.2.6)

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.5.7",
+    "version": "v0.5.8",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }

--- a/binary-versions.json
+++ b/binary-versions.json
@@ -1,10 +1,10 @@
 {
   "xml2st": {
-    "version": "v4.0.6",
+    "version": "v4.0.7",
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.5.7",
+    "version": "v0.5.9",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-plc-editor",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-plc-editor",
-      "version": "4.2.5",
+      "version": "4.2.6",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-plc-editor",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "license": "GPL-3.0",
   "author": {
     "name": "Autonomy Logic"

--- a/resources/sources/Baremetal/ModbusSlave.cpp
+++ b/resources/sources/Baremetal/ModbusSlave.cpp
@@ -1342,11 +1342,18 @@ void debugGetMd5(void * /*endianness*/)
         mb_frame[md5_len + 3] = md5[md5_len];
     }
 
-    // Native-order store of the endianness sentinel.  The reinterpret_cast
-    // is intentional: it preserves the target's byte ordering in the
-    // emitted bytes, which is exactly the signal the editor uses to choose
-    // its swap behaviour.
-    *reinterpret_cast<uint16_t *>(&mb_frame[md5_len + 3]) = 0xDEAD;
+    // Native-order store of the endianness sentinel.  Written byte-wise
+    // (not via `*reinterpret_cast<uint16_t*>`) because `md5_len + 3` is an
+    // odd offset for a 32-char MD5, and a typed 16-bit store there is an
+    // unaligned access that HardFaults on Cortex-M0+ (SAMD21: MKR Zero /
+    // P1AM-100) — hanging the device on the first debugger request. Copying
+    // the two bytes of a native-order uint16_t preserves the target's byte
+    // ordering (the signal the editor uses to choose its swap behaviour)
+    // while keeping every access byte-aligned.
+    const uint16_t endian_sentinel = 0xDEAD;
+    const uint8_t *sentinel_bytes = reinterpret_cast<const uint8_t *>(&endian_sentinel);
+    mb_frame[md5_len + 3] = sentinel_bytes[0];
+    mb_frame[md5_len + 4] = sentinel_bytes[1];
     mb_frame_len = md5_len + 5;
 }
 

--- a/resources/sources/arduino/arduino_runtime_glue.cpp
+++ b/resources/sources/arduino/arduino_runtime_glue.cpp
@@ -20,6 +20,21 @@
 #include "debug_dispatch.hpp"
 
 // ---------------------------------------------------------------------------
+// Runtime fault hook
+// ---------------------------------------------------------------------------
+// Weak default for strucpp::iec_runtime_fault (declared in iec_fault.hpp).
+// On MCU firmware (compiled -fno-exceptions) the runtime calls this instead
+// of throwing on an unrecoverable fault (null deref, array OOB, bad located
+// address). Default behaviour: halt. A VPP HAL may provide a STRONG override
+// to signal the fault its own way — blink a status LED, sound an alarm,
+// reboot, etc. Kept free of <Arduino.h> so this TU stays macro-clean.
+__attribute__((weak)) void strucpp::iec_runtime_fault(strucpp::IecFault /*reason*/,
+                                                       const char* /*context*/) noexcept {
+    for (;;) {
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Storage
 // ---------------------------------------------------------------------------
 strucpp::Configuration_CONFIG0 g_config;

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -100,7 +100,10 @@ import {
 } from '@root/backend/shared/utils/cpp/generateCBlocksHeader'
 import { validatePathId } from '@root/backend/shared/utils/path-safety'
 import { XmlGenerator } from '@root/backend/shared/utils/PLC/xml-generator'
-import { buildModuleConfigEntries, generateVendorPluginConfig } from '@root/backend/shared/utils/vpp/generate-vendor-plugin-config'
+import {
+  buildModuleConfigEntries,
+  generateVendorPluginConfig,
+} from '@root/backend/shared/utils/vpp/generate-vendor-plugin-config'
 import { getErrorMessage } from '@root/frontend/utils/get-error-message'
 import { app as electronApp, dialog, MessageChannelMain } from 'electron'
 import type { MessagePortMain } from 'electron/main'

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -100,7 +100,7 @@ import {
 } from '@root/backend/shared/utils/cpp/generateCBlocksHeader'
 import { validatePathId } from '@root/backend/shared/utils/path-safety'
 import { XmlGenerator } from '@root/backend/shared/utils/PLC/xml-generator'
-import { generateVendorPluginConfig } from '@root/backend/shared/utils/vpp/generate-vendor-plugin-config'
+import { buildModuleConfigEntries, generateVendorPluginConfig } from '@root/backend/shared/utils/vpp/generate-vendor-plugin-config'
 import { getErrorMessage } from '@root/frontend/utils/get-error-message'
 import { app as electronApp, dialog, MessageChannelMain } from 'electron'
 import type { MessagePortMain } from 'electron/main'
@@ -2353,6 +2353,71 @@ class CompilerModule {
   }
 
   /**
+   * Compute per-slot module-configuration bytes for an Arduino VPP
+   * target with a modular backplane.
+   *
+   * Microcontroller boards have no runtime JSON, so per-module config
+   * (analog ranges, thermocouple types, ...) must be baked into the
+   * firmware. This resolves the installed VPP device for `boardTarget`,
+   * loads each module's configScreen, and encodes the same bytes the
+   * runtime-v4 plugin path would — keyed by 1-based slot. The caller
+   * injects them into `vendorScreenData` under a synthetic
+   * `module-config` key so the `vpp_config.h` generator emits
+   * `VPP_MODULE_CONFIG_ENTRIES_*` macros for the HAL.
+   *
+   * Returns [] for non-modular / non-VPP boards. Never throws.
+   */
+  async buildVppArduinoModuleConfig(
+    boardTarget: string,
+    vendorScreenData: Record<string, unknown>,
+  ): Promise<Array<{ slot: number; bytes: number[] }>> {
+    try {
+      const packageManager = new PackageManagerModule()
+      const installed = packageManager.listInstalled()
+
+      let matchingPackagePath: string | null = null
+      let matchingDevice: PackageManifest['devices'][number] | null = null
+      for (const pkg of installed) {
+        const manifest = packageManager.getInstalledPackageManifest(pkg.packageId)
+        if (!manifest) continue
+        const device = manifest.devices.find((d) => d.name === boardTarget)
+        if (device) {
+          matchingPackagePath = pkg.path
+          matchingDevice = device
+          break
+        }
+      }
+
+      const rawModules = matchingDevice?.moduleSystem?.modules
+      if (!matchingDevice || !matchingPackagePath || !rawModules || rawModules.length === 0) return []
+
+      const pkgPath = matchingPackagePath
+      const modules = await Promise.all(
+        rawModules.map(async (m) => {
+          let configScreenDefinition: unknown
+          const rel = (m as { configScreen?: string }).configScreen
+          if (rel) {
+            try {
+              const raw = await readFile(join(pkgPath, rel), 'utf-8')
+              configScreenDefinition = JSON.parse(raw)
+            } catch {
+              // Missing/invalid configScreen — module contributes no bytes.
+            }
+          }
+          return { ...m, configScreenDefinition }
+        }),
+      )
+
+      return buildModuleConfigEntries(
+        vendorScreenData as Parameters<typeof buildModuleConfigEntries>[0],
+        modules as Parameters<typeof buildModuleConfigEntries>[1],
+      )
+    } catch {
+      return []
+    }
+  }
+
+  /**
    * Main compile entry point.  Drives the full Step 0-13 flow
    * through the shared `runCompilePipeline` orchestrator
    * (`backend/shared/compile/pipeline.ts`); platform-specific bits
@@ -2660,6 +2725,20 @@ class CompilerModule {
       }
     }
 
+    // For Arduino VPP targets with a modular backplane, bake the
+    // per-slot module-configuration bytes into vpp_config.h (the MCU
+    // has no runtime JSON to load them from). The synthetic
+    // `module-config` key flows through the generic vpp_config.h walker
+    // as VPP_MODULE_CONFIG_ENTRIES_* macros. No-op for non-modular /
+    // non-VPP / runtime-v4 / simulator targets.
+    let effectiveVendorScreenData = vendorScreenData
+    if (!isRuntimeV4 && !isSimulator) {
+      const moduleConfigEntries = await this.buildVppArduinoModuleConfig(boardTarget, vendorScreenData ?? {})
+      if (moduleConfigEntries.length > 0) {
+        effectiveVendorScreenData = { ...(vendorScreenData ?? {}), 'module-config': { entries: moduleConfigEntries } }
+      }
+    }
+
     // --- Run the shared pipeline ---
     const result = await runCompilePipeline(
       {
@@ -2685,7 +2764,7 @@ class CompilerModule {
         deviceContext,
         communicationPort: communicationPort ?? undefined,
         ...(vppModbusState ? { vppModbusState } : {}),
-        vendorScreenData,
+        vendorScreenData: effectiveVendorScreenData,
       },
       platformPort,
       (event) => {

--- a/src/backend/shared/compile/__tests__/generate-confs.test.ts
+++ b/src/backend/shared/compile/__tests__/generate-confs.test.ts
@@ -137,6 +137,19 @@ describe('generateRuntimeConfs — happy path', () => {
     expect(log).toHaveBeenCalledWith('OPC-UA Address Space: 5 node(s) configured', 'info')
   })
 
+  it('forwards Modbus master skip diagnostics through the log callback as level=warning', () => {
+    const log = jest.fn()
+    mockedModbusMaster.mockImplementation((_devices, innerLog) => {
+      innerLog?.('Modbus RTU device "BadRTU" is missing a serial port configuration and will be skipped.')
+      return null
+    })
+    generateRuntimeConfs(makeInput({ log }))
+    expect(log).toHaveBeenCalledWith(
+      'Modbus RTU device "BadRTU" is missing a serial port configuration and will be skipped.',
+      'warning',
+    )
+  })
+
   it('returns null for confs whose generator returned null', () => {
     // Default-mock behavior (all null).
     const result = generateRuntimeConfs(makeInput())

--- a/src/backend/shared/compile/steps/generate-confs.ts
+++ b/src/backend/shared/compile/steps/generate-confs.ts
@@ -74,7 +74,7 @@ export interface GenerateConfsInput {
    *  via this; error logs go here too before the relevant errors
    *  are rethrown.  Each adapter wires its native log channel
    *  through this callback. */
-  log: (message: string, level: 'info' | 'error') => void
+  log: (message: string, level: 'info' | 'warning' | 'error') => void
 }
 
 /**
@@ -112,13 +112,18 @@ export interface GenerateConfsOutput {
 export function generateRuntimeConfs(input: GenerateConfsInput): GenerateConfsOutput {
   const { servers, remoteDevices, instances, debugMapContent, log } = input
 
-  // Modbus slave / master / S7Comm: pure helpers, no I/O.  Each
-  // returns `null` when the project has no config of that type.
+  // Modbus slave / master / S7Comm: pure helpers.  Each returns `null`
+  // when the project has no config of that type.  Master also forwards
+  // non-fatal skip diagnostics (e.g. an RTU device missing a serial
+  // port) through `log` so they reach the build console.
   // Type assertions match the editor's call sites — the generators
   // accept a narrower shape than `PLCServer[]` / `PLCRemoteDevice[]`
   // but the runtime values are compatible.
   const modbusSlave = generateModbusSlaveConfig(servers as Parameters<typeof generateModbusSlaveConfig>[0])
-  const modbusMaster = generateModbusMasterConfig(remoteDevices as Parameters<typeof generateModbusMasterConfig>[0])
+  const modbusMaster = generateModbusMasterConfig(
+    remoteDevices as Parameters<typeof generateModbusMasterConfig>[0],
+    (msg) => log(msg, 'warning'),
+  )
   const s7Comm = generateS7CommConfig(servers)
 
   // OPC-UA: throws `OpcUaConfigError` on invalid project state.

--- a/src/backend/shared/utils/PLC/__tests__/collect-library-blocks.test.ts
+++ b/src/backend/shared/utils/PLC/__tests__/collect-library-blocks.test.ts
@@ -143,8 +143,16 @@ describe('collectLibraryBlocks', () => {
     }
     const project = fbdProject(
       [
-        blockNode({ name: 'ADD', type: 'function', variables: [{ name: 'OUT', class: 'output', type: genericType('ANY_NUM') }] }),
-        blockNode({ name: 'ADD', type: 'function', variables: [{ name: 'OUT', class: 'output', type: genericType('ANY_NUM') }] }),
+        blockNode({
+          name: 'ADD',
+          type: 'function',
+          variables: [{ name: 'OUT', class: 'output', type: genericType('ANY_NUM') }],
+        }),
+        blockNode({
+          name: 'ADD',
+          type: 'function',
+          variables: [{ name: 'OUT', class: 'output', type: genericType('ANY_NUM') }],
+        }),
         blockNode({ name: 'MyFB', type: 'function-block', variables: [] }),
       ],
       [userFb],

--- a/src/backend/shared/utils/PLC/__tests__/collect-library-blocks.test.ts
+++ b/src/backend/shared/utils/PLC/__tests__/collect-library-blocks.test.ts
@@ -33,6 +33,25 @@ function fbdProject(nodes: unknown[], extraPous: unknown[] = []): PLCProjectData
   } as unknown as PLCProjectData
 }
 
+/** Build a project with a single Ladder program; blocks live in rungs[].nodes. */
+function ldProject(nodesByRung: unknown[][]): PLCProjectData {
+  return {
+    dataTypes: [],
+    pous: [
+      {
+        type: 'program',
+        data: {
+          name: 'main',
+          language: 'ld',
+          variables: [],
+          documentation: '',
+          body: { language: 'ld', value: { name: 'main', rungs: nodesByRung.map((nodes) => ({ nodes })) } },
+        },
+      },
+    ],
+  } as unknown as PLCProjectData
+}
+
 describe('collectLibraryBlocks', () => {
   it('returns null when there are no graphical blocks', () => {
     const project = {
@@ -133,5 +152,34 @@ describe('collectLibraryBlocks', () => {
 
     const pous = (collectLibraryBlocks(project) as any).data.libraryBlocks.pou
     expect(pous.map((p: any) => p['@name'])).toEqual(['ADD'])
+  })
+
+  it('collects blocks from Ladder rungs (the common case)', () => {
+    const project = ldProject([
+      [
+        blockNode({
+          name: 'TON',
+          type: 'function-block',
+          variables: [
+            { name: 'IN', class: 'input', type: baseType('BOOL') },
+            { name: 'PT', class: 'input', type: baseType('TIME') },
+            { name: 'Q', class: 'output', type: baseType('BOOL') },
+          ],
+        }),
+      ],
+      [
+        blockNode({
+          name: 'CURRENT_DT',
+          type: 'function',
+          variables: [{ name: 'OUT', class: 'output', type: baseType('DT') }],
+        }),
+      ],
+    ])
+
+    const pous = (collectLibraryBlocks(project) as any).data.libraryBlocks.pou
+    // blocks gathered across both rungs, sorted by name
+    expect(pous.map((p: any) => p['@name'])).toEqual(['CURRENT_DT', 'TON'])
+    expect(pous.find((p: any) => p['@name'] === 'TON')['@pouType']).toBe('functionBlock')
+    expect(pous.find((p: any) => p['@name'] === 'CURRENT_DT').interface.returnType).toEqual({ DT: '' })
   })
 })

--- a/src/backend/shared/utils/PLC/__tests__/collect-library-blocks.test.ts
+++ b/src/backend/shared/utils/PLC/__tests__/collect-library-blocks.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for collectLibraryBlocks — the pure project→<addData> collector that
+ * embeds used library-block signatures for the xml2st transpiler.
+ */
+
+import type { PLCProjectData } from '@root/middleware/shared/ports/open-plc-types'
+
+import { collectLibraryBlocks } from '../collect-library-blocks'
+
+const baseType = (value: string) => ({ definition: 'base-type' as const, value })
+const genericType = (value: string) => ({ definition: 'generic-type' as const, value })
+
+const blockNode = (variant: unknown) => ({ type: 'block', data: { variant } })
+
+/** Build a project with a single FBD program containing the given block nodes. */
+function fbdProject(nodes: unknown[], extraPous: unknown[] = []): PLCProjectData {
+  return {
+    dataTypes: [],
+    pous: [
+      {
+        type: 'program',
+        data: {
+          name: 'main',
+          language: 'fbd',
+          variables: [],
+          documentation: '',
+          body: { language: 'fbd', value: { name: 'main', rung: { nodes } } },
+        },
+      },
+      ...extraPous,
+    ],
+    // configuration etc. are unused by the collector
+  } as unknown as PLCProjectData
+}
+
+describe('collectLibraryBlocks', () => {
+  it('returns null when there are no graphical blocks', () => {
+    const project = {
+      dataTypes: [],
+      pous: [{ type: 'program', data: { name: 'main', body: { language: 'st', value: '' } } }],
+    } as unknown as PLCProjectData
+    expect(collectLibraryBlocks(project)).toBeNull()
+  })
+
+  it('emits a nullary function as a returnType-only pou', () => {
+    const project = fbdProject([
+      blockNode({
+        name: 'CURRENT_DT',
+        type: 'function',
+        variables: [
+          { name: 'EN', class: 'input', type: baseType('BOOL') },
+          { name: 'ENO', class: 'output', type: baseType('BOOL') },
+          { name: 'OUT', class: 'output', type: baseType('DT') },
+        ],
+      }),
+    ])
+
+    const result = collectLibraryBlocks(project) as any
+    expect(result.data['@name']).toBe('openplc.org/xml2st/library-blocks')
+    const pous = result.data.libraryBlocks.pou
+    expect(pous).toHaveLength(1)
+    expect(pous[0]).toMatchObject({
+      '@name': 'CURRENT_DT',
+      '@pouType': 'function',
+      interface: { returnType: { DT: '' } },
+    })
+    // EN/ENO are dropped; no spurious inputVars/outputVars
+    expect(pous[0].interface.inputVars).toBeUndefined()
+    expect(pous[0].interface.outputVars).toBeUndefined()
+    expect(pous[0]['@extensible']).toBeUndefined()
+  })
+
+  it('preserves generic types and the extensible flag for variadic functions', () => {
+    const project = fbdProject([
+      blockNode({
+        name: 'ADD',
+        type: 'function',
+        extensible: true,
+        variables: [
+          { name: 'EN', class: 'input', type: baseType('BOOL') },
+          { name: 'IN1', class: 'input', type: genericType('ANY_NUM') },
+          { name: 'IN2', class: 'input', type: genericType('ANY_NUM') },
+          { name: 'OUT', class: 'output', type: genericType('ANY_NUM') },
+        ],
+      }),
+    ])
+
+    const pou = (collectLibraryBlocks(project) as any).data.libraryBlocks.pou[0]
+    expect(pou['@extensible']).toBe(true)
+    expect(pou.interface.returnType).toEqual({ ANY_NUM: '' })
+    expect(pou.interface.inputVars.variable).toEqual([
+      { '@name': 'IN1', type: { ANY_NUM: '' } },
+      { '@name': 'IN2', type: { ANY_NUM: '' } },
+    ])
+  })
+
+  it('emits function blocks with outputVars (no returnType)', () => {
+    const project = fbdProject([
+      blockNode({
+        name: 'TON',
+        type: 'function-block',
+        variables: [
+          { name: 'IN', class: 'input', type: baseType('BOOL') },
+          { name: 'PT', class: 'input', type: baseType('TIME') },
+          { name: 'Q', class: 'output', type: baseType('BOOL') },
+          { name: 'ET', class: 'output', type: baseType('TIME') },
+        ],
+      }),
+    ])
+
+    const pou = (collectLibraryBlocks(project) as any).data.libraryBlocks.pou[0]
+    expect(pou['@pouType']).toBe('functionBlock')
+    expect(pou.interface.returnType).toBeUndefined()
+    expect(pou.interface.outputVars.variable).toEqual([
+      { '@name': 'Q', type: { BOOL: '' } },
+      { '@name': 'ET', type: { TIME: '' } },
+    ])
+  })
+
+  it('dedupes by name and skips user-defined POUs', () => {
+    const userFb = {
+      type: 'function-block',
+      data: { name: 'MyFB', body: { language: 'st', value: '' } },
+    }
+    const project = fbdProject(
+      [
+        blockNode({ name: 'ADD', type: 'function', variables: [{ name: 'OUT', class: 'output', type: genericType('ANY_NUM') }] }),
+        blockNode({ name: 'ADD', type: 'function', variables: [{ name: 'OUT', class: 'output', type: genericType('ANY_NUM') }] }),
+        blockNode({ name: 'MyFB', type: 'function-block', variables: [] }),
+      ],
+      [userFb],
+    )
+
+    const pous = (collectLibraryBlocks(project) as any).data.libraryBlocks.pou
+    expect(pous.map((p: any) => p['@name'])).toEqual(['ADD'])
+  })
+})

--- a/src/backend/shared/utils/PLC/collect-library-blocks.ts
+++ b/src/backend/shared/utils/PLC/collect-library-blocks.ts
@@ -1,0 +1,137 @@
+import type { PLCProjectData } from '@root/middleware/shared/ports/open-plc-types'
+
+/**
+ * Collect the signatures of every *library* block a project uses and emit them
+ * as a PLCopen `<addData>` payload that the xml2st transpiler reads.
+ *
+ * Why: xml2st emits a local temporary per FUNCTION output and must declare it
+ * with a concrete type. It infers that type from the wired connections, but
+ * cannot when a function has no typed pin to borrow from (e.g. a nullary
+ * `CURRENT_DT` whose output is unconnected) — it then falls back to the illegal
+ * type `ANY`, which STruC++ rejects. Rather than make xml2st carry a block
+ * library (which would diverge from the real STruC++ library), we hand it the
+ * exact signatures the project uses, embedded in the project file itself.
+ *
+ * Every graphical block instance already carries its full typed signature in
+ * `node.data.variant` (the editor stamps it from the library on placement), so
+ * this is a pure function over the project model — no I/O, no library archives,
+ * no platform specifics. It therefore lives on the shared surface and is
+ * identical across the desktop and web builds.
+ *
+ * Output shape feeds xmlbuilder2 (see XmlGenerator); it is inserted as
+ * `<project>/<addData>` after `<instances>`. Contract: xml2st/docs/library-blocks.md.
+ */
+
+const DATA_NAME = 'openplc.org/xml2st/library-blocks'
+
+type XmlElement = Record<string, unknown>
+
+// Minimal view of a block variant's variable; the full schema lives in
+// middleware/shared/ports/block-types.ts (blockVariantVariableSchema).
+type VariantVariable = {
+  name: string
+  class: 'input' | 'output' | 'local' | 'inOut'
+  type: { definition: 'base-type' | 'generic-type'; value: string }
+}
+
+type BlockVariant = {
+  name: string
+  type: 'function' | 'function-block' | 'generic'
+  extensible?: boolean
+  variables: VariantVariable[]
+}
+
+/** `<INT/>`, `<ANY_NUM/>`, ... — xml2st reads the (upper-cased) tag name. */
+const typeElement = (variable: VariantVariable): XmlElement => ({ [variable.type.value]: '' })
+
+const variableElement = (variable: VariantVariable): XmlElement => ({
+  '@name': variable.name,
+  type: typeElement(variable),
+})
+
+/** Walk every graphical POU body and yield each block instance's variant. */
+const collectBlockVariants = (project: PLCProjectData): BlockVariant[] => {
+  const variants: BlockVariant[] = []
+
+  const visitNodes = (nodes: unknown) => {
+    if (!Array.isArray(nodes)) return
+    for (const node of nodes) {
+      const n = node as { type?: string; data?: { variant?: BlockVariant } }
+      if (n?.type === 'block' && n.data?.variant?.name) variants.push(n.data.variant)
+    }
+  }
+
+  for (const pou of project.pous) {
+    const body = pou.data?.body as { language?: string; value?: unknown } | undefined
+    if (!body) continue
+    if (body.language === 'fbd') {
+      const value = body.value as { rung?: { nodes?: unknown } } | undefined
+      visitNodes(value?.rung?.nodes)
+    } else if (body.language === 'ld') {
+      const value = body.value as { rungs?: Array<{ nodes?: unknown }> } | undefined
+      for (const rung of value?.rungs ?? []) visitNodes(rung?.nodes)
+    }
+  }
+
+  return variants
+}
+
+const variantToPou = (variant: BlockVariant): XmlElement => {
+  const isFunctionBlock = variant.type === 'function-block'
+  // EN/ENO are implicit control pins; xml2st adds them itself.
+  const vars = variant.variables.filter((v) => v.name !== 'EN' && v.name !== 'ENO')
+  const inputs = vars.filter((v) => v.class === 'input')
+  const inouts = vars.filter((v) => v.class === 'inOut')
+  const outputs = vars.filter((v) => v.class === 'output')
+
+  const iface: XmlElement = {}
+
+  if (!isFunctionBlock) {
+    // A function returns a single value; model its primary output (OUT) as the
+    // return type, any extra outputs as VAR_OUTPUT.
+    const ret = outputs.find((v) => v.name === 'OUT') ?? outputs[0]
+    if (ret) iface.returnType = typeElement(ret)
+    const extraOutputs = outputs.filter((v) => v !== ret)
+    if (extraOutputs.length) iface.outputVars = { variable: extraOutputs.map(variableElement) }
+  } else if (outputs.length) {
+    iface.outputVars = { variable: outputs.map(variableElement) }
+  }
+
+  if (inputs.length) iface.inputVars = { variable: inputs.map(variableElement) }
+  if (inouts.length) iface.inOutVars = { variable: inouts.map(variableElement) }
+
+  return {
+    '@name': variant.name,
+    '@pouType': isFunctionBlock ? 'functionBlock' : 'function',
+    ...(variant.extensible ? { '@extensible': true } : {}),
+    interface: iface,
+  }
+}
+
+/**
+ * Build the `<addData>` library-blocks payload for a project, or `null` when the
+ * project references no library blocks (e.g. text-only POUs).
+ *
+ * User-defined POUs are excluded: their definitions already travel in
+ * `<types><pous>` and xml2st resolves them directly.
+ */
+export const collectLibraryBlocks = (project: PLCProjectData): XmlElement | null => {
+  const userPouNames = new Set(project.pous.map((pou) => pou.data?.name))
+
+  const byName = new Map<string, BlockVariant>()
+  for (const variant of collectBlockVariants(project)) {
+    if (userPouNames.has(variant.name)) continue
+    if (!byName.has(variant.name)) byName.set(variant.name, variant)
+  }
+  if (byName.size === 0) return null
+
+  const pous = [...byName.values()].sort((a, b) => a.name.localeCompare(b.name)).map(variantToPou)
+
+  return {
+    data: {
+      '@name': DATA_NAME,
+      '@handleUnknown': 'discard',
+      libraryBlocks: { pou: pous },
+    },
+  }
+}

--- a/src/backend/shared/utils/PLC/xml-generator.ts
+++ b/src/backend/shared/utils/PLC/xml-generator.ts
@@ -3,7 +3,6 @@ import { BaseXml as codeSysBaseXml } from '@root/middleware/shared/ports/xml-typ
 import { BaseXml as oldBaseXml } from '@root/middleware/shared/ports/xml-types/old-editor'
 import { create } from 'xmlbuilder2'
 
-import { collectLibraryBlocks } from './collect-library-blocks'
 import {
   codeSysInstanceToXml,
   codeSysParseDataTypesToXML,
@@ -16,6 +15,7 @@ import {
   oldEditorParseDataTypesToXML,
   oldEditorParsePousToXML,
 } from '../../../../frontend/utils/PLC/xml-generator/old-editor'
+import { collectLibraryBlocks } from './collect-library-blocks'
 
 const XmlGenerator = (
   projectToGenerateXML: PLCProjectData,

--- a/src/backend/shared/utils/PLC/xml-generator.ts
+++ b/src/backend/shared/utils/PLC/xml-generator.ts
@@ -3,6 +3,7 @@ import { BaseXml as codeSysBaseXml } from '@root/middleware/shared/ports/xml-typ
 import { BaseXml as oldBaseXml } from '@root/middleware/shared/ports/xml-types/old-editor'
 import { create } from 'xmlbuilder2'
 
+import { collectLibraryBlocks } from './collect-library-blocks'
 import {
   codeSysInstanceToXml,
   codeSysParseDataTypesToXML,
@@ -67,6 +68,17 @@ const XmlGenerator = (
      */
     const configuration = projectToGenerateXML.configuration
     xmlResult = codeSysInstanceToXml(csXml, configuration)
+  }
+
+  /**
+   * Embed the signatures of every library block the project uses, so xml2st
+   * can type the temporaries it generates for FUNCTION outputs without
+   * carrying a block library of its own.  Added last so it serialises after
+   * <instances>, as the PLCopen schema requires for <addData>.
+   */
+  const libraryBlocks = collectLibraryBlocks(projectToGenerateXML)
+  if (libraryBlocks) {
+    ;(xmlResult as unknown as { project: Record<string, unknown> }).project.addData = libraryBlocks
   }
 
   const doc = create(xmlResult)

--- a/src/backend/shared/utils/modbus/__tests__/generate-modbus-master-config.test.ts
+++ b/src/backend/shared/utils/modbus/__tests__/generate-modbus-master-config.test.ts
@@ -153,6 +153,35 @@ describe('generateModbusMasterConfig', () => {
     expect(generateModbusMasterConfig([device])).toBeNull()
   })
 
+  it('logs a skip warning for an RTU device without a serial port', () => {
+    const device: PLCRemoteDevice = {
+      name: 'BadRTU',
+      protocol: 'modbus-tcp',
+      modbusTcpConfig: {
+        transport: 'rtu',
+        timeout: 500,
+        ioGroups: [
+          {
+            id: 'g1',
+            name: 'Group1',
+            functionCode: '3',
+            cycleTime: 100,
+            offset: '0',
+            length: 1,
+            errorHandling: 'keep-last-value',
+            ioPoints: [{ id: 'p1', name: 'P1', type: 'WORD', iecLocation: '%MW0' }],
+          },
+        ],
+      },
+    }
+
+    const log = jest.fn()
+    expect(generateModbusMasterConfig([device], log)).toBeNull()
+    expect(log).toHaveBeenCalledWith(
+      'Modbus RTU device "BadRTU" is missing a serial port configuration and will be skipped.',
+    )
+  })
+
   it('uses default values for optional TCP fields', () => {
     const device: PLCRemoteDevice = {
       name: 'Defaults',

--- a/src/backend/shared/utils/modbus/generate-modbus-master-config.ts
+++ b/src/backend/shared/utils/modbus/generate-modbus-master-config.ts
@@ -45,6 +45,14 @@ interface ModbusMasterDevice {
 type ModbusMasterConfig = ModbusMasterDevice[]
 
 /**
+ * Sink for non-fatal diagnostics emitted while building the config
+ * (e.g. an RTU device dropped for a missing serial port).  The compile
+ * pipeline wires this to the build console so the skip is visible to
+ * the user instead of vanishing into `console.warn`.
+ */
+type ModbusMasterConfigLog = (message: string) => void
+
+/**
  * Formats an offset value as a hexadecimal string.
  * If the offset is already in hex format (starts with 0x), returns it as-is.
  * Otherwise, converts the decimal number to hex format.
@@ -82,7 +90,10 @@ const convertIOGroupToIOPoint = (ioGroup: ModbusIOGroup): ModbusMasterIOPoint =>
  * Converts a PLCRemoteDevice with Modbus configuration to a ModbusMasterDevice
  * for the runtime configuration. Supports both TCP and RTU transports.
  */
-const convertRemoteDeviceToModbusMaster = (device: PLCRemoteDevice): ModbusMasterDevice | null => {
+const convertRemoteDeviceToModbusMaster = (
+  device: PLCRemoteDevice,
+  log?: ModbusMasterConfigLog,
+): ModbusMasterDevice | null => {
   /* istanbul ignore next -- defensive: callers pre-filter to modbus-tcp with config */
   if (device.protocol !== 'modbus-tcp' || !device.modbusTcpConfig) {
     return null
@@ -103,8 +114,10 @@ const convertRemoteDeviceToModbusMaster = (device: PLCRemoteDevice): ModbusMaste
   if (transport === 'rtu') {
     // RTU configuration
     if (!modbusTcpConfig.serialPort) {
-      // RTU requires a serial port
-      console.warn(`Modbus RTU device "${device.name}" is missing a serial port configuration and will be skipped.`)
+      // RTU requires a serial port.  Route the skip through the caller's
+      // log so it lands in the build console — otherwise the device is
+      // dropped silently and the runtime just reports "no config found".
+      log?.(`Modbus RTU device "${device.name}" is missing a serial port configuration and will be skipped.`)
       return null
     }
 
@@ -147,9 +160,14 @@ const convertRemoteDeviceToModbusMaster = (device: PLCRemoteDevice): ModbusMaste
  * Returns null if there are no Modbus TCP devices configured.
  *
  * @param remoteDevices - Array of PLCRemoteDevice from the project data
+ * @param log - Optional sink for non-fatal skip diagnostics (e.g. an RTU
+ *   device dropped for a missing serial port). Wired to the build console.
  * @returns The Modbus Master configuration as a JSON string, or null if no devices are configured
  */
-export const generateModbusMasterConfig = (remoteDevices: PLCRemoteDevice[] | undefined): string | null => {
+export const generateModbusMasterConfig = (
+  remoteDevices: PLCRemoteDevice[] | undefined,
+  log?: ModbusMasterConfigLog,
+): string | null => {
   if (!remoteDevices || remoteDevices.length === 0) {
     return null
   }
@@ -161,7 +179,7 @@ export const generateModbusMasterConfig = (remoteDevices: PLCRemoteDevice[] | un
   }
 
   const config: ModbusMasterConfig = modbusTcpDevices
-    .map(convertRemoteDeviceToModbusMaster)
+    .map((device) => convertRemoteDeviceToModbusMaster(device, log))
     .filter((device): device is ModbusMasterDevice => device !== null)
 
   if (config.length === 0) {

--- a/src/backend/shared/utils/vpp/__tests__/generate-vendor-plugin-config.test.ts
+++ b/src/backend/shared/utils/vpp/__tests__/generate-vendor-plugin-config.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildModuleConfigEntries,
   generateVendorPluginConfig,
   type VendorScreenData,
   type VppModuleDefinition,
@@ -737,5 +738,46 @@ describe('generateVendorPluginConfig — pins[] (GPIO pin-mapping)', () => {
     )
     expect(result.slots).toEqual([])
     expect(result.pins).toEqual([{ pin: 11, direction: 'output', byte: 0, bit: 0 }])
+  })
+})
+
+describe('buildModuleConfigEntries', () => {
+  const modules: VppModuleDefinition[] = [moduleDi8, moduleThm4]
+
+  it('encodes per-slot config bytes for a configurable module, keyed by 1-based slot', () => {
+    const vsd = {
+      'module-configuration': {
+        slots: [null, 'thm-4'], // slot 2 holds the THM-4
+        slotsConfig: { '2': { ch1_type: '0x5' } }, // override CH1 -> Type T
+      },
+    } as unknown as VendorScreenData
+    const entries = buildModuleConfigEntries(vsd, modules)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].slot).toBe(2)
+    // 20-byte buffer: 0x4003, 0x6005 defaults, ch1 = 0x2100 | 0x5 = 0x2105
+    expect(entries[0].bytes).toHaveLength(20)
+    expect(entries[0].bytes.slice(0, 6)).toEqual([0x40, 0x03, 0x60, 0x05, 0x21, 0x05])
+  })
+
+  it('falls back to field defaults when the user set no values', () => {
+    const vsd = {
+      'module-configuration': { slots: ['thm-4'] },
+    } as unknown as VendorScreenData
+    const entries = buildModuleConfigEntries(vsd, modules)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].slot).toBe(1)
+    // ch1 defaults to 0x0 -> 0x2100 | 0x0 = 0x2100
+    expect(entries[0].bytes.slice(0, 6)).toEqual([0x40, 0x03, 0x60, 0x05, 0x21, 0x00])
+  })
+
+  it('omits modules with no configScreen and unknown/empty slots', () => {
+    const vsd = {
+      'module-configuration': { slots: ['di-8', null, 'not-a-module'] },
+    } as unknown as VendorScreenData
+    expect(buildModuleConfigEntries(vsd, modules)).toEqual([])
+  })
+
+  it('returns [] when there is no module-configuration', () => {
+    expect(buildModuleConfigEntries({} as VendorScreenData, modules)).toEqual([])
   })
 })

--- a/src/backend/shared/utils/vpp/generate-vendor-plugin-config.ts
+++ b/src/backend/shared/utils/vpp/generate-vendor-plugin-config.ts
@@ -301,6 +301,44 @@ function buildSlots(vendorScreenData: VendorScreenData, modules: VppModuleDefini
 }
 
 /**
+ * Build the per-slot module-configuration byte entries for an Arduino
+ * (microcontroller) VPP target.
+ *
+ * The runtime-v4 path serialises module config bytes into the plugin's
+ * JSON (see `buildSlots` -> `module_config`). Arduino targets have no
+ * runtime JSON: every byte must be baked into flash through
+ * `vpp_config.h`. This helper produces the same encoded bytes, keyed by
+ * 1-based slot, so the caller can inject them into `vendorScreenData`
+ * under a synthetic `module-config` key — the generic `vpp_config.h`
+ * walker then emits them as `VPP_MODULE_CONFIG_ENTRIES_*` macros that
+ * the HAL feeds to `P1.configureModule()` (or equivalent) at boot.
+ *
+ * Only slots whose module declared a configScreen and resolved to a
+ * non-empty byte array are returned; everything else is omitted (the
+ * module library's factory defaults apply).
+ */
+export function buildModuleConfigEntries(
+  vendorScreenData: VendorScreenData,
+  modules: VppModuleDefinition[],
+): Array<{ slot: number; bytes: number[] }> {
+  const moduleConfig = (vendorScreenData['module-configuration'] as ModuleConfiguration | undefined) ?? {}
+  const slotAssignments = moduleConfig.slots ?? []
+  const slotsConfigBag = moduleConfig.slotsConfig ?? {}
+
+  const entries: Array<{ slot: number; bytes: number[] }> = []
+  for (let slotIndex = 0; slotIndex < slotAssignments.length; slotIndex++) {
+    const moduleId = slotAssignments[slotIndex]
+    if (!moduleId) continue
+    const moduleDef = modules.find((m) => m.id === moduleId)
+    if (!moduleDef) continue
+    const slotNumber = slotIndex + 1
+    const bytes = encodeModuleConfig(moduleDef.configScreenDefinition, slotsConfigBag[String(slotNumber)] ?? {})
+    if (bytes && bytes.length > 0) entries.push({ slot: slotNumber, bytes })
+  }
+  return entries
+}
+
+/**
  * Build the `pins` array for a pin-based plugin from the editor's GPIO
  * pin-mapping table.
  *

--- a/src/frontend/components/_atoms/generic-table-inputs/generic-combobox-cell.tsx
+++ b/src/frontend/components/_atoms/generic-table-inputs/generic-combobox-cell.tsx
@@ -25,6 +25,7 @@ export const GenericComboboxCell = ({
   selected = true,
   openOnSelectedOption = false,
   canAddACustomOption = false,
+  allowClearWhenEmpty = false,
   displayLabel,
 }: {
   value: string
@@ -33,6 +34,11 @@ export const GenericComboboxCell = ({
   selected?: boolean
   openOnSelectedOption?: boolean
   canAddACustomOption?: boolean
+  /** Keep the "Clear" affordance enabled even when `value` is empty.
+   *  Used by the variable location cell for orphaned aliases: sync blanks
+   *  the location (so it's empty) but a stale alias label remains, and the
+   *  user must still be able to clear it — sending '' drops the stale alias. */
+  allowClearWhenEmpty?: boolean
   /** Visible text in the closed-state trigger. When omitted, the
    *  trigger shows `value` verbatim (the original behavior). Used by
    *  variable cells to render `alias (address)` so the bound alias
@@ -87,7 +93,7 @@ export const GenericComboboxCell = ({
         : item.value === inputValue.trim(),
     )
 
-  const isClearButtonDisabled = !value.trim()
+  const isClearButtonDisabled = !value.trim() && !allowClearWhenEmpty
 
   const handleOnOpenChange = (open: boolean) => {
     setSelectIsOpen(open)

--- a/src/frontend/components/_features/[workspace]/editor/device/remote-device/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/remote-device/index.tsx
@@ -44,6 +44,12 @@ const TRANSPORT_OPTIONS = [
   { value: 'rtu', label: 'RTU (Serial)' },
 ]
 
+// Default serial port for RTU devices.  Pre-filled as a real value (not
+// just the combobox placeholder) so it is persisted to the device config
+// and reaches the compiler — an empty serial port makes the runtime drop
+// the Modbus master plugin entirely.
+const DEFAULT_SERIAL_PORT = '/dev/ttyUSB0'
+
 // RTU configuration options
 const BAUD_RATE_OPTIONS = [
   { value: '9600', label: '9600' },
@@ -632,8 +638,9 @@ const RemoteDeviceEditor = () => {
       // TCP fields
       setHost(config.host ?? '127.0.0.1')
       setPort((config.port ?? 502).toString())
-      // RTU fields
-      setSerialPort(config.serialPort ?? '')
+      // RTU fields — show the default serial port as a real value when
+      // none is stored (the self-heal effect below persists it).
+      setSerialPort(config.serialPort || DEFAULT_SERIAL_PORT)
       setBaudRate((config.baudRate ?? 9600).toString())
       setParity(config.parity ?? 'N')
       setStopBits((config.stopBits ?? 1).toString())
@@ -645,7 +652,7 @@ const RemoteDeviceEditor = () => {
       setTransport('tcp')
       setHost('127.0.0.1')
       setPort('502')
-      setSerialPort('')
+      setSerialPort(DEFAULT_SERIAL_PORT)
       setBaudRate('9600')
       setParity('N')
       setStopBits('1')
@@ -654,6 +661,19 @@ const RemoteDeviceEditor = () => {
       setSlaveId('1')
     }
   }, [remoteDevice])
+
+  // Self-heal: an RTU device must carry a concrete serial port, otherwise
+  // the compiler silently drops it from the Modbus master config.  The UI
+  // shows DEFAULT_SERIAL_PORT as a real value, so persist it whenever the
+  // stored config has none — keeping disk in sync with what's displayed
+  // and fixing projects saved before the serial port was pre-filled.
+  useEffect(() => {
+    const config = remoteDevice?.modbusTcpConfig
+    if (config && (config.transport ?? 'tcp') === 'rtu' && !config.serialPort) {
+      projectActions.updateRemoteDeviceConfig(deviceName, { serialPort: DEFAULT_SERIAL_PORT })
+      sharedWorkspaceActions.handleFileAndWorkspaceSavedState(deviceName)
+    }
+  }, [remoteDevice, deviceName, projectActions, sharedWorkspaceActions])
 
   const ioGroups = useMemo(
     () => remoteDevice?.modbusTcpConfig?.ioGroups || [],

--- a/src/frontend/components/_molecules/variables-table/editable-cell.tsx
+++ b/src/frontend/components/_molecules/variables-table/editable-cell.tsx
@@ -560,6 +560,10 @@ const EditableLocationCell = ({
       selected={selected}
       openOnSelectedOption
       canAddACustomOption
+      // Orphaned/mismatched aliases blank the location (sync clears it for
+      // compilation) but leave a stale alias label. Keep "Clear" enabled even
+      // when the location is empty so the user can drop the stale alias.
+      allowClearWhenEmpty={id === 'location' && (isOrphaned || isMismatched)}
     />
   ) : (
     <div

--- a/src/frontend/data/constants/app-version.ts
+++ b/src/frontend/data/constants/app-version.ts
@@ -18,4 +18,4 @@
  * compares a per-deploy `BUILD_ID` (git commit SHA), not this version, so a
  * stale tab is detected on every deploy even without a version bump.
  */
-export const APP_VERSION = '4.2.5'
+export const APP_VERSION = '4.2.6'

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -2058,6 +2058,28 @@ describe('createProjectSlice', () => {
       expect(cfg.timeout).toBe(2000)
     })
 
+    it('persists RTU (serial) fields and the transport selector', () => {
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      const result = store.getState().projectActions.updateRemoteDeviceConfig('Dev1', {
+        transport: 'rtu',
+        serialPort: '/dev/ttyUSB0',
+        baudRate: 19200,
+        parity: 'E',
+        stopBits: 2,
+        dataBits: 7,
+        slaveId: 7,
+      })
+      expect(result.ok).toBe(true)
+      const cfg = store.getState().project.data.remoteDevices![0].modbusTcpConfig!
+      expect(cfg.transport).toBe('rtu')
+      expect(cfg.serialPort).toBe('/dev/ttyUSB0')
+      expect(cfg.baudRate).toBe(19200)
+      expect(cfg.parity).toBe('E')
+      expect(cfg.stopBits).toBe(2)
+      expect(cfg.dataBits).toBe(7)
+      expect(cfg.slaveId).toBe(7)
+    })
+
     it('does nothing when device has no modbusTcpConfig', () => {
       seedRemoteDevice(store, { name: 'EtherCAT', protocol: 'ethercat' })
       const result = store.getState().projectActions.updateRemoteDeviceConfig('EtherCAT', { host: '10.0.0.1' })

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -791,7 +791,9 @@ describe('createProjectSlice', () => {
       store.getState().projectActions.createVariable({ scope: 'global', data: makeVariable('gx', 'global') })
       store.getState().projectActions.updateVariable({ scope: 'global', variableId: 'gx', data: { location: '%QW0' } })
       // Attach a stale alias (no producer declares it).
-      store.getState().projectActions.updateVariable({ scope: 'global', variableId: 'gx', data: { alias: 'StaleAlias' } })
+      store
+        .getState()
+        .projectActions.updateVariable({ scope: 'global', variableId: 'gx', data: { alias: 'StaleAlias' } })
       let v = store.getState().project.data.configurations.resource.globalVariables[0]
       expect(v.location).toBe('%QW0')
       expect(v.alias).toBe('StaleAlias')

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -782,6 +782,30 @@ describe('createProjectSlice', () => {
       })
       expect(result.ok).toBe(false)
     })
+
+    it('clearing the location drops a stale alias', () => {
+      // Reproduces the orphaned-alias case: a variable that carries a
+      // location plus an alias no longer backed by any producer (target
+      // changed / device removed). Clearing the location (location: '')
+      // must succeed AND drop the stale alias.
+      store.getState().projectActions.createVariable({ scope: 'global', data: makeVariable('gx', 'global') })
+      store.getState().projectActions.updateVariable({ scope: 'global', variableId: 'gx', data: { location: '%QW0' } })
+      // Attach a stale alias (no producer declares it).
+      store.getState().projectActions.updateVariable({ scope: 'global', variableId: 'gx', data: { alias: 'StaleAlias' } })
+      let v = store.getState().project.data.configurations.resource.globalVariables[0]
+      expect(v.location).toBe('%QW0')
+      expect(v.alias).toBe('StaleAlias')
+
+      const result = store.getState().projectActions.updateVariable({
+        scope: 'global',
+        variableId: 'gx',
+        data: { location: '' },
+      })
+      expect(result.ok).toBe(true)
+      v = store.getState().project.data.configurations.resource.globalVariables[0]
+      expect(v.location).toBe('')
+      expect(v.alias ?? '').toBe('')
+    })
   })
 
   describe('getVariable', () => {

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -1472,8 +1472,18 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
         produce((slice: ProjectSlice) => {
           const device = slice.project.data.remoteDevices?.find((d) => d.name === name)
           if (!device?.modbusTcpConfig) return
+          // Transport selector + TCP fields
+          if (config.transport !== undefined) device.modbusTcpConfig.transport = config.transport
           if (config.host !== undefined) device.modbusTcpConfig.host = config.host
           if (config.port !== undefined) device.modbusTcpConfig.port = config.port
+          // RTU (serial) fields — previously dropped, so editing an RTU remote
+          // device silently lost its serial settings on save.
+          if (config.serialPort !== undefined) device.modbusTcpConfig.serialPort = config.serialPort
+          if (config.baudRate !== undefined) device.modbusTcpConfig.baudRate = config.baudRate
+          if (config.parity !== undefined) device.modbusTcpConfig.parity = config.parity
+          if (config.stopBits !== undefined) device.modbusTcpConfig.stopBits = config.stopBits
+          if (config.dataBits !== undefined) device.modbusTcpConfig.dataBits = config.dataBits
+          // Common fields
           if (config.slaveId !== undefined) device.modbusTcpConfig.slaveId = config.slaveId
           if (config.timeout !== undefined) device.modbusTcpConfig.timeout = config.timeout
         }),

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -5,6 +5,7 @@ import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 import { parseIecStringToVariables } from '../../../utils/generate-iec-string-to-variables'
 import { generateIecVariablesToString } from '../../../utils/generate-iec-variables-to-string'
 import { syncNodesWithVariables, syncNodesWithVariablesFBD } from '../../../utils/graphical/sync-nodes-with-variables'
+import { restampFlowLibraryVariants } from '../../../utils/PLC/restamp-library-variants'
 import { collectAllSlaveNames } from '../../../utils/unique-slave-name'
 import type { FBDFlowType } from '../fbd'
 import type { FileSliceDataObject } from '../file'
@@ -565,16 +566,38 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       // path see no change in behaviour; projects with the legacy
       // drift auto-recover on first open.
       const pous = data.projectData.pous
+
+      // Refresh placed library-block variant types from the current libraries
+      // before the flows enter the store, so existing projects pick up library
+      // type changes (e.g. ADR: ULINT -> __XWORD). Blocks backed by a
+      // user-defined POU are skipped — the project owns their interface. A
+      // no-op when the libraries haven't loaded yet or nothing is stale.
+      const systemLibraries = getState().libraries.system
+      const userPouNames = pous.filter((pou) => pou.pouType !== 'program').map((pou) => pou.name)
+      let restampedCount = 0
+
       pous.forEach((pou) => {
         if (pou.body.language === 'ld') {
-          const bodyValue = pou.body.value as LadderFlowType
+          // The loaded project data is frozen, so clone before re-stamping
+          // (which mutates variant types in place) and hand the store the copy.
+          const bodyValue = structuredClone(pou.body.value) as LadderFlowType
+          restampedCount += restampFlowLibraryVariants([bodyValue], systemLibraries, userPouNames)
           getState().ladderFlowActions.addLadderFlow({ ...bodyValue, name: pou.name })
         }
         if (pou.body.language === 'fbd') {
-          const bodyValue = pou.body.value as FBDFlowType
+          const bodyValue = structuredClone(pou.body.value) as FBDFlowType
+          restampedCount += restampFlowLibraryVariants([bodyValue], systemLibraries, userPouNames)
           getState().fbdFlowActions.addFBDFlow({ ...bodyValue, name: pou.name })
         }
       })
+
+      if (restampedCount > 0) {
+        getState().consoleActions.addLog({
+          id: crypto.randomUUID(),
+          level: 'info',
+          message: `Refreshed ${restampedCount} library block pin type(s) from the current library definitions.`,
+        })
+      }
 
       // Register user-defined functions/function-blocks in the library
       pous.forEach((pou) => {

--- a/src/frontend/utils/PLC/__tests__/restamp-library-variants.test.ts
+++ b/src/frontend/utils/PLC/__tests__/restamp-library-variants.test.ts
@@ -1,0 +1,118 @@
+import type { SystemLibrary } from '../../../../middleware/shared/ports/library-types'
+import { restampFlowLibraryVariants } from '../restamp-library-variants'
+
+// ---------------------------------------------------------------------------
+// Factory helpers
+// ---------------------------------------------------------------------------
+
+/** A system library whose ADR function now returns __XWORD (was ULINT). */
+function makeSystemLibraries(): SystemLibrary[] {
+  return [
+    {
+      name: 'STANDARD_FUNCTIONS',
+      pous: [
+        {
+          name: 'ADR',
+          type: 'function',
+          language: 'st',
+          body: '',
+          documentation: '',
+          variables: [
+            { name: 'OUT', class: 'output', type: { definition: 'base-type', value: '__XWORD' } },
+            { name: 'IN', class: 'input', type: { definition: 'generic-type', value: 'ANY' } },
+          ],
+        },
+      ],
+    },
+  ] as unknown as SystemLibrary[]
+}
+
+/** A block node whose ADR variant is still stamped with the old ULINT return. */
+function makeStaleAdrNode() {
+  return {
+    id: 'block-1',
+    type: 'block',
+    data: {
+      variant: {
+        name: 'ADR',
+        type: 'function',
+        language: 'st',
+        body: '',
+        documentation: '',
+        variables: [
+          { name: 'OUT', class: 'output', type: { definition: 'base-type', value: 'ULINT' } },
+          { name: 'IN', class: 'input', type: { definition: 'generic-type', value: 'ANY' } },
+        ],
+      },
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('restampFlowLibraryVariants', () => {
+  it('refreshes a stale library block return type (ADR ULINT -> __XWORD)', () => {
+    const node = makeStaleAdrNode()
+    const flow = { rung: { nodes: [node] } }
+
+    const changed = restampFlowLibraryVariants([flow], makeSystemLibraries(), [])
+
+    expect(changed).toBe(1)
+    expect(node.data.variant.variables.find((v) => v.name === 'OUT')!.type.value).toBe('__XWORD')
+  })
+
+  it('walks every rung of a ladder flow', () => {
+    const node = makeStaleAdrNode()
+    const flow = { rungs: [{ nodes: [] }, { nodes: [node] }] }
+
+    const changed = restampFlowLibraryVariants([flow], makeSystemLibraries(), [])
+
+    expect(changed).toBe(1)
+    expect(node.data.variant.variables[0].type.value).toBe('__XWORD')
+  })
+
+  it('skips blocks backed by a user-defined POU', () => {
+    // A user POU named "ADR" (contrived) must NOT be re-stamped even though a
+    // library entry of the same name exists.
+    const node = makeStaleAdrNode()
+    const flow = { rung: { nodes: [node] } }
+
+    const changed = restampFlowLibraryVariants([flow], makeSystemLibraries(), ['ADR'])
+
+    expect(changed).toBe(0)
+    expect(node.data.variant.variables[0].type.value).toBe('ULINT')
+  })
+
+  it('leaves up-to-date variants untouched (no spurious changes)', () => {
+    const node = makeStaleAdrNode()
+    node.data.variant.variables[0].type.value = '__XWORD'
+    const flow = { rung: { nodes: [node] } }
+
+    const changed = restampFlowLibraryVariants([flow], makeSystemLibraries(), [])
+
+    expect(changed).toBe(0)
+  })
+
+  it('ignores blocks not present in any library (user blocks, unknown types)', () => {
+    const node = makeStaleAdrNode()
+    node.data.variant.name = 'MY_CUSTOM_FB'
+    const flow = { rung: { nodes: [node] } }
+
+    const changed = restampFlowLibraryVariants([flow], makeSystemLibraries(), [])
+
+    expect(changed).toBe(0)
+    expect(node.data.variant.variables[0].type.value).toBe('ULINT')
+  })
+
+  it('is a no-op when no libraries are loaded yet', () => {
+    const node = makeStaleAdrNode()
+    const flow = { rung: { nodes: [node] } }
+
+    const changed = restampFlowLibraryVariants([flow], [], [])
+
+    expect(changed).toBe(0)
+    expect(node.data.variant.variables[0].type.value).toBe('ULINT')
+  })
+})

--- a/src/frontend/utils/PLC/restamp-library-variants.ts
+++ b/src/frontend/utils/PLC/restamp-library-variants.ts
@@ -1,0 +1,117 @@
+import type { BlockVariant } from '@root/middleware/shared/ports/block-types'
+import type { SystemLibrary } from '@root/middleware/shared/ports/library-types'
+
+/**
+ * Refresh the *types* carried by placed graphical block variants from the
+ * current library definitions.
+ *
+ * A block's signature is copied into `node.data.variant` once, when the block
+ * is dropped on the canvas (see the FBD/LD `handleAddElementByDropping`), and
+ * then frozen in the saved project. When a library updates a block's pin or
+ * return type — e.g. `ADR` moving from `ULINT` to the platform-width `__XWORD`
+ * — already-placed blocks keep the stale type and the transpiler (which reads
+ * `node.data.variant` via `collect-library-blocks`) emits the old type.
+ *
+ * On project load we re-stamp the variable types of every block that resolves
+ * to a **library** definition (the bundled / system libraries in
+ * `libraries.system`). Blocks backed by a **user-defined POU** (a function or
+ * function-block authored in this project) are skipped — their interface lives
+ * in the project, not the library, so the project is the source of truth.
+ *
+ * The refresh is intentionally type-only: it matches variables by name and
+ * copies the library's `type`, leaving the pin set, ids, handles and wiring
+ * untouched. That keeps extensible (variadic) blocks and existing connections
+ * intact while still propagating type changes.
+ */
+
+type VariantVariable = BlockVariant['variables'][number]
+
+/** Index every library POU by name → its variables, for O(1) lookup. */
+function indexLibraryPous(systemLibraries: SystemLibrary[]): Map<string, SystemLibrary['pous'][number]> {
+  const byName = new Map<string, SystemLibrary['pous'][number]>()
+  for (const library of systemLibraries) {
+    for (const pou of library.pous) {
+      // First definition wins; bundled libraries don't collide on name.
+      if (!byName.has(pou.name)) byName.set(pou.name, pou)
+    }
+  }
+  return byName
+}
+
+/** A minimal block-bearing node shape; both FBD and LD nodes satisfy it. */
+type BlockBearingNode = { type?: string; data?: { variant?: BlockVariant } }
+
+/**
+ * Re-stamp variable types in place for every library-backed block node.
+ *
+ * @param nodes            the flow's nodes (FBD `rung.nodes` or an LD
+ *                         `rung.nodes`)
+ * @param libraryPousByName library POUs indexed by name
+ * @param userPouNames     names of user-defined POUs to skip (uppercased)
+ * @returns the number of variables actually changed (for logging/tests)
+ */
+function restampNodes(
+  nodes: BlockBearingNode[],
+  libraryPousByName: Map<string, SystemLibrary['pous'][number]>,
+  userPouNames: Set<string>,
+): number {
+  let changed = 0
+  for (const node of nodes) {
+    if (node?.type !== 'block') continue
+    const variant = node.data?.variant
+    const name = variant?.name
+    if (!variant || !name) continue
+
+    // Skip blocks backed by a user-defined POU — the project owns their shape.
+    if (userPouNames.has(name.toUpperCase())) continue
+
+    const libPou = libraryPousByName.get(name)
+    if (!libPou) continue
+
+    // Index the library's variables by name for matching.
+    const libVarByName = new Map(libPou.variables.map((v) => [v.name, v]))
+
+    for (const variable of variant.variables) {
+      const libVar = libVarByName.get(variable.name)
+      if (!libVar) continue
+      const next = libVar.type
+      const current = variable.type
+      if (current.definition === next.definition && current.value === next.value) continue
+      // The block-variant type union only admits 'base-type' / 'generic-type';
+      // library `typeRef()` emits exactly those, so the shape is compatible.
+      variable.type = { definition: next.definition, value: next.value } as VariantVariable['type']
+      changed += 1
+    }
+  }
+  return changed
+}
+
+/**
+ * Re-stamp every block in the given flows from the current system libraries.
+ * Mutates the flow objects in place. Returns the total number of variable
+ * types changed (0 when nothing was stale).
+ *
+ * `flows` accepts both FBD flows (single `rung`) and LD flows (`rungs[]`); the
+ * shape is duck-typed so the helper stays language-agnostic and on the shared
+ * surface.
+ */
+export function restampFlowLibraryVariants(
+  flows: Array<{ rung?: { nodes?: unknown }; rungs?: Array<{ nodes?: unknown }> }>,
+  systemLibraries: SystemLibrary[],
+  userPouNames: Iterable<string>,
+): number {
+  const libraryPousByName = indexLibraryPous(systemLibraries)
+  if (libraryPousByName.size === 0) return 0
+  const skip = new Set<string>()
+  for (const n of userPouNames) skip.add(n.toUpperCase())
+
+  let changed = 0
+  for (const flow of flows) {
+    const rungs = flow.rungs ?? (flow.rung ? [flow.rung] : [])
+    for (const rung of rungs) {
+      const nodes = rung?.nodes
+      if (Array.isArray(nodes)) changed += restampNodes(nodes as BlockBearingNode[], libraryPousByName, skip)
+    }
+  }
+  return changed
+}

--- a/src/frontend/utils/keywords.ts
+++ b/src/frontend/utils/keywords.ts
@@ -116,6 +116,7 @@ const keywords = [
   'WORD',
   'DWORD',
   'LWORD',
+  '__XWORD',
   'REAL',
   'LREAL',
   'TIME',

--- a/src/frontend/utils/pou-helpers.ts
+++ b/src/frontend/utils/pou-helpers.ts
@@ -53,6 +53,7 @@ const BASE_TYPES = [
   'WORD',
   'DWORD',
   'LWORD',
+  '__XWORD',
 ]
 
 /**

--- a/src/frontend/utils/python/generatePythonLspPreamble.ts
+++ b/src/frontend/utils/python/generatePythonLspPreamble.ts
@@ -69,7 +69,8 @@ function mapIecBaseTypeToPython(value: string): string | null {
     upper === 'BYTE' ||
     upper === 'WORD' ||
     upper === 'DWORD' ||
-    upper === 'LWORD'
+    upper === 'LWORD' ||
+    upper === '__XWORD'
   ) {
     return 'int'
   }

--- a/src/frontend/utils/stlib-to-system-library.ts
+++ b/src/frontend/utils/stlib-to-system-library.ts
@@ -66,6 +66,7 @@ const BASE_TYPE_NAMES = new Set([
   'WORD',
   'DWORD',
   'LWORD',
+  '__XWORD',
   'SINT',
   'INT',
   'DINT',

--- a/src/middleware/shared/ports/plc-schemas.ts
+++ b/src/middleware/shared/ports/plc-schemas.ts
@@ -49,7 +49,7 @@ const genericTypeSchema = z.object({
     z.literal('ANY_ELEMENTARY'),
   ]),
   ANY_INT: baseTypeEnum.extract(['SINT', 'INT', 'DINT', 'LINT', 'USINT', 'UINT', 'UDINT', 'ULINT']),
-  ANY_BIT: baseTypeEnum.extract(['BOOL', 'BYTE', 'WORD', 'DWORD', 'LWORD']),
+  ANY_BIT: baseTypeEnum.extract(['BOOL', 'BYTE', 'WORD', 'DWORD', 'LWORD', '__XWORD']),
   ANY_STRING: baseTypeEnum.extract(['STRING']),
   ANY_REAL: baseTypeEnum.extract(['REAL', 'LREAL']),
   ANY_DATE: baseTypeEnum.extract(['TIME', 'DATE', 'TOD', 'DT']),


### PR DESCRIPTION
Promotes development to main for the v4.2.6 release.

- Embedded library-block definitions for xml2st + `__XWORD` support across the toolchain
- Load-time re-stamp of library block variant types
- Bumps: strucpp v0.5.9, xml2st v4.0.7
- App version 4.2.5 → 4.2.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)