### PR TITLE
Revert ladder shortcuts feature (mirror of openplc-web revert #547)

### DIFF
--- a/src/frontend/components/_atoms/graphical-editor/ladder/block.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/block.tsx
@@ -373,15 +373,7 @@ export const BlockNodeElement = <T extends object>({
         className='w-full bg-transparent p-1 text-center text-xs outline-none'
         disabled={disabled}
         onFocus={handleFocusInput}
-        onBlur={(e) => {
-          if (inputNameFocus) {
-            handleNameInputOnBlur()
-            const container = e.currentTarget.closest('div[tabindex="0"]') as unknown as HTMLDivElement | null
-            if (container) {
-              container.focus()
-            }
-          }
-        }}
+        onBlur={() => inputNameFocus && handleNameInputOnBlur()}
         onKeyDown={(e) => e.key === 'Enter' && inputNameRef.current?.blur()}
         ref={inputNameRef}
       />
@@ -892,7 +884,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
               })
               return
             }}
-            onBlur={(e) => {
+            onBlur={() => {
               if (!node || !rung) return
               updateNode({
                 editorName: pouName,
@@ -903,10 +895,6 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
                   draggable: node.data.draggable as boolean,
                 },
               })
-              const container = e.currentTarget.closest('div[tabindex="0"]') as unknown as HTMLDivElement | null
-              if (container) {
-                container.focus()
-              }
               return
             }}
             inputHeight={{

--- a/src/frontend/components/_atoms/graphical-editor/ladder/coil.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/coil.tsx
@@ -280,7 +280,7 @@ export const Coil = (block: CoilProps) => {
               })
               return
             }}
-            onBlur={(e) => {
+            onBlur={() => {
               const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
                 nodeId: id ?? '',
               })
@@ -294,10 +294,6 @@ export const Coil = (block: CoilProps) => {
                   draggable: node.data.draggable as boolean,
                 },
               })
-              const container = e.currentTarget.closest('div[tabindex="0"]') as unknown as HTMLDivElement | null
-              if (container) {
-                container.focus()
-              }
               return
             }}
             onChange={onChangeHandler}

--- a/src/frontend/components/_atoms/graphical-editor/ladder/contact.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/contact.tsx
@@ -279,7 +279,7 @@ export const Contact = (block: ContactProps) => {
               })
               return
             }}
-            onBlur={(e) => {
+            onBlur={() => {
               const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
                 nodeId: id ?? '',
               })
@@ -293,10 +293,6 @@ export const Contact = (block: ContactProps) => {
                   draggable: node.data.draggable as boolean,
                 },
               })
-              const container = e.currentTarget.closest('div[tabindex="0"]') as unknown as HTMLDivElement | null
-              if (container) {
-                container.focus()
-              }
               return
             }}
             onChange={onChangeHandler}

--- a/src/frontend/components/_atoms/graphical-editor/ladder/power-rail.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/power-rail.tsx
@@ -1,12 +1,11 @@
 import { useUpdateNodeInternals } from '@xyflow/react'
 import { useEffect, useMemo } from 'react'
 
-import { cn } from '../../../../utils/cn'
 import { CustomHandle } from './handle'
 import { DEFAULT_POWER_RAIL_HEIGHT, DEFAULT_POWER_RAIL_WIDTH } from './utils/constants'
 import { PowerRailProps } from './utils/types'
 
