### PR TITLE
feat(compile): stop a running PLC before building on connection targets

### DIFF
--- a/src/frontend/components/_organisms/modals/debugger-message-modal.tsx
+++ b/src/frontend/components/_organisms/modals/debugger-message-modal.tsx
@@ -11,6 +11,13 @@ const DebuggerMessageModal = () => {
     message: string
     buttons: string[]
     onResponse: (buttonIndex: number) => void
+    // Optional layout overrides. By default the FIRST button is the primary
+    // (brand) action and dismissing the modal (Escape / click-away) resolves to
+    // the LAST button. Usages where the affirmative action isn't first — e.g. a
+    // [Cancel, Proceed] layout — set primaryButtonIndex to brand-style the right
+    // button and dismissButtonIndex so Escape routes to Cancel.
+    primaryButtonIndex?: number
+    dismissButtonIndex?: number
   } | null
 
   const handleButtonClick = (index: number) => {
@@ -34,11 +41,12 @@ const DebuggerMessageModal = () => {
           // Capture callback and button count before closing (closeModal clears data)
           const onResponse = modalData?.onResponse
           const lastButtonIndex = modalData?.buttons?.length ? modalData.buttons.length - 1 : 0
+          const dismissButtonIndex = modalData?.dismissButtonIndex ?? lastButtonIndex
           // Close modal first, then call callback to avoid race condition
           // when callback opens another modal
           modalActions.closeModal()
           if (onResponse) {
-            onResponse(lastButtonIndex)
+            onResponse(dismissButtonIndex)
           }
         }
         modalActions.onOpenChange('debugger-message', open)
@@ -56,7 +64,7 @@ const DebuggerMessageModal = () => {
               key={index}
               onClick={() => handleButtonClick(index)}
               className={`flex-1 rounded-md px-4 py-2 text-sm font-medium ${
-                index === 0
+                index === (modalData.primaryButtonIndex ?? 0)
                   ? 'bg-brand text-white hover:bg-brand-medium-dark'
                   : 'bg-neutral-100 text-neutral-1000 hover:bg-neutral-200 dark:bg-neutral-850 dark:text-neutral-100'
               }`}

--- a/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
@@ -38,6 +38,7 @@ const showDebuggerMessage = (
   title: string,
   message: string,
   buttons: string[],
+  options?: { primaryButtonIndex?: number; dismissButtonIndex?: number },
 ): Promise<number> => {
   return new Promise((resolve) => {
     useOpenPLCStore.getState().modalActions.openModal('debugger-message', {
@@ -45,6 +46,7 @@ const showDebuggerMessage = (
       title,
       message,
       buttons,
+      ...options,
       onResponse: (buttonIndex: number) => resolve(buttonIndex),
     })
   })
@@ -181,6 +183,51 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
       }
 
       setIsCompiling(true)
+
+      // Targets that build through the device runtime (everything except the
+      // arduino-cli / in-process-simulator pipelines, i.e. directUsbUpload)
+      // run the FINAL build step ON the device. If the runtime is actively
+      // scanning a program, that heavy on-device work can stall the build or
+      // make the running program miss scan cycles / deadlines. So when we're
+      // connected to a RUNNING runtime, require the user to stop the PLC first
+      // and, on their consent, stop it before compiling.
+      {
+        const state = useOpenPLCStore.getState()
+        const boardInfo = state.deviceAvailableOptions.availableBoards.get(
+          state.deviceDefinitions.configuration.deviceBoard,
+        )
+        const requiresRuntimeConnection = !resolveTargetCapabilities(boardInfo).directUsbUpload
+        const { connectionStatus: connStatus, plcStatus: runStatus } = state.runtimeConnection
+        if (requiresRuntimeConnection && connStatus === 'connected' && runStatus === 'RUNNING') {
+          const response = await showDebuggerMessage(
+            'warning',
+            'Stop PLC',
+            'The PLC must be stopped before continuing.',
+            ['Cancel', 'Stop PLC and Continue'],
+            // Cancel is first (left, neutral); proceed is the blue primary on
+            // the right; Escape / click-away routes to Cancel.
+            { primaryButtonIndex: 1, dismissButtonIndex: 0 },
+          )
+          if (response !== 1) {
+            // User declined — abort the build and leave the PLC running.
+            setIsCompiling(false)
+            return
+          }
+          const stopResult = await runtime.stopPlc()
+          if (!stopResult.success) {
+            addLog({
+              id: crypto.randomUUID(),
+              level: 'error',
+              message: `Failed to stop PLC: ${stopResult.error ?? 'Unknown error'}`,
+            })
+            setIsCompiling(false)
+            return
+          }
+          useOpenPLCStore.getState().deviceActions.setPlcRuntimeStatus('STOPPED')
+          addLog({ id: crypto.randomUUID(), level: 'info', message: 'PLC stopped before build.' })
+        }
+      }
+
       addLog({ id: crypto.randomUUID(), level: 'info', message: 'Build process started' })
 
       // Pre-compile alias sync: ensure every located variable's
@@ -275,6 +322,7 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
       executeSave,
       canEdit,
       jwtToken,
+      runtime,
     ],
   )
 


### PR DESCRIPTION
## Summary (bug #1)

When building for a target that builds **through the device runtime** (everything except the arduino-cli / in-process-simulator pipelines), the **final compilation step runs on the device**. If the runtime is actively scanning a program, that on-device work can stall the build or make the running program miss scan cycles / deadlines.

## Change

In `handleBuild` (`workspace-activity-bar/default.tsx`), after the pre-build save, when the target requires a runtime connection (`!resolveTargetCapabilities(boardInfo).directUsbUpload`) **and** we're `connected` to a **RUNNING** runtime:
- Warning modal *"Stop the PLC to continue …"* with **[Stop PLC and Continue] / [Cancel]**.
- **Cancel** → abort build, leave PLC running.
- **Stop PLC and Continue** → `runtime.stopPlc()`; on failure log + abort; on success set `STOPPED`, log, proceed.

Runtime state read fresh from the store at click time. Arduino-cli / simulator targets unaffected. `tsc` + lint clean. Byte-identical to openplc-web#553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a safety check before building on device-runtime targets so users are prompted to stop a running PLC first.
  * If the PLC cannot be stopped, the build now stops with an error instead of continuing.
  * Confirming the prompt stops the PLC and proceeds with the build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->