### PR TITLE
feat: LSP-powered type-aware autocomplete + validation for LD/FBD variable boxes

### DIFF
--- a/src/frontend/components/_atoms/graphical-editor/autocomplete/index.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/autocomplete/index.tsx
@@ -260,6 +260,11 @@ export const GraphicalEditorAutocomplete = forwardRef<HTMLDivElement, GraphicalE
                               'bg-neutral-400 dark:bg-neutral-800': selectedVariable.variable.name === variable.name,
                             },
                           )}
+                          // Keep the editor textarea focused through the click: some
+                          // consumers (LD contact/coil) refocus their container on the
+                          // textarea's blur, which would close this popover before the
+                          // click resolves and swallow the selection.
+                          onMouseDown={(e) => e.preventDefault()}
                           onClick={() => {
                             submitAutocompletion({
                               variable: {
@@ -292,6 +297,7 @@ export const GraphicalEditorAutocomplete = forwardRef<HTMLDivElement, GraphicalE
                         'rounded-lg': !variables || variables.length === 0,
                       },
                     )}
+                    onMouseDown={(e) => e.preventDefault()}
                     onClick={() =>
                       submitAutocompletion({
                         variable: newBlock.canCreate
@@ -317,6 +323,7 @@ export const GraphicalEditorAutocomplete = forwardRef<HTMLDivElement, GraphicalE
                       'rounded-lg': !variables || variables.length === 0,
                     },
                   )}
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
                     if (newBlock.options) {
                       submitAutocompletion({ variable: selectableValues[selectableValues.length - 1].variable })

--- a/src/frontend/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
@@ -1,20 +1,22 @@
 import { Node } from '@xyflow/react'
-import { isArray } from 'lodash'
-import { ComponentPropsWithRef, forwardRef, useMemo } from 'react'
+import { ComponentPropsWithRef, forwardRef, useEffect, useMemo, useState } from 'react'
 
 import { PLCVariable } from '../../../../../../middleware/shared/ports/types'
+import {
+  getScopeCompletions,
+  newVariableTypeForExpected,
+  type ScopeCompletion,
+  scopeCompletionToVariable,
+} from '../../../../../services/graphical-scope'
 import { useOpenPLCStore } from '../../../../../store'
-import { extractNumberAtEnd } from '../../../../../store/slices/project/validation/variables'
 import { cn } from '../../../../../utils/cn'
 import { getLiteralType } from '../../../../../utils/keywords'
-import { expandArrayVariables } from '../../../../../utils/PLC/array-variable-utils'
 import { toast } from '../../../../_features/[app]/toast/use-toast'
 import { useBoundPou } from '../../../../_features/[workspace]/editor/graphical/active-context'
 import { buildGenericNode } from '../../../../_molecules/graphical-editor/fbd/fbd-utils/nodes'
 import { GraphicalEditorAutocomplete } from '../../autocomplete'
 import { BlockVariant } from '../../types/block'
-import { getVariableRestrictionType } from '../../utils'
-import { CustomFbdNodeTypes, customNodeTypes } from '..'
+import { CustomFbdNodeTypes } from '..'
 import { BasicNodeData } from '../utils'
 import { getFBDPouVariablesRungNodeAndEdges } from '../utils/utils'
 
@@ -39,96 +41,75 @@ const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProp
     } = useOpenPLCStore()
 
     const block = unknownBlock as Node<BasicNodeData> & { positionAbsoluteX?: number; positionAbsoluteY?: number }
-    const { edges, pou, variables, rung } = useMemo(() => {
+    const { edges, rung } = useMemo(() => {
       return getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
         nodeId: block.id,
       })
     }, [pous, fbdFlows, pouName, block.id])
 
-    const variableRestrictions = useMemo(() => {
-      switch (block.type as keyof typeof customNodeTypes) {
-        case 'input-variable':
-        case 'output-variable': {
-          const connections = block.type === 'input-variable' ? edges.source : edges.target
-          const restrictions: {
-            values: string[]
-            definition: string[]
-          } = {
-            values: [],
-            definition: [],
-          }
-          connections?.forEach((edge) => {
-            const connectedNode = rung?.nodes.find(
-              (node) => node.id === (block.type === 'input-variable' ? edge.target : edge.source),
-            )
-            if (!connectedNode || !(connectedNode.data.variant as BlockVariant).variables) return
+    const isVariableBox = block.type === 'input-variable' || block.type === 'output-variable'
+    const isConnectionBox = block.type === 'connector' || block.type === 'continuation'
 
-            const variableType = (connectedNode.data.variant as BlockVariant).variables.find(
-              (variable) => variable.name === (block.type === 'input-variable' ? edge.targetHandle : edge.sourceHandle),
-            )?.type.value
-            if (!variableType) return
-
-            const restriction = getVariableRestrictionType(variableType)
-            restrictions.values = Array.from(
-              new Set([
-                ...restrictions.values,
-                ...(restriction.values
-                  ? isArray(restriction.values)
-                    ? restriction.values
-                    : [restriction.values]
-                  : []),
-              ]),
-            )
-            restrictions.definition = Array.from(
-              new Set([...restrictions.definition, restriction.definition ?? undefined].filter((v) => v !== undefined)),
-            )
-          })
-
-          return {
-            values: restrictions.values.length > 0 ? restrictions.values : undefined,
-            definition: restrictions.definition.length > 0 ? restrictions.definition : undefined,
-          }
-        }
-        default:
-          return {
-            values: undefined,
-            definition: undefined,
-          }
+    /**
+     * The IEC type the connected block pin expects. Drives both the LSP
+     * type filter and the type of any newly-created variable. `undefined`
+     * when the box isn't wired to a pin (no filter — suggest everything).
+     */
+    const expectedType = useMemo<string | undefined>(() => {
+      if (!isVariableBox) return undefined
+      const connections = block.type === 'input-variable' ? edges.source : edges.target
+      for (const edge of connections ?? []) {
+        const connectedNode = rung?.nodes.find(
+          (node) => node.id === (block.type === 'input-variable' ? edge.target : edge.source),
+        )
+        const variableType = (connectedNode?.data.variant as BlockVariant | undefined)?.variables?.find(
+          (variable) => variable.name === (block.type === 'input-variable' ? edge.targetHandle : edge.sourceHandle),
+        )?.type.value
+        if (variableType) return variableType
       }
-    }, [pou])
+      return undefined
+    }, [isVariableBox, block.type, edges, rung])
 
-    const expandedVariables = expandArrayVariables(variables.all)
+    // Variable boxes: LSP-backed candidates (variables + instance/struct
+    // members in scope) filtered by the connected pin's type.
+    const [variableCandidates, setVariableCandidates] = useState<ScopeCompletion[]>([])
+    useEffect(() => {
+      if (!isVariableBox) {
+        setVariableCandidates([])
+        return
+      }
+      let cancelled = false
+      void getScopeCompletions(pouName, valueToSearch, expectedType).then((items) => {
+        if (!cancelled) setVariableCandidates(items)
+      })
+      return () => {
+        cancelled = true
+      }
+    }, [isVariableBox, pouName, valueToSearch, expectedType, pous])
 
-    const filteredVariables = block.type?.includes('variable')
-      ? expandedVariables
-          .filter(
-            (variable) =>
-              variable.name.toLowerCase().includes(valueToSearch.toLowerCase()) &&
-              (variableRestrictions.values === undefined ||
-                variableRestrictions.values.map((v) => v.toLowerCase()).includes(variable.type.value.toLowerCase())),
-          )
-          .sort((a, b) => {
-            const aNumber = extractNumberAtEnd(a.name).number
-            const bNumber = extractNumberAtEnd(b.name).number
-            if (aNumber === bNumber) {
-              return a.name.localeCompare(b.name)
-            }
-            return aNumber - bNumber
-          })
-      : block.type === 'connector' || block.type === 'continuation'
-        ? (rung?.nodes
-            .filter((node) => (block.type === 'connector' ? node.type === 'continuation' : node.type === 'connector'))
-            .map((node) => {
-              return node.data.variable as PLCVariable
-            })
-            .filter((variable) => variable.name !== '') ?? ([] as PLCVariable[]))
-        : ([] as PLCVariable[])
+    // Connector/continuation boxes suggest the matching pair's labels — a
+    // graph-topology concern, unrelated to variable scope, kept as-is.
+    const connectionCandidates = useMemo<PLCVariable[]>(() => {
+      if (!isConnectionBox) return []
+      return (
+        rung?.nodes
+          .filter((node) => (block.type === 'connector' ? node.type === 'continuation' : node.type === 'connector'))
+          .map((node) => node.data.variable as PLCVariable)
+          .filter((variable) => variable.name !== '') ?? []
+      )
+    }, [isConnectionBox, rung, block.type])
+
+    const displayVariables = isVariableBox
+      ? variableCandidates.map((c) => ({ id: c.insertText, name: c.insertText }))
+      : isConnectionBox
+        ? connectionCandidates.map((v) => ({ id: v.id ?? '', name: v.name }))
+        : []
 
     const submitVariableToBlock = (variable: PLCVariable) => {
-      const { rung, node: variableNode } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
+      const { rung: freshRung, node: variableNode } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
         nodeId: block.id,
       })
-      if (!rung || !variableNode) return
+      if (!freshRung || !variableNode) return
 
       updateNode({
         editorName: pouName,
@@ -153,51 +134,20 @@ const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProp
         return
       }
 
-      const { rung, node } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
+      const { rung: freshRung, node } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
         nodeId: block.id,
       })
-      if (!rung || !node) return
+      if (!freshRung || !node) return
 
-      // If there is more than one variable definition, we can't create a variable
-      if (
-        !variableRestrictions.definition ||
-        variableRestrictions.definition.length === 0 ||
-        variableRestrictions.definition.length > 1
-      ) {
-        toast({
-          title: 'Error',
-          description: 'Cannot create a variable with multiple definitions',
-          variant: 'fail',
-        })
-        return
-      }
-
-      const variableTypeRestriction = {
-        definition: variableRestrictions.definition[0] || 'base-type',
-        value: variableRestrictions.values
-          ? Array.isArray(variableRestrictions.values)
-            ? variableRestrictions.values[0]
-            : variableRestrictions.values
-          : 'dint',
-      }
-
-      // If there is no type restriction, we can't create a variable
-      if (!variableTypeRestriction.value) {
-        toast({
-          title: 'Error',
-          description: 'Cannot create a variable with no type',
-          variant: 'fail',
-        })
-        return
-      }
+      const variableType = newVariableTypeForExpected(expectedType)
 
       const res = createVariable({
         data: {
           id: crypto.randomUUID(),
           name: variableName,
           type: {
-            definition: variableTypeRestriction.definition as 'base-type' | 'derived' | 'array' | 'user-data-type',
-            value: variableTypeRestriction.value,
+            definition: variableType.definition,
+            value: variableType.value,
           },
           class: 'local',
           location: '',
@@ -247,8 +197,7 @@ const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProp
 
     const submit = ({ variable }: { variable: { id: string; name: string } }) => {
       if (variable.id === 'add') {
-        // Check if the input is a literal value (e.g., 2.0, TRUE, 'hello')
-        // Literals should be submitted directly to the block, not created as variables
+        // A literal value (e.g. 2.0, TRUE, 'hello') binds directly to the block.
         if (getLiteralType(valueToSearch)) {
           submitVariableToBlock({ name: valueToSearch } as PLCVariable)
           return
@@ -262,17 +211,27 @@ const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProp
         return
       }
 
-      // Look up by name to ensure correct selection for continuation/connector blocks
-      // (all connection nodes share the same ID, so ID lookup would always match the first item)
-      const selectedVariable = filteredVariables.find(
-        (variableItem) => variableItem.name.toLowerCase() === variable.name.toLowerCase(),
-      )
-      if (!selectedVariable) {
+      if (isVariableBox) {
+        // Dropdown items are LSP candidates keyed by their full insert text
+        // (e.g. `TON0.Q`); bind the node to the chosen one, carrying its type.
+        const candidate = variableCandidates.find((c) => c.insertText.toLowerCase() === variable.name.toLowerCase())
+        if (candidate) {
+          submitVariableToBlock(scopeCompletionToVariable(candidate))
+          return
+        }
         submitAddVariable({ variableName: valueToSearch })
         return
       }
 
-      submitVariableToBlock(selectedVariable)
+      // Connector/continuation: bind to the matching node label.
+      const selected = connectionCandidates.find(
+        (variableItem) => variableItem.name.toLowerCase() === variable.name.toLowerCase(),
+      )
+      if (!selected) {
+        submitAddVariable({ variableName: valueToSearch })
+        return
+      }
+      submitVariableToBlock(selected)
     }
 
     return (
@@ -281,9 +240,9 @@ const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProp
         className={cn('h-[200px] w-[200px] overflow-auto', isOpen ? 'block' : 'hidden')}
         isOpen={isOpen}
         setIsOpen={setIsOpen}
-        canCreateNewVariable={!(block.type === 'connector' || block.type === 'continuation')}
+        canCreateNewVariable={!isConnectionBox}
         newBlock={{
-          canCreate: block.type === 'connector' || block.type === 'continuation',
+          canCreate: isConnectionBox,
           options: {
             label: `Add ${block.type === 'connector' ? 'continuation' : 'connector'}`,
             block: {
@@ -293,7 +252,7 @@ const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProp
         }}
         keyPressed={keyPressed}
         searchValue={valueToSearch}
-        variables={filteredVariables}
+        variables={displayVariables}
         submit={submit}
       />
     )

--- a/src/frontend/components/_atoms/graphical-editor/fbd/variable.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/fbd/variable.tsx
@@ -431,8 +431,9 @@ const VariableElement = (block: VariableProps) => {
     // type) when it's a plain local/array reference, otherwise store the raw
     // name (e.g. an instance member like `TON0.Q`). The validation effect
     // resolves and type-checks it against the full project scope.
-    const variable: PLCVariable | { name: string } =
-      (pou.interface?.variables ?? []).find((v) => v.name.toLowerCase() === variableNameToSubmit.toLowerCase()) ||
+    const variable: PLCVariable | { name: string } = (pou.interface?.variables ?? []).find(
+      (v) => v.name.toLowerCase() === variableNameToSubmit.toLowerCase(),
+    ) ||
       resolveArrayVariableByName(pou.interface?.variables ?? [], variableNameToSubmit) || {
         name: variableNameToSubmit,
       }

--- a/src/frontend/components/_atoms/graphical-editor/fbd/variable.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/fbd/variable.tsx
@@ -6,6 +6,7 @@ import { useDebugger } from '../../../../../middleware/shared/providers'
 import { useDebugCompositeKey } from '../../../../hooks/use-debug-composite-key'
 import { useDebugValue, useIsDebuggerVisible } from '../../../../hooks/use-debug-value'
 import { forceDebugVariable, releaseDebugVariable } from '../../../../services/debug-force-variable'
+import { resolveScopeExpressionType } from '../../../../services/graphical-scope'
 import { useOpenPLCStore } from '../../../../store'
 import { cn } from '../../../../utils/cn'
 import { resolveArrayVariableByName } from '../../../../utils/PLC/array-variable-utils'
@@ -45,7 +46,7 @@ const VariableElement = (block: VariableProps) => {
     fbdFlows,
     fbdFlowActions: { updateNode },
     project: {
-      data: { pous, dataTypes },
+      data: { pous },
     },
   } = useOpenPLCStore()
 
@@ -211,76 +212,68 @@ const VariableElement = (block: VariableProps) => {
   }, [data.variable?.name])
 
   /**
-   * Update inputError state when the table of variables is updated
+   * Validate the variable node against its connected block pins via the
+   * STruC++ LSP. The typed value may be an instance member or struct/array
+   * access the local interface list can't resolve; `isAVariable` (yellow)
+   * means "not a known symbol", `inputError` (red) means "known but
+   * incompatible with a connection". Re-runs when the project variables or
+   * the node's own variable name change.
    */
   useEffect(() => {
-    const { node: variableNode, variables } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
-      nodeId: id,
-      variableName: variableValue,
-    })
-    if (!variableNode) return
-
-    const variable = variables.selected
-    if (!variable || !inputVariableRef) {
+    const name = data.variable?.name?.trim() ?? ''
+    if (!name) {
       setIsAVariable(false)
-    } else {
-      if (variable.name.toLowerCase() !== (variableNode as VariableNode).data.variable.name.toLowerCase()) {
-        updateNode({
-          editorName: pouName,
-          nodeId: variableNode.id,
-          node: {
-            ...variableNode,
-            data: {
-              ...variableNode.data,
-              variable: variable,
-            },
-          },
-        })
+      setInputError(false)
+      setErrorDescription('')
+      return
+    }
+    let cancelled = false
+    void resolveScopeExpressionType(pouName, name).then((res) => {
+      if (cancelled) return
+      // Leave state untouched while the LSP warms so we never flash a false flag.
+      if (res.status === 'unavailable') return
+      if (res.status === 'unknown') {
+        setIsAVariable(false)
+        setInputError(false)
+        setErrorDescription('')
+        return
+      }
+      setIsAVariable(true)
+
+      // No connections → nothing to type-check against.
+      if (!connections.length) {
+        setInputError(false)
+        setErrorDescription('')
+        return
       }
 
-      let isValid = allConnectionsType.every(
-        (connection) => validateVariableType(variable.type.value, connection.variable).isValid,
+      const resolvedType = res.type
+      const isValid = allConnectionsType.every(
+        (connection) => validateVariableType(resolvedType, connection.variable).isValid,
       )
-
-      if (!isValid && dataTypes.length > 0) {
-        const userDataTypes = dataTypes.map((dataType) => dataType.name)
-        isValid = userDataTypes.includes(variable.type.value)
-      }
-
+      setInputError(!isValid)
       if (!isValid) {
-        const validWithPrimaryConnection = validateVariableType(
-          variable.type.value,
-          primaryConnectionType.variable,
-        ).isValid
-
-        if (!validWithPrimaryConnection) {
-          setErrorDescription(
-            `Variable type ${variable.type.value} is not compatible with ${primaryConnectionType.variable.name}`,
-          )
-        } else {
-          setErrorDescription(
-            `Variable type ${variable.type.value} is not compatible with one or more connections: ${allConnectionsType
-              .map((connection) => connection.variable.name)
-              .join(', ')}`,
-          )
-        }
+        const validWithPrimaryConnection = validateVariableType(resolvedType, primaryConnectionType.variable).isValid
+        setErrorDescription(
+          validWithPrimaryConnection
+            ? `Variable type ${resolvedType} is not compatible with one or more connections: ${allConnectionsType
+                .map((connection) => connection.variable.name)
+                .join(', ')}`
+            : `Variable type ${resolvedType} is not compatible with ${primaryConnectionType.variable.name}`,
+        )
       } else {
         setErrorDescription('')
       }
-
-      if (!inputVariableRef.current?.isFocused) {
-        setVariableValue(variable.name)
-      }
-      setInputError(!isValid)
-      setIsAVariable(true)
+    })
+    return () => {
+      cancelled = true
     }
-
-    if (!connections.length) {
-      setErrorDescription('')
-      setInputError(false)
-      return
-    }
-  }, [pous])
+    // `connections`/`allConnectionsType`/`primaryConnectionType` are read from
+    // the latest render via closure; keeping them out of the dep array avoids
+    // re-run storms from their changing object identity (which would flood the
+    // single-threaded LSP worker).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pous, pouName, data.variable?.name])
 
   const getVariableType = (): string | undefined => {
     if (!data.variable || !data.variable.name) return undefined
@@ -434,17 +427,15 @@ const VariableElement = (block: VariableProps) => {
     if (!pou || !rung || !node) return
     const variableNode = node as VariableNode
 
-    // For variable nodes, allow all types including derived (user-defined types)
-    // Don't use getVariableByName here as it filters out derived types
-    let variable: PLCVariable | { name: string } | undefined =
+    // Persist the typed value: enrich with the local variable (carrying its
+    // type) when it's a plain local/array reference, otherwise store the raw
+    // name (e.g. an instance member like `TON0.Q`). The validation effect
+    // resolves and type-checks it against the full project scope.
+    const variable: PLCVariable | { name: string } =
       (pou.interface?.variables ?? []).find((v) => v.name.toLowerCase() === variableNameToSubmit.toLowerCase()) ||
-      resolveArrayVariableByName(pou.interface?.variables ?? [], variableNameToSubmit)
-    if (!variable) {
-      setIsAVariable(false)
-      variable = { name: variableNameToSubmit }
-    } else {
-      setIsAVariable(true)
-    }
+      resolveArrayVariableByName(pou.interface?.variables ?? [], variableNameToSubmit) || {
+        name: variableNameToSubmit,
+      }
 
     updateNode({
       editorName: pouName,
@@ -457,8 +448,6 @@ const VariableElement = (block: VariableProps) => {
         },
       },
     })
-
-    setInputError(false)
   }
 
   const onChangeHandler = () => {

--- a/src/frontend/components/_atoms/graphical-editor/ladder/autocomplete/index.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/autocomplete/index.tsx
@@ -1,17 +1,20 @@
 import { Node } from '@xyflow/react'
-import { ComponentPropsWithRef, forwardRef } from 'react'
+import { ComponentPropsWithRef, forwardRef, useEffect, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
 import { PLCVariable } from '../../../../../../middleware/shared/ports'
+import {
+  getScopeCompletions,
+  newVariableTypeForExpected,
+  type ScopeCompletion,
+  scopeCompletionToVariable,
+} from '../../../../../services/graphical-scope'
 import { useOpenPLCStore } from '../../../../../store'
-import { extractNumberAtEnd } from '../../../../../store/slices/project/validation/variables'
 import { cn } from '../../../../../utils/cn'
 import { getLiteralType } from '../../../../../utils/keywords'
-import { expandArrayVariables } from '../../../../../utils/PLC/array-variable-utils'
 import { toast } from '../../../../_features/[app]/toast/use-toast'
 import { useBoundPou } from '../../../../_features/[workspace]/editor/graphical/active-context'
 import { GraphicalEditorAutocomplete } from '../../autocomplete'
-import { getVariableRestrictionType } from '../../utils'
 import { getLadderPouVariablesRungNodeAndEdges } from '../utils'
 import { BasicNodeData, BlockNodeData, BlockVariant, LadderBlockConnectedVariables, VariableNode } from '../utils/types'
 
@@ -24,34 +27,24 @@ type VariablesBlockAutoCompleteProps = ComponentPropsWithRef<'div'> & {
   valueToSearch: string
 }
 
-const blockTypeRestrictions = (block: unknown, blockType: VariablesBlockAutoCompleteProps['blockType']) => {
+/**
+ * The IEC type a box accepts, used to filter LSP completions and to type a
+ * newly-created variable. Contacts/coils are BOOL; a variable node on a
+ * block pin inherits the pin's type (which may be a generic like ANY_NUM).
+ * Everything else is unconstrained.
+ */
+const expectedTypeForBlock = (
+  block: unknown,
+  blockType: VariablesBlockAutoCompleteProps['blockType'],
+): string | undefined => {
   switch (blockType) {
     case 'contact':
-      return {
-        values: ['bool'],
-        definition: 'base-type',
-        limitations: ['derived'],
-      }
-    case 'variable': {
-      const variableType = (block as VariableNode).data.block.variableType.type
-      const restriction = getVariableRestrictionType(variableType.value)
-      return {
-        ...restriction,
-        limitations: ['derived'],
-      }
-    }
     case 'coil':
-      return {
-        values: ['bool'],
-        definition: 'base-type',
-        limitations: ['derived'],
-      }
+      return 'BOOL'
+    case 'variable':
+      return (block as VariableNode).data.block.variableType.type.value
     default:
-      return {
-        values: undefined,
-        definition: undefined,
-        limitations: undefined,
-      }
+      return undefined
   }
 }
 
@@ -70,38 +63,25 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
       ladderFlowActions: { updateNode },
     } = useOpenPLCStore()
 
-    const pou = pous.find((pou) => pou.name === pouName)
-    const variables = pou?.interface?.variables ?? []
-    const variableRestrictions = blockTypeRestrictions(block, blockType)
+    const expectedType = expectedTypeForBlock(block, blockType)
 
-    const expandedVariables = expandArrayVariables(variables)
-
-    const filteredVariables =
-      blockType !== 'block'
-        ? expandedVariables
-            .filter(
-              (variable) =>
-                variable.name.toLowerCase().includes(valueToSearch.toLowerCase()) &&
-                // Variable type restrictions
-                (variableRestrictions.values === undefined ||
-                  (Array.isArray(variableRestrictions.values)
-                    ? variableRestrictions.values
-                    : [variableRestrictions.values]
-                  )
-                    .map((v) => v.toLowerCase())
-                    .includes(variable.type.value.toLowerCase())) &&
-                (variableRestrictions.limitations === undefined ||
-                  !variableRestrictions.limitations.includes(variable.type.definition)),
-            )
-            .sort((a, b) => {
-              const aNumber = extractNumberAtEnd(a.name).number
-              const bNumber = extractNumberAtEnd(b.name).number
-              if (aNumber === bNumber) {
-                return a.name.localeCompare(b.name)
-              }
-              return aNumber - bNumber
-            })
-        : []
+    // LSP-backed candidates (variables + instance/struct members in scope),
+    // filtered by the box's expected type. The block-name box has no
+    // variable autocomplete.
+    const [candidates, setCandidates] = useState<ScopeCompletion[]>([])
+    useEffect(() => {
+      if (blockType === 'block') {
+        setCandidates([])
+        return
+      }
+      let cancelled = false
+      void getScopeCompletions(pouName, valueToSearch, expectedType).then((items) => {
+        if (!cancelled) setCandidates(items)
+      })
+      return () => {
+        cancelled = true
+      }
+    }, [pouName, valueToSearch, expectedType, blockType, pous])
 
     const submitVariableToBlock = (variable: PLCVariable) => {
       const { rung, node: variableNode } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
@@ -200,23 +180,15 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
       })
       if (!rung || !node) return
 
-      const variableTypeRestriction = {
-        definition: variableRestrictions.definition || 'base-type',
-        value: variableRestrictions.values
-          ? Array.isArray(variableRestrictions.values)
-            ? variableRestrictions.values[0]
-            : variableRestrictions.values
-          : 'dint',
-      }
-      if (!variableTypeRestriction.definition || !variableTypeRestriction.value) return
+      const variableType = newVariableTypeForExpected(expectedType)
 
       const res = createVariable({
         data: {
           id: uuidv4(),
           name: variableName,
           type: {
-            definition: variableTypeRestriction.definition as 'base-type' | 'derived' | 'array' | 'user-data-type',
-            value: variableTypeRestriction.value,
+            definition: variableType.definition,
+            value: variableType.value,
           },
           class: 'local',
           location: '',
@@ -253,8 +225,8 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
 
     const submit = ({ variable }: { variable: { id: string; name: string } }) => {
       if (variable.id === 'add') {
-        // Check if the input is a literal value (e.g., 2.0, TRUE, 'hello')
-        // Literals should be submitted directly to the block, not created as variables
+        // A literal value (e.g. 2.0, TRUE, 'hello') binds directly to the
+        // block rather than creating a variable.
         if (getLiteralType(valueToSearch)) {
           submitVariableToBlock({ name: valueToSearch } as PLCVariable)
           return
@@ -263,18 +235,12 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
         return
       }
 
-      // Look up in the expanded variables list (includes array elements)
-      // This ensures we find the variable even if the filter state changed
-      const selectedVariable = expandedVariables.find(
-        (variableItem) => variableItem.name.toLowerCase() === variable.name.toLowerCase(),
-      )
-      if (!selectedVariable) {
-        // Don't create a new variable if lookup fails - this prevents accidental variable creation
-        // Variables should only be created when the user explicitly selects "Add variable"
-        return
-      }
+      // The dropdown items are LSP candidates keyed by their full insert text
+      // (e.g. `TON0.Q`); bind the node to the chosen one, carrying its type.
+      const candidate = candidates.find((c) => c.insertText.toLowerCase() === variable.name.toLowerCase())
+      if (!candidate) return
 
-      submitVariableToBlock(selectedVariable)
+      submitVariableToBlock(scopeCompletionToVariable(candidate))
     }
 
     return (
@@ -285,7 +251,7 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
         setIsOpen={setIsOpen}
         keyPressed={keyPressed}
         searchValue={valueToSearch}
-        variables={filteredVariables}
+        variables={candidates.map((c) => ({ id: c.insertText, name: c.insertText }))}
         submit={submit}
       />
     )

--- a/src/frontend/components/_atoms/graphical-editor/ladder/coil.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/coil.tsx
@@ -5,6 +5,7 @@ import { useDebugger } from '../../../../../middleware/shared/providers'
 import { useDebugCompositeKey } from '../../../../hooks/use-debug-composite-key'
 import { useDebugValue, useIsDebuggerVisible } from '../../../../hooks/use-debug-value'
 import { forceDebugVariable, releaseDebugVariable } from '../../../../services/debug-force-variable'
+import { isExpressionValidForType } from '../../../../services/graphical-scope'
 import { useOpenPLCStore } from '../../../../store'
 import { cn } from '../../../../utils/cn'
 import { useBoundPou } from '../../../_features/[workspace]/editor/graphical/active-context'
@@ -13,7 +14,7 @@ import { VariablesBlockAutoComplete } from './autocomplete'
 import { CustomHandle } from './handle'
 import { getLadderPouVariablesRungNodeAndEdges } from './utils'
 import { DEFAULT_COIL_BLOCK_HEIGHT, DEFAULT_COIL_BLOCK_WIDTH, DEFAULT_COIL_TYPES } from './utils/constants'
-import type { BasicNodeData, CoilProps } from './utils/types'
+import type { CoilProps } from './utils/types'
 
 export type { CoilNode } from './utils/types'
 
@@ -83,55 +84,22 @@ export const Coil = (block: CoilProps) => {
   }, [])
 
   /**
-   * Update wrongVariable state when the table of variables is updated
+   * Validate the coil's variable against the full project scope via the
+   * STruC++ LSP: a coil accepts any BOOL expression, including instance
+   * members (`TON0.Q`) and struct/array members the local interface list
+   * can't see. Re-runs when the project variables change or the coil's own
+   * variable name changes.
    */
   useEffect(() => {
-    const {
-      node: coilNode,
-      rung,
-      variables,
-    } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
-      nodeId: id,
+    const name = data.variable?.name?.trim() ?? ''
+    let cancelled = false
+    void isExpressionValidForType(pouName, name, 'BOOL').then((valid) => {
+      if (!cancelled) setWrongVariable(!valid)
     })
-
-    if (!rung || !coilNode) return
-
-    const canonicalVariableName = (coilNode.data as BasicNodeData).variable?.name?.trim() ?? ''
-
-    const variable = variables.all.find(
-      (v) => v.name.toLowerCase() === canonicalVariableName.toLowerCase() && v.type.definition !== 'derived',
-    )
-
-    if (!variable) {
-      setWrongVariable(true)
-      return
+    return () => {
+      cancelled = true
     }
-
-    if (variable && (variable.type.definition !== 'base-type' || variable.type.value.toUpperCase() !== 'BOOL')) {
-      setWrongVariable(true)
-      return
-    }
-
-    if ((coilNode.data as BasicNodeData).variable.name.toLowerCase() !== variable.name.toLowerCase()) {
-      setCoilVariableValue(variable.name)
-      updateNode({
-        editorName: pouName,
-        rungId: rung.id,
-        nodeId: coilNode.id,
-        node: {
-          ...coilNode,
-          data: {
-            ...coilNode.data,
-            variable,
-          },
-        },
-      })
-      setWrongVariable(false)
-      return
-    }
-
-    setWrongVariable(false)
-  }, [pous])
+  }, [pous, pouName, data.variable.name])
 
   const debuggerFillColor = (() => {
     if (!isDebuggerVisible || !data.variable.name || wrongVariable) return undefined
@@ -181,35 +149,14 @@ export const Coil = (block: CoilProps) => {
    */
   const handleSubmitCoilVariableOnTextareaBlur = (variableName?: string) => {
     const variableNameToSubmit = variableName || coilVariableValue
-    const { variables, rung, node } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+    const { rung, node } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
       nodeId: id,
       variableName: variableNameToSubmit,
     })
     if (!rung || !node) return
 
-    const variable = variables.selected
-    if (
-      !variable ||
-      variable.name !== variableNameToSubmit ||
-      variable.type.definition !== 'base-type' ||
-      variable.type.value.toUpperCase() !== 'BOOL'
-    ) {
-      updateNode({
-        editorName: pouName,
-        rungId: rung.id,
-        nodeId: node.id,
-        node: {
-          ...node,
-          data: {
-            ...node.data,
-            variable: { name: variableNameToSubmit },
-          },
-        },
-      })
-      setWrongVariable(true)
-      return
-    }
-
+    // Persist whatever the user typed; the validation effect resolves and
+    // type-checks it against the full project scope and drives the red state.
     updateNode({
       editorName: pouName,
       rungId: rung.id,
@@ -218,11 +165,10 @@ export const Coil = (block: CoilProps) => {
         ...node,
         data: {
           ...node.data,
-          variable: variable,
+          variable: { name: variableNameToSubmit },
         },
       },
     })
-    setWrongVariable(false)
   }
 
   const onChangeHandler = () => {

--- a/src/frontend/components/_atoms/graphical-editor/ladder/contact.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/contact.tsx
@@ -5,6 +5,7 @@ import { useDebugger } from '../../../../../middleware/shared/providers'
 import { useDebugCompositeKey } from '../../../../hooks/use-debug-composite-key'
 import { useDebugValue, useIsDebuggerVisible } from '../../../../hooks/use-debug-value'
 import { forceDebugVariable, releaseDebugVariable } from '../../../../services/debug-force-variable'
+import { isExpressionValidForType } from '../../../../services/graphical-scope'
 import { useOpenPLCStore } from '../../../../store'
 import { cn } from '../../../../utils/cn'
 import { useBoundPou } from '../../../_features/[workspace]/editor/graphical/active-context'
@@ -13,7 +14,7 @@ import { VariablesBlockAutoComplete } from './autocomplete'
 import { CustomHandle } from './handle'
 import { getLadderPouVariablesRungNodeAndEdges } from './utils'
 import { DEFAULT_CONTACT_BLOCK_HEIGHT, DEFAULT_CONTACT_BLOCK_WIDTH, DEFAULT_CONTACT_TYPES } from './utils/constants'
-import type { BasicNodeData, ContactProps } from './utils/types'
+import type { ContactProps } from './utils/types'
 
 export type { ContactNode } from './utils/types'
 
@@ -84,53 +85,22 @@ export const Contact = (block: ContactProps) => {
   }, [])
 
   /**
-   * Update wrongVariable state when the table of variables is updated
+   * Validate the contact's variable against the full project scope via the
+   * STruC++ LSP: a contact accepts any BOOL expression, including instance
+   * members (`TON0.Q`) and struct/array members the local interface list
+   * can't see. Re-runs when the project variables change or the contact's
+   * own variable name changes.
    */
   useEffect(() => {
-    const {
-      node: contactNode,
-      rung,
-      variables,
-    } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
-      nodeId: id,
+    const name = data.variable?.name?.trim() ?? ''
+    let cancelled = false
+    void isExpressionValidForType(pouName, name, 'BOOL').then((valid) => {
+      if (!cancelled) setWrongVariable(!valid)
     })
-    if (!rung || !contactNode) return
-
-    const canonicalVariableName = (contactNode.data as BasicNodeData).variable?.name?.trim() ?? ''
-
-    const variable = variables.all.find(
-      (v) => v.name.toLowerCase() === canonicalVariableName.toLowerCase() && v.type.definition !== 'derived',
-    )
-
-    if (!variable) {
-      setWrongVariable(true)
-      return
+    return () => {
+      cancelled = true
     }
-    if (variable && (variable.type.definition !== 'base-type' || variable.type.value.toUpperCase() !== 'BOOL')) {
-      setWrongVariable(true)
-      return
-    }
-
-    if ((contactNode.data as BasicNodeData).variable.name.toLowerCase() !== variable.name.toLowerCase()) {
-      updateNode({
-        editorName: pouName,
-        rungId: rung.id,
-        nodeId: contactNode.id,
-        node: {
-          ...contactNode,
-          data: {
-            ...contactNode.data,
-            variable,
-          },
-        },
-      })
-      setContactVariableValue(variable.name)
-      setWrongVariable(false)
-      return
-    }
-
-    setWrongVariable(false)
-  }, [pous])
+  }, [pous, pouName, data.variable.name])
 
   const debuggerStrokeColor = (() => {
     if (!isDebuggerVisible || !data.variable.name || wrongVariable) return undefined
@@ -180,35 +150,14 @@ export const Contact = (block: ContactProps) => {
    */
   const handleSubmitContactVariableOnTextareaBlur = (variableName?: string) => {
     const variableNameToSubmit = variableName || contactVariableValue
-    const { rung, node, variables } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+    const { rung, node } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
       nodeId: id,
       variableName: variableNameToSubmit,
     })
     if (!rung || !node) return
 
-    const variable = variables.selected
-    if (
-      !variable ||
-      variable.name !== variableNameToSubmit ||
-      variable.type.definition !== 'base-type' ||
-      variable.type.value.toUpperCase() !== 'BOOL'
-    ) {
-      updateNode({
-        editorName: pouName,
-        rungId: rung.id,
-        nodeId: node.id,
-        node: {
-          ...node,
-          data: {
-            ...node.data,
-            variable: { name: variableNameToSubmit },
-          },
-        },
-      })
-      setWrongVariable(true)
-      return
-    }
-
+    // Persist whatever the user typed; the validation effect resolves and
+    // type-checks it against the full project scope and drives the red state.
     updateNode({
       editorName: pouName,
       rungId: rung.id,
@@ -217,11 +166,10 @@ export const Contact = (block: ContactProps) => {
         ...node,
         data: {
           ...node.data,
-          variable,
+          variable: { name: variableNameToSubmit },
         },
       },
     })
-    setWrongVariable(false)
   }
 
   const onChangeHandler = () => {

--- a/src/frontend/components/_atoms/graphical-editor/ladder/variable.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/variable.tsx
@@ -6,6 +6,7 @@ import { useDebugger } from '../../../../../middleware/shared/providers'
 import { useDebugCompositeKey } from '../../../../hooks/use-debug-composite-key'
 import { useDebugValue, useIsDebuggerVisible } from '../../../../hooks/use-debug-value'
 import { forceDebugVariable, releaseDebugVariable } from '../../../../services/debug-force-variable'
+import { resolveScopeExpressionType } from '../../../../services/graphical-scope'
 import { useOpenPLCStore } from '../../../../store'
 import { RungLadderState } from '../../../../store/slices/ladder'
 import { cn } from '../../../../utils/cn'
@@ -35,7 +36,7 @@ const VariableElement = (block: VariableProps) => {
   const pouName = useBoundPou()
   const {
     project: {
-      data: { pous, dataTypes },
+      data: { pous },
     },
     ladderFlows,
     ladderFlowActions: { updateNode },
@@ -126,74 +127,37 @@ const VariableElement = (block: VariableProps) => {
   }, [data.variable?.name])
 
   /**
-   * Update inputError state when the table of variables is updated
+   * Validate the variable node against the block pin's expected type via the
+   * STruC++ LSP. The pin type may be a generic (ANY_NUM, …) and the typed
+   * value may be an instance member or struct/array access the local
+   * interface list can't resolve. `isAVariable` (yellow) means "not a known
+   * symbol"; `inputError` (red) means "known but type-incompatible".
    */
   useEffect(() => {
-    const { node: variableNode, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
-      nodeId: id,
-      variableName: data.variable?.name,
-    })
-    if (!rung || !variableNode) return
-
-    // Use the node's current variable name (from the store) as the source of truth.
-    // The prop `data.variable?.name` may be stale during React's render cycle, so
-    // looking up the POU variable by the node's actual name avoids overwriting
-    // user-initiated changes (selection, clearing) with stale prop values.
-    const nodeVariableName = (variableNode as VariableNode).data.variable.name
-    const nodeVarRef = (variableNode as VariableNode).data.variable
-
-    if (!nodeVariableName) {
+    const name = data.variable?.name?.trim() ?? ''
+    if (!name) {
       setIsAVariable(false)
+      setInputError(false)
       return
     }
-
-    // Find the POU variable that matches the node's current variable name
-    const pouVariables = pous.find((p) => p.name === pouName)?.interface?.variables ?? []
-    const variable = pouVariables.find((v) => v.name.toLowerCase() === nodeVariableName.toLowerCase())
-
-    if (!variable || !inputVariableRef) {
-      setIsAVariable(false)
-    } else {
-      const namesMatchCI = variable.name.toLowerCase() === nodeVariableName.toLowerCase()
-      const caseDiffers = variable.name !== nodeVariableName
-      const refStale = nodeVarRef !== variable
-
-      if (!namesMatchCI || caseDiffers || refStale) {
-        updateNode({
-          editorName: pouName,
-          rungId: rung.id,
-          nodeId: variableNode.id,
-          node: {
-            ...variableNode,
-            data: {
-              ...variableNode.data,
-              variable: variable,
-            },
-          },
-        })
-        updateRelatedNode(rung, variableNode as VariableNode, variable)
+    let cancelled = false
+    void resolveScopeExpressionType(pouName, name).then((res) => {
+      if (cancelled) return
+      // Leave the current state untouched while the LSP is still warming so
+      // we never flash a false error/warning during boot.
+      if (res.status === 'unavailable') return
+      if (res.status === 'unknown') {
+        setIsAVariable(false)
+        setInputError(false)
+        return
       }
-
-      const validation = validateVariableType(variable.type.value, data.block.variableType)
-      if (!validation.isValid && dataTypes.length > 0) {
-        const userDataTypes = dataTypes.map((dataType) => dataType.name)
-        validation.isValid = userDataTypes.includes(variable.type.value)
-        validation.error = undefined
-      }
-      // Only sync variableValue when not actively editing (autocomplete closed)
-      if (!openAutocomplete) {
-        setVariableValue(variable.name)
-      }
-      setInputError(!validation.isValid)
       setIsAVariable(true)
+      setInputError(!validateVariableType(res.type, data.block.variableType).isValid)
+    })
+    return () => {
+      cancelled = true
     }
-
-    const relatedBlock = rung.nodes.find((node) => node.id === data.block.id)
-    if (!relatedBlock) {
-      setInputError(true)
-      return
-    }
-  }, [pous, data.variable?.name])
+  }, [pous, pouName, data.variable?.name, data.block.variableType.type.value])
 
   /**
    * Handle with the variable input onBlur event

--- a/src/frontend/services/graphical-scope.ts
+++ b/src/frontend/services/graphical-scope.ts
@@ -53,10 +53,7 @@ export interface ScopeCompletion {
  *     in scope — the box is invalid.
  *   - `resolved`: the expression resolves to `type`.
  */
-export type ScopeTypeResult =
-  | { status: 'unavailable' }
-  | { status: 'unknown' }
-  | { status: 'resolved'; type: string }
+export type ScopeTypeResult = { status: 'unavailable' } | { status: 'unknown' } | { status: 'resolved'; type: string }
 
 /** Split `value` into the completion anchor (up to and including the last `.`) and the trailing segment. */
 function splitExpression(value: string): { anchor: string; segment: string } {
@@ -95,9 +92,7 @@ export async function getScopeCompletions(
   const { anchor, segment } = splitExpression(value)
   const items = await api.completeInScope(pouName, anchor)
   const needle = segment.toLowerCase()
-  const matching = items.filter(
-    (item) => item.kind === LSP_KIND_VARIABLE && item.label.toLowerCase().includes(needle),
-  )
+  const matching = items.filter((item) => item.kind === LSP_KIND_VARIABLE && item.label.toLowerCase().includes(needle))
 
   const direct = matching
     .filter((item) => {
@@ -151,9 +146,7 @@ export async function resolveScopeExpressionType(pouName: string, expression: st
   if (items.length === 0) return { status: 'unavailable' }
 
   const { name, indexed } = stripSubscript(segment)
-  const match = items.find(
-    (item) => item.kind === LSP_KIND_VARIABLE && item.label.toLowerCase() === name.toLowerCase(),
-  )
+  const match = items.find((item) => item.kind === LSP_KIND_VARIABLE && item.label.toLowerCase() === name.toLowerCase())
   if (!match || !match.type) return { status: 'unknown' }
 
   if (indexed) {

--- a/src/frontend/services/graphical-scope.ts
+++ b/src/frontend/services/graphical-scope.ts
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+/**
+ * Variable resolution for the graphical (LD / FBD) editors, backed by the
+ * STruC++ LSP.
+ *
+ * The graphical variable boxes used to filter a flat list of the POU's
+ * local `interface.variables` by a hardcoded type map. That couldn't see
+ * instance members (`TON0.Q`), struct/enum members or anything the type
+ * system knows. This module replaces it with the same intelligence the ST
+ * editor gets: it asks strucpp to complete an expression in the POU's
+ * scope (see `st-lsp/scoped-query`), keeps the real variables/members
+ * (LSP `Variable` kind, which carry a resolved IEC type), and filters them
+ * by the box's expected type via {@link validateVariableType}.
+ *
+ * Two entry points, sharing the same machinery:
+ *   - {@link getScopeCompletions} — autocomplete candidates for a box.
+ *   - {@link resolveScopeExpressionType} — the type of a typed-in
+ *     expression, for red/valid validation.
+ */
+
+import type { PLCVariable } from '../../middleware/shared/ports/types'
+import { getVariableRestrictionType, validateVariableType } from '../utils/PLC/validate-variable-type'
+import { getScopedQueryApi } from './st-lsp'
+
+/** LSP `CompletionItemKind.Variable` — strucpp's kind for in-scope variables and instance/struct members. */
+const LSP_KIND_VARIABLE = 6
+
+/** Max instance/struct variables to drill into when a type-filtered search has no direct hits. */
+const SCOPE_EXPAND_LIMIT = 8
+
+/** True for an instance/struct/enum (non-base) type — i.e. one that may expose dotted members. */
+function isDerivedType(type: string): boolean {
+  return getVariableRestrictionType(type).definition === 'derived'
+}
+
+/** A single autocomplete candidate for a graphical variable box. */
+export interface ScopeCompletion {
+  /** Symbol/member name as shown in the dropdown (e.g. `Q`, `Moisture`). */
+  label: string
+  /** Full text to write into the box — the resolved anchor prefix plus the label (e.g. `TON0.Q`). */
+  insertText: string
+  /** Resolved IEC type, when strucpp provided one. */
+  type?: string
+}
+
+/**
+ * Outcome of resolving an expression's type:
+ *   - `unavailable`: the LSP couldn't answer (not ready / no context) —
+ *     callers should NOT flag the box invalid (avoids a false red during
+ *     boot or while the worker warms).
+ *   - `unknown`: the LSP answered but the expression isn't a valid symbol
+ *     in scope — the box is invalid.
+ *   - `resolved`: the expression resolves to `type`.
+ */
+export type ScopeTypeResult =
+  | { status: 'unavailable' }
+  | { status: 'unknown' }
+  | { status: 'resolved'; type: string }
+
+/** Split `value` into the completion anchor (up to and including the last `.`) and the trailing segment. */
+function splitExpression(value: string): { anchor: string; segment: string } {
+  const lastDot = value.lastIndexOf('.')
+  if (lastDot < 0) return { anchor: '', segment: value }
+  return { anchor: value.slice(0, lastDot + 1), segment: value.slice(lastDot + 1) }
+}
+
+/** Strip a trailing array subscript (`foo[3]` → `foo`). Returns the name and whether a subscript was present. */
+function stripSubscript(segment: string): { name: string; indexed: boolean } {
+  const bracket = segment.indexOf('[')
+  if (bracket < 0) return { name: segment, indexed: false }
+  return { name: segment.slice(0, bracket), indexed: true }
+}
+
+/** Pull the element type out of an `ARRAY [..] OF <type>` detail string. */
+function arrayElementType(type: string): string | undefined {
+  const match = type.match(/\bOF\s+([A-Za-z_][A-Za-z0-9_]*)/i)
+  return match ? match[1] : undefined
+}
+
+/**
+ * Autocomplete candidates for `value` typed into a box in `pouName`'s
+ * scope. `value` is the full current box text (e.g. `TON0.Q`, `mo`).
+ * When `expectedType` is given, only candidates whose resolved type is
+ * compatible with it are returned. Returns [] when the LSP is unavailable.
+ */
+export async function getScopeCompletions(
+  pouName: string,
+  value: string,
+  expectedType?: string,
+): Promise<ScopeCompletion[]> {
+  const api = getScopedQueryApi()
+  if (!api) return []
+
+  const { anchor, segment } = splitExpression(value)
+  const items = await api.completeInScope(pouName, anchor)
+  const needle = segment.toLowerCase()
+  const matching = items.filter(
+    (item) => item.kind === LSP_KIND_VARIABLE && item.label.toLowerCase().includes(needle),
+  )
+
+  const direct = matching
+    .filter((item) => {
+      if (!expectedType) return true
+      if (!item.type) return false
+      return validateVariableType(item.type, expectedType).isValid
+    })
+    .map((item) => ({
+      label: item.label,
+      insertText: anchor + item.label,
+      ...(item.type ? { type: item.type } : {}),
+    }))
+
+  // When a type-filtered search yields no direct hits, the user may be
+  // reaching for a member of an instance/struct whose own type doesn't match
+  // the box (e.g. `TO` on a BOOL contact: `TON0` is a TON, but `TON0.Q` is
+  // BOOL). Drill one level into the matching instance/struct variables and
+  // surface their compatible members. Gated on "no direct hits" + capped, so
+  // the extra LSP round-trips stay rare and bounded.
+  if (!expectedType || direct.length > 0) return direct
+
+  const expandable = matching.filter((item) => item.type && isDerivedType(item.type)).slice(0, SCOPE_EXPAND_LIMIT)
+  const expanded = await Promise.all(
+    expandable.map(async (instance) => {
+      const memberAnchor = `${anchor}${instance.label}.`
+      const members = await api.completeInScope(pouName, memberAnchor)
+      return members
+        .filter((m) => m.kind === LSP_KIND_VARIABLE && m.type && validateVariableType(m.type, expectedType).isValid)
+        .map((m) => ({ label: `${instance.label}.${m.label}`, insertText: memberAnchor + m.label, type: m.type }))
+    }),
+  )
+  return expanded.flat()
+}
+
+/**
+ * Resolve the IEC type of `expression` in `pouName`'s scope. Handles bare
+ * identifiers, member chains (`TON0.Q`, `s.a.b`) and 1-D array element
+ * access (`arr[3]`). See {@link ScopeTypeResult} for the tri-state result.
+ */
+export async function resolveScopeExpressionType(pouName: string, expression: string): Promise<ScopeTypeResult> {
+  const api = getScopedQueryApi()
+  if (!api) return { status: 'unavailable' }
+
+  const expr = expression.trim()
+  if (!expr) return { status: 'unknown' }
+
+  const { anchor, segment } = splitExpression(expr)
+  const items = await api.completeInScope(pouName, anchor)
+  // Empty even after the service's warm-up retries means the worker has no
+  // context yet — treat as unavailable rather than flag a false invalid.
+  if (items.length === 0) return { status: 'unavailable' }
+
+  const { name, indexed } = stripSubscript(segment)
+  const match = items.find(
+    (item) => item.kind === LSP_KIND_VARIABLE && item.label.toLowerCase() === name.toLowerCase(),
+  )
+  if (!match || !match.type) return { status: 'unknown' }
+
+  if (indexed) {
+    const element = arrayElementType(match.type)
+    return element ? { status: 'resolved', type: element } : { status: 'unknown' }
+  }
+  return { status: 'resolved', type: match.type }
+}
+
+/**
+ * Convenience for validation: does `expression` resolve to a type
+ * compatible with `expectedType`? `unavailable` resolves to `true` so the
+ * caller doesn't paint a false invalid while the LSP is warming.
+ */
+export async function isExpressionValidForType(
+  pouName: string,
+  expression: string,
+  expectedType: string,
+): Promise<boolean> {
+  const result = await resolveScopeExpressionType(pouName, expression)
+  if (result.status === 'unavailable') return true
+  if (result.status === 'unknown') return false
+  return validateVariableType(result.type, expectedType).isValid
+}
+
+/** Concrete `{definition, value}` to type a brand-new variable created from a box's expected type. */
+export function newVariableTypeForExpected(expectedType: string | undefined): {
+  definition: PLCVariable['type']['definition']
+  value: string
+} {
+  if (!expectedType) return { definition: 'base-type', value: 'dint' }
+  const restriction = getVariableRestrictionType(expectedType)
+  const value = restriction.values
+    ? Array.isArray(restriction.values)
+      ? restriction.values[0]
+      : restriction.values
+    : 'dint'
+  return { definition: (restriction.definition as PLCVariable['type']['definition']) ?? 'base-type', value }
+}
+
+/** Build the variable reference a graphical node stores when an LSP completion is chosen. */
+export function scopeCompletionToVariable(candidate: ScopeCompletion): PLCVariable {
+  const restriction = candidate.type ? getVariableRestrictionType(candidate.type) : undefined
+  const value = restriction?.values
+    ? Array.isArray(restriction.values)
+      ? restriction.values[0]
+      : restriction.values
+    : (candidate.type ?? '')
+  return {
+    id: '',
+    name: candidate.insertText,
+    type: {
+      definition: (restriction?.definition as PLCVariable['type']['definition']) ?? 'base-type',
+      value,
+    },
+    class: 'local',
+    location: '',
+    documentation: '',
+    debug: false,
+  } as PLCVariable
+}

--- a/src/frontend/services/st-lsp/completion-type.ts
+++ b/src/frontend/services/st-lsp/completion-type.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+/**
+ * Extract the IEC type of a strucpp completion item.
+ *
+ * strucpp surfaces a symbol's type through the LSP completion item's
+ * `detail` field. The exact shape is confirmed empirically against the
+ * worker (see the scoped-query probe); this parser is intentionally
+ * tolerant of the common renderings so a format tweak in the worker
+ * degrades to "type unknown" rather than a wrong type.
+ */
+
+/**
+ * Pull the type token out of a completion item's `detail`.
+ *
+ * Handles the shapes strucpp emits, e.g.:
+ *   - `BOOL`                         → `BOOL`
+ *   - `Q : BOOL`                     → `BOOL`
+ *   - `VAR_OUTPUT Q : BOOL`          → `BOOL`
+ *   - `my_struct : MyStruct`         → `MyStruct`
+ *   - `(variable) TON0 : TON`        → `TON`
+ *
+ * Returns undefined when no plausible type can be recovered.
+ */
+export function parseScopedCompletionType(detail: string | undefined): string | undefined {
+  if (!detail) return undefined
+  const trimmed = detail.trim()
+  if (!trimmed) return undefined
+
+  // Prefer the segment after the last ` : ` — that's where ST renders a
+  // declaration's type (`name : TYPE`). Fall back to the whole string.
+  const colonIdx = trimmed.lastIndexOf(':')
+  const candidate = (colonIdx >= 0 ? trimmed.slice(colonIdx + 1) : trimmed).trim()
+  if (!candidate) return undefined
+
+  // The type may be followed by array/length qualifiers (`ARRAY[..]`,
+  // `STRING[80]`) — keep the leading identifier, which is what we match
+  // for type compatibility.
+  const match = candidate.match(/^[A-Za-z_][A-Za-z0-9_]*/)
+  return match ? match[0] : undefined
+}

--- a/src/frontend/services/st-lsp/index.ts
+++ b/src/frontend/services/st-lsp/index.ts
@@ -243,9 +243,7 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
     return result
   }
 
-  function normalizeCompletionItems(
-    result: CompletionList | LspCompletionItem[] | null,
-  ): ScopedCompletionItem[] {
+  function normalizeCompletionItems(result: CompletionList | LspCompletionItem[] | null): ScopedCompletionItem[] {
     if (!result) return []
     const items = Array.isArray(result) ? result : result.items
     return items.map((item) => {

--- a/src/frontend/services/st-lsp/index.ts
+++ b/src/frontend/services/st-lsp/index.ts
@@ -25,9 +25,17 @@
  * disposed only at shutdown.
  */
 
-import type { Diagnostic, Location as LspLocation, MessageConnection } from 'vscode-languageserver-protocol'
+import {
+  type CompletionItem as LspCompletionItem,
+  type CompletionList,
+  CompletionRequest,
+  type Diagnostic,
+  type Location as LspLocation,
+  type MessageConnection,
+} from 'vscode-languageserver-protocol'
 
 import { openPLCStoreBase } from '../../store'
+import { serializePouScopeForQuery } from '../../utils/PLC/pou-signature-serializer'
 import {
   getBodyLineOffset,
   type LanguageService,
@@ -36,8 +44,10 @@ import {
   startLanguageService,
   suppressNoDefinitionFound,
 } from '../lsp-shared'
+import { parseScopedCompletionType } from './completion-type'
 import { redirectDefinitionToStore } from './goto-definition-redirect'
 import { redirectToGraphicalPou } from './graphical-redirect'
+import { registerScopedQueryApi, type ScopedCompletionItem } from './scoped-query'
 import {
   parsePouUri,
   parsePouVarsUri,
@@ -184,6 +194,178 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
     ...(onCrash ? { onCrash } : {}),
   })
 
+  // ---------------------------------------------------------------------------
+  // Scoped completion for the graphical (LD/FBD) editors.
+  //
+  // Synthesize a throwaway ST doc that puts `prefix` in the POU's scope,
+  // ask strucpp for completions there, and return candidates carrying
+  // their resolved IEC type. A fresh URI per call avoids races between
+  // concurrent queries (many variable boxes validate at once).
+  // ---------------------------------------------------------------------------
+  const SCOPE_QUERY_MAX_ATTEMPTS = 2
+  const SCOPE_QUERY_RETRY_MS = 120
+  const SCOPE_QUERY_TIMEOUT_MS = 3000
+  const SCOPE_QUERY_DEFERRED_CLOSE_MS = 8000
+  const SCOPE_QUERY_TIMEOUT = Symbol('scope-query-timeout')
+  const SCOPE_WARMUP_POLL_MS = 500
+  const SCOPE_WARMUP_MAX_POLLS = 60
+  // Delay the first warm-up probe so the project-sync didOpen flood (every POU
+  // stub at boot) settles first — probing the worker while it's churning those
+  // is what wedges it.
+  const SCOPE_WARMUP_INITIAL_DELAY_MS = 3500
+  let scopeQuerySeq = 0
+
+  // Firing a scope query while the worker is still doing its initial project
+  // analysis (cold) wedges it permanently. So we gate all component-driven
+  // queries behind a warm-up: a single background prober (sequential, the only
+  // querier while cold) keeps trying until the worker returns results, then
+  // resolves `scopeWarmReady`. `completeInScope` awaits that before touching
+  // the worker, so a screenful of boxes mounting cold just parks until warm
+  // instead of stampeding the cold worker.
+  let resolveScopeWarmReady: () => void = () => undefined
+  const scopeWarmReady = new Promise<void>((resolve) => {
+    resolveScopeWarmReady = resolve
+  })
+
+  // Opening a graphical editor mounts many variable boxes that each query at
+  // once. The worker is single-threaded, so we (a) coalesce identical
+  // in-flight queries and (b) serialize execution to one request at a time —
+  // without this, a screenful of boxes floods the worker and stalls it.
+  const inFlightScopeQueries = new Map<string, Promise<ScopedCompletionItem[]>>()
+  let scopeQueryTail: Promise<unknown> = Promise.resolve()
+
+  function runScopeQuerySerialized<T>(task: () => Promise<T>): Promise<T> {
+    const result = scopeQueryTail.then(task, task)
+    scopeQueryTail = result.then(
+      () => undefined,
+      () => undefined,
+    )
+    return result
+  }
+
+  function normalizeCompletionItems(
+    result: CompletionList | LspCompletionItem[] | null,
+  ): ScopedCompletionItem[] {
+    if (!result) return []
+    const items = Array.isArray(result) ? result : result.items
+    return items.map((item) => {
+      const insertText =
+        item.textEdit && 'newText' in item.textEdit ? item.textEdit.newText : (item.insertText ?? item.label)
+      return {
+        label: item.label,
+        insertText,
+        ...(parseScopedCompletionType(item.detail) !== undefined
+          ? { type: parseScopedCompletionType(item.detail) }
+          : {}),
+        ...(item.kind !== undefined ? { kind: item.kind } : {}),
+        ...(item.detail !== undefined ? { detail: item.detail } : {}),
+      }
+    })
+  }
+
+  async function requestOnce(
+    connection: MessageConnection,
+    uri: string,
+    text: string,
+    position: { line: number; character: number },
+  ): Promise<ScopedCompletionItem[]> {
+    sharedService.openDocument(uri, text)
+    try {
+      // Race against a timeout so a stalled worker request can never freeze
+      // the caller (validation runs in component effects).
+      const result = await Promise.race([
+        connection.sendRequest(CompletionRequest.type, { textDocument: { uri }, position }),
+        new Promise<typeof SCOPE_QUERY_TIMEOUT>((resolve) =>
+          setTimeout(() => resolve(SCOPE_QUERY_TIMEOUT), SCOPE_QUERY_TIMEOUT_MS),
+        ),
+      ])
+      if (result === SCOPE_QUERY_TIMEOUT) {
+        // The worker is still analysing this doc — closing it now (mid-analysis)
+        // wedges the worker. Defer the close until analysis has surely finished.
+        setTimeout(() => sharedService.closeDocument(uri), SCOPE_QUERY_DEFERRED_CLOSE_MS)
+        return []
+      }
+      // Completion returned → analysis settled → safe to close immediately.
+      sharedService.closeDocument(uri)
+      return normalizeCompletionItems(result)
+    } catch {
+      sharedService.closeDocument(uri)
+      return []
+    }
+  }
+
+  async function runScopeQuery(pouName: string, prefix: string): Promise<ScopedCompletionItem[]> {
+    // Park until the worker is warm — querying it cold wedges it permanently.
+    await scopeWarmReady
+    const connection = serviceConnection
+    if (!connection) return []
+    const pou = openPLCStoreBase.getState().project.data.pous.find((p) => p.name === pouName)
+    if (!pou) return []
+
+    // Once warm, fresh per-query docs resolve instantly; a single short retry
+    // covers a rare transient miss. Each attempt uses a unique URI + unique
+    // synthetic POU name so docs never collide.
+    for (let attempt = 0; attempt < SCOPE_QUERY_MAX_ATTEMPTS; attempt += 1) {
+      const id = (scopeQuerySeq += 1)
+      const { text, position } = serializePouScopeForQuery(pou, prefix, id)
+      const uri = `inmemory://scopequery/${id}.st`
+      const items = await requestOnce(connection, uri, text, position)
+      if (items.length > 0) return items
+      if (attempt < SCOPE_QUERY_MAX_ATTEMPTS - 1) {
+        await new Promise((r) => setTimeout(r, SCOPE_QUERY_RETRY_MS))
+      }
+    }
+    return []
+  }
+
+  function completeInScope(pouName: string, prefix: string): Promise<ScopedCompletionItem[]> {
+    const key = `${pouName} ${prefix}`
+    const existing = inFlightScopeQueries.get(key)
+    if (existing) return existing
+    const query = runScopeQuerySerialized(() => runScopeQuery(pouName, prefix)).finally(() => {
+      inFlightScopeQueries.delete(key)
+    })
+    inFlightScopeQueries.set(key, query)
+    return query
+  }
+
+  // Background warm-up: the ONLY querier while the worker is cold. Probes a
+  // real POU sequentially until it returns results, then unblocks every parked
+  // component query. Resolves anyway after a bounded number of polls so the
+  // feature degrades to best-effort rather than hanging forever.
+  async function warmUpScopeWorker(): Promise<void> {
+    try {
+      await sharedService.ready
+    } catch {
+      resolveScopeWarmReady()
+      return
+    }
+    const connection = serviceConnection
+    if (!connection) {
+      resolveScopeWarmReady()
+      return
+    }
+    await new Promise((r) => setTimeout(r, SCOPE_WARMUP_INITIAL_DELAY_MS))
+    for (let poll = 0; poll < SCOPE_WARMUP_MAX_POLLS; poll += 1) {
+      const pou = openPLCStoreBase.getState().project.data.pous[0]
+      if (pou) {
+        const id = (scopeQuerySeq += 1)
+        const { text, position } = serializePouScopeForQuery(pou, '', id)
+        const uri = `inmemory://scopequery/warmup-${id}.st`
+        const items = await requestOnce(connection, uri, text, position)
+        if (items.length > 0) {
+          resolveScopeWarmReady()
+          return
+        }
+      }
+      await new Promise((r) => setTimeout(r, SCOPE_WARMUP_POLL_MS))
+    }
+    resolveScopeWarmReady()
+  }
+
+  registerScopedQueryApi({ completeInScope })
+  void warmUpScopeWorker()
+
   async function pushAllStlibs(connection: MessageConnection): Promise<void> {
     const sources = await stlibSource.listStlibs()
     // Honor the project's enabled-library set, plus the always-on
@@ -248,10 +430,12 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
     },
 
     dispose() {
+      registerScopedQueryApi(null)
       sharedService.dispose()
     },
   }
 }
 
+export { getScopedQueryApi, type ScopedCompletionItem, type ScopedQueryApi } from './scoped-query'
 export type { StLspService, StLspStartOptions } from './types'
 export { parsePouUri, POU_URI_SCHEME, pouUri, stubUri } from './types'

--- a/src/frontend/services/st-lsp/scoped-query.ts
+++ b/src/frontend/services/st-lsp/scoped-query.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+/**
+ * Scoped completion / type-resolution backed by the STruC++ LSP, for the
+ * graphical (LD / FBD) editors.
+ *
+ * Graphical POUs have no ST body the LSP can see (their stub body is
+ * opaque), so the graphical variable boxes can't use the normal Monaco
+ * completion path. Instead this module drives the LSP directly: it
+ * synthesizes a throwaway ST document that puts a partial expression in
+ * the scope of the POU's real declarations, asks strucpp for completions
+ * at that position, and returns the candidates — each carrying the IEC
+ * type strucpp resolved for it. The graphical editors then filter those
+ * candidates by the box's expected type and reuse the result for both
+ * autocomplete and red/valid validation.
+ *
+ * The concrete implementation lives in `st-lsp/index.ts` (where the LSP
+ * connection + document API are in scope) and registers itself here at
+ * service start. Consumers reach it through {@link getScopedQueryApi};
+ * when the LSP isn't available (tests, boot races, worker crash) the API
+ * is null and callers degrade gracefully (no suggestions / skip
+ * validation rather than false-flag).
+ */
+
+/** A single completion candidate resolved in a POU's scope. */
+export interface ScopedCompletionItem {
+  /** Display name of the symbol/member (e.g. `Q`, `MyVar`). */
+  label: string
+  /** Text to insert when this candidate is chosen. */
+  insertText: string
+  /**
+   * The IEC type strucpp resolved for this candidate (e.g. `BOOL`,
+   * `INT`, `TON`, a user struct/enum name), or undefined when strucpp
+   * supplied no parseable type (e.g. keywords).
+   */
+  type?: string
+  /** Raw LSP completion-item kind, when present. */
+  kind?: number
+  /** Raw LSP `detail` string, retained for debugging / fallback. */
+  detail?: string
+}
+
+export interface ScopedQueryApi {
+  /**
+   * Completions for `prefix` evaluated in `pouName`'s scope. `prefix` is
+   * the partial expression up to the cursor (e.g. `TON0.`, `my_struct.`,
+   * or a bare partial like `to`). Returns [] if the LSP can't answer.
+   */
+  completeInScope(pouName: string, prefix: string): Promise<ScopedCompletionItem[]>
+}
+
+let api: ScopedQueryApi | null = null
+
+/** Register (or clear, with null) the scoped-query implementation. Called by the LSP service. */
+export function registerScopedQueryApi(next: ScopedQueryApi | null): void {
+  api = next
+}
+
+/** The active scoped-query API, or null when the LSP isn't available. */
+export function getScopedQueryApi(): ScopedQueryApi | null {
+  return api
+}

--- a/src/frontend/utils/PLC/__tests__/pou-signature-serializer.test.ts
+++ b/src/frontend/utils/PLC/__tests__/pou-signature-serializer.test.ts
@@ -1,5 +1,10 @@
 import type { PLCPou } from '../../../../middleware/shared/ports/types'
-import { OPAQUE_BODY_PLACEHOLDER, serializePouSignatureToST } from '../pou-signature-serializer'
+import {
+  OPAQUE_BODY_PLACEHOLDER,
+  SCOPE_QUERY_POU_NAME,
+  serializePouScopeForQuery,
+  serializePouSignatureToST,
+} from '../pou-signature-serializer'
 
 function makePou(overrides: Partial<PLCPou> = {}): PLCPou {
   return {
@@ -155,6 +160,53 @@ describe('serializePouSignatureToST', () => {
       expect(inputSlice).toContain('in1')
       expect(inputSlice).not.toContain('out1')
       expect(inputSlice).not.toContain('state')
+    })
+  })
+
+  describe('serializePouScopeForQuery', () => {
+    it('wraps the partial expression in the POU scope with a throwaway name', () => {
+      const pou = makePou({
+        name: 'Irrigation',
+        pouType: 'function-block',
+        interface: FB_VARIABLES,
+        body: { language: 'ld', value: {} as never },
+      })
+      const { text, position } = serializePouScopeForQuery(pou, 'in1.')
+      // Emits the POU's real kind + a throwaway name (not the real one).
+      expect(text).toMatch(new RegExp(`^FUNCTION_BLOCK ${SCOPE_QUERY_POU_NAME}\\b`, 'm'))
+      expect(text).not.toContain('FUNCTION_BLOCK Irrigation')
+      // VAR sections + the partial expression as the body line.
+      expect(text).toContain('in1 : BOOL;')
+      expect(text).toContain('in1.')
+      expect(text).toContain('END_FUNCTION_BLOCK')
+      // Cursor sits at the end of the body expression.
+      expect(position.character).toBe('in1.'.length)
+      // The body line is after the declaration + VAR blocks.
+      expect(text.split('\n')[position.line]).toBe('in1.')
+    })
+
+    it('keeps the function return type while swapping only the name', () => {
+      const pou = makePou({
+        name: 'AbsInt',
+        pouType: 'function',
+        interface: { returnType: 'INT', variables: [] },
+        body: { language: 'st', value: '' },
+      })
+      const { text } = serializePouScopeForQuery(pou, 'x')
+      expect(text).toMatch(new RegExp(`^FUNCTION ${SCOPE_QUERY_POU_NAME} : INT\\b`, 'm'))
+      expect(text).toMatch(/END_FUNCTION\b/m)
+    })
+
+    it('omits the return type for a program', () => {
+      const pou = makePou({ name: 'MainProg', pouType: 'program', interface: { variables: [] } })
+      const { text } = serializePouScopeForQuery(pou, '')
+      expect(text).toMatch(new RegExp(`^PROGRAM ${SCOPE_QUERY_POU_NAME}$`, 'm'))
+    })
+
+    it('makes the synthetic POU name unique when a uniqueId is given', () => {
+      const pou = makePou({ name: 'Foo', pouType: 'function-block', interface: { variables: [] } })
+      const { text } = serializePouScopeForQuery(pou, '', 42)
+      expect(text).toContain(`FUNCTION_BLOCK ${SCOPE_QUERY_POU_NAME}42__`)
     })
   })
 

--- a/src/frontend/utils/PLC/pou-signature-serializer.ts
+++ b/src/frontend/utils/PLC/pou-signature-serializer.ts
@@ -100,4 +100,52 @@ export function serializePouSignatureToSTWithBodyOffset(pou: PLCPou): {
   }
 }
 
-export { OPAQUE_BODY_PLACEHOLDER }
+/**
+ * Synthesize a self-contained ST document that places `bodyExpr` in the
+ * scope of `pou`'s declarations, for driving strucpp completion / type
+ * resolution programmatically from the graphical (LD/FBD) editors.
+ *
+ * The POU is always emitted as a `PROGRAM` under a throwaway name —
+ * the POU kind and return type are irrelevant to in-scope variable /
+ * member resolution, and a throwaway name avoids colliding with the
+ * POU's real stub document (`stub://<name>.st`) which is open at the
+ * same time. All the POU's VAR blocks are inlined verbatim so instance
+ * members (`TON0.Q`), struct/enum members and array elements resolve
+ * exactly as they would inside a real ST POU. `bodyExpr` is the partial
+ * expression the user is typing (e.g. `TON0.` or `my_struct.value.`);
+ * the returned `position` is the 0-indexed LSP cursor at its end.
+ *
+ * `bodyExpr` MUST be a single line (no newlines) — the position math
+ * assumes the expression occupies one body line.
+ */
+const SCOPE_QUERY_POU_NAME = '__openplc_scope_query__'
+
+export function serializePouScopeForQuery(
+  pou: PLCPou,
+  bodyExpr: string,
+  uniqueId?: number | string,
+): { text: string; position: { line: number; character: number } } {
+  // Emit with the POU's REAL kind + return type so the VAR sections stay
+  // legal (e.g. VAR_IN_OUT is only valid in FUNCTION_BLOCK/FUNCTION — a
+  // PROGRAM wrapper makes strucpp choke). The name is swapped to a
+  // throwaway so it can't collide with the POU's real stub document; a
+  // per-query `uniqueId` further guarantees no two in-flight query docs
+  // ever declare the same symbol (a duplicate definition stalls the
+  // worker if an open laps the previous doc's close).
+  const name = uniqueId === undefined ? SCOPE_QUERY_POU_NAME : `${SCOPE_QUERY_POU_NAME}${uniqueId}__`
+  const startKeyword = getStartKeyword(pou.pouType)
+  const endKeyword = getEndKeyword(pou.pouType)
+  const declaration =
+    pou.pouType === 'function' && pou.interface?.returnType
+      ? `${startKeyword} ${name} : ${pou.interface.returnType}`
+      : `${startKeyword} ${name}`
+  const variables = generateIecVariablesToString(pou.interface?.variables ?? [])
+  const prefix = `${declaration}\n${variables}\n`
+  // `prefix` ends with '\n', so split length - 1 is the 0-indexed line
+  // the body expression sits on.
+  const bodyLine = prefix.split('\n').length - 1
+  const text = `${prefix}${bodyExpr}\n${endKeyword}`
+  return { text, position: { line: bodyLine, character: bodyExpr.length } }
+}
+
+export { OPAQUE_BODY_PLACEHOLDER, SCOPE_QUERY_POU_NAME }


### PR DESCRIPTION
## Summary

**Byte-identical companion** to openplc-web PR autonomy-logic/openplc-web#548 — every change is in the shared `src/frontend/` surface.

Replaces the hardcoded, shallow LD/FBD variable-box autocomplete (which filtered a flat local `interface.variables` list by a static type map) with the same intelligence the ST editor gets, driven directly by the STruC++ LSP. The red/valid validation is rewired the same way — it previously only checked local-variable existence, so valid expressions like `TON0.Q` or `my_struct.value.my_bool` were painted red.

## What changed
- **New `st-lsp/scoped-query` + `graphical-scope` service**: synthesizes a throwaway ST doc placing the partial expression in the POU's real scope, asks strucpp to complete it (resolving instance/struct/enum members with their IEC types), and filters candidates by the box's expected type.
- **LD contact/coil/variable + FBD variable** boxes now source autocomplete and validation from that service; `blockTypeRestrictions` hack removed.
- **Partial completions**: `TO` on a BOOL contact surfaces `TON0.IN`/`TON0.Q` (drill one level into matching instances when a type-filtered search has no direct hits; gated + capped).
- **LD click-to-select** fixed (shared dropdown rows `preventDefault` on mousedown).
- Worker robustness: warm-up gate + coalescing/serialization so cold strucpp queries can't wedge the worker.

## Shared-surface verification
All changes under `src/frontend/`; verified byte-identical against openplc-web with the bundled `scripts/compare-surfaces.py` → **match: true, 0 diffs**. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)