-export const PowerRail = ({ id, data, selected }: PowerRailProps) => {
+export const PowerRail = ({ id, data }: PowerRailProps) => {
   const updateNodeInternals = useUpdateNodeInternals()
 
   // Calculate dynamic height to cover all handles (including branch handles)
@@ -36,13 +35,7 @@ export const PowerRail = ({ id, data, selected }: PowerRailProps) => {
   return (
     <>
       <svg width={DEFAULT_POWER_RAIL_WIDTH} height={railHeight} xmlns='http://www.w3.org/2000/svg'>
-        <rect
-          width={DEFAULT_POWER_RAIL_WIDTH}
-          height={railHeight}
-          className={cn('fill-neutral-500 transition-colors', {
-            'fill-brand': selected,
-          })}
-        />
+        <rect width={DEFAULT_POWER_RAIL_WIDTH} height={railHeight} className='fill-neutral-500' />
       </svg>
       {data.handles.map((handle, index) => (
         <CustomHandle key={index} {...handle} />

--- a/src/frontend/components/_atoms/graphical-editor/ladder/utils/types.ts
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/utils/types.ts
@@ -127,12 +127,7 @@ export type ParallelBuilderProps = BuilderBasicProps & { type: 'open' | 'close' 
 // placeholder
 
 export type PlaceholderNode = Node<
-  BasicNodeData & {
-    relatedNode: Node | undefined
-    position: 'left' | 'right' | 'bottom'
-    edgeSourceId?: string
-    selectedEdgeId?: string
-  }
+  BasicNodeData & { relatedNode: Node | undefined; position: 'left' | 'right' | 'bottom' }
 >
 export type PlaceholderProps = NodeProps<PlaceholderNode>
 export type PlaceholderBuilderProps = BuilderBasicProps & {

--- a/src/frontend/components/_atoms/highlighted-textarea/index.tsx
+++ b/src/frontend/components/_atoms/highlighted-textarea/index.tsx
@@ -128,7 +128,6 @@ const HighlightedTextArea = forwardRef<HTMLTextAreaElement, HighlightedTextAreaP
           />
         </div>
         <textarea
-          id={props.id}
           value={textAreaValue}
           onChange={onChangeHandler}
           placeholder={placeholder ?? '???'}

--- a/src/frontend/components/_atoms/react-flow/style.css
+++ b/src/frontend/components/_atoms/react-flow/style.css
@@ -32,9 +32,3 @@ html:not(.dark) .react-flow {
 .react-flow__controls-button {
   border-radius: 25%;
 }
-
-.react-flow__edge.selected .react-flow__edge-path {
-  stroke: #0464fb !important;
-  stroke-width: 3px !important;
-  filter: drop-shadow(0px 0px 4px rgba(4, 100, 251, 0.5));
-}

--- a/src/frontend/components/_features/[workspace]/editor/graphical/ladder/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/ladder/index.tsx
@@ -15,7 +15,7 @@ import {
 import { restrictToParentElement } from '@dnd-kit/modifiers'
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import * as Portal from '@radix-ui/react-portal'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -77,6 +77,7 @@ export default function LadderEditor() {
 
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null)
   const [activeItem, setActiveItem] = useState<RungLadderState | null>(null)
+  const nodeDivergences = getLibraryDivergences()
 
   const scrollableRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
@@ -205,7 +206,7 @@ export default function LadderEditor() {
     closeModal()
   }
 
-  const nodeDivergences = useMemo<string[]>(() => {
+  function getLibraryDivergences() {
     if (!flow) return []
 
     const divergences = []
@@ -260,7 +261,7 @@ export default function LadderEditor() {
     }
 
     return divergences
-  }, [flow, userLibraries, pous])
+  }
 
   return (
     <div className='h-full w-full overflow-y-auto' ref={scrollableRef} style={{ scrollbarGutter: 'stable' }}>

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/body.tsx
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/body.tsx
@@ -1,8 +1,7 @@
-import type { CoordinateExtent, Edge, Node as FlowNode, OnNodesChange, ReactFlowInstance } from '@xyflow/react'
+import type { CoordinateExtent, Node as FlowNode, OnNodesChange, ReactFlowInstance } from '@xyflow/react'
 import { applyNodeChanges, getNodesBounds } from '@xyflow/react'
 import { differenceWith, isEqual, parseInt } from 'lodash'
 import { DragEventHandler, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { v4 as uuidv4 } from 'uuid'
 
 import type { PLCVariable } from '../../../../../../middleware/shared/ports/types'
 import { useDebugCompositeKey } from '../../../../../hooks/use-debug-composite-key'
@@ -15,8 +14,7 @@ import { getLadderBlockType, isLadderBlockDrag } from '../../../../../utils/grap
 import { getFunctionBlockVariablesToCleanup } from '../../../../../utils/graphical/get-function-block-variables-to-cleanup'
 import { syncNodesWithVariables } from '../../../../../utils/graphical/sync-nodes-with-variables'
 import { customNodeTypes } from '../../../../_atoms/graphical-editor/ladder'
-import { nodesBuilder } from '../../../../_atoms/graphical-editor/ladder/node-builders'
-import type { BasicNodeData, ParallelNode } from '../../../../_atoms/graphical-editor/ladder/utils/types'
+import type { BasicNodeData } from '../../../../_atoms/graphical-editor/ladder/utils/types'
 import { getVariableRestrictionType } from '../../../../_atoms/graphical-editor/utils'
 import { ReactFlowPanel } from '../../../../_atoms/react-flow'
 import { toast } from '../../../../_features/[app]/toast/use-toast'
@@ -28,7 +26,6 @@ import {
   renderPlaceholderElements,
   searchNearestPlaceholder,
 } from './ladder-utils/elements/placeholder'
-import { getNodesInsideParallel, getPlaceholderPositionBasedOnNode } from './ladder-utils/elements/utils'
 import { findNode } from './ladder-utils/nodes'
 
 /**
@@ -72,21 +69,15 @@ type RungBodyProps = {
 }
 
 const EDGE_COLOR_TRUE = '#00FF00'
-const EMPTY_ARRAY: string[] = []
 
-export const RungBody = ({
-  rung,
-  className,
-  nodeDivergences = EMPTY_ARRAY,
-  isDebuggerActive = false,
-}: RungBodyProps) => {
+export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActive = false }: RungBodyProps) => {
   const pouName = useBoundPou()
   const editor = useBoundEditorModel()
   const {
     ladderFlowActions,
     ladderFlows,
     libraries,
-    editorActions: { updateModelVariables, updateModelLadder },
+    editorActions: { updateModelVariables },
     project,
     projectActions: { deleteVariable },
     modalActions: { openModal },
@@ -105,41 +96,8 @@ export const RungBody = ({
   const [rungLocal, setRungLocal] = useState<RungLadderState>(rung)
   const [dragging, setDragging] = useState(false)
 
-  const flow = useMemo(() => ladderFlows.find((f) => f.name === pouName), [ladderFlows, pouName])
-  const rungs = useMemo(() => flow?.rungs || [], [flow])
-
-  const clearLocalSelection = useCallback(() => {
-    ladderFlowActions.setSelectedNodes({
-      editorName: pouName,
-      rungId: rung.id,
-      nodes: [],
-    })
-    const updatedEdges = rungLocal.edges.map((e) => (e.selected ? { ...e, selected: false } : e))
-    ladderFlowActions.setEdges({
-      editorName: pouName,
-      rungId: rung.id,
-      edges: updatedEdges,
-    })
-  }, [pouName, rung.id, rungLocal.edges, ladderFlowActions])
-
   const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null)
   const reactFlowViewportRef = useRef<HTMLDivElement>(null)
-
-  // Id of a rung that was just created via keyboard and still needs to receive focus.
-  // Focus happens in an effect once the rung is committed to the DOM (see below),
-  // instead of guessing a render delay with setTimeout.
-  const pendingFocusRungIdRef = useRef<string | null>(null)
-
-  useEffect(() => {
-    const pendingId = pendingFocusRungIdRef.current
-    if (!pendingId) return
-    const newRungElement = document.getElementById(pendingId)
-    const focusable = newRungElement?.querySelector('div[tabindex="0"]') as unknown as HTMLDivElement | null
-    if (focusable) {
-      focusable.focus()
-      pendingFocusRungIdRef.current = null
-    }
-  }, [rungs])
 
   /**
    * -- Which means, by default, the flow panel extent is:
@@ -171,22 +129,15 @@ export const RungBody = ({
     if (bounds.width < defaultWidth) bounds.width = defaultWidth
     if (bounds.height < defaultHeight) bounds.height = defaultHeight
 
-    const nextWidth = bounds.width
-    const nextHeight = bounds.height + 20
-
     setReactFlowPanelExtent([
       [0, 0],
-      [nextWidth, nextHeight],
+      [bounds.width, bounds.height + 20],
     ])
-
-    const [currentWidth, currentHeight] = rung.reactFlowViewport ?? [0, 0]
-    if (currentWidth !== nextWidth || currentHeight !== nextHeight) {
-      ladderFlowActions.updateReactFlowViewport({
-        editorName: pouName,
-        rungId: rung.id,
-        reactFlowViewport: [nextWidth, nextHeight],
-      })
-    }
+    ladderFlowActions.updateReactFlowViewport({
+      editorName: pouName,
+      rungId: rungLocal.id,
+      reactFlowViewport: [bounds.width, bounds.height + 20],
+    })
   }
 
   // --- Debug edge coloring and node lockdown ---
@@ -417,7 +368,7 @@ export const RungBody = ({
       })),
     })
     updateReactFlowPanelExtent(rung)
-  }, [rung.nodes, rung.edges, rung.selectedNodes, rung.handleBranches, rung.id, nodeDivergences])
+  }, [rung.nodes])
 
   /**
    *  Update the local rung state when the rung state changes
@@ -736,14 +687,12 @@ export const RungBody = ({
   const onNodesChange: OnNodesChange<FlowNode> = useCallback(
     (changes) => {
       let selectedNodes: FlowNode[] = rungLocal.nodes.filter((node) => node.selected)
-      let hasNewSelection = false
       changes.forEach((change) => {
         switch (change.type) {
           case 'select': {
             const node = rungLocal.nodes.find((n) => n.id === change.id) as FlowNode
             if (change.selected) {
               selectedNodes.push(node)
-              hasNewSelection = true
               return
             }
 
@@ -766,16 +715,8 @@ export const RungBody = ({
         nodes: applyNodeChanges(changes, rungLocal.nodes),
         selectedNodes: selectedNodes,
       }))
-
-      if (hasNewSelection && rungLocal.edges.some((e) => e.selected)) {
-        ladderFlowActions.setEdges({
-          editorName: pouName,
-          rungId: rung.id,
-          edges: rungLocal.edges.map((e) => ({ ...e, selected: false })),
-        })
-      }
     },
-    [rungLocal, rung, dragging, pouName, ladderFlowActions],
+    [rungLocal, rung, dragging],
   )
 
   /**
@@ -938,459 +879,11 @@ export const RungBody = ({
     ],
   )
 
-  const selectedNode = useMemo(() => rungLocal.nodes.find((n) => n.selected), [rungLocal.nodes])
-  const selectedEdge = useMemo(() => rungLocal.edges.find((e) => e.selected), [rungLocal.edges])
-
-  const selectNode = useCallback(
-    (node: FlowNode) => {
-      ladderFlowActions.setSelectedNodes({
-        editorName: pouName,
-        rungId: rung.id,
-        nodes: [node],
-      })
-      const updatedEdges = rungLocal.edges.map((e) => (e.selected ? { ...e, selected: false } : e))
-      ladderFlowActions.setEdges({
-        editorName: pouName,
-        rungId: rung.id,
-        edges: updatedEdges,
-      })
-    },
-    [pouName, rung.id, rungLocal.edges, ladderFlowActions],
-  )
-
-  const selectEdge = useCallback(
-    (edgeId: string) => {
-      ladderFlowActions.setSelectedNodes({
-        editorName: pouName,
-        rungId: rung.id,
-        nodes: [],
-      })
-      const updatedEdges = rungLocal.edges.map((e) => ({
-        ...e,
-        selected: e.id === edgeId,
-      }))
-      ladderFlowActions.setEdges({
-        editorName: pouName,
-        rungId: rung.id,
-        edges: updatedEdges,
-      })
-    },
-    [pouName, rung.id, rungLocal.edges, ladderFlowActions],
-  )
-
-  const handleAddElementAtEdge = useCallback(
-    (elementType: string) => {
-      if (!selectedEdge) return
-
-      const targetNode = rungLocal.nodes.find((n) => n.id === selectedEdge.target)
-      if (!targetNode) return
-
-      const tempPlaceholderId = `placeholder_temp_${uuidv4()}`
-      const targetIndex = rungLocal.nodes.findIndex((n) => n.id === targetNode.id)
-      if (targetIndex === -1) return
-
-      const tempPlaceholderNode = nodesBuilder.placeholder({
-        id: tempPlaceholderId,
-        type: 'default',
-        relatedNode: targetNode,
-        position: 'left',
-        ...getPlaceholderPositionBasedOnNode(targetNode, 'left'),
-      })
-      tempPlaceholderNode.selected = true
-      tempPlaceholderNode.data = {
-        ...tempPlaceholderNode.data,
-        edgeSourceId: selectedEdge.source,
-        selectedEdgeId: selectedEdge.id,
-      }
-
-      const modifiedNodes = [
-        ...rungLocal.nodes.slice(0, targetIndex),
-        tempPlaceholderNode,
-        ...rungLocal.nodes.slice(targetIndex),
-      ]
-
-      const { nodes, edges, newNode, handleBranches } = addNewElement(
-        {
-          ...rungLocal,
-          nodes: modifiedNodes,
-        },
-        { elementType },
-      )
-
-      captureAndPush(pouName)
-
-      ladderFlowActions.setNodes({ editorName: pouName, rungId: rungLocal.id, nodes })
-      ladderFlowActions.setEdges({ editorName: pouName, rungId: rungLocal.id, edges })
-      if (handleBranches) {
-        ladderFlowActions.setHandleBranches({ editorName: pouName, rungId: rungLocal.id, handleBranches })
-      }
-
-      if (newNode) {
-        ladderFlowActions.setSelectedNodes({
-          editorName: pouName,
-          rungId: rungLocal.id,
-          nodes: [newNode],
-        })
-      }
-
-      if (pouRef) {
-        syncNodesWithVariables(pouRef.interface?.variables ?? [], ladderFlows, ladderFlowActions.updateNode, pouName)
-      }
-    },
-    [selectedEdge, rungLocal, pouName, ladderFlowActions, captureAndPush, pouRef, ladderFlows],
-  )
-
-  const handleAddBranchAtNode = useCallback(() => {
-    if (!selectedNode) return
-    if (selectedNode.type === 'powerRail' || selectedNode.type === 'parallel') {
-      toast({
-        variant: 'warn',
-        title: 'Action not supported',
-        description: 'Cannot add a branch on a rail or parallel junction.',
-      })
-      return
-    }
-
-    const openParallels = rungLocal.nodes.filter(
-      (n) => n.type === 'parallel' && (n as ParallelNode).data.type === 'open',
-    ) as ParallelNode[]
-
-    let hasBranchUnderneath = false
-    for (const openParallel of openParallels) {
-      const closeParallel = rungLocal.nodes.find((n) => n.id === openParallel.data.parallelCloseReference)
-      if (!closeParallel) continue
-      const { serial } = getNodesInsideParallel(rungLocal, closeParallel)
-      if (serial.some((n) => n.id === selectedNode.id)) {
-        hasBranchUnderneath = true
-        break
-      }
-    }
-
-    if (hasBranchUnderneath) {
-      toast({
-        variant: 'warn',
-        title: 'Action not supported',
-        description: 'Cannot add a branch when there is already a branch underneath the contact.',
-      })
-      return
-    }
-
-    const selectedNodeIndex = rungLocal.nodes.findIndex((n) => n.id === selectedNode.id)
-    if (selectedNodeIndex === -1) return
-
-    const tempPlaceholderId = `parallelPlaceholder_${selectedNode.id}_${uuidv4()}`
-    const tempPlaceholderNode = nodesBuilder.placeholder({
-      id: tempPlaceholderId,
-      type: 'parallel',
-      relatedNode: selectedNode,
-      position: 'bottom',
-      ...getPlaceholderPositionBasedOnNode(selectedNode, 'bottom'),
-    })
-    tempPlaceholderNode.selected = true
-
-    const modifiedNodes = [
-      ...rungLocal.nodes.slice(0, selectedNodeIndex + 1),
-      tempPlaceholderNode,
-      ...rungLocal.nodes.slice(selectedNodeIndex + 1),
-    ]
-
-    const { nodes, edges, newNode, handleBranches } = addNewElement(
-      {
-        ...rungLocal,
-        nodes: modifiedNodes,
-      },
-      { elementType: 'contact' },
-    )
-
-    captureAndPush(pouName)
-
-    ladderFlowActions.setNodes({ editorName: pouName, rungId: rungLocal.id, nodes })
-    ladderFlowActions.setEdges({ editorName: pouName, rungId: rungLocal.id, edges })
-    if (handleBranches) {
-      ladderFlowActions.setHandleBranches({ editorName: pouName, rungId: rungLocal.id, handleBranches })
-    }
-
-    if (newNode) {
-      ladderFlowActions.setSelectedNodes({
-        editorName: pouName,
-        rungId: rungLocal.id,
-        nodes: [newNode],
-      })
-    }
-
-    if (pouRef) {
-      syncNodesWithVariables(pouRef.interface?.variables ?? [], ladderFlows, ladderFlowActions.updateNode, pouName)
-    }
-  }, [selectedNode, rungLocal, pouName, ladderFlowActions, captureAndPush, pouRef, ladderFlows])
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (isDebuggerActive) return
-
-      const target = e.target as HTMLElement
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
-        return
-      }
-
-      const isShiftE = e.key.toLowerCase() === 'e' && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey
-      const isShiftArrow =
-        (e.key === 'ArrowDown' || e.key === 'ArrowUp') && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey
-      const isCtrlArrow =
-        (e.key === 'ArrowDown' || e.key === 'ArrowUp') && (e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey
-
-      if (!isShiftE && !isShiftArrow && !isCtrlArrow && (e.ctrlKey || e.altKey || e.metaKey || e.shiftKey)) {
-        return
-      }
-
-      if (isShiftArrow) {
-        const currentRungContainer = e.currentTarget.closest('[aria-label="Rung container"]')
-        const targetRungContainer =
-          e.key === 'ArrowDown'
-            ? currentRungContainer?.nextElementSibling
-            : currentRungContainer?.previousElementSibling
-
-        if (targetRungContainer) {
-          clearLocalSelection()
-          const focusable = targetRungContainer.querySelector('div[tabindex="0"]') as unknown as HTMLDivElement | null
-          focusable?.focus()
-          e.preventDefault()
-        }
-        return
-      }
-
-      if (isCtrlArrow) {
-        const currentRungIndex = rungs.findIndex((r) => r.id === rung.id)
-        if (currentRungIndex !== -1) {
-          const insertBelow = e.key === 'ArrowDown'
-          const insertAtIndex = insertBelow ? currentRungIndex + 1 : currentRungIndex
-          const rungIdToBeAdded = `rung_${pouName}_${uuidv4()}`
-          const defaultViewport: [number, number] = [300, 100]
-
-          clearLocalSelection()
-
-          captureAndPush(pouName)
-
-          ladderFlowActions.startLadderRung({
-            editorName: pouName,
-            rungId: rungIdToBeAdded,
-            defaultBounds: defaultViewport,
-            reactFlowViewport: defaultViewport,
-            insertAtIndex,
-          })
-          updateModelLadder({ openRung: { rungId: rungIdToBeAdded, open: true } })
-
-          // Defer focus until the new rung is actually rendered (see the effect keyed on `rungs`).
-          pendingFocusRungIdRef.current = rungIdToBeAdded
-
-          e.preventDefault()
-        }
-        return
-      }
-
-      if (e.key === 'Enter') {
-        if (selectedNode) {
-          let inputEl: HTMLElement | null = null
-          if (selectedNode.type === 'contact') {
-            inputEl = document.getElementById(`contact-variable-input-${selectedNode.id}`)
-          } else if (selectedNode.type === 'coil') {
-            inputEl = document.getElementById(`coil-variable-input-${selectedNode.id}`)
-          }
-
-          if (inputEl) {
-            inputEl.focus()
-            if (inputEl instanceof HTMLTextAreaElement || inputEl instanceof HTMLInputElement) {
-              inputEl.select()
-            }
-            e.preventDefault()
-            return
-          }
-        }
-      }
-
-      if (!selectedNode && !selectedEdge) {
-        if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
-          const firstEdge = rungLocal.edges.find((edge) => edge.source.startsWith('left-rail'))
-          if (firstEdge) {
-            selectEdge(firstEdge.id)
-            e.preventDefault()
-          }
-        }
-        return
-      }
-
-      if (e.key === 'ArrowRight') {
-        if (selectedNode) {
-          const outgoingEdges = rungLocal.edges.filter((edge) => edge.source === selectedNode.id)
-          if (outgoingEdges.length > 0) {
-            const sortedEdges = [...outgoingEdges].sort((a, b) => {
-              const nodeA = rungLocal.nodes.find((n) => n.id === a.target)
-              const nodeB = rungLocal.nodes.find((n) => n.id === b.target)
-              return (nodeA?.position?.y ?? 0) - (nodeB?.position?.y ?? 0)
-            })
-            selectEdge(sortedEdges[0].id)
-            e.preventDefault()
-          }
-        } else if (selectedEdge) {
-          const targetNode = rungLocal.nodes.find((n) => n.id === selectedEdge.target)
-          if (targetNode) {
-            selectNode(targetNode)
-            e.preventDefault()
-          }
-        }
-      } else if (e.key === 'ArrowLeft') {
-        if (selectedNode) {
-          const incomingEdges = rungLocal.edges.filter((edge) => edge.target === selectedNode.id)
-          if (incomingEdges.length > 0) {
-            const sortedEdges = [...incomingEdges].sort((a, b) => {
-              const nodeA = rungLocal.nodes.find((n) => n.id === a.source)
-              const nodeB = rungLocal.nodes.find((n) => n.id === b.source)
-              return (nodeA?.position?.y ?? 0) - (nodeB?.position?.y ?? 0)
-            })
-            selectEdge(sortedEdges[0].id)
-            e.preventDefault()
-          }
-        } else if (selectedEdge) {
-          const sourceNode = rungLocal.nodes.find((n) => n.id === selectedEdge.source)
-          if (sourceNode) {
-            selectNode(sourceNode)
-            e.preventDefault()
-          }
-        }
-      } else if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
-        if (selectedEdge) {
-          const siblings = rungLocal.edges.filter(
-            (edge) => edge.source === selectedEdge.source || edge.target === selectedEdge.target,
-          )
-          if (siblings.length > 1) {
-            const getEdgeY = (edge: Edge) => {
-              const src = rungLocal.nodes.find((n) => n.id === edge.source)
-              const tgt = rungLocal.nodes.find((n) => n.id === edge.target)
-              return ((src?.position?.y ?? 0) + (tgt?.position?.y ?? 0)) / 2
-            }
-            const sortedSiblings = [...siblings].sort((a, b) => getEdgeY(a) - getEdgeY(b))
-            const currentIndex = sortedSiblings.findIndex((s) => s.id === selectedEdge.id)
-            if (e.key === 'ArrowDown' && currentIndex < sortedSiblings.length - 1) {
-              selectEdge(sortedSiblings[currentIndex + 1].id)
-              e.preventDefault()
-            } else if (e.key === 'ArrowUp' && currentIndex > 0) {
-              selectEdge(sortedSiblings[currentIndex - 1].id)
-              e.preventDefault()
-            }
-          }
-        } else if (selectedNode) {
-          const selectedNodeX = selectedNode.position.x
-          const verticalSiblings = rungLocal.nodes.filter(
-            (n) => n.id !== selectedNode.id && n.type !== 'powerRail' && Math.abs(n.position.x - selectedNodeX) < 50,
-          )
-          if (verticalSiblings.length > 0) {
-            const sortedNodes = [selectedNode, ...verticalSiblings].sort((a, b) => a.position.y - b.position.y)
-            const currentIndex = sortedNodes.findIndex((n) => n.id === selectedNode.id)
-            if (e.key === 'ArrowDown' && currentIndex < sortedNodes.length - 1) {
-              selectNode(sortedNodes[currentIndex + 1])
-              e.preventDefault()
-            } else if (e.key === 'ArrowUp' && currentIndex > 0) {
-              selectNode(sortedNodes[currentIndex - 1])
-              e.preventDefault()
-            }
-          }
-        }
-      } else if (e.key.toLowerCase() === 'c') {
-        if (selectedEdge) {
-          handleAddElementAtEdge('contact')
-          e.preventDefault()
-        }
-      } else if (e.key.toLowerCase() === 'q') {
-        if (selectedEdge) {
-          handleAddElementAtEdge('coil')
-          e.preventDefault()
-        }
-      } else if (e.key.toLowerCase() === 'f') {
-        if (selectedEdge) {
-          handleAddElementAtEdge('block')
-          e.preventDefault()
-        }
-      } else if (e.key.toLowerCase() === 'b') {
-        if (selectedNode) {
-          handleAddBranchAtNode()
-          e.preventDefault()
-        }
-      } else if (e.key.toLowerCase() === 'e' && e.shiftKey) {
-        if (selectedNode) {
-          if (selectedNode.type === 'contact') {
-            const contactVariants = ['default', 'negated', 'risingEdge', 'fallingEdge']
-            const currentVariant = (selectedNode.data.variant as string) || 'default'
-            const currentIndex = contactVariants.indexOf(currentVariant)
-            const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % contactVariants.length
-            const nextVariant = contactVariants[nextIndex]
-
-            captureAndPush(pouName)
-            ladderFlowActions.updateNode({
-              editorName: pouName,
-              rungId: rungLocal.id,
-              nodeId: selectedNode.id,
-              node: {
-                ...selectedNode,
-                data: {
-                  ...selectedNode.data,
-                  variant: nextVariant,
-                },
-              },
-            })
-            e.preventDefault()
-          } else if (selectedNode.type === 'coil') {
-            const coilVariants = ['default', 'set', 'reset', 'negated', 'risingEdge', 'fallingEdge']
-            const currentVariant = (selectedNode.data.variant as string) || 'default'
-            const currentIndex = coilVariants.indexOf(currentVariant)
-            const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % coilVariants.length
-            const nextVariant = coilVariants[nextIndex]
-
-            captureAndPush(pouName)
-            ladderFlowActions.updateNode({
-              editorName: pouName,
-              rungId: rungLocal.id,
-              nodeId: selectedNode.id,
-              node: {
-                ...selectedNode,
-                data: {
-                  ...selectedNode.data,
-                  variant: nextVariant,
-                },
-              },
-            })
-            e.preventDefault()
-          } else if (selectedNode.type === 'block') {
-            openModal('block-ladder-element', selectedNode)
-            e.preventDefault()
-          }
-        }
-      }
-    },
-    [
-      isDebuggerActive,
-      selectedNode,
-      selectedEdge,
-      rungLocal,
-      selectEdge,
-      selectNode,
-      handleAddElementAtEdge,
-      handleAddBranchAtNode,
-      captureAndPush,
-      pouName,
-      ladderFlowActions,
-      openModal,
-      clearLocalSelection,
-      updateModelLadder,
-      rungs,
-      rung,
-    ],
-  )
-
   return (
     <div
-      tabIndex={0}
-      onKeyDown={handleKeyDown}
       className={cn(
-        'relative h-fit w-full p-1 outline-none focus-within:ring-1 focus-within:ring-brand focus-within:ring-offset-1 dark:focus-within:ring-offset-neutral-900',
+        'relative h-fit w-full p-1',
+        // 'rounded-b-lg border border-t-0 dark:border-neutral-800',
         className,
       )}
     >
@@ -1407,29 +900,14 @@ export const RungBody = ({
               nodes: styledNodes,
               edges: styledEdges,
               nodesFocusable: false,
-              edgesFocusable: true,
+              edgesFocusable: false,
               elementsSelectable: true,
               nodesDraggable: !isDebuggerActive,
               nodesConnectable: !isDebuggerActive,
               defaultEdgeOptions: {
                 deletable: false,
-                selectable: !isDebuggerActive,
+                selectable: false,
                 type: 'smoothstep',
-              },
-              onEdgesChange: (changes) => {
-                const isEdgeSelecting = changes.some((c) => c.type === 'select' && c.selected)
-                if (isEdgeSelecting) {
-                  ladderFlowActions.setSelectedNodes({
-                    editorName: pouName,
-                    rungId: rungLocal.id,
-                    nodes: [],
-                  })
-                }
-                ladderFlowActions.onEdgesChange({
-                  changes,
-                  rungId: rungLocal.id,
-                  editorName: pouName,
-                })
               },
 
               onInit: setReactFlowInstance,

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/edges.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/edges.ts
@@ -7,7 +7,6 @@ import { isNodeOfType } from './nodes'
 type ConnectionOptions = {
   sourceHandle?: string
   targetHandle?: string
-  selectedEdgeId?: string
 }
 
 export const checkIfConnectedInParallel = (
@@ -42,25 +41,17 @@ export const connectNodes = (
 ): Edge[] => {
   // Find the source edge
   const sourceNode = rung.nodes.find((node) => node.id === sourceNodeId) as Node
-  // When a specific edge was selected (keyboard edge insertion), only honor it if it
-  // actually belongs to sourceNodeId; otherwise fall back to the normal source-edge lookup
-  // so we never rewire the wrong edge path.
-  const selectedSourceEdge = options?.selectedEdgeId
-    ? rung.edges.find((edge) => edge.id === options.selectedEdgeId && edge.source === sourceNodeId)
-    : undefined
-  const sourceEdge =
-    selectedSourceEdge ??
-    rung.edges.find((edge) => {
-      return (
-        edge.source === sourceNodeId &&
-        (type === 'parallel' && isNodeOfType(sourceNode, 'parallel')
-          ? edge.sourceHandle === (sourceNode as ParallelNode).data.parallelOutputConnector?.id
-          : isNodeOfType(sourceNode, 'parallel') && sourceNode.data.type === 'close'
-            ? edge.sourceHandle === (sourceNode as ParallelNode).data.parallelOutputConnector?.id ||
-              edge.sourceHandle === (sourceNode as ParallelNode).data.outputConnector?.id
-            : edge.sourceHandle === (sourceNode.data as BasicNodeData).outputConnector?.id)
-      )
-    })
+  const sourceEdge = rung.edges.find((edge) => {
+    return (
+      edge.source === sourceNodeId &&
+      (type === 'parallel' && isNodeOfType(sourceNode, 'parallel')
+        ? edge.sourceHandle === (sourceNode as ParallelNode).data.parallelOutputConnector?.id
+        : isNodeOfType(sourceNode, 'parallel') && sourceNode.data.type === 'close'
+          ? edge.sourceHandle === (sourceNode as ParallelNode).data.parallelOutputConnector?.id ||
+            edge.sourceHandle === (sourceNode as ParallelNode).data.outputConnector?.id
+          : edge.sourceHandle === (sourceNode.data as BasicNodeData).outputConnector?.id)
+    )
+  })
 
   const targetNode = rung.nodes.find((node) => node.id === targetNodeId)
   const targetNodeData = targetNode?.data as BasicNodeData
@@ -69,8 +60,8 @@ export const connectNodes = (
    * targetHandle: where the the sourceEdge connects to targetNode
    * sourceHandle: where the targetNode connects to the previous sourceEdge target
    */
-  const targetHandle = options?.targetHandle ?? targetNodeData.inputConnector?.id
-  const sourceHandle = options?.sourceHandle ?? targetNodeData.outputConnector?.id
+  const targetHandle = !options ? targetNodeData.inputConnector?.id : options.targetHandle
+  const sourceHandle = !options ? targetNodeData.outputConnector?.id : options.sourceHandle
 
   // If the source edge is found, update the target
   if (sourceEdge) {
@@ -79,7 +70,7 @@ export const connectNodes = (
 
     // If source node is a parallel and the operation type is serial, lets check if we need to update the source handle
     let newSourceHandle = sourceEdge.sourceHandle ?? undefined
-    if (!options?.selectedEdgeId && type === 'serial' && isNodeOfType(sourceNode, 'parallel')) {
+    if (type === 'serial' && isNodeOfType(sourceNode, 'parallel')) {
       newSourceHandle = (sourceNode as ParallelNode).data.outputConnector?.id
     }
 

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/diagram/index.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/diagram/index.ts
@@ -534,14 +534,15 @@ export const updateDiagramElementsPosition = (
         const objectParallel = parallel[object]
         if (objectParallel.nodes.parallel.find((n) => n.id === node.id)) {
           foundInParallel = true
-          const refNode = objectParallel.highestNode ?? objectParallel.parallels.open
           const newPosY =
-            refNode.position.y +
+            objectParallel.highestNode.position.y +
             objectParallel.height +
-            getDefaultNodeStyle({ node: refNode }).verticalGap -
+            getDefaultNodeStyle({ node: objectParallel.highestNode }).verticalGap -
             getDefaultNodeStyle({ node }).handle.y
           const newHandleY =
-            refNode.position.y + objectParallel.height + getDefaultNodeStyle({ node: refNode }).verticalGap
+            objectParallel.highestNode.position.y +
+            objectParallel.height +
+            getDefaultNodeStyle({ node: objectParallel.highestNode }).verticalGap
           newNodePosition = {
             ...newNodePosition,
             posY: newPosY,
@@ -657,7 +658,7 @@ export const updateDiagramElementsPosition = (
             const nodeIndex = objectParallel.nodes.serial.findIndex((n) => n.id === node.id)
             parallelsDepth[index][object].nodes.serial.splice(nodeIndex, 1, newNode)
           }
-          if (objectParallel.highestNode?.id === node.id) {
+          if (objectParallel.highestNode.id === node.id) {
             parallelsDepth[index][object].highestNode = newNode
           }
           if (objectParallel.parallels.open.id === node.id) {

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/serial/index.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/serial/index.ts
@@ -55,19 +55,12 @@ export const appendSerialConnection = <T>(
   if (!relatedNodePreviousNodes || !relatedNodePreviousEdges) return { nodes: newNodes, edges: newEdges }
 
   /**
-   * Get the previous node.
-   * If the placeholder specifies edgeSourceId (from keyboard edge selection), use it.
+   * Get the previous node
    */
-  let previousNode: Node | undefined
-  if (placeholder.selected.data.edgeSourceId) {
-    previousNode = newNodes.find((n) => n.id === placeholder.selected.data.edgeSourceId)
-  }
-  if (!previousNode) {
-    previousNode = getPreviousElement(
-      { ...rung, nodes: newNodes, edges: newEdges },
-      newNodes.findIndex((n) => n.id === newElement.id),
-    )
-  }
+  let previousNode = getPreviousElement(
+    { ...rung, nodes: newNodes, edges: newEdges },
+    newNodes.findIndex((n) => n.id === newElement.id),
+  )
 
   /**
    * If the related node is a parallel, check if it is an open or close parallel
@@ -76,7 +69,6 @@ export const appendSerialConnection = <T>(
    * If it is not a parallel, connect the new element to the previous node
    */
   if (
-    !placeholder.selected.data.edgeSourceId &&
     // Check if there is serial previous nodes
     relatedNodePreviousNodes.serial.length > 0 &&
     // Check if the node is a open parallel node
@@ -91,15 +83,7 @@ export const appendSerialConnection = <T>(
     previousNode = relatedNodePreviousNodes.serial[0]
     newEdges = connectNodes({ ...rung, nodes: newNodes, edges: newEdges }, previousNode.id, newElement.id, 'parallel')
   } else {
-    newEdges = connectNodes(
-      { ...rung, nodes: newNodes, edges: newEdges },
-      previousNode.id,
-      newElement.id,
-      'serial',
-      placeholder.selected.data.selectedEdgeId
-        ? { selectedEdgeId: placeholder.selected.data.selectedEdgeId }
-        : undefined,
-    )
+    newEdges = connectNodes({ ...rung, nodes: newNodes, edges: newEdges }, previousNode.id, newElement.id, 'serial')
   }
 
   return { nodes: newNodes, edges: newEdges, newNode: newElement }

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/utils/index.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/utils/index.ts
@@ -255,7 +255,7 @@ export const findAllParallelsDepthAndNodes = (
       }
       depth: number
       height: number
-      highestNode: Node | undefined
+      highestNode: Node
       nodes: {
         serial: Node[]
         parallel: Node[]
@@ -268,8 +268,8 @@ export const findAllParallelsDepthAndNodes = (
 
   // check serial nodes
   const serialNodes = nodesInsideParallel.serial
-  let highestNode: Node | undefined = serialNodes[0]
-  let serialHeight = highestNode ? (highestNode.height ?? 0) : 0
+  let highestNode = serialNodes[0]
+  let serialHeight = highestNode.height ?? 0
   for (const serialNode of serialNodes) {
     // If it is a parallel node, check if it is an open parallel
     // If it is, call the function recursively

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/nodes.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/nodes.ts
@@ -23,8 +23,7 @@ export const isNodeOfType = (node: Node, nodeType: string): boolean => {
 }
 
 export const getDefaultNodeStyle = ({ node, nodeType }: { node?: Node; nodeType?: string }) => {
-  const type = node?.type ?? nodeType ?? 'mockNode'
-  return defaultCustomNodesStyles[type] ?? defaultCustomNodesStyles['mockNode']
+  return defaultCustomNodesStyles[node?.type ?? nodeType ?? 'mockNode']
 }
 
 export const buildGenericNode = <T>({

--- a/src/frontend/store/__tests__/ladder-slice.test.ts
+++ b/src/frontend/store/__tests__/ladder-slice.test.ts
@@ -266,31 +266,6 @@ describe('createLadderFlowSlice', () => {
     expect(ladderFlows[0].rungs).toHaveLength(2)
   })
 
-  it('startLadderRung inserts rung at specific index when insertAtIndex is provided', () => {
-    store.getState().ladderFlowActions.startLadderRung({
-      editorName: 'editor-1',
-      rungId: 'rung-1',
-      defaultBounds: [800, 200],
-    })
-    store.getState().ladderFlowActions.startLadderRung({
-      editorName: 'editor-1',
-      rungId: 'rung-2',
-      defaultBounds: [800, 200],
-    })
-    store.getState().ladderFlowActions.startLadderRung({
-      editorName: 'editor-1',
-      rungId: 'rung-3',
-      defaultBounds: [800, 200],
-      insertAtIndex: 1,
-    })
-
-    const { ladderFlows } = store.getState()
-    expect(ladderFlows[0].rungs).toHaveLength(3)
-    expect(ladderFlows[0].rungs[0].id).toBe('rung-1')
-    expect(ladderFlows[0].rungs[1].id).toBe('rung-3')
-    expect(ladderFlows[0].rungs[2].id).toBe('rung-2')
-  })
-
   // -------------------------------------------------------------------------
   // setRungs
   // -------------------------------------------------------------------------

--- a/src/frontend/store/slices/ladder/slice.ts
+++ b/src/frontend/store/slices/ladder/slice.ts
@@ -101,7 +101,7 @@ export const createLadderFlowSlice: StateCreator<LadderFlowSlice, [], [], Ladder
     /**
      * Control the rungs of the flow
      */
-    startLadderRung: ({ editorName, rungId, defaultBounds, reactFlowViewport, insertAtIndex }) => {
+    startLadderRung: ({ editorName, rungId, defaultBounds, reactFlowViewport }) => {
       setState(
         produce(({ ladderFlows }: LadderFlowState) => {
           if (!ladderFlows.find((flow) => flow.name === editorName)) {
@@ -135,7 +135,7 @@ export const createLadderFlowSlice: StateCreator<LadderFlowSlice, [], [], Ladder
               handleY: defaultBounds[1] / 2,
             }),
           ]
-          const newRung = {
+          flow.rungs.push({
             id: rungId,
             comment: '',
             defaultBounds,
@@ -153,20 +153,7 @@ export const createLadderFlowSlice: StateCreator<LadderFlowSlice, [], [], Ladder
               },
             ],
             selectedNodes: [],
-          }
-
-          // Clamp to a valid range so NaN/negative/out-of-bounds indices can't place the rung wrong.
-          const normalizedInsertAtIndex =
-            typeof insertAtIndex === 'number' && Number.isFinite(insertAtIndex)
-              ? Math.min(Math.max(Math.trunc(insertAtIndex), 0), flow.rungs.length)
-              : undefined
-
-          if (normalizedInsertAtIndex !== undefined) {
-            flow.rungs.splice(normalizedInsertAtIndex, 0, newRung)
-          } else {
-            flow.rungs.push(newRung)
-          }
-          flow.updated = true
+          })
         }),
       )
     },

--- a/src/frontend/store/slices/ladder/types.ts
+++ b/src/frontend/store/slices/ladder/types.ts
@@ -58,13 +58,11 @@ type LadderFlowActions = {
     rungId,
     defaultBounds,
     reactFlowViewport,
-    insertAtIndex,
   }: {
     editorName: string
     rungId: string
     defaultBounds: [number, number]
     reactFlowViewport?: [number, number]
-    insertAtIndex?: number
   }) => void
   setRungs: ({ rungs, editorName }: { rungs: RungLadderState[]; editorName: string }) => void
   removeRung: (editorName: string, rungId: string) => void


### PR DESCRIPTION
## Revert ladder shortcuts (equivalent of openplc-web #541)

openplc-web PR #541 (`feat: add ladder shortcuts, sync with editor`) was merged to `development` before full validation and bugs were found. This reverts the **equivalent ladder-shortcuts code on the editor side**.

Mechanism: restores the **17 shared ladder files** (`body.tsx`, `edges.ts`, `serial`, `diagram`, ladder atoms, `slice`/`types`, etc.) to their pre-feature state, **byte-identical with the openplc-web revert** so the shared-surface check stays green. **17 files, +61 / −686** — matching the web revert exactly.

Verified on the reverted tree:
- All 17 files byte-identical to the openplc-web reverted state.
- No dangling references to the reverted symbols (`edgeSourceId`, `selectedEdgeId`, `insertAtIndex`).
- `tsc --noEmit` passes; `ladder-slice` + `ladder-xml` suites pass (161 tests).

### Companion
openplc-web revert: Autonomy-Logic/openplc-web#547

### Note — left in place
The feature commit also tweaked `tsconfig.json` (added `jest` to `types`, stopped excluding test files from type-checking). That's build config, not ladder code, and reverting it risks breaking type-checking of test files — so it is **intentionally left in place**. Say the word if you want it reverted too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus behavior in ladder editing so blur actions no longer shift focus unexpectedly after renaming or editing values.
  * Simplified edge and selection handling in the ladder editor for more consistent interaction.
  * Updated rung and connection behavior to rely on current diagram structure, reducing unexpected edge-selection side effects.
  * New ladder rungs are now added to the end of the flow consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->