### PR TITLE
fix(ladder): handle-branch corruption on add/delete/duplicate + QU/QD XML

### DIFF
--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/handle-branch/index.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/handle-branch/index.ts
@@ -1326,3 +1326,37 @@ export function reconcileBranchNodeIds(rung: RungLadderState, branch: HandleBran
 
   return nodeIds
 }
+
+/**
+ * Rebuild the handle-branch index from a rung's graph.
+ *
+ * `handleBranches` is runtime-only state — it is NOT persisted in the .ld file,
+ * so a project loaded from disk that contains handle branches (contacts/coils
+ * wired to a block's secondary input/output handles, e.g. CTUD CD/QD) comes
+ * back with an empty index. Branch-aware operations (deletion cleanup,
+ * `getBranch`, nodeId reconciliation) then can't find those branches and
+ * corrupt the diagram on the first edit. We reconstruct the index from the
+ * `branchContext` stamped on each branch node plus the block's handle
+ * directions, deriving the ordered nodeIds via `reconcileBranchNodeIds`.
+ */
+export function deriveHandleBranches(rung: RungLadderState): HandleBranch[] {
+  const seen = new Map<string, { blockId: string; handleId: string }>()
+  for (const node of rung.nodes) {
+    const ctx = (node.data as BasicNodeData).branchContext
+    if (ctx?.blockId && ctx?.handleId) {
+      seen.set(`${ctx.blockId}::${ctx.handleId}`, { blockId: ctx.blockId, handleId: ctx.handleId })
+    }
+  }
+
+  const branches: HandleBranch[] = []
+  for (const { blockId, handleId } of seen.values()) {
+    const block = rung.nodes.find((n) => n.id === blockId)
+    if (!block) continue
+    const data = block.data as BasicNodeData
+    const isOutput = (data.outputHandles ?? []).some((h) => h.id === handleId)
+    const direction: 'input' | 'output' = isOutput ? 'output' : 'input'
+    const nodeIds = reconcileBranchNodeIds(rung, { blockId, handleId, direction, nodeIds: [] })
+    if (nodeIds.length > 0) branches.push({ blockId, handleId, direction, nodeIds })
+  }
+  return branches
+}

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/serial/index.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/serial/index.ts
@@ -57,10 +57,7 @@ export const appendSerialConnection = <T>(
   /**
    * Get the previous node
    */
-  let previousNode = getPreviousElement(
-    { ...rung, nodes: newNodes, edges: newEdges },
-    newNodes.findIndex((n) => n.id === newElement.id),
-  )
+  let previousNode = getPreviousElement({ ...rung, nodes: newNodes, edges: newEdges }, newElement.id)
 
   /**
    * If the related node is a parallel, check if it is an open or close parallel

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/utils/__tests__/get-previous-element.test.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/utils/__tests__/get-previous-element.test.ts
@@ -1,0 +1,74 @@
+import type { Node } from '@xyflow/react'
+
+import type { RungLadderState } from '@root/frontend/store/slices'
+
+import { getPreviousElement } from '../index'
+
+/**
+ * Minimal node/rung factories — getPreviousElement only reads node.type,
+ * node.id and node.data.branchContext.
+ */
+const node = (
+  id: string,
+  type: string,
+  branchContext?: { blockId: string; handleId: string; direction: 'input' | 'output' },
+): Node =>
+  ({
+    id,
+    type,
+    position: { x: 0, y: 0 },
+    data: branchContext ? { branchContext } : {},
+  }) as unknown as Node
+
+const rung = (nodes: Node[]): RungLadderState => ({ nodes }) as unknown as RungLadderState
+
+describe('getPreviousElement', () => {
+  // Regression: adding a coil to a counter block's primary output corrupted a
+  // handle branch (e.g. a contact on the R input). Branch elements are
+  // interleaved in the node array between the block and the right rail, so a
+  // freshly-inserted main-line coil's placeholder sits AFTER the branch contact.
+  // The old index-based walk picked the branch contact as the serial
+  // predecessor and spliced the coil into the branch edge (dropping the coil and
+  // breaking the branch). The predecessor must be the block, skipping the branch.
+  it('returns the main-line predecessor, skipping handle-branch elements', () => {
+    const r = rung([
+      node('left-rail', 'powerRail'),
+      node('cu-contact', 'contact'),
+      node('block', 'block'),
+      node('r-contact', 'contact', { blockId: 'block', handleId: 'R', direction: 'input' }),
+      node('new-coil', 'coil'),
+      node('right-rail', 'powerRail'),
+    ])
+
+    const previous = getPreviousElement(r, 'new-coil')
+
+    expect(previous.id).toBe('block')
+    expect(previous.id).not.toBe('r-contact')
+  })
+
+  it('skips placeholders and variables when resolving the predecessor', () => {
+    const r = rung([
+      node('left-rail', 'powerRail'),
+      node('contact-1', 'contact'),
+      node('a-variable', 'variable'),
+      node('a-placeholder', 'placeholder'),
+      node('new-contact', 'contact'),
+      node('right-rail', 'powerRail'),
+    ])
+
+    expect(getPreviousElement(r, 'new-contact').id).toBe('contact-1')
+  })
+
+  it('skips multiple consecutive branch elements before the inserted node', () => {
+    const r = rung([
+      node('left-rail', 'powerRail'),
+      node('block', 'block'),
+      node('cd-contact', 'contact', { blockId: 'block', handleId: 'CD', direction: 'input' }),
+      node('r-contact', 'contact', { blockId: 'block', handleId: 'R', direction: 'input' }),
+      node('new-coil', 'coil'),
+      node('right-rail', 'powerRail'),
+    ])
+
+    expect(getPreviousElement(r, 'new-coil').id).toBe('block')
+  })
+})

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/utils/index.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/utils/index.ts
@@ -65,19 +65,36 @@ export const getPreviousElementsByEdge = (
 }
 
 /**
- * Get the previous node when adding a new element
- * It works when removing the placeholder and variables elements
+ * Get the previous main-line element when adding a new serial element.
+ *
+ * Walks the rung's node list skipping placeholders, variables and branch
+ * elements, then returns the element immediately before the just-inserted one.
+ *
+ * Branch elements (contacts/coils wired to a block's secondary handles, e.g. a
+ * contact on a counter's R input) are interleaved in the node array between the
+ * block and the right rail, but they are NOT part of the serial spine. A plain
+ * index walk that included them would treat such a branch element as the serial
+ * predecessor of a main-line element — so a coil added to a block's primary
+ * output (whose placeholder sits after the branch element in the array) would be
+ * wired into the branch edge instead, dropping the coil and breaking the branch.
+ * Skipping branchContext nodes here mirrors getPreviousElementsByEdge. Keying off
+ * the element id (rather than an externally-computed index) keeps the lookup
+ * consistent with this filtered spine.
  *
  * @param rung: RungLadderState
- * @param nodeIndex: number
+ * @param newElementId: string
  *
  * @returns Node
  */
-export const getPreviousElement = (rung: RungLadderState, nodeIndex: number): Node => {
-  const nodesWithNoPlaceholderAndVariables = rung.nodes.filter(
-    (n) => n.type !== 'placeholder' && n.type !== 'parallelPlaceholder' && n.type !== 'variable',
+export const getPreviousElement = (rung: RungLadderState, newElementId: string): Node => {
+  const serialSpine = rung.nodes.filter(
+    (n) =>
+      n.type !== 'placeholder' &&
+      n.type !== 'parallelPlaceholder' &&
+      n.type !== 'variable' &&
+      !(n.data as BasicNodeData).branchContext,
   )
-  return nodesWithNoPlaceholderAndVariables[nodeIndex - 1]
+  return serialSpine[serialSpine.findIndex((n) => n.id === newElementId) - 1]
 }
 
 /**

--- a/src/frontend/store/slices/ladder/slice.ts
+++ b/src/frontend/store/slices/ladder/slice.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../components/_atoms/graphical-editor/ladder/node-builders'
 import type { LadderBlockConnectedVariables } from '../../../components/_atoms/graphical-editor/ladder/utils/types'
 import { removeElements } from '../../../components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements'
+import { deriveHandleBranches } from '../../../components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/handle-branch'
 import { LadderFlowSlice, LadderFlowState } from './types'
 import { duplicateLadderRung } from './utils'
 
@@ -56,9 +57,20 @@ export const createLadderFlowSlice: StateCreator<LadderFlowSlice, [], [], Ladder
               }))
             : flow.rungs.map((rung) => ({ ...rung, selectedNodes: [] }))
 
+          // handleBranches (the index of contacts/coils wired to a block's
+          // secondary handles, e.g. CTUD CD/QD) is runtime-only state — it is
+          // NOT persisted in the .ld. Without rebuilding it on load, a project
+          // containing handle branches comes back with an empty index and the
+          // first branch-aware edit (e.g. deleting a coil on a block output)
+          // corrupts the diagram. Reconstruct it from the graph here.
+          const rungsWithBranches = rungs.map((rung) => ({
+            ...rung,
+            handleBranches: deriveHandleBranches(rung),
+          }))
+
           // Reset updated to false on load — the flow is being loaded from a saved project.
           // Only mark as updated if legacy data was migrated so the next save writes the new format.
-          const newFlow = { ...flow, rungs, updated: needsMigration }
+          const newFlow = { ...flow, rungs: rungsWithBranches, updated: needsMigration }
 
           if (flowIndex === -1) {
             ladderFlows.push(newFlow)

--- a/src/frontend/store/slices/ladder/utils/index.ts
+++ b/src/frontend/store/slices/ladder/utils/index.ts
@@ -15,6 +15,7 @@ import type {
   PowerRailNode,
   VariableNode,
 } from '../../../../components/_atoms/graphical-editor/ladder/utils/types'
+import { updateDiagramElementsPosition } from '../../../../components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/diagram'
 import { generateNumericUUID } from '../../../../utils/generate-uuid'
 import { newGraphicalEditorNodeID } from '../../../../utils/new-graphical-editor-node-id'
 import { RungLadderState } from '../types'
@@ -129,6 +130,7 @@ export const duplicateLadderRung = (editorName: string, rung: RungLadderState): 
         } as ContactNode
       }
       case 'parallel': {
+        const parallelData = node.data as BasicNodeData
         return {
           ...node,
           id: nodeMaps[node.id].id,
@@ -141,6 +143,16 @@ export const duplicateLadderRung = (editorName: string, rung: RungLadderState): 
             parallelOpenReference: (node as ParallelNode).data.parallelOpenReference
               ? nodeMaps[(node as ParallelNode).data.parallelOpenReference ?? ''].id
               : undefined,
+            // Branch parallel nodes (a parallel inside a handle branch) carry a
+            // branchContext whose blockId must be remapped to the duplicated
+            // block — same as coils/contacts. Without this the copy's parallel
+            // nodes point at the original block id, breaking branch operations.
+            ...(parallelData.branchContext && {
+              branchContext: {
+                ...parallelData.branchContext,
+                blockId: nodeMaps[parallelData.branchContext.blockId]?.id ?? parallelData.branchContext.blockId,
+              },
+            }),
           },
         } as ParallelNode
       }
@@ -208,7 +220,15 @@ export const duplicateLadderRung = (editorName: string, rung: RungLadderState): 
     }),
   }
 
-  return newRung
+  // Blocks/coils/contacts are rebuilt at their DEFAULT dimensions by
+  // nodesBuilder, so a block that was branch-expanded in the source rung comes
+  // back compact while its branch elements keep the expanded positions —
+  // leaving the duplicated diagram visually broken. Re-run the (branch-aware)
+  // layout solver so the block re-expands and every element is repositioned
+  // against the actual node set.
+  const laidOut = updateDiagramElementsPosition(newRung, newRung.defaultBounds as [number, number])
+
+  return { ...newRung, nodes: laidOut.nodes, edges: laidOut.edges }
 }
 
 /**

--- a/src/frontend/utils/PLC/xml-generator/codesys/language/ladder-xml.ts
+++ b/src/frontend/utils/PLC/xml-generator/codesys/language/ladder-xml.ts
@@ -90,6 +90,20 @@ const findConnections = (
 ) => {
   const { nodes: rungNodes, edges: rungEdges } = rung
 
+  // Resolve the formal parameter (block output pin) for a source node that
+  // feeds into a parallel chain. A block's `outputConnector` only records its
+  // PRIMARY output (e.g. QU on a CTUD_DINT), so reading it directly maps EVERY
+  // branch back to that one pin — which is why coils wired to a secondary
+  // output (QD) were serialized as connected to QU. Instead, use the handle of
+  // the edge that actually leaves the node into the parallel chain (QU vs QD).
+  // Falls back to the default output connector for single-output elements;
+  // 'OUT' (the unnamed function return) maps to an empty formal parameter.
+  const formalParameterFromParallel = (srcNode: Node<BasicNodeData>, parallelChain: ParallelNode[]): string => {
+    const edge = rungEdges.find((e) => e.source === srcNode.id && parallelChain.some((p) => p.id === e.target))
+    const handle = edge?.sourceHandle ?? srcNode.data.outputConnector?.id ?? ''
+    return handle === 'OUT' ? '' : handle
+  }
+
   const connectedEdges = rungEdges.filter(
     (edge) => edge.target === node.id && (targetHandle === undefined || edge.targetHandle === targetHandle),
   )
@@ -148,7 +162,7 @@ const findConnections = (
       if (lastParallelSerialEdge && lastParallelSerialEdge.target === node.id) {
         return nodes.map((node, index) => ({
           '@refLocalId': node.data.numericId,
-          '@formalParameter': node.data.outputConnector?.id === 'OUT' ? '' : node.data.outputConnector?.id || '',
+          '@formalParameter': formalParameterFromParallel(node, parallels),
           position:
             index === 0
               ? [
@@ -220,7 +234,7 @@ const findConnections = (
       return nodes.map((node) => {
         return {
           '@refLocalId': node.data.numericId,
-          '@formalParameter': node.data.outputConnector?.id === 'OUT' ? '' : node.data.outputConnector?.id || '',
+          '@formalParameter': formalParameterFromParallel(node, parallels),
           position: [
             // Final edge destination
             {
@@ -255,7 +269,7 @@ const findConnections = (
     const closeConnections = nodes.map((node, index) => {
       return {
         '@refLocalId': node.data.numericId,
-        '@formalParameter': node.data.outputConnector?.id === 'OUT' ? '' : node.data.outputConnector?.id || '',
+        '@formalParameter': formalParameterFromParallel(node, parallels),
         position:
           index === 0
             ? [


### PR DESCRIPTION
## Summary

Fixes four related **handle-branch** defects in the ladder editor. The headline bug: adding a coil to a counter block's primary output (e.g. `Q`/`QU`) corrupted an existing input-handle branch — the coil didn't appear on the output and the branch contact's connection to the block was severed.

## Root causes & fixes

1. **Add-to-primary-output corrupts a handle branch** (`elements/serial`, `elements/utils`)
   The serial predecessor for a main-line insert was resolved by **array index** (`getPreviousElement`). Handle-branch elements (e.g. a contact wired to a counter's `R` input) are interleaved in the node array *between the block and the right rail*, so a coil dropped on the output picked the branch contact as its predecessor and was spliced into the branch edge — dropping the coil and breaking the branch. `getPreviousElement` now skips `branchContext` nodes (mirroring `getPreviousElementsByEdge`) and is keyed by element id. Integrated with the existing `edgeSourceId` keyboard-selection path.

2. **handleBranches lost on load** (`store/slices/ladder/slice`)
   `handleBranches` is runtime-only state (not persisted in `.ld`). It's now rebuilt from the graph on project load via `deriveHandleBranches`, so the first branch-aware edit no longer corrupts diagrams that contain handle branches.

3. **Duplicate rung corrupts branched blocks** (`store/slices/ladder/utils`)
   Duplication rebuilt blocks at default dimensions without re-running the layout solver and dropped `branchContext` remapping on branch parallel nodes. Now re-runs `updateDiagramElementsPosition` and remaps the parallel `branchContext`.

4. **PLCopen XML maps all block-output branches to the primary pin** (`ladder-xml`)
   Every block-output branch was serialized as connected to the primary output (`QU`). The serializer now resolves the actual edge `sourceHandle`, distinguishing `QU`/`QD`.

## Testing
- New regression unit test for `getPreviousElement` (branch-aware predecessor).
- Existing ladder suites pass (`ladder-slice`, `ladder-xml`) — 165 tests under jest.
- Headline fix verified live in the running editor: coil lands on the output, the `R` branch stays intact, no orphan edges (reproduced before/after).

## Companion PR
Mirrored **byte-identical** to the shared surface in **openplc-web**: Autonomy-Logic/openplc-web#546 (same commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved ladder flow loading so branch connections are restored more reliably after importing and opening diagrams.
  * Duplicated ladder sections now keep parallel branches aligned and positioned correctly.

* **Bug Fixes**
  * Fixed predecessor detection when inserting serial items, especially around placeholders and branch elements.
  * Improved ladder XML export for parallel connections so the correct handle information is preserved.

* **Tests**
  * Added coverage for predecessor-resolution behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->