### PR TITLE
fix(console): reveal + re-follow console on build start

### DIFF
--- a/src/frontend/components/_organisms/console/index.tsx
+++ b/src/frontend/components/_organisms/console/index.tsx
@@ -18,6 +18,7 @@ const STICK_THRESHOLD_PX = 4
 const Console = memo(() => {
   const logs = useOpenPLCStore((state) => state.logs)
   const filters = useOpenPLCStore((state) => state.filters)
+  const followRequestId = useOpenPLCStore((state) => state.followRequestId)
   const navigateToCompileError = useNavigateToCompileError()
   const containerRef = useRef<HTMLDivElement | null>(null)
 
@@ -98,6 +99,28 @@ const Console = memo(() => {
     if (!container) return
     container.scrollTop = container.scrollHeight
   }, [filteredLogs])
+
+  /**
+   * One-shot "kick to bottom" requested externally (e.g. a build starting).
+   * Unlike the auto-scroll above, this re-engages auto-follow and scrolls to
+   * the latest line regardless of the current scroll position — so a build
+   * that starts while the user has scrolled up still snaps to the tail and
+   * keeps following. The rAF re-assert covers the case where the console panel
+   * is being revealed on this same tick (its height isn't final until after
+   * this layout pass). `followRequestId` starts at 0, so the initial mount is
+   * skipped and we never force-scroll unprompted.
+   */
+  useLayoutEffect(() => {
+    if (followRequestId === 0) return
+    stickToBottomRef.current = true
+    const container = containerRef.current
+    if (container) container.scrollTop = container.scrollHeight
+    const raf = requestAnimationFrame(() => {
+      const c = containerRef.current
+      if (c && stickToBottomRef.current) c.scrollTop = c.scrollHeight
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [followRequestId])
 
   return (
     <div

--- a/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
@@ -77,7 +77,7 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
     project: { data: projectData, meta: projectMeta },
     deviceDefinitions,
     deviceAvailableOptions: { availableBoards },
-    consoleActions: { addLog },
+    consoleActions: { addLog, requestConsoleFollow },
   } = useOpenPLCStore()
 
   // Project-type capability matrix.  Drives which set of action
@@ -155,6 +155,11 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
   const handleBuild = useCallback(
     async (overrides?: { compileOnly?: boolean; cleanBuild?: boolean }) => {
       if (isCompiling) return
+
+      // Reveal the console and re-attach it to the tail so build output is
+      // visible from the first line, even if the console was collapsed or the
+      // user had scrolled up. One-shot — it won't fight a later manual scroll.
+      requestConsoleFollow()
 
       // Always save the full project before building. The compile
       // pipeline reads source from disk (project.json, devices/*.json,
@@ -323,6 +328,7 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
       canEdit,
       jwtToken,
       runtime,
+      requestConsoleFollow,
     ],
   )
 
@@ -336,6 +342,9 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
   const handleBuildLibrary = useCallback(
     async (overrides?: { cleanBuild?: boolean }) => {
       if (isCompiling) return
+
+      // Reveal the console and re-attach to the tail (see handleBuild).
+      requestConsoleFollow()
 
       // Always save before building.  The manifest tab and any POU
       // bodies may have edits the workspace-level `editingState`
@@ -401,7 +410,7 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
         setIsCompiling(false)
       }
     },
-    [compiler, projectData, projectMeta, addLog, isCompiling, executeSave],
+    [compiler, projectData, projectMeta, addLog, isCompiling, executeSave, requestConsoleFollow],
   )
 
   // ---------------------------------------------------------------------------

--- a/src/frontend/screens/workspace-screen.tsx
+++ b/src/frontend/screens/workspace-screen.tsx
@@ -314,6 +314,7 @@ const WorkspaceScreen = () => {
   const workspacePanelRef = useRef<PanelMethods | null>(null)
   const consolePanelRef = useRef<PanelMethods | null>(null)
   const [activeTab, setActiveTab] = useState('console')
+  const consoleFollowRequestId = useOpenPLCStore((state) => state.followRequestId)
   const hasSearchResults = searchResults.length > 0
 
   const togglePanel = () => {
@@ -352,6 +353,16 @@ const WorkspaceScreen = () => {
       }
     })
   }, [isCollapsed])
+
+  // A build (or other producer) requested the console: reveal the console
+  // panel and switch to the Console tab. The console component handles the
+  // kick-to-bottom off the same nonce. Skip the initial value (0) so we never
+  // force the console open on first render.
+  useEffect(() => {
+    if (consoleFollowRequestId === 0) return
+    consolePanelRef.current?.expand()
+    setActiveTab('console')
+  }, [consoleFollowRequestId])
 
   // Load available boards via device port.
   // `setAvailableOptions` owns the alias sync — once the boards land,

--- a/src/frontend/store/__tests__/console-slice.test.ts
+++ b/src/frontend/store/__tests__/console-slice.test.ts
@@ -40,6 +40,7 @@ describe('createConsoleSlice', () => {
       searchTerm: '',
       timestampFormat: 'full',
     })
+    expect(state.followRequestId).toBe(0)
   })
 
   // -------------------------------------------------------------------------
