### PR TITLE
fix(ethercat): don't filter scanned interface list while typing

### DIFF
--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/__tests__/interface-selector.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/__tests__/interface-selector.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import type { NetworkInterface } from '@root/middleware/shared/ports/ethercat-types'
+
+import { InterfaceSelector } from '../interface-selector'
+
+const interfaces: NetworkInterface[] = [
+  { name: 'eth0', description: 'Ethernet adapter' },
+  { name: 'eth1', description: 'Second Ethernet' },
+  { name: 'wlan0', description: 'Wireless adapter' },
+]
+
+const renderSelector = (overrides?: Partial<React.ComponentProps<typeof InterfaceSelector>>) =>
+  render(
+    <InterfaceSelector
+      interfaces={interfaces}
+      selectedInterface=''
+      onSelectInterface={() => {}}
+      isLoading={false}
+      error={null}
+      {...overrides}
+    />,
+  )
+
+describe('InterfaceSelector', () => {
+  it('lists every scanned interface when the dropdown opens', () => {
+    renderSelector()
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('eth0')).toBeTruthy()
+    expect(screen.getByText('eth1')).toBeTruthy()
+    expect(screen.getByText('wlan0')).toBeTruthy()
+  })
+
+  it('does NOT filter the adapter list as the user types', () => {
+    renderSelector()
+    fireEvent.click(screen.getByRole('button'))
+
+    // Type text that, under the old behavior, would have hidden eth0/eth1.
+    fireEvent.change(screen.getByPlaceholderText('eth0'), { target: { value: 'wlan' } })
+
+    // All adapters remain visible — the scan list is never narrowed.
+    expect(screen.getByText('eth0')).toBeTruthy()
+    expect(screen.getByText('eth1')).toBeTruthy()
+    expect(screen.getByText('wlan0')).toBeTruthy()
+  })
+
+  it('still allows entering a custom interface name not in the scan', () => {
+    const onSelectInterface = vi.fn()
+    renderSelector({ onSelectInterface })
+    fireEvent.click(screen.getByRole('button'))
+
+    const input = screen.getByPlaceholderText('eth0')
+    fireEvent.change(input, { target: { value: 'enp3s0' } })
+
+    // The "Use ..." affordance for a custom value is present...
+    expect(screen.getByText('Use "enp3s0"')).toBeTruthy()
+    // ...and Enter commits the custom value.
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onSelectInterface).toHaveBeenCalledWith('enp3s0')
+  })
+})

--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/interface-selector.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/interface-selector.tsx
@@ -44,14 +44,10 @@ const InterfaceSelector = ({
     [interfaces],
   )
 
-  // Filter options based on input
-  const filteredOptions = useMemo(() => {
-    if (!inputValue.trim()) return options
-    const lowerInput = inputValue.toLowerCase()
-    return options.filter(
-      (opt) => opt.value.toLowerCase().includes(lowerInput) || opt.label.toLowerCase().includes(lowerInput),
-    )
-  }, [options, inputValue])
+  // No typed-text filtering: the scan returns the full set of adapters the
+  // runtime can see, and that list should always be shown in full. The input
+  // is for entering a custom interface name (e.g. one not yet up), not for
+  // narrowing the discovered list — narrowing only hid valid choices.
 
   // Focus input and select all text when dropdown opens
   useEffect(() => {
@@ -67,10 +63,10 @@ const InterfaceSelector = ({
 
   // Scroll highlighted option into view
   useEffect(() => {
-    if (highlightedIndex >= 0 && highlightedIndex < filteredOptions.length && optionRefs.current[highlightedIndex]) {
+    if (highlightedIndex >= 0 && highlightedIndex < options.length && optionRefs.current[highlightedIndex]) {
       optionRefs.current[highlightedIndex]?.scrollIntoView({ block: 'nearest' })
     }
-  }, [highlightedIndex, filteredOptions.length])
+  }, [highlightedIndex, options.length])
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value)
@@ -95,14 +91,14 @@ const InterfaceSelector = ({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'ArrowDown') {
       e.preventDefault()
-      setHighlightedIndex((prev) => (prev < filteredOptions.length - 1 ? prev + 1 : 0))
+      setHighlightedIndex((prev) => (prev < options.length - 1 ? prev + 1 : 0))
     } else if (e.key === 'ArrowUp') {
       e.preventDefault()
-      setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : filteredOptions.length - 1))
+      setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : options.length - 1))
     } else if (e.key === 'Enter') {
       e.preventDefault()
-      if (highlightedIndex >= 0 && highlightedIndex < filteredOptions.length) {
-        handleSelectOption(filteredOptions[highlightedIndex].value)
+      if (highlightedIndex >= 0 && highlightedIndex < options.length) {
+        handleSelectOption(options[highlightedIndex].value)
       } else if (inputValue.trim()) {
         onSelectInterface(inputValue.trim())
         setIsOpen(false)
@@ -156,8 +152,8 @@ const InterfaceSelector = ({
                 <div className='flex items-center justify-center py-2 text-xs text-neutral-500'>
                   Loading interfaces...
                 </div>
-              ) : filteredOptions.length > 0 ? (
-                filteredOptions.map((option, index) => (
+              ) : options.length > 0 ? (
+                options.map((option, index) => (
                   <div
                     key={option.value}
                     ref={(el) => (optionRefs.current[index] = el)}
@@ -183,13 +179,11 @@ const InterfaceSelector = ({
                 ))
               ) : (
                 <div className='px-2 py-2 text-center text-xs text-neutral-500'>
-                  {options.length === 0
-                    ? 'No interfaces available. Type a custom value.'
-                    : 'No matches. Type a custom value.'}
+                  No interfaces available. Type a custom value.
                 </div>
               )}
             </div>
-            {inputValue.trim() && !filteredOptions.some((opt) => opt.value === inputValue.trim()) && (
+            {inputValue.trim() && !options.some((opt) => opt.value === inputValue.trim()) && (
               <div
                 className='flex cursor-pointer items-center gap-2 border-t border-neutral-200 px-2 py-1 hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800'
                 onClick={() => handleSelectOption(inputValue.trim())}


### PR DESCRIPTION
## Summary

On the EtherCAT configuration screen, the **Network Interface** combobox filtered the discovered-adapter list by whatever the user typed, which could hide adapters the runtime scan returned. The input is for entering a **custom** interface name — not for filtering. The full scanned list is now **always shown**, with custom-value entry preserved.

Mirror of openplc-web PR #557 (byte-identical shared surface).

## Changes

- Removed the `inputValue`-based `filteredOptions` memo in `interface-selector.tsx`; dropdown, keyboard nav, and empty-state now operate on the full `options` list.
- Custom-value entry unchanged (type + Enter, or the "Use ..." affordance).

## Testing

- New component test — 3/3 pass (all adapters shown, no narrowing while typing, custom value commits on Enter).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the EtherCAT interface picker to keep showing all discovered network interfaces while you type.
  * Improved keyboard selection so arrow keys and Enter work consistently with the full list.
  * Added clearer empty-state messaging when no interfaces are found.
  * Enabled using a custom interface name directly from the dropdown when it isn’t in the scanned list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->