### PR TITLE
fix(package-manager): verify installed VPP signatures on project open

### DIFF
--- a/src/backend/editor/package-manager/__tests__/verify-installed-signatures.test.ts
+++ b/src/backend/editor/package-manager/__tests__/verify-installed-signatures.test.ts
@@ -1,0 +1,215 @@
+import { createHash, sign as cryptoSign } from 'node:crypto'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { app } from 'electron'
+
+import { canonicalize, SIGNATURE_FILENAME } from '../../../shared/utils/vpp/verify-package-signature'
+
+// Heavy/side-effecting deps that the module pulls in transitively but this
+// suite has no use for. Mocking them keeps `import { PackageManagerModule }`
+// free of winston file transports and extract-zip's ESM entry point.
+jest.mock('electron', () => ({ app: { getPath: jest.fn(() => '/mock/path') } }))
+jest.mock('extract-zip', () => ({ __esModule: true, default: jest.fn() }))
+jest.mock('../../services/logger-service', () => ({
+  logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}))
+
+// Replace the real trusted-key store with a freshly generated test keypair so
+// fixtures can be signed with a private key we actually hold. The factory may
+// not reference outer-scope variables, so it generates the pair inline and
+// re-exports the private PEM for the test to sign with.
+jest.mock('../../../shared/utils/vpp/trusted-keys', () => {
+  const { generateKeyPairSync } = jest.requireActual<typeof import('node:crypto')>('node:crypto')
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519')
+  return {
+    TRUSTED_PACKAGE_KEYS: { 'test-key': publicKey.export({ type: 'spki', format: 'pem' }).toString() },
+    __TEST_PRIVATE_PEM: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+  }
+})
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const PRIVATE_PEM: string = (require('../../../shared/utils/vpp/trusted-keys') as { __TEST_PRIVATE_PEM: string })
+  .__TEST_PRIVATE_PEM
+
+import { PackageManagerModule } from '../package-manager-module'
+
+const KEY_ID = 'test-key'
+
+const sha256 = (s: string): string =>
+  createHash('sha256')
+    .update(Uint8Array.from(Buffer.from(s, 'utf-8')))
+    .digest('hex')
+
+const DEFAULT_FILES: Record<string, string> = {
+  'manifest.json': '{"formatVersion":"1.0"}',
+  'hal/arduino/hal.cpp': 'void hardwareInit() {}',
+}
+
+interface FixtureOpts {
+  files?: Record<string, string>
+  /** Override fields on the signed payload (e.g. a foreign keyId). */
+  payloadOverride?: Record<string, unknown>
+  /** Mutate a file's bytes AFTER signing, to simulate tampering. */
+  tamperFile?: { rel: string; content: string }
+  /** Skip writing signature.json entirely (a side-loaded package). */
+  omitSignature?: boolean
+}
+
+describe('PackageManagerModule.verifyInstalledSignatures', () => {
+  let userDataDir: string
+  let packagesDir: string
+
+  beforeEach(() => {
+    userDataDir = mkdtempSync(join(tmpdir(), 'pkg-sweep-'))
+    packagesDir = join(userDataDir, 'packages')
+    ;(app.getPath as jest.Mock).mockReturnValue(userDataDir)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    rmSync(userDataDir, { recursive: true, force: true })
+  })
+
+  /** Write a package directory under packagesDir and register it. */
+  function installFixture(packageId: string, opts: FixtureOpts = {}): string {
+    const dir = join(packagesDir, packageId)
+    const files = opts.files ?? DEFAULT_FILES
+    const fileHashes: Record<string, string> = {}
+    for (const [rel, content] of Object.entries(files)) {
+      const full = join(dir, rel)
+      mkdirSync(dirname(full), { recursive: true })
+      writeFileSync(full, content)
+      fileHashes[rel] = sha256(content)
+    }
+
+    if (!opts.omitSignature) {
+      const payload = {
+        formatVersion: '1.0',
+        alg: 'ed25519',
+        keyId: KEY_ID,
+        packageId,
+        version: '1.0.0',
+        signedAt: '2026-06-01T00:00:00.000Z',
+        files: fileHashes,
+        ...opts.payloadOverride,
+      }
+      const signature = cryptoSign(
+        null,
+        Uint8Array.from(Buffer.from(canonicalize(payload), 'utf-8')),
+        PRIVATE_PEM,
+      ).toString('base64')
+      writeFileSync(join(dir, SIGNATURE_FILENAME), JSON.stringify({ ...payload, signature }, null, 2))
+    }
+
+    if (opts.tamperFile) {
+      writeFileSync(join(dir, opts.tamperFile.rel), opts.tamperFile.content)
+    }
+
+    return dir
+  }
+
+  /** Write registry.json with the given packageId -> path entries. */
+  function writeRegistry(entries: Record<string, { path: string }>): void {
+    mkdirSync(packagesDir, { recursive: true })
+    const packages: Record<string, unknown> = {}
+    for (const [id, e] of Object.entries(entries)) {
+      packages[id] = { version: '1.0.0', installedAt: '2026-06-01T00:00:00.000Z', path: e.path, devices: [] }
+    }
+    writeFileSync(join(packagesDir, 'registry.json'), JSON.stringify({ formatVersion: '1.0', packages }, null, 2))
+  }
+
+  function readRegistryIds(): string[] {
+    const raw = JSON.parse(require('node:fs').readFileSync(join(packagesDir, 'registry.json'), 'utf-8')) as {
+      packages: Record<string, unknown>
+    }
+    return Object.keys(raw.packages)
+  }
+
+  it('keeps a package that is validly signed by a trusted key', () => {
+    const dir = installFixture('com.test.valid')
+    writeRegistry({ 'com.test.valid': { path: dir } })
+
+    const warn = jest.fn()
+    const removed = new PackageManagerModule().verifyInstalledSignatures(warn)
+
+    expect(removed).toEqual([])
+    expect(warn).not.toHaveBeenCalled()
+    expect(existsSync(dir)).toBe(true)
+    expect(readRegistryIds()).toEqual(['com.test.valid'])
+  })
+
+  it('removes a package that has no signature.json', () => {
+    const dir = installFixture('com.test.unsigned', { omitSignature: true })
+    writeRegistry({ 'com.test.unsigned': { path: dir } })
+
+    const warn = jest.fn()
+    const removed = new PackageManagerModule().verifyInstalledSignatures(warn)
+
+    expect(removed).toEqual(['com.test.unsigned'])
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('com.test.unsigned'))
+    expect(existsSync(dir)).toBe(false)
+    expect(readRegistryIds()).toEqual([])
+  })
+
+  it('removes a package whose signature names an untrusted key', () => {
+    // keyId is not present in TRUSTED_PACKAGE_KEYS.
+    const dir = installFixture('com.test.selfsigned', { payloadOverride: { keyId: 'untrusted-key' } })
+    writeRegistry({ 'com.test.selfsigned': { path: dir } })
+
+    const removed = new PackageManagerModule().verifyInstalledSignatures(jest.fn())
+
+    expect(removed).toEqual(['com.test.selfsigned'])
+    expect(existsSync(dir)).toBe(false)
+  })
+
+  it('removes a package whose files were tampered after signing', () => {
+    const dir = installFixture('com.test.tampered', {
+      tamperFile: { rel: 'hal/arduino/hal.cpp', content: 'void hardwareInit() { /* altered */ }' },
+    })
+    writeRegistry({ 'com.test.tampered': { path: dir } })
+
+    const removed = new PackageManagerModule().verifyInstalledSignatures(jest.fn())
+
+    expect(removed).toEqual(['com.test.tampered'])
+    expect(existsSync(dir)).toBe(false)
+  })
+
+  it('drops a stale registry entry whose directory is missing', () => {
+    writeRegistry({ 'com.test.ghost': { path: join(packagesDir, 'com.test.ghost') } })
+
+    const removed = new PackageManagerModule().verifyInstalledSignatures(jest.fn())
+
+    expect(removed).toEqual(['com.test.ghost'])
+    expect(readRegistryIds()).toEqual([])
+  })
+
+  it('de-lists an out-of-tree registry path without touching disk', () => {
+    // Registry path outside packagesDir: the entry is dropped and files there
+    // are left untouched.
+    const outside = mkdtempSync(join(tmpdir(), 'outside-'))
+    writeFileSync(join(outside, 'keepme.txt'), 'data')
+    writeRegistry({ 'com.test.escape': { path: outside } })
+
+    const removed = new PackageManagerModule().verifyInstalledSignatures(jest.fn())
+
+    expect(removed).toEqual(['com.test.escape'])
+    expect(readRegistryIds()).toEqual([])
+    expect(existsSync(join(outside, 'keepme.txt'))).toBe(true)
+    rmSync(outside, { recursive: true, force: true })
+  })
+
+  it('removes only the invalid package in a mixed registry', () => {
+    const good = installFixture('com.test.good')
+    const bad = installFixture('com.test.bad', { omitSignature: true })
+    writeRegistry({ 'com.test.good': { path: good }, 'com.test.bad': { path: bad } })
+
+    const removed = new PackageManagerModule().verifyInstalledSignatures(jest.fn())
+
+    expect(removed).toEqual(['com.test.bad'])
+    expect(existsSync(good)).toBe(true)
+    expect(existsSync(bad)).toBe(false)
+    expect(readRegistryIds()).toEqual(['com.test.good'])
+  })
+})

