### PR TITLE
fix(security): re-verify VPP signature on use, not only on import

### DIFF
--- a/src/backend/editor/package-manager/__tests__/package-manager-module.test.ts
+++ b/src/backend/editor/package-manager/__tests__/package-manager-module.test.ts
@@ -1,0 +1,87 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// app.getPath('userData') drives packagesDir/registryPath in the constructor.
+// Point it at a per-test temp dir (mock-prefixed so jest's factory may close
+// over it).
+let mockUserData = ''
+jest.mock('electron', () => ({ app: { getPath: () => mockUserData } }))
+
+// Control the signature verdict directly — this suite verifies the gating
+// logic (verify-on-use), not the Ed25519 crypto (covered by
+// verify-package-signature.test.ts). Without a mock we'd need the private
+// signing key.
+const mockVerify = jest.fn()
+jest.mock('../../../shared/utils/vpp/verify-package-signature', () => ({
+  SIGNATURE_FILENAME: 'signature.json',
+  verifyPackageSignature: (dir: string, keys: unknown) => mockVerify(dir, keys),
+}))
+
+// Keep the schema out of scope — return the raw JSON as-is so the test focuses
+// on signature gating, not manifest shape (the schema has its own tests).
+jest.mock('../../../../middleware/shared/ports/package-manifest-schema', () => ({
+  PackageManifestSchema: { safeParse: (raw: unknown) => ({ success: true, data: raw }) },
+}))
+
+import { PackageManagerModule } from '../package-manager-module'
+
+describe('PackageManagerModule signature re-verification (verify-on-use)', () => {
+  const PKG_ID = 'com.test.board'
+  let pm: PackageManagerModule
+  let pkgDir: string
+
+  const manifest = {
+    formatVersion: '1.0',
+    package: { id: PKG_ID, name: 'Test', version: '1.0.0', vendor: { name: 'x', logo: 'l.png' }, description: 'd' },
+    devices: [{ id: 'b1', name: 'Board 1' }],
+  }
+
+  beforeEach(() => {
+    mockUserData = mkdtempSync(join(tmpdir(), 'pm-verify-'))
+    const packagesDir = join(mockUserData, 'packages')
+    pkgDir = join(packagesDir, PKG_ID)
+    mkdirSync(pkgDir, { recursive: true })
+    writeFileSync(join(pkgDir, 'manifest.json'), JSON.stringify(manifest), 'utf-8')
+    // A registry entry a user could have written by hand — the bypass under test.
+    writeFileSync(
+      join(packagesDir, 'registry.json'),
+      JSON.stringify({
+        formatVersion: '1.0',
+        packages: { [PKG_ID]: { version: '1.0.0', installedAt: 'now', path: pkgDir, devices: ['b1'] } },
+      }),
+      'utf-8',
+    )
+    mockVerify.mockReset()
+    pm = new PackageManagerModule()
+  })
+
+  afterEach(() => {
+    rmSync(mockUserData, { recursive: true, force: true })
+  })
+
+  it('hides a registered package whose on-disk signature does not verify (manual-drop bypass closed)', () => {
+    mockVerify.mockReturnValue({ valid: false, error: 'Untrusted signing key' })
+
+    expect(pm.listInstalled()).toEqual([])
+    expect(pm.getInstalledPackageManifest(PKG_ID)).toBeNull()
+    // The verdict came from re-verifying the on-disk package, not the registry.
+    expect(mockVerify).toHaveBeenCalledWith(pkgDir, expect.anything())
+  })
+
+  it('treats a verification throw as untrusted (fails closed)', () => {
+    mockVerify.mockImplementation(() => {
+      throw new Error('boom')
+    })
+
+    expect(pm.listInstalled()).toEqual([])
+    expect(pm.getInstalledPackageManifest(PKG_ID)).toBeNull()
+  })
+
+  it('surfaces and reads a package that still verifies on disk', () => {
+    mockVerify.mockReturnValue({ valid: true })
+
+    expect(pm.listInstalled().map((p) => p.packageId)).toContain(PKG_ID)
+    expect(pm.getInstalledPackageManifest(PKG_ID)?.package.id).toBe(PKG_ID)
+  })
+})