@@ -238,5 +239,31 @@ describe('createConsoleSlice', () => {
 
     expect(store.getState().filters.searchTerm).toBe('kept')
     expect(store.getState().filters.levels.debug).toBe(false)
+  })
+
+  // -------------------------------------------------------------------------
+  // requestConsoleFollow
+  // -------------------------------------------------------------------------
+  it('requestConsoleFollow increments the follow nonce', () => {
+    expect(store.getState().followRequestId).toBe(0)
+    store.getState().consoleActions.requestConsoleFollow()
+    expect(store.getState().followRequestId).toBe(1)
+  })
+
+  it('requestConsoleFollow produces a fresh nonce on every call', () => {
+    store.getState().consoleActions.requestConsoleFollow()
+    store.getState().consoleActions.requestConsoleFollow()
+    store.getState().consoleActions.requestConsoleFollow()
+    expect(store.getState().followRequestId).toBe(3)
+  })
+
+  it('requestConsoleFollow does not affect logs or filters', () => {
+    store.getState().consoleActions.addLog({ id: '1', level: 'info', message: 'kept' })
+    store.getState().consoleActions.setSearchTerm('term')
+
+    store.getState().consoleActions.requestConsoleFollow()
+
+    expect(store.getState().logs).toHaveLength(1)
+    expect(store.getState().filters.searchTerm).toBe('term')
   })
 })

--- a/src/frontend/store/slices/console/slice.ts
+++ b/src/frontend/store/slices/console/slice.ts
@@ -15,6 +15,7 @@ const createConsoleSlice: StateCreator<ConsoleSlice, [], [], ConsoleSlice> = (se
     searchTerm: '',
     timestampFormat: 'full',
   },
+  followRequestId: 0,
   consoleActions: {
     addLog: (log) => {
       setState(
@@ -58,6 +59,13 @@ const createConsoleSlice: StateCreator<ConsoleSlice, [], [], ConsoleSlice> = (se
       setState(
         produce((state: ConsoleSlice) => {
           state.filters.timestampFormat = format
+        }),
+      )
+    },
+    requestConsoleFollow: () => {
+      setState(
+        produce((state: ConsoleSlice) => {
+          state.followRequestId += 1
         }),
       )
     },

--- a/src/frontend/store/slices/console/types.ts
+++ b/src/frontend/store/slices/console/types.ts
@@ -13,6 +13,12 @@ export type ConsoleFilters = {
 export type ConsoleState = {
   logs: LogObject[]
   filters: ConsoleFilters
+  // Monotonic nonce bumped each time something (e.g. a build start) wants the
+  // console to become visible and re-attach to the tail. Consumers compare it
+  // to the previous value and, on change, reveal the console panel and perform
+  // a single "kick to bottom" so auto-follow resumes — without overriding the
+  // user's manual scroll position at any other time.
+  followRequestId: number
 }
 
 export type ConsoleActions = {
@@ -22,6 +28,8 @@ export type ConsoleActions = {
   setLevelFilter: (level: LogLevel, enabled: boolean) => void
   setSearchTerm: (term: string) => void
   setTimestampFormat: (format: TimestampFormat) => void
+  // Reveal the console and kick it to the latest line (re-engaging auto-follow).
+  requestConsoleFollow: () => void
 }
 
 export type ConsoleSlice = ConsoleState & {


### PR DESCRIPTION
## Summary

When a build (PLC program or library) starts, the console now:
1. **Reveals itself** if collapsed/hidden and selects the **Console** tab.
2. Performs a **single kick-to-bottom** so auto-follow re-engages and build output is visible from the first line — even if the user had previously scrolled up.

Mirror of openplc-web PR #555 (byte-identical shared surface).

## Implementation

- New monotonic `followRequestId` nonce on the **console slice**, bumped by a new `requestConsoleFollow()` action.
- `handleBuild` / `handleBuildLibrary` call `requestConsoleFollow()` at the very start.
- **workspace-screen** consumes the nonce: `consolePanelRef.expand()` + `setActiveTab('console')`.
- **console component** consumes the nonce: sets `stickToBottomRef = true`, scrolls to `scrollHeight`, with a `requestAnimationFrame` re-assert for the just-revealed-panel layout timing.

The existing "don't fight a mid-build manual scroll-up" behavior is **unchanged** — the kick fires only on the build trigger.

## Testing

- `console-slice` jest tests extended — 24/24 pass.
- `tsc --noEmit` clean.
- Behavior validated in the browser on the web build (collapsed → build reveals + follows; scrolled-up → build snaps to tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)