--- a/src/backend/editor/package-manager/package-manager-module.ts
+++ b/src/backend/editor/package-manager/package-manager-module.ts
@@ -7,6 +7,7 @@ import { PackageManifestSchema } from '../../../middleware/shared/ports/package-
 import { validatePathId } from '../../shared/utils/path-safety'
 import { TRUSTED_PACKAGE_KEYS } from '../../shared/utils/vpp/trusted-keys'
 import { verifyPackageSignature } from '../../shared/utils/vpp/verify-package-signature'
+import { logger } from '../services/logger-service'
 import { assertPathContained } from '../utils/path-containment'
 import type { ImportResult, InstalledPackage, PackageManifest, PackageRegistry } from './types'
 
@@ -130,6 +131,73 @@ class PackageManagerModule {
         rmSync(tempDir, { recursive: true, force: true })
       }
     }
+  }
+
+  /**
+   * Re-verify every registry-listed package against the trusted keys and remove
+   * any whose signature does not validate, returning the ids removed. For each
+   * failing entry the package directory is deleted (when its recorded path
+   * resolves inside packagesDir) and the registry entry is dropped, emitting a
+   * warning per removal. No-op when REQUIRE_SIGNATURE is false. Directories with
+   * no registry entry are not listed and are left as-is.
+   */
+  verifyInstalledSignatures(warn: (message: string) => void = (m) => logger.warn(m)): string[] {
+    if (!REQUIRE_SIGNATURE) return []
+
+    const registry = this.readRegistry()
+    const removed: string[] = []
+    let mutated = false
+
+    for (const [packageId, info] of Object.entries(registry.packages)) {
+      const reason = this.signatureRejectionReason(packageId, info?.path)
+      if (!reason) continue
+
+      // Drop the registry entry; delete on-disk contents only when the recorded
+      // path resolves inside packagesDir.
+      try {
+        assertPathContained(this.packagesDir, info.path, 'registry package path')
+        if (existsSync(info.path)) {
+          rmSync(info.path, { recursive: true, force: true })
+        }
+      } catch {
+        // Out-of-tree or unusable path: leave disk untouched, just de-list.
+      }
+
+      delete registry.packages[packageId]
+      mutated = true
+      removed.push(packageId)
+      warn(`VPP package "${packageId}" was removed at startup due to an invalid or missing signature: ${reason}`)
+    }
+
+    if (mutated) this.writeRegistry(registry)
+    return removed
+  }
+
+  /**
+   * Returns null when the installed package recorded at `packagePath` is
+   * genuinely signed by a trusted key, or a short human-readable reason when it
+   * is not (bad id shape, path escaping packagesDir, missing files, or any
+   * failure surfaced by `verifyPackageSignature`).
+   */
+  private signatureRejectionReason(packageId: string, packagePath: string | undefined): string | null {
+    try {
+      validatePathId(packageId, 'registry package id')
+    } catch {
+      return 'invalid package id'
+    }
+    if (typeof packagePath !== 'string' || packagePath.length === 0) {
+      return 'registry entry has no package path'
+    }
+    try {
+      assertPathContained(this.packagesDir, packagePath, 'registry package path')
+    } catch {
+      return 'package path resolves outside the packages directory'
+    }
+    if (!existsSync(packagePath)) {
+      return 'package files are missing'
+    }
+    const verification = verifyPackageSignature(packagePath, TRUSTED_PACKAGE_KEYS)
+    return verification.valid ? null : (verification.error ?? 'invalid signature')
   }
 
   listInstalled(): InstalledPackage[] {

--- a/src/frontend/screens/workspace-screen.tsx
+++ b/src/frontend/screens/workspace-screen.tsx
@@ -69,6 +69,7 @@ const WorkspaceScreen = () => {
     useCallback((s) => s.workspaceActions, []),
   )
   const { setAvailableOptions } = useOpenPLCStore(useCallback((s) => s.deviceActions, []))
+  const addLog = useOpenPLCStore(useCallback((s) => s.consoleActions.addLog, []))
 
   // RARE: UI state (changes on user interaction, not during debug polling)
   const tabs = useOpenPLCStore(useCallback((s) => s.tabs, []))
@@ -405,6 +406,31 @@ const WorkspaceScreen = () => {
       unsubBoards()
     }
   }, [packagesPort, device, setAvailableOptions])