--- a/src/backend/editor/package-manager/package-manager-module.ts
+++ b/src/backend/editor/package-manager/package-manager-module.ts
@@ -134,10 +134,22 @@ class PackageManagerModule {
 
   listInstalled(): InstalledPackage[] {
     const registry = this.readRegistry()
-    return Object.entries(registry.packages).map(([packageId, info]) => ({
-      packageId,
-      ...info,
-    }))
+    // Only surface packages that still pass signature verification on disk.
+    // The registry is not a trust anchor (it lives in user-writable userData),
+    // so a tampered or manually-dropped package must not appear as installed.
+    return Object.entries(registry.packages)
+      .filter(([, info]) => {
+        try {
+          assertPathContained(this.packagesDir, info.path, 'registry package path')
+        } catch {
+          return false
+        }
+        return this.isInstalledPackageTrusted(info.path)
+      })
+      .map(([packageId, info]) => ({
+        packageId,
+        ...info,
+      }))
   }
 
   uninstall(packageId: string): { success: boolean; error?: string } {
@@ -191,6 +203,12 @@ class PackageManagerModule {
       return null
     }
 
+    // Re-verify the signature against the on-disk bytes before trusting the
+    // manifest. This is the trust boundary for consumption (the compiler reads
+    // hal.source / hal.pluginEntry / screen paths from here); the import-time
+    // check does not cover packages placed directly under packagesDir.
+    if (!this.isInstalledPackageTrusted(pkg.path)) return null
+
     const manifestPath = join(pkg.path, 'manifest.json')
     if (!existsSync(manifestPath)) return null
 
@@ -208,6 +226,26 @@ class PackageManagerModule {
     const registry = this.readRegistry()
     const pkg = registry.packages[packageId]
     return pkg?.path ?? null
+  }
+
+  /**
+   * Re-verify an installed package's signature against the bytes currently on
+   * disk. `importFromFile` only proves the package was signed WHEN IT ARRIVED;
+   * the extracted package then lives under the user-writable
+   * `userData/packages` dir, and `registry.json` is editor-owned but also
+   * user-writable. So anything that reads a package back must re-verify before
+   * trusting it — otherwise dropping files into the packages dir plus a
+   * registry entry bypasses signing entirely (verify-on-import was never
+   * verify-on-use). Honours REQUIRE_SIGNATURE so the local/offline unsigned
+   * dev workflow still works.
+   */
+  private isInstalledPackageTrusted(packagePath: string): boolean {
+    if (!REQUIRE_SIGNATURE) return true
+    try {
+      return verifyPackageSignature(packagePath, TRUSTED_PACKAGE_KEYS).valid
+    } catch {
+      return false
+    }
   }
 
   private readRegistry(): PackageRegistry {


### PR DESCRIPTION
## Summary

VPP signature verification ran **only** at import time (`importFromFile`). After import, the package lives under the user-writable `userData/packages` dir and `registry.json` is trusted as the system of record — so `listInstalled()` and `getInstalledPackageManifest()` returned package contents **without re-checking the signature**.

A user could drop an extracted (unsigned or self-signed) package into `packages/<id>/` plus a `registry.json` entry and the editor would enumerate it and compile its HAL/plugin — fully bypassing the trust anchor. Verify-on-import was never verify-on-use.

## Fix

- New `isInstalledPackageTrusted()` — re-verifies the on-disk package against `TRUSTED_PACKAGE_KEYS`, honours `REQUIRE_SIGNATURE`, and fails closed on any throw.
- `getInstalledPackageManifest()` re-verifies before returning the manifest (the compiler reads `hal.source` / `hal.pluginEntry` / screen paths from here).
- `listInstalled()` filters to packages that still pass **path-containment AND signature verification**, so tampered or manually-dropped packages never surface.

Editor-only module (`src/backend/editor/`), not the shared surface — no openplc-web mirror needed.

## Tests

`package-manager-module.test.ts` (new): untrusted on-disk package is hidden + manifest returns null; a verification throw fails closed; a still-valid package surfaces normally.

## Scope note

This closes the **post-import tampering / manual-drop** vector in the official binary. It does not (and cannot) prevent someone who builds the open-source editor from source from relaxing `REQUIRE_SIGNATURE` or adding their own trusted key — that is inherent to an open-source app and out of scope.

Generated with [Claude Code](https://claude.com/claude-code)