### PR TITLE
OPC-UA canonical size/type contract + bare-metal force re-imposition

### DIFF
--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -34,7 +34,7 @@ jobs:
           cd editor
           git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1
           CHANGED=$(git diff --name-only FETCH_HEAD HEAD)
-          if echo "$CHANGED" | grep -qE '^(src/frontend/|src/middleware/shared/|src/backend/shared/|src/__architecture__/)'; then
+          if echo "$CHANGED" | grep -qE '^(src/frontend/|src/middleware/shared/|src/backend/shared/|src/__architecture__/|resources/sources/(arduino|Baremetal|hal)/)'; then
             echo "shared=true" >> "$GITHUB_OUTPUT"
           else
             echo "shared=false" >> "$GITHUB_OUTPUT"

--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.5.9",
+    "version": "v0.5.10",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-plc-editor",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "license": "GPL-3.0",
   "author": {
     "name": "Autonomy Logic"

--- a/resources/sources/Baremetal/Baremetal.ino
+++ b/resources/sources/Baremetal/Baremetal.ino
@@ -347,6 +347,14 @@ void modbusTask()
             }
         }
     #endif
+
+    // The reverse-copies above (COILS → bool_output, holding → int_output,
+    // memory) write located variables' raw storage directly, clobbering any
+    // debugger force. Re-impose forces here so forcing works while STILL
+    // mirroring Modbus client writes into mapped outputs. (Supersedes the open
+    // PR #719, which made forcing work by deleting the digital reverse-copy —
+    // at the cost of Modbus coil mirroring.)
+    runtime_apply_located_forces();
 }
 #endif
 

--- a/resources/sources/Baremetal/ModbusSlave.cpp
+++ b/resources/sources/Baremetal/ModbusSlave.cpp
@@ -398,71 +398,143 @@ void handle_tcp()
 #endif
 
 #ifdef MBSERIAL
+// Inter-frame idle, in milliseconds, used ONLY to abandon a frame whose
+// remainder never arrives. Modbus RTU was defined for RS485, where bytes of a
+// frame are ~one character time apart (T1.5/T3.5, tens of microseconds at
+// 115200) and the byte cadence delimits frames. That assumption is INVALID on
+// USB-CDC (and any store-and-forward link): a single request is split into
+// 64-byte USB packets separated by USB-frame-scale gaps far longer than T1.5,
+// so cadence framing tears requests apart (the bug that made the P1AM-100 /
+// SAMD21 debugger crawl). We therefore frame by the request's DECLARED length
+// (derived from the function code) and fall back to this idle only to drop a
+// truncated partial. It must exceed any intra-frame USB gap yet stay well below
+// a master's request timeout.
+#define MB_RTU_FRAME_GAP_MS 8
+
+// Persistent RX-assembly state. handle_serial() is called every scan cycle and
+// never blocks; a request whose bytes straddle several calls is carried across
+// them in mb_frame[0..mb_rx_len). (This shares mb_frame with handle_tcp, which
+// is safe because an OpenPLC board is configured for a single Modbus transport;
+// the two are not driven mid-frame at the same time.)
+static uint16_t mb_rx_len = 0;
+static uint32_t mb_rx_last_ms = 0;
+
+// Total on-wire length (slave id + PDU + 2 CRC bytes) of the request whose
+// first `n` bytes are in `f`. Returns >0 for a known length, 0 when more header
+// bytes are needed to size it, and -1 for a function code we do not serve (so
+// the byte cannot be a frame head). Length is implicit in Modbus RTU — derived
+// per function code, exactly as `process_mbpacket()` later parses the fields.
+static int32_t mb_rtu_frame_len(const uint8_t *f, uint16_t n)
+{
+    if (n < 2) return 0;                                // need at least id + FC
+    switch (f[1])
+    {
+        case MB_FC_READ_COILS:
+        case MB_FC_READ_INPUT_STAT:
+        case MB_FC_READ_REGS:
+        case MB_FC_READ_INPUT_REGS:
+        case MB_FC_WRITE_COIL:
+        case MB_FC_WRITE_REG:
+            return 8;                                   // [id][fc][a:2][b:2][crc:2]
+        case MB_FC_WRITE_COILS:
+        case MB_FC_WRITE_REGS:
+            if (n < 7) return 0;                        // byte count lives at f[6]
+            return 9 + (int32_t)f[6];                   // + [bc:1][data:bc][crc:2]
+        case MB_FC_DEBUG_INFO:
+            return 4;                                   // [id][fc][crc:2]
+        case MB_FC_DEBUG_GET:
+            return 9;                                   // [id][fc][arr:1][s:2][e:2][crc:2]
+        case MB_FC_DEBUG_GET_LIST:
+            if (n < 4) return 0;                        // count lives at f[2..3]
+            return 6 + 3 * (int32_t)(((uint16_t)f[2] << 8) | f[3]);
+        case MB_FC_DEBUG_SET:
+            if (n < 8) return 0;                         // value len lives at f[6..7]
+            return 10 + (int32_t)(((uint16_t)f[6] << 8) | f[7]);
+        case MB_FC_DEBUG_GET_MD5:
+            return 8;                                   // [id][fc][endian:2][00:2][crc:2]
+        default:
+            return -1;                                  // not one of our function codes
+    }
+}
+
+// Drop the first `k` bytes of the assembly buffer, keeping the remainder. Used
+// for one-byte realignment on a bad/foreign frame head — NEVER a blind flush —
+// so a genuine frame head sitting further into the buffer always survives and
+// is eventually found (guarantees resync convergence; no "discard every frame"
+// loop). Slides only run on the error path, so the O(n) cost is irrelevant.
+static void mb_rtu_drop_front(uint16_t k)
+{
+    if (k >= mb_rx_len) { mb_rx_len = 0; return; }
+    for (uint16_t i = k; i < mb_rx_len; i++)
+        mb_frame[i - k] = mb_frame[i];
+    mb_rx_len = (uint16_t)(mb_rx_len - k);
+}
+
 void handle_serial()
 {
-    mb_frame_len = 0;
-
-    if ((*mb_serialport).available() == 0)
-        return;
-
-    while ((*mb_serialport).available() > mb_frame_len)
-    {
-        mb_frame_len = (*mb_serialport).available();
-        delayMicroseconds(mb_t15);
-    }
-
-    //Check if packet is too big or too small
-    if ((*mb_serialport).available() > MAX_MB_FRAME || (*mb_serialport).available() < 6)
-    {
-        //(*mb_serialport).println("Packet too big");
-        //(*mb_serialport).flush();
-        return;
-    }
-
-    //Read packet
-    for (uint16_t i = 0; i < mb_frame_len; i++)
-    {
-        mb_frame[i] = (*mb_serialport).read();
-    }
-
-    //Validate crc
     uint16_t packet_crc;
-    //Ignore CRC errors when using debugger functions
-    if (mb_frame[1] != MB_FC_DEBUG_INFO && mb_frame[1] != MB_FC_DEBUG_SET && mb_frame[1] != MB_FC_DEBUG_GET && mb_frame[1] != MB_FC_DEBUG_GET_LIST && mb_frame[1] != MB_FC_DEBUG_GET_MD5)
+
+    // 1) Drain the RX buffer without blocking. One frame's bytes may arrive
+    //    across several calls; the scan cycle is never stalled waiting on them.
+    while ((*mb_serialport).available() > 0)
     {
-        packet_crc = ((mb_frame[mb_frame_len - 2] << 8) | mb_frame[mb_frame_len - 1]);
-        if (packet_crc != calcCrc())
+        if (mb_rx_len >= MAX_MB_FRAME) break;           // full — let the parser drain it
+        mb_frame[mb_rx_len++] = (uint8_t)(*mb_serialport).read();
+        mb_rx_last_ms = millis();
+    }
+
+    // 2) Extract every complete frame in the buffer. Each iteration either
+    //    consumes/realigns by >=1 byte or returns to await more data, so the
+    //    loop always terminates.
+    for (;;)
+    {
+        if (mb_rx_len == 0)
+            return;
+
+        // Header byte-alignment: the first byte must be OUR slave id. This is
+        // the cheap framing check, and it is the ONLY validation applied to
+        // debugger frames (CRC is deliberately skipped on debug FCs for
+        // performance — those function codes are private and well-formed).
+        if (mb_frame[0] != modbus.slaveid)
         {
-        /* DEBUG
-	    char buffer[100];
-            (*mb_serialport).println("Invalid CRC for packet: ");
-            int offset = 0; // Initialize offset for buffer
-            for (int i = 0; i < mb_frame_len; i++)
-            {
-                offset += sprintf(buffer + offset, "%02X ", mb_frame[i]);
-            }
-            (*mb_serialport).println(buffer);
-            (*mb_serialport).print("Packet_crc: ");
-            (*mb_serialport).println(packet_crc);
-            (*mb_serialport).print("Calc CRC: ");
-            (*mb_serialport).println(calcCrc());
-            (*mb_serialport).flush();
-        */
-	    return;
+            mb_rtu_drop_front(1);                       // foreign/garbage head — slide
+            continue;
         }
-    }
 
-    //Validate SlaveID
-    if (mb_frame[0] != modbus.slaveid)
-    {
-        (*mb_serialport).flush();
-        return;
-    }
+        int32_t expected = mb_rtu_frame_len(mb_frame, mb_rx_len);
 
-    //Remove CRC (must do that before processing packet)
-    mb_frame_len -= 2;
+        if (expected < 0 || expected > MAX_MB_FRAME)
+        {
+            mb_rtu_drop_front(1);                       // illegal FC / impossible length
+            continue;
+        }
+        if (expected == 0 || mb_rx_len < (uint16_t)expected)
+        {
+            // Header incomplete, or the frame's tail has not arrived yet. Wait
+            // for it; abandon the partial only if its remainder never comes.
+            if ((uint32_t)(millis() - mb_rx_last_ms) > MB_RTU_FRAME_GAP_MS)
+                mb_rx_len = 0;
+            return;
+        }
 
-    //Process packet and write back
+        // 3) A full candidate frame occupies mb_frame[0 .. expected).
+        //    Standard FCs are validated by CRC (the arbiter that makes resync
+        //    trustworthy); a mismatch means corruption or misalignment, so we
+        //    slide one byte and retry instead of discarding the whole buffer.
+        if (mb_frame[1] != MB_FC_DEBUG_INFO && mb_frame[1] != MB_FC_DEBUG_SET && mb_frame[1] != MB_FC_DEBUG_GET && mb_frame[1] != MB_FC_DEBUG_GET_LIST && mb_frame[1] != MB_FC_DEBUG_GET_MD5)
+        {
+            mb_frame_len = (uint16_t)expected;
+            packet_crc = ((mb_frame[expected - 2] << 8) | mb_frame[expected - 1]);
+            if (packet_crc != calcCrc())
+            {
+                mb_rtu_drop_front(1);
+                continue;
+            }
+        }
+
+        // 4) Accepted. Hand the PDU (CRC stripped) to the shared processor,
+        //    which builds the response back into mb_frame.
+        mb_frame_len = (uint16_t)expected - 2;
     process_mbpacket();
 
     //Add CRC
@@ -505,6 +577,16 @@ void handle_serial()
             digitalWrite(CUSTOM_RS485_DEFAULT_RE_PIN, LOW);
         }
     #endif