+
+  // Desktop security safeguard: whenever a project opens, re-verify the
+  // signatures of every installed VPP package and drop any that no longer
+  // validate (a locally-crafted/unsigned .vpp can bypass the signed import
+  // flow). Each removal is surfaced as a WARNING in the console panel; the
+  // main process emits `packages:boards-updated` on removal, so the board
+  // list refreshes via the subscription above. On web `packagesPort` is
+  // undefined (packages are backend-provided), so this is a no-op.
+  useEffect(() => {
+    if (!packagesPort || !projectPath) return
+    let cancelled = false
+    void packagesPort.verifyInstalledSignatures().then((removed) => {
+      if (cancelled) return
+      for (const packageId of removed) {
+        addLog({
+          id: crypto.randomUUID(),
+          level: 'warning',
+          message: `Removed untrusted VPP package "${packageId}": its signature is missing or invalid.`,
+        })
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [packagesPort, projectPath, addLog])
 
   return (
     <div className='flex h-full w-full flex-col overflow-hidden bg-brand-dark dark:bg-neutral-950'>

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -18,6 +18,7 @@ import { CompilerModule } from '../backend/editor/compiler'
 // TODO: Refactor this type declaration
 import { MainIpcModuleConstructor } from '../backend/editor/contracts/types/modules/ipc/main'
 import { HardwareModule } from '../backend/editor/hardware'
+import { PackageManagerModule } from '../backend/editor/package-manager'
 import { logger, PouService, ProjectService, UserService } from '../backend/editor/services'
 import { resolveHtmlPath } from '../backend/editor/utils'
 import { getErrorMessage } from '../frontend/utils/get-error-message'
@@ -403,6 +404,17 @@ app.on('second-instance', () => {
 app
   .whenReady()
   .then(() => {
+    // Re-verify installed VPP package signatures once per launch, before the
+    // first window reads them; removes any package whose signature no longer
+    // validates.
+    try {
+      const removed = new PackageManagerModule().verifyInstalledSignatures()
+      if (removed.length > 0) {
+        logger.warn(`Removed ${removed.length} untrusted VPP package(s) at startup: ${removed.join(', ')}`)
+      }
+    } catch (err) {
+      logger.error('VPP package signature sweep failed: ' + getErrorMessage(err))
+    }
     void createMainWindow()
     // Handle the app activation event;
     app.on('activate', () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -18,7 +18,6 @@ import { CompilerModule } from '../backend/editor/compiler'
 // TODO: Refactor this type declaration
 import { MainIpcModuleConstructor } from '../backend/editor/contracts/types/modules/ipc/main'
 import { HardwareModule } from '../backend/editor/hardware'
-import { PackageManagerModule } from '../backend/editor/package-manager'
 import { logger, PouService, ProjectService, UserService } from '../backend/editor/services'
 import { resolveHtmlPath } from '../backend/editor/utils'
 import { getErrorMessage } from '../frontend/utils/get-error-message'
@@ -404,17 +403,6 @@ app.on('second-instance', () => {
 app
   .whenReady()
   .then(() => {
-    // Re-verify installed VPP package signatures once per launch, before the
-    // first window reads them; removes any package whose signature no longer
-    // validates.
-    try {
-      const removed = new PackageManagerModule().verifyInstalledSignatures()
-      if (removed.length > 0) {
-        logger.warn(`Removed ${removed.length} untrusted VPP package(s) at startup: ${removed.join(', ')}`)
-      }
-    } catch (err) {
-      logger.error('VPP package signature sweep failed: ' + getErrorMessage(err))
-    }
     void createMainWindow()
     // Handle the app activation event;
     app.on('activate', () => {

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -842,6 +842,7 @@ class MainProcessBridge implements MainIpcModule {
     this.registerHandle('packages:list-installed', this.handlePackagesListInstalled)
     this.registerHandle('packages:uninstall', this.handlePackagesUninstall)
     this.registerHandle('packages:get-manifest', this.handlePackagesGetManifest)
+    this.registerHandle('packages:verify-signatures', this.handlePackagesVerifySignatures)
 
     // ===================== UTILITIES =====================
     this.registerHandle('util:get-preview-image', this.handleUtilGetPreviewImage)
@@ -1373,6 +1374,16 @@ class MainProcessBridge implements MainIpcModule {
       this.mainWindow?.webContents.send('packages:boards-updated')
     }
     return result
+  }
+  // Re-verify installed VPP signatures (invoked by the renderer when a project
+  // opens) and return the ids removed. If anything was dropped, notify the
+  // renderer so the board/device list refreshes via the existing subscription.
+  handlePackagesVerifySignatures = async (): Promise<string[]> => {
+    const removed = this.packageManagerModule.verifyInstalledSignatures()
+    if (removed.length > 0) {
+      this.mainWindow?.webContents.send('packages:boards-updated')
+    }
+    return removed
   }
   handlePackagesGetManifest = async (_event: IpcMainInvokeEvent, packageId: string) =>
     this.packageManagerModule.getInstalledPackageManifest(packageId)

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -365,6 +365,7 @@ const rendererProcessBridge = {
   uninstallPackage: (packageId: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('packages:uninstall', packageId),
   getPackageManifest: (packageId: string): Promise<unknown> => ipcRenderer.invoke('packages:get-manifest', packageId),
+  verifyInstalledPackageSignatures: (): Promise<string[]> => ipcRenderer.invoke('packages:verify-signatures'),
   onOpenPackageManager: (callback: () => void) => {
     const listener = () => callback()
     ipcRenderer.on('packages:open-manager', listener)

--- a/src/middleware/adapters/editor/__tests__/package-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/package-adapter.test.ts
@@ -50,6 +50,7 @@ beforeEach(() => {
     getPackageManifest: jest.fn().mockResolvedValue(validManifest),
     onOpenPackageManager: jest.fn().mockImplementation(() => jest.fn()),
     onBoardsUpdated: jest.fn().mockImplementation(() => jest.fn()),
+    verifyInstalledPackageSignatures: jest.fn().mockResolvedValue([]),
   } as unknown as typeof window.bridge
 
   global.fetch = jest.fn() as unknown as typeof fetch
@@ -207,6 +208,19 @@ describe('createEditorPackageAdapter', () => {
       const off = adapter.onBoardsUpdated(cb)
       expect(window.bridge.onBoardsUpdated).toHaveBeenCalledWith(cb)
       expect(off).toBe(unsubscribe)
+    })
+  })
+
+  describe('verifyInstalledSignatures', () => {
+    it('delegates to the bridge and returns the removed package ids', async () => {
+      ;(window.bridge.verifyInstalledPackageSignatures as jest.Mock).mockResolvedValue(['com.synergy-logic.slm-rp4'])
+      const removed = await adapter.verifyInstalledSignatures()
+      expect(window.bridge.verifyInstalledPackageSignatures).toHaveBeenCalledTimes(1)
+      expect(removed).toEqual(['com.synergy-logic.slm-rp4'])
+    })
+
+    it('returns an empty array when nothing was removed', async () => {
+      expect(await adapter.verifyInstalledSignatures()).toEqual([])
     })
   })
 })

--- a/src/middleware/adapters/editor/package-adapter.ts
+++ b/src/middleware/adapters/editor/package-adapter.ts
@@ -123,5 +123,9 @@ export function createEditorPackageAdapter(): PackagePort {
     onBoardsUpdated(callback: () => void): Unsubscribe {
       return window.bridge.onBoardsUpdated(callback)
     },
+
+    verifyInstalledSignatures(): Promise<string[]> {
+      return window.bridge.verifyInstalledPackageSignatures()
+    },
   }
 }

--- a/src/middleware/shared/ports/package-port.ts
+++ b/src/middleware/shared/ports/package-port.ts
@@ -59,4 +59,14 @@ export interface PackagePort {
    * Subscribe to board list updates (triggered after package install/uninstall).
    */
   onBoardsUpdated(callback: () => void): Unsubscribe
+
+  /**
+   * Re-verify the signatures of every installed package and remove any whose
+   * signature no longer validates, returning the ids removed. A desktop-only
+   * safeguard: locally-installed `.vpp` files can be added or altered outside
+   * the signed import flow, so they are re-checked whenever a project opens.
+   * Platforms where packages are backend-provided (web) don't wire a `packages`
+   * port and never call this; a no-op shim there returns `[]`.
+   */
+  verifyInstalledSignatures(): Promise<string[]>
 }


### PR DESCRIPTION
## Summary

Re-verifies installed VPP package signatures **when a project opens** (moved from a one-shot app-startup sweep) and surfaces each removal as a **WARNING in the console panel**. Any registry-listed package whose signature no longer validates against `TRUSTED_PACKAGE_KEYS` is removed (directory + registry entry).

`verifyInstalledSignatures()` is exposed through the shared `PackagePort`:
`workspace-screen` (shared) calls it on project load → editor adapter → `packages:verify-signatures` IPC → `PackageManagerModule`. On removal the main process emits `packages:boards-updated`, so the device list refreshes via the existing subscription.

## Threat model (intentional scope)

The signature is a **licensing gate** (only VPPs signed by us run in official builds), not a hardened security boundary. Being open source, a fork can ship its own key or disable the check — but then must maintain its own editor fork. On-disk tampering is caught at the **next project open**, which is an accepted window. Verify-at-compile was considered and intentionally **not** added.

## Cross-repo

Touches two shared-surface files (`middleware/shared/ports/package-port.ts`, `frontend/screens/workspace-screen.tsx`). Web has no local package store and doesn't wire a `packages` port, so `usePackages()` is `undefined` there and the shared open-project effect is a **no-op** (the shim). Paired with the matching openplc-web branch `fix/vpp-verify-installed-signatures-on-startup` so Shared Surface Sync stays green.

## Tests
`verifyInstalledSignatures()` unit tests (add/remove/out-of-tree/no-op) + editor package-adapter delegation test. tsc / eslint / prettier / build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic signature checks for installed packages when opening a project on desktop.
  * Packages with invalid, missing, or untrusted signatures are now removed, and the app reports which ones were affected.

* **Bug Fixes**
  * Stale or broken package entries are cleaned up more safely, including entries that point to missing locations.
  * Valid packages remain installed when mixed with invalid ones, and external files are left untouched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->