### PR TITLE
fix(transpiler): LD coil grouping (#836) + chained-block output ordering (#830)

### DIFF
--- a/docs/transpiler/block-output-ordering-830.md
+++ b/docs/transpiler/block-output-ordering-830.md
@@ -1,0 +1,58 @@
+# Chained block output ordering in LD → ST (issue #830)
+
+Status: **resolved** on `fix/parity/parallel-coil-single-if` (folded into PR #891 / web #543).
+Applied identically in both repos across the byte-identical
+`src/backend/shared/transpilers/st-transpiler/` surface.
+
+## The bug
+
+When a rung chains function/FB calls, the generated ST emitted **all the block calls
+first, then all the output assignments afterward**, so a later block read a variable whose
+write had not been emitted yet. Reporter's case:
+
+```st
+_TMP_MOD6363443_OUT := MOD(EN := TRUE, IN1 := Input, IN2 := 86400, ENO => _TMP_MOD6363443_ENO);
+_TMP_DIV4651235_OUT := DIV(EN := _TMP_MOD6363443_ENO, IN1 := Output, IN2 := 60, ENO => _TMP_DIV4651235_ENO);  -- reads Output before it is set
+IF _TMP_MOD6363443_ENO THEN Output := _TMP_MOD6363443_OUT; END_IF;
+IF _TMP_DIV4651235_ENO THEN Output := _TMP_DIV4651235_OUT; END_IF;
+```
+`DIV` reads `Output` while it is still stale → `Output` is always 0.
+
+## Root cause
+
+Both the TS walker and the python oracle (`PLCGenerator.py:1339-1359`, `ComputeProgram`) emit
+instances as *all execution-ordered (eo>0) instances first, then eo=0 instances by position*.
+When the editor numbers the blocks but leaves their output variables at executionOrderId 0,
+every block call emits in the ordered pass and every assignment in the unordered pass. A
+shared bug with xml2st; regressed from v1.x; FBD escapes it via interleaved execution orders.
+The same hazard applies to **coils** fed by a block (confirmed).
+
+## The fix
+
+An output-write sink (coil / output / inOut variable) fed solely by a block is that block's
+output binding, so it must emit immediately after the block's **actual call** — eager or lazy.
+Implemented at the emission level in `walker/ld.ts`:
+
+- `blockFedSink` identifies such sinks (single incoming edge from a block).
+- `emitLdBody` indexes them per block into `state.consumersByBlock`.
+- `emitFunctionCall` / `emitFunctionBlockCall` call `emitBlockConsumers` right after pushing
+  the call, which emits the block's consumers through the existing coil-grouping sweep (so the
+  #836 grouping still applies to multiple SET/RESET coils off one block).
+- `state.emittedSinks` makes emission idempotent; the main sink sweep skips what coupling
+  already emitted.
+
+Emitting at the *call* (not the sink slot) is what makes it robust to blocks pulled lazily
+through a later block's `EN` expression (e.g. `GT.EN := MUL.ENO OR SUB.ENO`), where the call
+lands mid-walk. The earlier sink-list-reorder approach failed that case.
+
+This is a deliberate divergence from xml2st (same class as #836 / the D1 task-sort fix).
+
+## Verification
+
+- Regression test `st-transpiler/__tests__/block-output-ordering-830.test.ts` — the reported
+  MOD→DIV chain, the eager-pull (`GT.EN`) shape, and a block-fed coil; exact-ST assertions.
+- Corpus: 10 of 193 LD fixtures changed, **all corrections** — each block's output write moved
+  to immediately follow its call. Notably `edge__matiasacuna_..._sc_freidora` (a 4-block
+  `INT_TO_REAL→SUB→MUL→DIV` chain) and `edge__frontadomarcositsu_...` (a 5-block chain) were
+  fully broken and are now correct. The other 183 fixtures are unchanged.
+- #836 coil-grouping regression test still passes; 301 compile/library integration tests pass.

--- a/docs/transpiler/coil-reevaluation-836.md
+++ b/docs/transpiler/coil-reevaluation-836.md
@@ -1,0 +1,61 @@
+# Coil condition re-evaluation in LD → ST (issue #836)
+
+Status: **resolved** on `fix/parity/parallel-coil-single-if` (folded into PR #891 / web #543,
+which become the complete "coil grouping" fix). Applied identically in both repos
+(openplc-editor + openplc-web) across the byte-identical
+`src/backend/shared/transpilers/st-transpiler/` surface; verified with
+`scripts/compare-surfaces.py`.
+
+## The bug
+
+The LD walker emitted one `IF <condition> THEN <coil> := …; END_IF;` per coil, re-reading
+the condition's variables each time. When a coil writes a variable that a later-emitted
+coil's condition reads, the later coil sees the mutated value. The reporter's case: a
+`FirstScan` contact feeding `Output1(S)`, a `FirstScan(R)` reset, and `Output2(S)` — with
+`FirstScan` initially TRUE, the reset clears it before `Output2`'s `IF` re-reads it, so
+`Output2` never sets.
+
+The old `xml2st` engine has the same bug, so this fix is a deliberate divergence from the
+oracle (consistent with the D1-fix precedent on the parity branch).
+
+## Expected behaviour (from the maintainer, three topologies)
+
+| Topology | Expected ST |
+|---|---|
+| **S1** `FirstScan → [Output1(S) ∥ Output2(S)] → FirstScan(R)` | `Output1`+`Output2` in one `IF`; reset in a separate `IF` |
+| **S2** `FirstScan → [Output1(S) ∥ FirstScan(R) ∥ Output2(S)]` | all three assignments in one `IF` |
+| **S3** sequential `FirstScan → Output1(S) → FirstScan(R) → Output2(S)` | three separate `IF`s (Output2 stays unset) |
+
+The rule: SET/RESET coils that branch off the **same source** (parallel rails) share one
+energization and collapse into a single `IF`; coils with **distinct sources** (sequential)
+stay as separate `IF`s. Sequential coils intentionally keep the re-evaluation semantics.
+
+## The fix (two edits)
+
+1. **`walker/ld.ts` — `emitSinksWithCoilGrouping`**: collapse same-source SET/RESET coils
+   into one `IF`, gathering them **even when not adjacent** in emission order. A coil fed by
+   their merge (sharing neither source) can sort between two parallel branches by position;
+   the branches still group, emitted at the first branch's slot, with the merge-fed coil
+   following after (its dataflow order). The group key is the coil's sorted immediate
+   incoming source-node ids (`setResetCoilGroupKey`); the group emits via `emitCoilGroup`.
+2. **`core/path-tree.ts` — `factorizePaths`**: drop byte-identical duplicate paths
+   (`X OR X` → `X`) before factoring. Two parallel branches tracing to the same contact
+   would otherwise render the reset condition as `FirstScan AND (TRUE OR TRUE)` (the TS
+   port's factorization of two identical single-leaf paths; xml2st renders the same
+   topology as `FirstScan OR FirstScan`). Dedup keys on the full repr — text **and** source
+   locations — so two *distinct* contacts on the same variable still survive as separate OR
+   terms. No behavioural change; cosmetic only.
+
+This supersedes the earlier "Approach A" (condition snapshotting into temps), which was
+dropped once the maintainer's expected outputs showed the intended solution is grouping —
+and that sequential coils (S3) should *not* be "fixed" by a snapshot.
+
+## Verification
+
+- Unit regression test (byte-identical both repos):
+  `st-transpiler/__tests__/coil-grouping-836.test.ts` — reconstructs all three topologies
+  and asserts exact ST. All three now match the maintainer's expected output.
+- Corpus: ran the 193-project LD corpus (`~/src/xml2st/fixtures/golden/real_projects_json`)
+  through `emitLdBody` before/after. **0 fixtures changed** for the grouping extension and
+  **0** for the dedup — S1's topology (parallel branches merging into a downstream coil)
+  does not occur in the corpus, which is why it was a blind spot.

--- a/src/backend/shared/transpilers/st-transpiler/__tests__/block-output-ordering-830.test.ts
+++ b/src/backend/shared/transpilers/st-transpiler/__tests__/block-output-ordering-830.test.ts
@@ -1,0 +1,203 @@
+import { emitLdBody } from '@root/backend/shared/transpilers/st-transpiler/walker/ld'
+import type { RFBody, RFEdge, RFNode } from '@root/backend/shared/transpilers/st-transpiler/walker/types'
+
+// Regression coverage for issue #830 — when function calls are chained in
+// a rung, each block's output assignment must emit immediately after the
+// call, so a downstream block reads the written value and not a stale one.
+
+let edgeId = 0
+const e = (s: string, t: string, sh: string | null, th: string | null): RFEdge => ({
+  id: `e${edgeId++}`,
+  source: s,
+  target: t,
+  sourceHandle: sh,
+  targetHandle: th,
+})
+const rail = (id: string, variant: 'left' | 'right', x: number): RFNode => ({
+  id,
+  type: 'powerRail',
+  position: { x, y: 30 },
+  data: { variant },
+})
+const inVar = (id: string, name: string, x: number, y: number): RFNode => ({
+  id,
+  type: 'variable',
+  position: { x, y },
+  data: { variant: 'input', variable: { name }, executionOrder: 0, numericId: id },
+})
+const outVar = (id: string, name: string, x: number, y: number): RFNode => ({
+  id,
+  type: 'variable',
+  position: { x, y },
+  data: { variant: 'output', variable: { name }, executionOrder: 0, numericId: id },
+})
+const coil = (id: string, name: string, x: number, y: number): RFNode => ({
+  id,
+  type: 'coil',
+  position: { x, y },
+  data: { variant: 'default', variable: { name }, executionOrder: 0, numericId: id },
+})
+const fblock = (id: string, name: string, nid: string, eo: number, x: number, y: number, outType = 'DINT'): RFNode => ({
+  id,
+  type: 'block',
+  position: { x, y },
+  data: {
+    numericId: nid,
+    executionOrder: eo,
+    executionControl: true,
+    variant: {
+      name,
+      type: 'function',
+      extensible: false,
+      variables: [
+        { name: 'EN', class: 'input', type: { definition: 'generic-type', value: 'BOOL' } },
+        { name: 'ENO', class: 'output', type: { definition: 'generic-type', value: 'BOOL' } },
+        { name: 'OUT', class: 'output', type: { definition: 'base-type', value: outType } },
+        { name: 'IN1', class: 'input', type: { definition: 'base-type', value: 'DINT' } },
+        { name: 'IN2', class: 'input', type: { definition: 'base-type', value: 'DINT' } },
+      ],
+    },
+  },
+})
+
+const call = (lhs: string, rhs: string): string => `  ${lhs} := ${rhs};\n`
+const enoIf = (eno: string, v: string, val: string): string => `  IF ${eno} THEN\n      ${v} := ${val};\n  END_IF;\n`
+const asg = (v: string, val: string): string => `  ${v} := ${val};\n`
+
+describe('issue 830 — chained block output assignments emit before downstream calls', () => {
+  it('writes a block output before the next block reads it (reported MOD->DIV chain)', () => {
+    // MOD(EN:=TRUE) -> Output ; DIV(EN:=MOD.ENO, IN1:=Output) -> Output. Blocks numbered, writes at eo 0.
+    const body: RFBody = {
+      rungs: [
+        {
+          reactFlowViewport: [800, 300],
+          nodes: [
+            rail('L', 'left', 0),
+            inVar('901', 'Input', 20, 80),
+            inVar('902', '86400', 20, 120),
+            fblock('MOD', 'MOD', '6363443', 1, 150, 30),
+            outVar('903', 'Output', 320, 30),
+            inVar('904', 'Output', 20, 200),
+            inVar('905', '60', 20, 240),
+            fblock('DIV', 'DIV', '4651235', 2, 450, 30),
+            outVar('906', 'Output', 620, 30),
+            rail('R', 'right', 760),
+          ],
+          edges: [
+            e('L', 'MOD', 'left-rail', 'EN'),
+            e('901', 'MOD', null, 'IN1'),
+            e('902', 'MOD', null, 'IN2'),
+            e('MOD', '903', 'OUT', null),
+            e('MOD', 'DIV', 'ENO', 'EN'),
+            e('904', 'DIV', null, 'IN1'),
+            e('905', 'DIV', null, 'IN2'),
+            e('DIV', '906', 'OUT', null),
+          ],
+        },
+      ],
+    }
+    const { bodySt, warnings } = emitLdBody(body)
+    expect(warnings).toEqual([])
+    expect(bodySt).toBe(
+      '\n' +
+        call('_TMP_MOD6363443_OUT', 'MOD(EN := TRUE, IN1 := Input, IN2 := 86400, ENO => _TMP_MOD6363443_ENO)') +
+        enoIf('_TMP_MOD6363443_ENO', 'Output', '_TMP_MOD6363443_OUT') +
+        call(
+          '_TMP_DIV4651235_OUT',
+          'DIV(EN := _TMP_MOD6363443_ENO, IN1 := Output, IN2 := 60, ENO => _TMP_DIV4651235_ENO)',
+        ) +
+        enoIf('_TMP_DIV4651235_ENO', 'Output', '_TMP_DIV4651235_OUT'),
+    )
+  })
+
+  it('interleaves output writes for blocks pulled eagerly through a later block EN', () => {
+    // MUL -> producto ; SUB(IN1:=producto) -> dif ; GT(EN := MUL.ENO OR SUB.ENO) -> flag.
+    // No execution order: GT.EN pulls MUL and SUB; their writes must still land between the calls.
+    const body: RFBody = {
+      rungs: [
+        {
+          reactFlowViewport: [800, 300],
+          nodes: [
+            rail('L', 'left', 0),
+            inVar('901', 'valor', 20, 80),
+            inVar('902', 'k', 20, 120),
+            fblock('MUL', 'MUL', '111', 0, 150, 30),
+            outVar('903', 'producto', 320, 200),
+            inVar('904', 'producto', 20, 160),
+            inVar('905', 'k2', 20, 200),
+            fblock('SUB', 'SUB', '222', 0, 150, 130),
+            outVar('906', 'dif', 320, 260),
+            fblock('GT', 'GT', '333', 0, 500, 30, 'BOOL'),
+            outVar('907', 'flag', 660, 30),
+            rail('R', 'right', 760),
+          ],
+          edges: [
+            e('L', 'MUL', 'left-rail', 'EN'),
+            e('901', 'MUL', null, 'IN1'),
+            e('902', 'MUL', null, 'IN2'),
+            e('MUL', '903', 'OUT', null),
+            e('904', 'SUB', null, 'IN1'),
+            e('905', 'SUB', null, 'IN2'),
+            e('SUB', '906', 'OUT', null),
+            e('MUL', 'GT', 'ENO', 'EN'),
+            e('SUB', 'GT', 'ENO', 'EN'),
+            e('GT', '907', 'OUT', null),
+          ],
+        },
+      ],
+    }
+    const { bodySt, warnings } = emitLdBody(body)
+    expect(warnings).toEqual([])
+    expect(bodySt).toBe(
+      '\n' +
+        call('_TMP_MUL111_OUT', 'MUL(EN := TRUE, IN1 := valor, IN2 := k, ENO => _TMP_MUL111_ENO)') +
+        enoIf('_TMP_MUL111_ENO', 'producto', '_TMP_MUL111_OUT') +
+        call('_TMP_SUB222_OUT', 'SUB(IN1 := producto, IN2 := k2, ENO => _TMP_SUB222_ENO)') +
+        asg('dif', '_TMP_SUB222_OUT') +
+        call('_TMP_GT333_OUT', 'GT(EN := _TMP_MUL111_ENO OR _TMP_SUB222_ENO, ENO => _TMP_GT333_ENO)') +
+        enoIf('_TMP_GT333_ENO', 'flag', '_TMP_GT333_OUT'),
+    )
+  })
+
+  it('writes a block-fed coil before the next block reads it', () => {
+    // GEA -> coil Flag ; GEB(EN:=GEA.ENO, IN1:=Flag) -> coil Result.
+    const body: RFBody = {
+      rungs: [
+        {
+          reactFlowViewport: [800, 300],
+          nodes: [
+            rail('L', 'left', 0),
+            inVar('901', 'Input', 20, 80),
+            inVar('902', '86400', 20, 120),
+            fblock('GEA', 'GE', '111', 1, 150, 30, 'BOOL'),
+            coil('cFlag', 'Flag', 320, 30),
+            inVar('904', 'Flag', 20, 200),
+            inVar('905', '60', 20, 240),
+            fblock('GEB', 'GE', '222', 2, 450, 30, 'BOOL'),
+            coil('cRes', 'Result', 620, 30),
+            rail('R', 'right', 760),
+          ],
+          edges: [
+            e('L', 'GEA', 'left-rail', 'EN'),
+            e('901', 'GEA', null, 'IN1'),
+            e('902', 'GEA', null, 'IN2'),
+            e('GEA', 'cFlag', 'OUT', null),
+            e('GEA', 'GEB', 'ENO', 'EN'),
+            e('904', 'GEB', null, 'IN1'),
+            e('905', 'GEB', null, 'IN2'),
+            e('GEB', 'cRes', 'OUT', null),
+          ],
+        },
+      ],
+    }
+    const { bodySt, warnings } = emitLdBody(body)
+    expect(warnings).toEqual([])
+    expect(bodySt).toBe(
+      '\n' +
+        call('_TMP_GE111_OUT', 'GE(EN := TRUE, IN1 := Input, IN2 := 86400, ENO => _TMP_GE111_ENO)') +
+        asg('Flag', '_TMP_GE111_OUT') +
+        call('_TMP_GE222_OUT', 'GE(EN := _TMP_GE111_ENO, IN1 := Flag, IN2 := 60, ENO => _TMP_GE222_ENO)') +
+        asg('Result', '_TMP_GE222_OUT'),
+    )
+  })
+})

--- a/src/backend/shared/transpilers/st-transpiler/__tests__/coil-grouping-836.test.ts
+++ b/src/backend/shared/transpilers/st-transpiler/__tests__/coil-grouping-836.test.ts
@@ -1,0 +1,145 @@
+import { emitLdBody } from '@root/backend/shared/transpilers/st-transpiler/walker/ld'
+import type { RFBody, RFEdge, RFNode } from '@root/backend/shared/transpilers/st-transpiler/walker/types'
+
+// Regression coverage for issue #836 — a contact feeding multiple coils
+// must be evaluated once per energization path, not re-read between coil
+// assignments. SET/RESET coils that branch off the same source collapse
+// into one IF even when a merge-fed coil sorts between them; sequential
+// coils (distinct sources) stay as separate IFs.
+
+let edgeId = 0
+const e = (source: string, target: string): RFEdge => ({ id: `e${edgeId++}`, source, target })
+const rail = (id: string, variant: 'left' | 'right', x: number): RFNode => ({
+  id,
+  type: 'powerRail',
+  position: { x, y: 30 },
+  data: { variant },
+})
+const contact = (id: string, name: string, x: number, nid: string): RFNode => ({
+  id,
+  type: 'contact',
+  position: { x, y: 38 },
+  data: { variant: 'default', variable: { name }, numericId: nid },
+})
+const coil = (id: string, name: string, variant: 'set' | 'reset', x: number, y: number, nid: string): RFNode => ({
+  id,
+  type: 'coil',
+  position: { x, y },
+  data: { variant, variable: { name }, executionOrder: 0, numericId: nid },
+})
+const par = (id: string, side: 'open' | 'close', x: number): RFNode => ({
+  id,
+  type: 'parallel',
+  position: { x, y: 49 },
+  data: { type: side },
+})
+
+// One emitted `IF <cond> THEN <assign...> END_IF;` block, base indent 2.
+const block = (cond: string, ...assigns: string[]): string =>
+  `  IF ${cond} THEN\n${assigns.map((a) => `    ${a}\n`).join('')}  END_IF;\n`
+
+describe('issue 836 — contact evaluated once across multiple coils', () => {
+  it('groups parallel outputs even when the reset coil sorts between them', () => {
+    // FirstScan -> [Output1(S) || Output2(S)] -> FirstScan(R)
+    const body: RFBody = {
+      rungs: [
+        {
+          reactFlowViewport: [700, 300],
+          nodes: [
+            rail('L', 'left', 0),
+            contact('C', 'FirstScan', 68, '10'),
+            par('PO', 'open', 251),
+            coil('K1', 'Output1', 'set', 300, 38, '20'),
+            coil('K2', 'Output2', 'set', 300, 130, '21'),
+            par('PC', 'close', 373),
+            coil('KR', 'FirstScan', 'reset', 500, 38, '22'),
+            rail('R', 'right', 600),
+          ],
+          edges: [
+            e('L', 'C'),
+            e('C', 'PO'),
+            e('PO', 'K1'),
+            e('PO', 'K2'),
+            e('K1', 'PC'),
+            e('K2', 'PC'),
+            e('PC', 'KR'),
+            e('KR', 'R'),
+          ],
+        },
+      ],
+    }
+    const { bodySt, warnings } = emitLdBody(body)
+    expect(warnings).toEqual([])
+    expect(bodySt).toBe(
+      '\n' +
+        block('FirstScan', 'Output1 := TRUE; (*set*)', 'Output2 := TRUE; (*set*)') +
+        block('FirstScan', 'FirstScan := FALSE; (*reset*)'),
+    )
+  })
+
+  it('groups three coils sharing one source into a single IF', () => {
+    // FirstScan -> [Output1(S) || FirstScan(R) || Output2(S)]
+    const body: RFBody = {
+      rungs: [
+        {
+          reactFlowViewport: [600, 300],
+          nodes: [
+            rail('L', 'left', 0),
+            contact('C', 'FirstScan', 68, '10'),
+            par('PO', 'open', 251),
+            coil('K1', 'Output1', 'set', 300, 38, '20'),
+            coil('KR', 'FirstScan', 'reset', 300, 130, '22'),
+            coil('K2', 'Output2', 'set', 300, 220, '21'),
+            par('PC', 'close', 400),
+            rail('R', 'right', 500),
+          ],
+          edges: [
+            e('L', 'C'),
+            e('C', 'PO'),
+            e('PO', 'K1'),
+            e('PO', 'KR'),
+            e('PO', 'K2'),
+            e('K1', 'PC'),
+            e('KR', 'PC'),
+            e('K2', 'PC'),
+            e('PC', 'R'),
+          ],
+        },
+      ],
+    }
+    const { bodySt, warnings } = emitLdBody(body)
+    expect(warnings).toEqual([])
+    expect(bodySt).toBe(
+      '\n' +
+        block('FirstScan', 'Output1 := TRUE; (*set*)', 'FirstScan := FALSE; (*reset*)', 'Output2 := TRUE; (*set*)'),
+    )
+  })
+
+  it('keeps sequential coils (distinct sources) as separate IFs', () => {
+    // FirstScan -> Output1(S) -> FirstScan(R) -> Output2(S)
+    const body: RFBody = {
+      rungs: [
+        {
+          reactFlowViewport: [700, 100],
+          nodes: [
+            rail('L', 'left', 0),
+            contact('C', 'FirstScan', 68, '10'),
+            coil('K1', 'Output1', 'set', 200, 38, '20'),
+            coil('KR', 'FirstScan', 'reset', 350, 38, '22'),
+            coil('K2', 'Output2', 'set', 500, 38, '21'),
+            rail('R', 'right', 650),
+          ],
+          edges: [e('L', 'C'), e('C', 'K1'), e('K1', 'KR'), e('KR', 'K2'), e('K2', 'R')],
+        },
+      ],
+    }
+    const { bodySt, warnings } = emitLdBody(body)
+    expect(warnings).toEqual([])
+    expect(bodySt).toBe(
+      '\n' +
+        block('FirstScan', 'Output1 := TRUE; (*set*)') +
+        block('FirstScan', 'FirstScan := FALSE; (*reset*)') +
+        block('FirstScan', 'Output2 := TRUE; (*set*)'),
+    )
+  })
+})

--- a/src/backend/shared/transpilers/st-transpiler/core/path-tree.ts
+++ b/src/backend/shared/transpilers/st-transpiler/core/path-tree.ts
@@ -110,7 +110,9 @@ export function pythonReprString(s: string): string {
 /**
  * Boolean simplification — `(A AND B) OR (A AND C)` → `A AND (B OR C)`.
  *
- * Strategy mirrors `FactorizePaths` (PLCGenerator.py:1429):
+ * Strategy mirrors `FactorizePaths` (PLCGenerator.py:1429), with one
+ * deliberate divergence — duplicate-path dedup (see below):
+ *   0. Drop byte-identical duplicate paths (`X OR X` → `X`).
  *   1. Sort the paths by their Python `repr`.
  *   2. For each pair, find common head/tail prefixes/suffixes between
  *      adjacent AND nodes.
@@ -119,8 +121,25 @@ export function pythonReprString(s: string): string {
 export function factorizePaths(paths: readonly PathNode[]): PathNode[] {
   if (paths.length <= 1) return [...paths]
 
+  // Collapse byte-identical parallel paths (`X OR X` = `X`).  The
+  // python oracle keeps duplicates (parallel coils feeding a merged
+  // sink emit `FirstScan OR FirstScan`); we drop them, a deliberate
+  // divergence that yields the cleaner condition with no behavioural
+  // change.  Paths are equal only when their full repr — text AND
+  // source locations — matches, so two distinct contacts on the same
+  // variable still survive as separate OR terms.
+  const seenRepr = new Set<string>()
+  const unique: PathNode[] = []
+  for (const p of paths) {
+    const k = pythonReprNode(p)
+    if (seenRepr.has(k)) continue
+    seenRepr.add(k)
+    unique.push(p)
+  }
+  if (unique.length <= 1) return unique
+
   // Sort by stable repr key — same order Python produces.
-  const sorted = pythonStableSort(paths)
+  const sorted = pythonStableSort(unique)
 
   // Walk sorted list, group adjacent paths sharing head AND.
   const out: PathNode[] = []

--- a/src/backend/shared/transpilers/st-transpiler/walker/ld.ts
+++ b/src/backend/shared/transpilers/st-transpiler/walker/ld.ts
@@ -250,8 +250,8 @@ export function emitLdBody(body: RFBody, typeContext?: TypeContext): EmitResult 
   ordered.sort((a, b) => nodeExecutionOrder(a) - nodeExecutionOrder(b))
   others.sort((a, b) => compareNodePosition(state, a, b))
 
-  for (const sink of ordered) emitSink(state, sink)
-  for (const sink of others) emitSink(state, sink)
+  emitSinksWithCoilGrouping(state, ordered)
+  emitSinksWithCoilGrouping(state, others)
 
   const bodySt = '\n' + state.program.map((c) => c[0]).join('')
   const syntheticVars: SyntheticVar[] = [
@@ -297,7 +297,86 @@ function emitSink(state: WalkerState, node: RFNode): void {
   if (node.type === 'connector') return emitConnectorNode(state, node)
 }
 
+/**
+ * Emit sinks in order, but collapse a run of consecutive SET/RESET
+ * coils that branch off the SAME upstream source into a single `IF`.
+ * Parallel coils share one energization path, so the rung condition
+ * must be evaluated ONCE and applied to every branch — emitting a
+ * separate `IF` per coil re-evaluates the condition between
+ * assignments, which is wrong when the condition reads a coil an
+ * earlier branch just set (e.g. `IF NOT(coils1)... coils1 := TRUE`).
+ */
+function emitSinksWithCoilGrouping(state: WalkerState, sinks: RFNode[]): void {
+  let i = 0
+  while (i < sinks.length) {
+    const key = setResetCoilGroupKey(state, sinks[i])
+    if (key === null) {
+      emitSink(state, sinks[i])
+      i++
+      continue
+    }
+    let j = i + 1
+    while (j < sinks.length && setResetCoilGroupKey(state, sinks[j]) === key) j++
+    if (j - i === 1) emitCoilNode(state, sinks[i])
+    else emitCoilGroup(state, sinks.slice(i, j))
+    i = j
+  }
+}
+
+/**
+ * Group identity for a SET/RESET coil: the sorted set of its upstream
+ * source node ids.  Two coils with the same key branch off the same
+ * point (parallel rails) and therefore share a condition.  Returns
+ * null for anything not groupable (non-coils, plain/negated/edge
+ * coils, or an unconnected coil).
+ */
+function setResetCoilGroupKey(state: WalkerState, node: RFNode): string | null {
+  if (node.type !== 'coil') return null
+  const data = asCoilData(node.data)
+  if (data === null || (data.variant !== 'set' && data.variant !== 'reset')) return null
+  const sources = (state.incoming.get(node.id) ?? []).map((e) => e.source).sort()
+  if (sources.length === 0) return null
+  return sources.join('|')
+}
+
 /* ─────────────────────────── coil emission ──────────────────────────────── */
+
+/**
+ * Emit a group of parallel SET/RESET coils under one shared `IF`.
+ * The condition is computed once from the first coil's upstream (all
+ * coils in the group share it by construction), then each branch's
+ * assignment is written inside the single `THEN` body.
+ */
+function emitCoilGroup(state: WalkerState, coils: RFNode[]): void {
+  const first = coils[0]
+  const paths = pathsFromIncoming(state, first.id, /*order=*/ false)
+  if (paths.length === 0) {
+    // Shared upstream resolved to nothing — fall back to per-coil
+    // emission so each surfaces its own "must be connected" warning.
+    for (const coil of coils) emitCoilNode(state, coil)
+    return
+  }
+  const expr = pathsToChunks(paths)
+  const firstData = asCoilData(first.data)
+  const firstInfo: Location = [state.tagName, 'coil', locId(first)]
+
+  state.program.push([`${state.currentIndent}IF `, [...firstInfo, firstData?.variant ?? 'set']])
+  for (const chunk of expr) state.program.push(chunk)
+  state.program.push([' THEN\n', []])
+
+  const inner = state.currentIndent + '  '
+  for (const coil of coils) {
+    const data = asCoilData(coil.data)
+    if (data === null) continue
+    const storage = data.variant === 'reset' ? 'reset' : 'set'
+    const value = storage === 'set' ? 'TRUE' : 'FALSE'
+    const info: Location = [state.tagName, 'coil', locId(coil)]
+    state.program.push([inner, []])
+    state.program.push([data.variable, [...info, 'reference']])
+    state.program.push([` := ${value}; (*${storage}*)\n`, []])
+  }
+  state.program.push([`${state.currentIndent}END_IF;\n`, []])
+}
 
 function emitCoilNode(state: WalkerState, node: RFNode): void {
   const data = asCoilData(node.data)

--- a/src/backend/shared/transpilers/st-transpiler/walker/ld.ts
+++ b/src/backend/shared/transpilers/st-transpiler/walker/ld.ts
@@ -93,6 +93,13 @@ interface WalkerState {
     originFormalParameter: string
   }[]
   emittedBlocks: Set<string>
+  /** Output-write sinks (coil / output / inOut variable) keyed by the
+   *  block that feeds them — emitted right after the block's call so a
+   *  downstream block reads the written value, not a stale one (#830). */
+  consumersByBlock: Map<string, RFNode[]>
+  /** Sinks already emitted — by block coupling or the main sweep — so
+   *  the other path skips them. */
+  emittedSinks: Set<string>
   /** Connector expressions cached by name, consumed by continuation
    *  visits later in the same rung (FBD-only). */
   connectorExprs: Map<string, ProgramChunk[]>
@@ -172,6 +179,8 @@ export function emitLdBody(body: RFBody, typeContext?: TypeContext): EmitResult 
     triggerVars: [],
     functionTempVars: [],
     emittedBlocks: new Set(),
+    consumersByBlock: new Map(),
+    emittedSinks: new Set(),
     connectorExprs: new Map(),
     yOffset: new Map(),
     warnings: [],
@@ -250,6 +259,22 @@ export function emitLdBody(body: RFBody, typeContext?: TypeContext): EmitResult 
   ordered.sort((a, b) => nodeExecutionOrder(a) - nodeExecutionOrder(b))
   others.sort((a, b) => compareNodePosition(state, a, b))
 
+  // Index each block's output-write sinks (coils / output / inOut
+  // variables fed solely by that block).  These are emitted right after
+  // the block's call by `emitBlockConsumers` — wherever the call lands,
+  // eager or lazy — and skipped in the sweep below.  Otherwise a block
+  // numbered ahead of its output variable (write left at
+  // executionOrderId 0) emits its call in the ordered pass while the
+  // assignment waits for the unordered pass, so a later block in the
+  // rung reads the variable before it is written (#830).
+  for (const node of [...ordered, ...others]) {
+    const blockId = blockFedSink(state, node)
+    if (blockId === null) continue
+    const list = state.consumersByBlock.get(blockId) ?? []
+    list.push(node)
+    state.consumersByBlock.set(blockId, list)
+  }
+
   emitSinksWithCoilGrouping(state, ordered)
   emitSinksWithCoilGrouping(state, others)
 
@@ -277,6 +302,23 @@ function compareNodePosition(state: WalkerState, a: RFNode, b: RFNode): number {
   const by = Math.trunc(b.position.y + bOff)
   if (Math.abs(ay - by) >= 10) return ay - by
   return ax - bx
+}
+
+/**
+ * If `node` is an output-write sink (coil / output- or inOut-variable)
+ * whose value comes solely from a single block, return that block's id.
+ * Such a sink is the block's output binding — it must emit right after
+ * the block's call so downstream blocks read the written value, not a
+ * stale one (#830).  Returns null for anything else (multi-source
+ * sinks, non-block sources, blocks, connectors).
+ */
+function blockFedSink(state: WalkerState, node: RFNode): string | null {
+  if (node.type !== 'coil' && !isVariableNode(node)) return null
+  const edges = state.incoming.get(node.id) ?? []
+  if (edges.length !== 1) return null
+  const src = state.byId.get(edges[0].source)
+  if (src === undefined || src.type !== 'block') return null
+  return src.id
 }
 
 function emitSink(state: WalkerState, node: RFNode): void {
@@ -315,25 +357,36 @@ function emitSink(state: WalkerState, node: RFNode): void {
  * since a merge-fed sink is downstream of the branches it consumes.
  */
 function emitSinksWithCoilGrouping(state: WalkerState, sinks: RFNode[]): void {
-  const consumed = new Set<number>()
   for (let i = 0; i < sinks.length; i++) {
-    if (consumed.has(i)) continue
+    if (state.emittedSinks.has(sinks[i].id)) continue
     const key = setResetCoilGroupKey(state, sinks[i])
     if (key === null) {
+      state.emittedSinks.add(sinks[i].id)
       emitSink(state, sinks[i])
       continue
     }
     const group: RFNode[] = [sinks[i]]
     for (let j = i + 1; j < sinks.length; j++) {
-      if (consumed.has(j)) continue
-      if (setResetCoilGroupKey(state, sinks[j]) === key) {
-        group.push(sinks[j])
-        consumed.add(j)
-      }
+      if (state.emittedSinks.has(sinks[j].id)) continue
+      if (setResetCoilGroupKey(state, sinks[j]) === key) group.push(sinks[j])
     }
+    for (const g of group) state.emittedSinks.add(g.id)
     if (group.length === 1) emitCoilNode(state, sinks[i])
     else emitCoilGroup(state, group)
   }
+}
+
+/**
+ * Emit a block's output-write sinks (coils / output / inOut variables
+ * fed solely by it) right after its call — wherever that call lands.
+ * Reuses the coil-grouping sweep so parallel SET/RESET coils off the
+ * same block still collapse into one `IF`.  Idempotent via
+ * `state.emittedSinks`, so the main sweep skips what is emitted here.
+ */
+function emitBlockConsumers(state: WalkerState, blockId: string): void {
+  const consumers = state.consumersByBlock.get(blockId)
+  if (consumers === undefined) return
+  emitSinksWithCoilGrouping(state, consumers)
 }
 
 /**
@@ -766,6 +819,7 @@ function emitFunctionBlockCall(state: WalkerState, node: RFNode, data: BlockData
     for (const chunk of parts[i]) state.program.push(chunk)
   }
   state.program.push([');\n', []])
+  emitBlockConsumers(state, node.id)
 }
 
 function emitFunctionCall(state: WalkerState, node: RFNode, data: BlockData): void {
@@ -820,6 +874,7 @@ function emitFunctionCall(state: WalkerState, node: RFNode, data: BlockData): vo
   }
   state.program.push([');\n', []])
   void primaryFormal
+  emitBlockConsumers(state, node.id)
 }
 
 function buildInputArgs(

--- a/src/backend/shared/transpilers/st-transpiler/walker/ld.ts
+++ b/src/backend/shared/transpilers/st-transpiler/walker/ld.ts
@@ -298,28 +298,41 @@ function emitSink(state: WalkerState, node: RFNode): void {
 }
 
 /**
- * Emit sinks in order, but collapse a run of consecutive SET/RESET
- * coils that branch off the SAME upstream source into a single `IF`.
- * Parallel coils share one energization path, so the rung condition
- * must be evaluated ONCE and applied to every branch — emitting a
- * separate `IF` per coil re-evaluates the condition between
- * assignments, which is wrong when the condition reads a coil an
- * earlier branch just set (e.g. `IF NOT(coils1)... coils1 := TRUE`).
+ * Emit sinks in order, collapsing SET/RESET coils that branch off the
+ * SAME upstream source into a single `IF`.  Parallel coils share one
+ * energization path, so the rung condition must be evaluated ONCE and
+ * applied to every branch — emitting a separate `IF` per coil
+ * re-evaluates the condition between assignments, which is wrong when
+ * the condition reads a coil an earlier branch just set
+ * (e.g. `IF NOT(coils1)... coils1 := TRUE`).
+ *
+ * Same-source coils are gathered even when they are NOT adjacent in
+ * emission order: a coil fed by their merge (so it shares neither
+ * source) can sort between two parallel branches by position, yet the
+ * branches must still collapse into one `IF`.  The group is emitted at
+ * the first branch's slot; the intervening sink (and any other
+ * downstream work) follows after — which is also its dataflow order,
+ * since a merge-fed sink is downstream of the branches it consumes.
  */
 function emitSinksWithCoilGrouping(state: WalkerState, sinks: RFNode[]): void {
-  let i = 0
-  while (i < sinks.length) {
+  const consumed = new Set<number>()
+  for (let i = 0; i < sinks.length; i++) {
+    if (consumed.has(i)) continue
     const key = setResetCoilGroupKey(state, sinks[i])
     if (key === null) {
       emitSink(state, sinks[i])
-      i++
       continue
     }
-    let j = i + 1
-    while (j < sinks.length && setResetCoilGroupKey(state, sinks[j]) === key) j++
-    if (j - i === 1) emitCoilNode(state, sinks[i])
-    else emitCoilGroup(state, sinks.slice(i, j))
-    i = j
+    const group: RFNode[] = [sinks[i]]
+    for (let j = i + 1; j < sinks.length; j++) {
+      if (consumed.has(j)) continue
+      if (setResetCoilGroupKey(state, sinks[j]) === key) {
+        group.push(sinks[j])
+        consumed.add(j)
+      }
+    }
+    if (group.length === 1) emitCoilNode(state, sinks[i])
+    else emitCoilGroup(state, group)
   }
 }
 


### PR DESCRIPTION
This branch bundles two related LD → ST emission-ordering fixes. Both are deliberate divergences from the legacy xml2st engine (same class as the D1 task-sort fix); both are verified against the 193-project LD corpus and covered by regression tests byte-identical across editor + web.

## #836 — contact evaluated once across multiple coils
A contact feeding multiple coils was re-evaluated between coil assignments, so a coil that wrote a variable an earlier coil's condition read corrupted it.

- `walker/ld.ts` `emitSinksWithCoilGrouping`: collapse SET/RESET coils branching off the **same source** into one `IF`, gathering them even when a merge-fed coil sorts between them by position.
- `core/path-tree.ts` `factorizePaths`: drop byte-identical duplicate paths (`X OR X` → `X`) so the merged condition reads cleanly instead of `FirstScan AND (TRUE OR TRUE)`.

Matches the maintainer's expected output for all three reported topologies (parallel outputs + downstream reset; all-parallel; sequential stays separate). **0** corpus fixtures changed.

## #830 — chained block output writes
Chained function/FB calls emitted all calls first, then all output assignments — so a downstream block read a variable before the upstream block's write was emitted (`Output` stayed 0).

- `walker/ld.ts`: a coil / output / inOut variable fed solely by a block is that block's output binding and now emits **immediately after the block's actual call** (`emitBlockConsumers`, reusing the coil-grouping sweep). Emitting at the call — not the sink slot — makes it robust to blocks pulled lazily through a later block's `EN` expression (`GT.EN := MUL.ENO OR SUB.ENO`).

**10/193** corpus fixtures corrected (incl. real 4- and 5-block chains in `matiasacuna_…_freidora` and `frontadomarcositsu_…`), 183 unchanged.

## Tests
- `st-transpiler/__tests__/coil-grouping-836.test.ts` — 3 topologies.
- `st-transpiler/__tests__/block-output-ordering-830.test.ts` — reported chain, eager-pull shape, block-fed coil.
- 301 compile/library integration tests pass; shared-surface sync gate green.

Closes #836
Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)