+
+        // 5) The request — and the response built over it — consumed the whole
+        //    assembly buffer. Modbus RTU is turn-taking: the master waits for
+        //    this reply before sending its next request, so no following frame
+        //    can already be buffered. Reset for the next request. A
+        //    non-conformant pipelining master simply retransmits after its
+        //    timeout, and the gap/realignment logic above recovers cleanly.
+        mb_rx_len = 0;
+        return;
+    }
 }
 #endif
 

--- a/resources/sources/arduino/arduino_runtime_glue.cpp
+++ b/resources/sources/arduino/arduino_runtime_glue.cpp
@@ -186,12 +186,63 @@ void runtime_discover_tasks()
 }
 
 // ---------------------------------------------------------------------------
+// Force re-imposition for located variables.
+//
+// On bare-metal the image table aliases the IECVar's storage: a located var's
+// image slot pointer (bool_output[..], int_input[..], …) IS its raw_ptr()
+// (&value_). The program body can't defeat a force — IECVar::set() is a no-op
+// while forced_ — but DIRECT writes through the image pointer bypass set():
+//   - updateInputBuffers() writes *bool_input[..] = digitalRead(...)
+//   - the Modbus reverse-copy writes *bool_output[..] = COILS[..]
+// Either clobbers a forced located variable's storage. (This is the bug the
+// open PR #719 chases by DELETING the digital-output reverse-copy — which also
+// breaks Modbus coil mirroring into mapped outputs. We instead KEEP the
+// reverse-copy and re-impose the force right after each direct-write batch, so
+// both forcing AND Modbus mirroring work.)
+//
+// re-impose = restore value_ from forced_value_ for every forced located var.
+// locatedVars[i].pointer is the IECVar's raw_ptr() = &value_, and IECVar is
+// standard-layout with value_ as its first member, so the slot pointer is
+// pointer-interconvertible with the IECVar itself. The cast is by located
+// SIZE only; signed/unsigned/REAL of the same width share IECVar layout and
+// the restore is a width-correct value copy, so a single unsigned alias per
+// width is correct for all of them.
+template <typename T>
+static inline void reimpose_if_forced(void* p)
+{
+    if (!p) return;
+    auto* v = reinterpret_cast<strucpp::IECVar<T>*>(p);
+    if (v->is_forced()) {
+        *v->raw_ptr() = v->get_forced_value();
+    }
+}
+
+void runtime_apply_located_forces()
+{
+    using namespace strucpp;
+    for (uint32_t i = 0; i < locatedVarsCount; ++i) {
+        LocatedVar& lv = locatedVars[i];
+        if (!lv.pointer) continue;
+        switch (lv.size) {
+        case LocatedSize::Bit:   reimpose_if_forced<BOOL_t>(lv.pointer);  break;
+        case LocatedSize::Byte:  reimpose_if_forced<BYTE_t>(lv.pointer);  break;
+        case LocatedSize::Word:  reimpose_if_forced<WORD_t>(lv.pointer);  break;
+        case LocatedSize::DWord: reimpose_if_forced<DWORD_t>(lv.pointer); break;
+        case LocatedSize::LWord: reimpose_if_forced<LWORD_t>(lv.pointer); break;
+        default: break;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // One scan cycle: copy inputs → run scheduled programs → copy outputs →
 // advance IEC TIME() so TON/TOF/TP can progress.
 // ---------------------------------------------------------------------------
 void runtime_plc_cycle()
 {
     updateInputBuffers();
+    // HAL just wrote raw input storage directly — re-impose any forced input.
+    runtime_apply_located_forces();
 
     for (size_t i = 0; i < total_programs; ++i) {
         if (task_divisors[i] == 0 || (scan_counter % task_divisors[i]) == 0) {

--- a/resources/sources/arduino/arduino_runtime_glue.h
+++ b/resources/sources/arduino/arduino_runtime_glue.h
@@ -42,6 +42,14 @@ void runtime_discover_tasks();
 // Per-cycle helpers (call once per scan cycle from scheduler()/loop()).
 void runtime_plc_cycle();
 
+// Re-impose forced located variables' values onto their raw storage. Call
+// after any code path that writes the image pointers directly (HAL input
+// refresh, Modbus reverse-copy) so a debugger force is not clobbered. Cheap
+// no-op when nothing is forced. runtime_plc_cycle() already calls it after
+// the input refresh; the sketch must also call it after modbusTask()'s
+// reverse-copy.
+void runtime_apply_located_forces();
+
 // ---------------------------------------------------------------------------
 // Debug dispatch shims — extern "C" wrappers around strucpp::debug::handle_*.
 //

--- a/scripts/compare-surface-definitions.py
+++ b/scripts/compare-surface-definitions.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """
-Compare SURFACES definitions between the web and editor compare-surfaces.py scripts.
+Compare surface definitions between the web and editor compare-surfaces.py scripts.
 
-Parses the SURFACES variable from both scripts using Python's AST module
-and checks that they define the same set of surfaces.
+Parses the SURFACES and MAPPED_SURFACES variables from both scripts using
+Python's AST module and checks that they define the same surfaces, so the two
+repos can never silently check a different set.
 Exit code 0 = match, 1 = mismatch or parse failure.
 """
 
@@ -17,15 +18,30 @@ from pathlib import Path
 SCRIPT_RELATIVE_PATH = "scripts/compare-surfaces.py"
 
 
-def extract_surfaces(filepath: Path) -> list[str] | None:
+def extract_var(filepath: Path, varname: str):
+    """Return the literal value assigned to `varname` in the script, or None."""
     with open(filepath) as f:
         tree = ast.parse(f.read())
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign):
             for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == "SURFACES":
-                    return sorted(ast.literal_eval(node.value))
+                if isinstance(target, ast.Name) and target.id == varname:
+                    return ast.literal_eval(node.value)
     return None
+
+
+def extract_surfaces(filepath: Path) -> list[str] | None:
+    value = extract_var(filepath, "SURFACES")
+    return sorted(value) if value is not None else None
+
+
+def extract_mapped(filepath: Path) -> list | None:
+    """MAPPED_SURFACES as a list of dicts, normalized (sorted by name) for a
+    stable comparison; missing entirely returns None."""
+    value = extract_var(filepath, "MAPPED_SURFACES")
+    if value is None:
+        return None
+    return sorted(value, key=lambda m: m.get("name", ""))
 
 
 def main() -> int:
@@ -71,7 +87,18 @@ def main() -> int:
             print(f"  Only in editor: {', '.join(sorted(editor_only))}")
         return 1
 
+    # MAPPED_SURFACES must match too (it controls the path-mapped checks).
+    web_mapped = extract_mapped(web_script)
+    editor_mapped = extract_mapped(editor_script)
+    if web_mapped != editor_mapped:
+        print("::error::MAPPED_SURFACES definitions do not match:")
+        print(f"  web:    {web_mapped}")
+        print(f"  editor: {editor_mapped}")
+        return 1
+
     print(f"SURFACES definitions match: {web}")
+    mapped_names = [m.get("name") for m in (web_mapped or [])]
+    print(f"MAPPED_SURFACES definitions match: {mapped_names}")
     return 0
 
 

--- a/scripts/compare-surfaces.py
+++ b/scripts/compare-surfaces.py
@@ -2,15 +2,22 @@
 """
 Compare byte-identical surfaces between openplc-editor and openplc-web.
 
-Surfaces checked:
+Surfaces checked (same src-relative path in both repos):
   - frontend/          (UI layer)
   - middleware/shared/  (ports + providers)
   - backend/shared/    (application logic, use cases)
   - __architecture__/  (validation scripts)
 
-Every file in these directories must be byte-identical across both repos.
+Mapped surfaces (different path per repo, compared by structure within
+the mapped base — see MAPPED_SURFACES):
+  - bare-metal-runtime  (editor: resources/sources/{arduino,Baremetal};
+                         web:    src/assets/firmware/{arduino,Baremetal})
+
+Every file in these surfaces must be byte-identical across both repos.
 Exit code 0 = all identical, 1 = differences found.
 """
+
+from __future__ import annotations
 
 import argparse
 import hashlib
@@ -23,6 +30,28 @@ SURFACES = [
     "middleware/shared",
     "backend/shared",
     "__architecture__",
+]
+
+# Surfaces that live at a DIFFERENT path in each repo (so they can't be a
+# plain src-relative entry in SURFACES). `editor`/`web` are repo-root-relative
+# (the repo root is the parent of the --editor-root/--web-root src dirs).
+#
+# Checked ONE-WAY (web is a subset of the editor's tree): every file the web
+# bundle ships under `web` must be byte-identical to the editor's `editor`
+# tree at the same relative path. Editor-only files are NOT flagged — the
+# editor's resources/sources/hal/ also carries ~30 per-board HALs the web
+# bundle (AVR8js simulator only) does not ship. A content edit to any shared
+# runtime file still surfaces as a hash mismatch.
+MAPPED_SURFACES = [
+    {
+        "name": "bare-metal-runtime",
+        "editor": "resources/sources",
+        "web": "src/assets/firmware",
+        # Only the C/C++ runtime sources are shared; the web bundle also keeps
+        # its own bundler glue here (e.g. an index.ts that imports the sources
+        # as strings) which the editor does not have.
+        "exts": [".cpp", ".hpp", ".c", ".h", ".ino"],
+    },
 ]
 
 
@@ -71,6 +100,44 @@ def compare_surface(
     }
 
 
+def collect_all_hashes(base: Path, exts: list[str] | None = None) -> dict[str, str]:
+    """Hash every file under `base`, keyed by the path relative to `base`.
+    When `exts` is given, only files with one of those suffixes are included."""
+    result = {}
+    if not base.exists():
+        return result
+    ext_set = set(exts) if exts else None
+    for path in sorted(base.rglob("*")):
+        if path.is_file() and (ext_set is None or path.suffix in ext_set):
+            result[str(path.relative_to(base))] = hash_file(path)
+    return result
+
+
+def compare_mapped(web_repo: Path, editor_repo: Path, mapped: dict) -> dict:
+    """One-way check: every (filtered) file the web bundle ships under
+    `mapped['web']` must exist and be byte-identical in the editor tree at
+    `mapped['editor']`. Editor-only files are not flagged (web ships a
+    subset)."""
+    web_base = web_repo / mapped["web"]
+    editor_base = editor_repo / mapped["editor"]
+    web_hashes = collect_all_hashes(web_base, mapped.get("exts"))
+
+    diffs = []
+    for rel, h in sorted(web_hashes.items()):
+        editor_path = editor_base / rel
+        if not editor_path.is_file():
+            diffs.append({"file": rel, "reason": "only_in_web"})
+        elif hash_file(editor_path) != h:
+            diffs.append({"file": rel, "reason": "hash_mismatch"})
+
+    return {
+        "match": len(diffs) == 0,
+        "files_checked": len(web_hashes),
+        "diffs": diffs,
+        "mapped": {"editor": mapped["editor"], "web": mapped["web"]},
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Compare byte-identical surfaces between web and editor repos."
@@ -102,6 +169,15 @@ def main() -> int:
         surfaces[surface] = result
         total_diffs += len(result["diffs"])
 
+    # Mapped surfaces are repo-root-relative; the repo root is the parent of
+    # the src dir passed for --web-root/--editor-root.
+    web_repo = args.web_root.parent
+    editor_repo = args.editor_root.parent
+    for mapped in MAPPED_SURFACES:
+        result = compare_mapped(web_repo, editor_repo, mapped)
+        surfaces[mapped["name"]] = result
+        total_diffs += len(result["diffs"])
+
     total_files = sum(s["files_checked"] for s in surfaces.values())
     overall_match = all(s["match"] for s in surfaces.values())
 
@@ -120,16 +196,30 @@ def main() -> int:
         for surface, result in surfaces.items():
             if result["match"]:
                 continue
+            mapped = result.get("mapped")
             for diff in result["diffs"]:
                 reason = diff["reason"]
                 filepath = diff["file"]
-                if reason == "only_in_web":
-                    msg = f"[{surface}] File exists only in web repo: src/{filepath}"
-                elif reason == "only_in_editor":
-                    msg = f"[{surface}] File exists only in editor repo: src/{filepath}"
+                if mapped:
+                    # Mapped surfaces sit at a different path per repo, so there
+                    # is no single src-relative anchor; reference both sides.
+                    ew = f"{mapped['editor']}/{filepath}"
+                    ww = f"{mapped['web']}/{filepath}"
+                    if reason == "only_in_web":
+                        msg = f"[{surface}] File exists only in web repo: {ww}"
+                    elif reason == "only_in_editor":
+                        msg = f"[{surface}] File exists only in editor repo: {ew}"
+                    else:
+                        msg = f"[{surface}] File differs between repos: editor {ew} vs web {ww}"
+                    print(f"::error::{msg}", file=sys.stderr)
                 else:
-                    msg = f"[{surface}] File differs between repos: src/{filepath}"
-                print(f"::error file=src/{filepath}::{msg}", file=sys.stderr)
+                    if reason == "only_in_web":
+                        msg = f"[{surface}] File exists only in web repo: src/{filepath}"
+                    elif reason == "only_in_editor":
+                        msg = f"[{surface}] File exists only in editor repo: src/{filepath}"
+                    else:
+                        msg = f"[{surface}] File differs between repos: src/{filepath}"
+                    print(f"::error file=src/{filepath}::{msg}", file=sys.stderr)
 
     return 0 if overall_match else 1
 

--- a/src/frontend/hooks/useDebugPolling.ts
+++ b/src/frontend/hooks/useDebugPolling.ts
@@ -50,7 +50,15 @@ const HTTP_FALLBACK_POLL_INTERVAL_MS = 1000
 // board, since the same board can run over RTU or TCP depending on the
 // user's communication preferences.
 //
-// Modbus RTU             : 256-byte serial frame → ~20 vars per request.
+// Modbus RTU             : capped at 19 so the REQUEST stays ≤63 bytes and
+//                          fits in a single 64-byte USB-CDC packet. A 20-var
+//                          request is 6 + 3·20 = 66 bytes, which a USB-CDC
+//                          target (e.g. SAMD21 / P1AM-100) receives split
+//                          across two USB packets; older firmware whose serial
+//                          framer can't reassemble a multi-packet request then
+//                          drops it. Newer firmware (length-aware handle_serial)
+//                          handles any size, but 19 keeps us compatible with
+//                          field devices on both. 19·3 + 6 = 63 ≤ 64.
 // Modbus TCP             : Arduino sketch's MAX_MB_FRAME caps it; 60 is
 //                          well within the headroom.
 // WebSocket (Runtime v4) : Linux runtime's MAX_DEBUG_FRAME=4096; ~500
@@ -60,7 +68,7 @@ const HTTP_FALLBACK_POLL_INTERVAL_MS = 1000
 //                          down to a safe size.
 // Simulator              : virtual serial port mirrors the RTU framing,
 //                          so it shares the RTU ceiling.
-const RTU_BATCH_SIZE = 20
+const RTU_BATCH_SIZE = 19
 const TCP_BATCH_SIZE = 60
 const WEBSOCKET_BATCH_SIZE = 500
 const MIN_BATCH_SIZE = 2

--- a/src/frontend/utils/__tests__/debug-parser.test.ts
+++ b/src/frontend/utils/__tests__/debug-parser.test.ts
@@ -1,4 +1,11 @@
-import { buildLeafPathMap, type DebugMap, packDebugAddr, parseDebugMap, unpackDebugAddr } from '../debug-parser'
+import {
+  buildLeafInfoMap,
+  buildLeafPathMap,
+  type DebugMap,
+  packDebugAddr,
+  parseDebugMap,
+  unpackDebugAddr,
+} from '../debug-parser'
 
 describe('packDebugAddr / unpackDebugAddr', () => {
   it('packs (0, 0) as 0', () => {
@@ -149,5 +156,45 @@ describe('buildLeafPathMap', () => {
     const out = buildLeafPathMap(map)
     expect(out.size).toBe(1)
     expect(unpackDebugAddr(out.get('PRG.X')!)).toEqual({ arrayIdx: 0, elemIdx: 1 })
+  })
+})
+
+describe('buildLeafInfoMap', () => {
+  it('returns an empty map for a debug map with no leaves', () => {
+    const map: DebugMap = { version: 2, md5: 'x', typeTags: {}, arrays: [], leaves: [] }
+    expect(buildLeafInfoMap(map).size).toBe(0)
+  })
+
+  it('keys by uppercase path and retains canonical arr/elem/type/size', () => {
+    const map: DebugMap = {
+      version: 2,
+      md5: 'x',
+      typeTags: {},
+      arrays: [{ index: 0, count: 2 }],
+      leaves: [
+        { arrayIdx: 0, elemIdx: 1, path: 'cfg.g_b', type: 'DINT', size: 4 },
+        { arrayIdx: 5, elemIdx: 0, path: 'IH1.X', type: 'LREAL', size: 8 },
+      ],
+    }
+    const out = buildLeafInfoMap(map)
+    expect(out.get('CFG.G_B')).toEqual({ arr: 0, elem: 1, type: 'DINT', size: 4 })
+    expect(out.get('IH1.X')).toEqual({ arr: 5, elem: 0, type: 'LREAL', size: 8 })
+    expect(out.has('cfg.g_b')).toBe(false)
+  })
+
+  it('overwrites duplicate paths (last writer wins)', () => {
+    const map: DebugMap = {
+      version: 2,
+      md5: 'x',
+      typeTags: {},
+      arrays: [{ index: 0, count: 2 }],
+      leaves: [
+        { arrayIdx: 0, elemIdx: 0, path: 'PRG.X', type: 'INT', size: 2 },
+        { arrayIdx: 0, elemIdx: 1, path: 'PRG.X', type: 'REAL', size: 4 }, // dup
+      ],
+    }
+    const out = buildLeafInfoMap(map)
+    expect(out.size).toBe(1)
+    expect(out.get('PRG.X')).toEqual({ arr: 0, elem: 1, type: 'REAL', size: 4 })
   })
 })

--- a/src/frontend/utils/debug-parser.ts
+++ b/src/frontend/utils/debug-parser.ts
@@ -92,3 +92,39 @@ export function buildLeafPathMap(map: DebugMap): Map<string, number> {
   }
   return out
 }
+
+/**
+ * Canonical per-leaf info: address PLUS the compiler-authoritative
+ * `type`/`size`. Consumers that emit a variable's datatype or byte
+ * width to another component (notably the OPC-UA config generator)
+ * MUST source them from here — i.e. from the same STruC++ compile that
+ * builds the .so — rather than from the stored project-model datatype,
+ * which can drift from the compiled layout (a stale datatype/size is
+ * what lets a plugin write the wrong number of bytes to a variable).
+ */
+export interface DebugLeafInfo {
+  arr: number
+  elem: number
+  /** Canonical IEC type name straight from the compiler (e.g. "DINT"). */
+  type: string
+  /** Canonical byte width straight from the compiler (sizeof the leaf). */
+  size: number
+}
+
+/**
+ * Build an uppercase-path → {arr, elem, type, size} lookup over every
+ * leaf. Same path keys as buildLeafPathMap, but retains the canonical
+ * type/size so callers don't re-derive them from a drift-prone source.
+ */
+export function buildLeafInfoMap(map: DebugMap): Map<string, DebugLeafInfo> {
+  const out = new Map<string, DebugLeafInfo>()
+  for (const leaf of map.leaves) {
+    out.set(leaf.path.toUpperCase(), {
+      arr: leaf.arrayIdx,
+      elem: leaf.elemIdx,
+      type: leaf.type,
+      size: leaf.size,
+    })
+  }
+  return out
+}

--- a/src/frontend/utils/opcua/__tests__/generate-opcua-config.test.ts
+++ b/src/frontend/utils/opcua/__tests__/generate-opcua-config.test.ts
@@ -6,7 +6,7 @@ import type {
   PLCServer,
 } from '@root/middleware/shared/ports/open-plc-types'
 
-import { generateOpcUaConfig, validateOpcUaConfig } from '../generate-opcua-config'
+import { generateOpcUaConfig, OPCUA_CONFIG_FORMAT_VERSION, validateOpcUaConfig } from '../generate-opcua-config'
 import { OpcUaConfigError } from '../resolve-indices'
 import * as resolveIndices from '../resolve-indices'
 import type { PLCInstanceInfo } from '../types'
@@ -145,6 +145,35 @@ describe('generateOpcUaConfig', () => {
     const parsed = JSON.parse(json) as Array<{ config: { server: { endpoint_url: string; application_uri: string } } }>
     expect(parsed[0].config.server.endpoint_url).toBe('opc.tcp://0.0.0.0:4840/openplc')
     expect(parsed[0].config.server.application_uri).toBe('urn:test:server')
+  })
+
+  it('stamps the contract format_version so the runtime can gate old configs', () => {
+    const cfg = baseServerConfig()
+    const json = generateOpcUaConfig([makePLCServer(cfg)], debugMapJson([]), [])!
+    const parsed = JSON.parse(json) as Array<{ config: { format_version: number } }>
+    expect(parsed[0].config.format_version).toBe(OPCUA_CONFIG_FORMAT_VERSION)
+  })
+
+  it('emits canonical datatype + size for a simple variable from the debug map (not the stored type)', () => {
+    const cfg = baseServerConfig()
+    // Stored variableType is INT, but the compiler says the leaf is a
+    // 4-byte DINT — the runtime must encode 4 bytes, so the emitted
+    // datatype/size come from the debug map, not the stored type.
+    cfg.addressSpace.nodes = [makeNode({ pouName: 'GVL', variablePath: 'COUNTER', variableType: 'INT' })]
+    const json = generateOpcUaConfig(
+      [makePLCServer(cfg)],
+      debugMapJson([{ path: 'COUNTER', type: 'DINT', arr: 0, elem: 1, size: 4 }]),
+      [],
+    )!
+    const parsed = JSON.parse(json) as Array<{
+      config: { address_space: { variables: Array<{ datatype: string; size: number; arr: number; elem: number }> } }
+    }>
+    expect(parsed[0].config.address_space.variables[0]).toMatchObject({
+      datatype: 'DINT',
+      size: 4,
+      arr: 0,
+      elem: 1,
+    })
   })
 
   it('filters disabled security profiles', () => {
@@ -347,28 +376,28 @@ describe('generateOpcUaConfig', () => {
     expect(parsed[0].config.address_space.arrays[0].datatype).toBe('REAL')
   })
 
-  it('returns original variableType when no OF pattern found', () => {
+  it('uses the canonical element type/size from the debug map, ignoring the stored variableType', () => {
     const cfg = baseServerConfig()
     cfg.addressSpace.nodes = [
       makeNode({
         nodeType: 'array',
         variablePath: 'WEIRD',
-        variableType: 'WEIRD_TYPE',
+        variableType: 'WEIRD_TYPE', // stored type is bogus — must be ignored
         arrayLength: 1,
       }),
     ]
     const json = generateOpcUaConfig(
       [makePLCServer(cfg)],
-      debugMapJson([{ path: 'INSTANCE0.WEIRD[0]', type: 'INT', arr: 0, elem: 1 }]),
+      debugMapJson([{ path: 'INSTANCE0.WEIRD[0]', type: 'DINT', arr: 0, elem: 1, size: 4 }]),
       instances,
     )!
     const parsed = JSON.parse(json) as Array<{
-      config: { address_space: { arrays: Array<{ datatype: string }> } }
+      config: { address_space: { arrays: Array<{ datatype: string; size: number }> } }
     }>
-    expect(parsed[0].config.address_space.arrays[0].datatype).toBe('WEIRD_TYPE')
+    expect(parsed[0].config.address_space.arrays[0]).toMatchObject({ datatype: 'DINT', size: 4 })
   })
 
-  it('uses UNKNOWN when no elementType and variableType is empty', () => {
+  it('uses the canonical element type even when the stored variableType is empty', () => {
     const cfg = baseServerConfig()
     cfg.addressSpace.nodes = [
       makeNode({
@@ -380,13 +409,13 @@ describe('generateOpcUaConfig', () => {
     ]
     const json = generateOpcUaConfig(
       [makePLCServer(cfg)],
-      debugMapJson([{ path: 'INSTANCE0.A[0]', type: 'INT', arr: 0, elem: 0 }]),
+      debugMapJson([{ path: 'INSTANCE0.A[0]', type: 'INT', arr: 0, elem: 0, size: 2 }]),
       instances,
     )!
     const parsed = JSON.parse(json) as Array<{
-      config: { address_space: { arrays: Array<{ datatype: string }> } }
+      config: { address_space: { arrays: Array<{ datatype: string; size: number }> } }
     }>
-    expect(parsed[0].config.address_space.arrays[0].datatype).toBe('UNKNOWN')
+    expect(parsed[0].config.address_space.arrays[0]).toMatchObject({ datatype: 'INT', size: 2 })
   })
 
   it('defaults arrayLength to 1 when not set', () => {

--- a/src/frontend/utils/opcua/__tests__/resolve-indices.test.ts
+++ b/src/frontend/utils/opcua/__tests__/resolve-indices.test.ts
@@ -95,7 +95,9 @@ describe('resolveVariableAddress', () => {
 
   it('resolves an instance variable', () => {
     const node = makeNode({ pouName: 'MAIN', variablePath: 'MOTOR_SPEED' })
-    expect(resolveVariableAddress(node, pmap(['INSTANCE0.MOTOR_SPEED', 0, 11]), [inst('INSTANCE0', 'MAIN')])).toMatchObject({
+    expect(
+      resolveVariableAddress(node, pmap(['INSTANCE0.MOTOR_SPEED', 0, 11]), [inst('INSTANCE0', 'MAIN')]),
+    ).toMatchObject({
       arr: 0,
       elem: 11,
     })
@@ -103,7 +105,9 @@ describe('resolveVariableAddress', () => {
 
   it('resolves a nested-path instance variable (struct/FB field)', () => {
     const node = makeNode({ pouName: 'MAIN', variablePath: 'SENSOR.VALUE' })
-    expect(resolveVariableAddress(node, pmap(['INSTANCE0.SENSOR.VALUE', 0, 25]), [inst('INSTANCE0', 'MAIN')])).toMatchObject({
+    expect(
+      resolveVariableAddress(node, pmap(['INSTANCE0.SENSOR.VALUE', 0, 25]), [inst('INSTANCE0', 'MAIN')]),
+    ).toMatchObject({
       arr: 0,
       elem: 25,
     })
@@ -111,7 +115,9 @@ describe('resolveVariableAddress', () => {
 
   it('preserves array brackets in path segments', () => {
     const node = makeNode({ pouName: 'MAIN', variablePath: 'PROFILES[3]' })
-    expect(resolveVariableAddress(node, pmap(['INSTANCE0.PROFILES[3]', 0, 30]), [inst('INSTANCE0', 'MAIN')])).toMatchObject({
+    expect(
+      resolveVariableAddress(node, pmap(['INSTANCE0.PROFILES[3]', 0, 30]), [inst('INSTANCE0', 'MAIN')]),
+    ).toMatchObject({
       arr: 0,
       elem: 30,
     })
@@ -165,7 +171,9 @@ describe('resolveStructureAddresses', () => {
       variablePath: 'S',
       fields: [makeField({ fieldPath: 'X', datatype: 'INT' })],
     })
-    const result = resolveStructureAddresses(node, pmap(['INSTANCE0.S.X', 0, 3, 'REAL', 4]), [inst('INSTANCE0', 'MAIN')])
+    const result = resolveStructureAddresses(node, pmap(['INSTANCE0.S.X', 0, 3, 'REAL', 4]), [
+      inst('INSTANCE0', 'MAIN'),
+    ])
     expect(result[0]).toMatchObject({ name: 'X', datatype: 'REAL', size: 4, arr: 0, elem: 3 })
   })
 
@@ -268,7 +276,9 @@ describe('resolveStructureAddresses', () => {
 describe('resolveArrayAddress', () => {
   it('resolves the first element of an instance array', () => {
     const node = makeNode({ nodeType: 'array', variablePath: 'PROFILE', arrayLength: 5 })
-    expect(resolveArrayAddress(node, pmap(['INSTANCE0.PROFILE[0]', 0, 100]), [inst('INSTANCE0', 'MAIN')])).toMatchObject({
+    expect(
+      resolveArrayAddress(node, pmap(['INSTANCE0.PROFILE[0]', 0, 100]), [inst('INSTANCE0', 'MAIN')]),
+    ).toMatchObject({
       arr: 0,
       elem: 100,
     })

--- a/src/frontend/utils/opcua/__tests__/resolve-indices.test.ts
+++ b/src/frontend/utils/opcua/__tests__/resolve-indices.test.ts
@@ -1,6 +1,6 @@
 import type { OpcUaFieldConfig, OpcUaNodeConfig, OpcUaPermissions } from '@root/middleware/shared/ports/open-plc-types'
 
-import { packDebugAddr } from '../../debug-parser'
+import type { DebugLeafInfo } from '../../debug-parser'
 import {
   OpcUaConfigError,
   resolveArrayAddress,
@@ -32,13 +32,17 @@ const makeField = (overrides: Partial<OpcUaFieldConfig> = {}): OpcUaFieldConfig 
   ...overrides,
 })
 
-// Build the uppercase-path → packed-addr Map the resolver consumes.
-// Same shape buildLeafPathMap produces from a real debug-map.json,
-// so tests exercise the production lookup path verbatim.
-const pmap = (...entries: Array<[path: string, arr: number, elem: number]>): Map<string, number> => {
-  const out = new Map<string, number>()
-  for (const [path, arr, elem] of entries) {
-    out.set(path.toUpperCase(), packDebugAddr({ arrayIdx: arr, elemIdx: elem }))
+// Build the uppercase-path → DebugLeafInfo Map the resolver consumes.
+// Same shape buildLeafInfoMap produces from a real debug-map.json, so
+// tests exercise the production lookup path verbatim. type/size default
+// to INT/2; pass them explicitly to exercise canonical-type emission or
+// the empty-type fallback.
+const pmap = (
+  ...entries: Array<[path: string, arr: number, elem: number, type?: string, size?: number]>
+): Map<string, DebugLeafInfo> => {
+  const out = new Map<string, DebugLeafInfo>()
+  for (const [path, arr, elem, type = 'INT', size = 2] of entries) {
+    out.set(path.toUpperCase(), { arr, elem, type, size })
   }
   return out
 }
@@ -59,17 +63,29 @@ describe('OpcUaConfigError', () => {
 describe('resolveVariableAddress', () => {
   it('resolves a global variable (GVL)', () => {
     const node = makeNode({ pouName: 'GVL', variablePath: 'SPEED' })
-    expect(resolveVariableAddress(node, pmap(['SPEED', 0, 5]), [])).toEqual({ arr: 0, elem: 5 })
+    expect(resolveVariableAddress(node, pmap(['SPEED', 0, 5]), [])).toMatchObject({ arr: 0, elem: 5 })
+  })
+
+  it('returns the canonical type and size from the debug map (not the stored type)', () => {
+    // node.variableType is INT, but the compiler says LREAL/8 — the
+    // canonical map wins so the runtime encodes the right width.
+    const node = makeNode({ pouName: 'GVL', variablePath: 'TEMP', variableType: 'INT' })
+    expect(resolveVariableAddress(node, pmap(['TEMP', 2, 9, 'LREAL', 8]), [])).toEqual({
+      arr: 2,
+      elem: 9,
+      type: 'LREAL',
+      size: 8,
+    })
   })
 
   it('resolves a global variable (CONFIG)', () => {
     const node = makeNode({ pouName: 'CONFIG', variablePath: 'TEMP' })
-    expect(resolveVariableAddress(node, pmap(['TEMP', 1, 12]), [])).toEqual({ arr: 1, elem: 12 })
+    expect(resolveVariableAddress(node, pmap(['TEMP', 1, 12]), [])).toMatchObject({ arr: 1, elem: 12 })
   })
 
   it('matches case-insensitively', () => {
     const node = makeNode({ pouName: 'gvl', variablePath: 'b' })
-    expect(resolveVariableAddress(node, pmap(['B', 0, 7]), [])).toEqual({ arr: 0, elem: 7 })
+    expect(resolveVariableAddress(node, pmap(['B', 0, 7]), [])).toMatchObject({ arr: 0, elem: 7 })
   })
 
   it('throws when global variable not found', () => {
@@ -79,7 +95,7 @@ describe('resolveVariableAddress', () => {
 
   it('resolves an instance variable', () => {
     const node = makeNode({ pouName: 'MAIN', variablePath: 'MOTOR_SPEED' })
-    expect(resolveVariableAddress(node, pmap(['INSTANCE0.MOTOR_SPEED', 0, 11]), [inst('INSTANCE0', 'MAIN')])).toEqual({
+    expect(resolveVariableAddress(node, pmap(['INSTANCE0.MOTOR_SPEED', 0, 11]), [inst('INSTANCE0', 'MAIN')])).toMatchObject({
       arr: 0,
       elem: 11,
     })
@@ -87,7 +103,7 @@ describe('resolveVariableAddress', () => {
 
   it('resolves a nested-path instance variable (struct/FB field)', () => {
     const node = makeNode({ pouName: 'MAIN', variablePath: 'SENSOR.VALUE' })
-    expect(resolveVariableAddress(node, pmap(['INSTANCE0.SENSOR.VALUE', 0, 25]), [inst('INSTANCE0', 'MAIN')])).toEqual({
+    expect(resolveVariableAddress(node, pmap(['INSTANCE0.SENSOR.VALUE', 0, 25]), [inst('INSTANCE0', 'MAIN')])).toMatchObject({
       arr: 0,
       elem: 25,
     })
@@ -95,7 +111,7 @@ describe('resolveVariableAddress', () => {
 
   it('preserves array brackets in path segments', () => {
     const node = makeNode({ pouName: 'MAIN', variablePath: 'PROFILES[3]' })
-    expect(resolveVariableAddress(node, pmap(['INSTANCE0.PROFILES[3]', 0, 30]), [inst('INSTANCE0', 'MAIN')])).toEqual({
+    expect(resolveVariableAddress(node, pmap(['INSTANCE0.PROFILES[3]', 0, 30]), [inst('INSTANCE0', 'MAIN')])).toMatchObject({
       arr: 0,
       elem: 30,
     })
@@ -119,7 +135,7 @@ describe('resolveStructureAddresses', () => {
     const node = makeNode({ nodeType: 'structure', variablePath: 'STRUCT' })
     const result = resolveStructureAddresses(node, pmap(['INSTANCE0.STRUCT', 0, 9]), [inst('INSTANCE0', 'MAIN')])
     expect(result).toHaveLength(1)
-    expect(result[0]).toEqual({ name: 'STRUCT', datatype: 'INT', arr: 0, elem: 9, permissions: perm })
+    expect(result[0]).toMatchObject({ name: 'STRUCT', datatype: 'INT', arr: 0, elem: 9, permissions: perm })
   })
 
   it('throws when instance not found and fields are present', () => {
@@ -133,12 +149,24 @@ describe('resolveStructureAddresses', () => {
       variablePath: 'S',
       fields: [makeField({ fieldPath: 'X', datatype: 'INT' }), makeField({ fieldPath: 'Y', datatype: 'REAL' })],
     })
-    const result = resolveStructureAddresses(node, pmap(['INSTANCE0.S.X', 0, 3], ['INSTANCE0.S.Y', 0, 4]), [
-      inst('INSTANCE0', 'MAIN'),
-    ])
+    const result = resolveStructureAddresses(
+      node,
+      pmap(['INSTANCE0.S.X', 0, 3, 'INT', 2], ['INSTANCE0.S.Y', 0, 4, 'REAL', 4]),
+      [inst('INSTANCE0', 'MAIN')],
+    )
     expect(result).toHaveLength(2)
     expect(result[0]).toMatchObject({ name: 'X', arr: 0, elem: 3, datatype: 'INT' })
     expect(result[1]).toMatchObject({ name: 'Y', arr: 0, elem: 4, datatype: 'REAL' })
+  })
+
+  it('emits canonical type and size on leaf fields (debug map wins over stored datatype)', () => {
+    const node = makeNode({
+      nodeType: 'structure',
+      variablePath: 'S',
+      fields: [makeField({ fieldPath: 'X', datatype: 'INT' })],
+    })
+    const result = resolveStructureAddresses(node, pmap(['INSTANCE0.S.X', 0, 3, 'REAL', 4]), [inst('INSTANCE0', 'MAIN')])
+    expect(result[0]).toMatchObject({ name: 'X', datatype: 'REAL', size: 4, arr: 0, elem: 3 })
   })
 
   it('resolves nested fields recursively (FB inside FB)', () => {
@@ -155,7 +183,7 @@ describe('resolveStructureAddresses', () => {
     })
     const result = resolveStructureAddresses(
       node,
-      pmap(['INSTANCE0.MY_FB.TON0.IN', 0, 10], ['INSTANCE0.MY_FB.TON0.ET', 0, 11]),
+      pmap(['INSTANCE0.MY_FB.TON0.IN', 0, 10, 'BOOL', 1], ['INSTANCE0.MY_FB.TON0.ET', 0, 11, 'TIME', 8]),
       [inst('INSTANCE0', 'MAIN')],
     )
     expect(result).toHaveLength(1)
@@ -211,7 +239,7 @@ describe('resolveStructureAddresses', () => {
       variablePath: 'S',
       fields: [makeField({ fieldPath: 'B', datatype: 'REAL' })],
     })
-    const result = resolveStructureAddresses(node, pmap(['INSTANCE0.S.B', 0, 60]), [inst('INSTANCE0', 'MAIN')])
+    const result = resolveStructureAddresses(node, pmap(['INSTANCE0.S.B', 0, 60, '']), [inst('INSTANCE0', 'MAIN')])
     expect(result[0].datatype).toBe('REAL')
   })
 
@@ -221,7 +249,7 @@ describe('resolveStructureAddresses', () => {
       variablePath: 'S',
       fields: [makeField({ fieldPath: 'C' })],
     })
-    const result = resolveStructureAddresses(node, pmap(['INSTANCE0.S.C', 0, 61]), [inst('INSTANCE0', 'MAIN')])
+    const result = resolveStructureAddresses(node, pmap(['INSTANCE0.S.C', 0, 61, '']), [inst('INSTANCE0', 'MAIN')])
     expect(result[0].datatype).toBe('UNKNOWN')
   })
 
@@ -240,15 +268,25 @@ describe('resolveStructureAddresses', () => {
 describe('resolveArrayAddress', () => {
   it('resolves the first element of an instance array', () => {
     const node = makeNode({ nodeType: 'array', variablePath: 'PROFILE', arrayLength: 5 })
-    expect(resolveArrayAddress(node, pmap(['INSTANCE0.PROFILE[0]', 0, 100]), [inst('INSTANCE0', 'MAIN')])).toEqual({
+    expect(resolveArrayAddress(node, pmap(['INSTANCE0.PROFILE[0]', 0, 100]), [inst('INSTANCE0', 'MAIN')])).toMatchObject({
       arr: 0,
       elem: 100,
     })
   })
 
+  it('returns the canonical element type and size from the debug map', () => {
+    const node = makeNode({ nodeType: 'array', pouName: 'GVL', variablePath: 'TBL', arrayLength: 3 })
+    expect(resolveArrayAddress(node, pmap(['TBL[0]', 0, 5, 'DINT', 4]), [])).toEqual({
+      arr: 0,
+      elem: 5,
+      type: 'DINT',
+      size: 4,
+    })
+  })
+
   it('resolves the first element of a global array', () => {
     const node = makeNode({ nodeType: 'array', pouName: 'GVL', variablePath: 'TABLE', arrayLength: 4 })
-    expect(resolveArrayAddress(node, pmap(['TABLE[0]', 1, 7]), [])).toEqual({ arr: 1, elem: 7 })
+    expect(resolveArrayAddress(node, pmap(['TABLE[0]', 1, 7]), [])).toMatchObject({ arr: 1, elem: 7 })
   })
 
   it('throws when instance not found', () => {
@@ -274,7 +312,7 @@ describe('resolveArrayAddress', () => {
       ['INSTANCE0.MY_ARRAY[2]', 0, 31],
       ['INSTANCE0.MY_ARRAY[3]', 0, 32],
     )
-    expect(resolveArrayAddress(node, leaves, [inst('INSTANCE0', 'MAIN')])).toEqual({ arr: 0, elem: 30 })
+    expect(resolveArrayAddress(node, leaves, [inst('INSTANCE0', 'MAIN')])).toMatchObject({ arr: 0, elem: 30 })
   })
 
   it('resolves an array with negative lower bound (ARRAY[-2..2])', () => {
@@ -287,7 +325,7 @@ describe('resolveArrayAddress', () => {
       ['INSTANCE0.SIGNED_ARR[-1]', 0, 11],
       ['INSTANCE0.SIGNED_ARR[0]', 0, 12],
     )
-    expect(resolveArrayAddress(node, leaves, [inst('INSTANCE0', 'MAIN')])).toEqual({ arr: 0, elem: 10 })
+    expect(resolveArrayAddress(node, leaves, [inst('INSTANCE0', 'MAIN')])).toMatchObject({ arr: 0, elem: 10 })
   })
 
   it('does not match sub-elements of an array of structs as the array base', () => {

--- a/src/frontend/utils/opcua/generate-opcua-config.ts
+++ b/src/frontend/utils/opcua/generate-opcua-config.ts
@@ -8,7 +8,7 @@ import type {
   PLCServer,
 } from '@root/middleware/shared/ports/open-plc-types'
 
-import { buildLeafPathMap, parseDebugMap as parseDebugMapJson } from '../debug-parser'
+import { buildLeafInfoMap, type DebugLeafInfo, parseDebugMap as parseDebugMapJson } from '../debug-parser'
 import { getErrorMessage } from '../get-error-message'
 import {
   OpcUaConfigError,
@@ -17,6 +17,16 @@ import {
   resolveVariableAddress,
 } from './resolve-indices'
 import type { PLCInstanceInfo } from './types'
+
+/**
+ * opcua.json contract version. Bump when the per-variable schema changes
+ * in a way the runtime must detect. v2 introduced compiler-canonical
+ * `datatype` + `size` per leaf (sourced from debug-map.json) so the
+ * runtime never re-derives byte widths from a drift-prone project-model
+ * datatype. A runtime that requires >= 2 gracefully refuses an older
+ * (unversioned) config instead of writing the wrong number of bytes.
+ */
+export const OPCUA_CONFIG_FORMAT_VERSION = 2
 
 /**
  * Runtime configuration interfaces
@@ -71,6 +81,8 @@ interface RuntimeVariable {
   browse_name: string
   display_name: string
   datatype: string
+  /** Canonical byte width from the compiler's debug map. */
+  size: number
   description: string
   arr: number
   elem: number
@@ -80,6 +92,9 @@ interface RuntimeVariable {
 interface RuntimeStructureField {
   name: string
   datatype: string
+  // Canonical byte width from the compiler; null for complex parents
+  // (containers with nested fields) which have no leaf of their own.
+  size: number | null
   // null for complex types that have nested fields
   arr: number | null
   elem: number | null
@@ -100,6 +115,8 @@ interface RuntimeArray {
   browse_name: string
   display_name: string
   datatype: string
+  /** Canonical byte width of one element from the compiler's debug map. */
+  size: number
   length: number
   arr: number
   elem: number
@@ -114,6 +131,8 @@ interface RuntimeAddressSpace {
 }
 
 interface RuntimePluginConfig {
+  /** opcua.json contract version — see OPCUA_CONFIG_FORMAT_VERSION. */
+  format_version: number
   server: RuntimeServerConfig
   security: RuntimeSecurityConfig
   users: RuntimeUser[]
@@ -197,7 +216,7 @@ const convertPermissions = (permissions: OpcUaPermissions): RuntimeVariablePermi
  */
 const resolveVariable = (
   node: OpcUaNodeConfig,
-  pathToAddr: Map<string, number>,
+  pathToAddr: Map<string, DebugLeafInfo>,
   instances: PLCInstanceInfo[],
 ): RuntimeVariable => {
   const addr = resolveVariableAddress(node, pathToAddr, instances)
@@ -206,7 +225,10 @@ const resolveVariable = (
     node_id: node.nodeId,
     browse_name: node.browseName,
     display_name: node.displayName,
-    datatype: node.variableType,
+    // datatype/size from the compiler's debug map, NOT node.variableType
+    // (the stored project-model type can drift from the compiled layout).
+    datatype: addr.type,
+    size: addr.size,
     description: node.description,
     arr: addr.arr,
     elem: addr.elem,
@@ -220,6 +242,7 @@ const resolveVariable = (
 const convertResolvedFieldToRuntime = (field: {
   name: string
   datatype: string
+  size: number | null
   arr: number | null
   elem: number | null
   permissions: { viewer: 'r' | 'w' | 'rw'; operator: 'r' | 'w' | 'rw'; engineer: 'r' | 'w' | 'rw' }
@@ -228,6 +251,7 @@ const convertResolvedFieldToRuntime = (field: {
   const runtimeField: RuntimeStructureField = {
     name: field.name,
     datatype: field.datatype,
+    size: field.size,
     arr: field.arr,
     elem: field.elem,
     permissions: convertPermissions(field.permissions),
@@ -247,7 +271,7 @@ const convertResolvedFieldToRuntime = (field: {
  */
 const resolveStructure = (
   node: OpcUaNodeConfig,
-  pathToAddr: Map<string, number>,
+  pathToAddr: Map<string, DebugLeafInfo>,
   instances: PLCInstanceInfo[],
   droppedPaths: string[],
 ): RuntimeStructure | null => {
@@ -265,36 +289,24 @@ const resolveStructure = (
 }
 
 /**
- * Extract the element type from an array type string like "ARRAY[1..10] OF INT"
- * Returns the element type (e.g., "INT") or the original string if parsing fails.
- */
-const extractArrayElementType = (arrayTypeStr: string): string => {
-  const match = arrayTypeStr.match(/\bOF\s+([A-Za-z0-9_:.]+)\s*$/i)
-  return match ? match[1].toUpperCase() : arrayTypeStr
-}
-
-/**
  * Resolve an array and build runtime format
  */
 const resolveArray = (
   node: OpcUaNodeConfig,
-  pathToAddr: Map<string, number>,
+  pathToAddr: Map<string, DebugLeafInfo>,
   instances: PLCInstanceInfo[],
 ): RuntimeArray => {
   const addr = resolveArrayAddress(node, pathToAddr, instances)
 
-  // Get the element type - prefer explicit elementType, otherwise extract from variableType
-  let datatype = node.elementType
-  if (!datatype && node.variableType) {
-    datatype = extractArrayElementType(node.variableType)
-  }
-  datatype = datatype || 'UNKNOWN'
-
+  // Element datatype/size from the compiler's debug map (the resolved
+  // leaf is the array's first element — all elements share the type),
+  // NOT the stored element type which can drift from the compiled layout.
   return {
     node_id: node.nodeId,
     browse_name: node.browseName,
     display_name: node.displayName,
-    datatype,
+    datatype: addr.type,
+    size: addr.size,
     length: node.arrayLength || 1,
     arr: addr.arr,
     elem: addr.elem,
@@ -307,7 +319,7 @@ const resolveArray = (
  */
 const buildAddressSpace = (
   config: OpcUaServerConfig,
-  pathToAddr: Map<string, number>,
+  pathToAddr: Map<string, DebugLeafInfo>,
   instances: PLCInstanceInfo[],
   droppedPaths: string[],
 ): RuntimeAddressSpace => {
@@ -382,10 +394,10 @@ const buildAddressSpace = (
  * `addressSpace.nodes.length > 0 && map.size === 0` to distinguish
  * "no program loaded yet" from "config has no nodes".
  */
-const parseDebugMapToPathMap = (content: string): Map<string, number> => {
+const parseDebugMapToInfoMap = (content: string): Map<string, DebugLeafInfo> => {
   const map = parseDebugMapJson(content)
   if (!map) return new Map()
-  return buildLeafPathMap(map)
+  return buildLeafInfoMap(map)
 }
 
 /**
@@ -426,7 +438,7 @@ export const generateOpcUaConfig = (
 
   // 2. Parse debug-map.json into the same uppercase-path → packed-addr
   //    Map the debugger uses. One source of truth for resolution.
-  const pathToAddr = parseDebugMapToPathMap(debugMapContent)
+  const pathToAddr = parseDebugMapToInfoMap(debugMapContent)
 
   if (pathToAddr.size === 0 && config.addressSpace.nodes.length > 0) {
     throw new OpcUaConfigError(
@@ -460,6 +472,7 @@ export const generateOpcUaConfig = (
     name: 'opcua_server',
     protocol: 'OPC-UA',
     config: {
+      format_version: OPCUA_CONFIG_FORMAT_VERSION,
       server: buildServerConfig(config),
       security: buildSecurityConfig(config),
       users: buildUsersConfig(config),
@@ -496,7 +509,7 @@ export const validateOpcUaConfig = (
   }
 
   // Try to resolve all variables
-  const pathToAddr = parseDebugMapToPathMap(debugMapContent)
+  const pathToAddr = parseDebugMapToInfoMap(debugMapContent)
 
   for (const node of config.addressSpace.nodes) {
     try {

--- a/src/frontend/utils/opcua/resolve-indices.ts
+++ b/src/frontend/utils/opcua/resolve-indices.ts
@@ -21,7 +21,7 @@
 
 import type { OpcUaFieldConfig, OpcUaNodeConfig } from '@root/middleware/shared/ports/open-plc-types'
 
-import { unpackDebugAddr } from '../debug-parser'
+import type { DebugLeafInfo } from '../debug-parser'
 import {
   buildDebugPath,
   buildGlobalDebugPath,
@@ -33,6 +33,11 @@ import type { PLCInstanceInfo, ResolvedField } from './types'
 export interface LeafAddress {
   arr: number
   elem: number
+  /** Canonical IEC type from the compiler's debug map (single source of
+   *  truth — never the stored project-model datatype). */
+  type: string
+  /** Canonical byte width from the compiler's debug map. */
+  size: number
 }
 
 export class OpcUaConfigError extends Error {
@@ -53,11 +58,10 @@ const toInstanceMapping = (instances: PLCInstanceInfo[]): PLCInstanceMapping[] =
  * Look up a STruC++ debug path in the shared leaf map and return the
  * (arr, elem) address. Returns null on miss. Wraps unpackDebugAddr.
  */
-const lookup = (path: string, pathToAddr: Map<string, number>): LeafAddress | null => {
-  const packed = pathToAddr.get(path.toUpperCase())
-  if (packed === undefined) return null
-  const { arrayIdx, elemIdx } = unpackDebugAddr(packed)
-  return { arr: arrayIdx, elem: elemIdx }
+const lookup = (path: string, pathToAddr: Map<string, DebugLeafInfo>): LeafAddress | null => {
+  const info = pathToAddr.get(path.toUpperCase())
+  if (info === undefined) return null
+  return { arr: info.arr, elem: info.elem, type: info.type, size: info.size }
 }
 
 /**
@@ -95,7 +99,7 @@ const pathForNode = (
  */
 export const resolveVariableAddress = (
   node: OpcUaNodeConfig,
-  pathToAddr: Map<string, number>,
+  pathToAddr: Map<string, DebugLeafInfo>,
   instances: PLCInstanceInfo[],
 ): LeafAddress => {
   const result = pathForNode(node.pouName, node.variablePath, instances)
@@ -128,7 +132,7 @@ const resolveFieldRecursively = (
   field: OpcUaFieldConfig,
   parentPath: string,
   pouName: string,
-  pathToAddr: Map<string, number>,
+  pathToAddr: Map<string, DebugLeafInfo>,
   instanceName: string | null,
   droppedPaths: string[],
 ): ResolvedField | null => {
@@ -149,6 +153,7 @@ const resolveFieldRecursively = (
     return {
       name: field.fieldPath,
       datatype: field.datatype || 'UNKNOWN',
+      size: null,
       arr: null,
       elem: null,
       permissions: field.permissions,
@@ -156,7 +161,9 @@ const resolveFieldRecursively = (
     }
   }
 
-  // Leaf field.
+  // Leaf field. datatype/size come from the compiler's debug map (the
+  // canonical source), not the stored field.datatype — the runtime
+  // encodes/decodes this leaf by exactly these.
   const debugPath =
     pouName === 'GVL' || pouName === 'CONFIG'
       ? buildGlobalDebugPath(fullFieldPath)
@@ -169,7 +176,10 @@ const resolveFieldRecursively = (
 
   return {
     name: field.fieldPath,
-    datatype: field.datatype || 'UNKNOWN',
+    // Canonical type wins; fall back to the stored field datatype only if
+    // the debug map somehow carries no type (malformed/old map).
+    datatype: addr.type || field.datatype || 'UNKNOWN',
+    size: addr.size,
     arr: addr.arr,
     elem: addr.elem,
     permissions: field.permissions,
@@ -182,7 +192,7 @@ const resolveFieldRecursively = (
  */
 export const resolveStructureAddresses = (
   node: OpcUaNodeConfig,
-  pathToAddr: Map<string, number>,
+  pathToAddr: Map<string, DebugLeafInfo>,
   instances: PLCInstanceInfo[],
   droppedPaths: string[] = [],
 ): ResolvedField[] => {
@@ -191,7 +201,8 @@ export const resolveStructureAddresses = (
     return [
       {
         name: node.variablePath,
-        datatype: node.variableType,
+        datatype: addr.type,
+        size: addr.size,
         arr: addr.arr,
         elem: addr.elem,
         permissions: node.permissions,
@@ -231,7 +242,7 @@ export const resolveStructureAddresses = (
  */
 export const resolveArrayAddress = (
   node: OpcUaNodeConfig,
-  pathToAddr: Map<string, number>,
+  pathToAddr: Map<string, DebugLeafInfo>,
   instances: PLCInstanceInfo[],
 ): LeafAddress => {
   const result = pathForNode(node.pouName, node.variablePath, instances)
@@ -239,7 +250,7 @@ export const resolveArrayAddress = (
 
   const upperPrefix = `${result.path.toUpperCase()}[`
   let best: { addr: LeafAddress; idx: number } | null = null
-  for (const [path, packed] of pathToAddr) {
+  for (const [path, info] of pathToAddr) {
     if (!path.startsWith(upperPrefix)) continue
     const close = path.indexOf(']', upperPrefix.length)
     // Reject array-of-struct sub-elements: `FOO[1].FIELD` matches
@@ -248,8 +259,7 @@ export const resolveArrayAddress = (
     const idx = Number(path.slice(upperPrefix.length, close))
     if (!Number.isFinite(idx)) continue
     if (best === null || idx < best.idx) {
-      const { arrayIdx, elemIdx } = unpackDebugAddr(packed)
-      best = { addr: { arr: arrayIdx, elem: elemIdx }, idx }
+      best = { addr: { arr: info.arr, elem: info.elem, type: info.type, size: info.size }, idx }
     }
   }
   if (best) return best.addr

--- a/src/frontend/utils/opcua/types.ts
+++ b/src/frontend/utils/opcua/types.ts
@@ -30,7 +30,12 @@ export interface PLCInstanceInfo {
  */
 export interface ResolvedField {
   name: string
+  /** Canonical IEC type from the compiler's debug map for leaves; the
+   *  stored container type (FB/struct name) for complex parents. */
   datatype: string
+  /** Canonical byte width from the compiler — null for complex parents
+   *  (no leaf of their own; only their child leaves carry a size). */
+  size: number | null
   /** Address of the leaf — null for complex types whose own address
    *  doesn't make sense (only their child leaves do). */
   arr: number | null


### PR DESCRIPTION
## Summary
Two related editor-side fixes for the OPC-UA + forcing rework.

### OPC-UA canonical size/type contract (`462500fb5`)
- Source each exposed variable's datatype **and** byte size from the compiler **debug map** (the single shared surface) when generating `opcua.json`, instead of re-deriving them. This is the editor half of the OPC-UA `format_version: 2` contract the runtime now consumes — eliminating the type/size mismatch that drove the OPC-UA global-corruption bug.

### Bare-metal force re-imposition (`6345e259d`) — supersedes #719
- On bare-metal the image table aliases each located variable's storage, so direct image writes (HAL input refresh, the Modbus `COILS → bool_output` reverse-copy) clobber a debugger-forced `%QX`.
- Add `runtime_apply_located_forces()` (in the shared `arduino_runtime_glue`) and call it after the input refresh and after the Modbus reverse-copies. It walks `locatedVars[]` and restores `value_ = forced_value_` for forced leaves.
- **Keeps** the reverse-copy (so Modbus coil writes still mirror into mapped outputs) — unlike #719, which deleted it. Both behaviors now hold.
- Compile-checked against the bundled strucpp headers (gnu++17 and gnu++14). HIL-validated on SLM-RP4: forcing a mapped relay output held against the running program; unforce resumed control.

Supersedes #719 (alternative approach that preserves Modbus mirroring — see discussion there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OPC UA runtime configuration now includes compiler-authoritative byte-size information for variables, structure fields, and array elements, with `format_version` updated to **v2**.

* **Bug Fixes**
  * OPC UA datatype and byte-size resolution now consistently follows compiler debug information (including nested structures and arrays), overriding stored or fallback values.
  * Improved Modbus RTU/simulator request batching by reducing the batch size to better fit device packet reassembly limits.

* **Tests**
  * Updated and expanded unit tests to validate canonical datatype/size behavior and `format_version` stamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->