### PR TITLE
fix: avoid duplicate/misleading compile errors after a failed build

### DIFF
--- a/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
@@ -244,6 +244,10 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
       const freshProjectData = useOpenPLCStore.getState().project.data
 
       try {
+        // Track whether the compile stream already surfaced an error so we
+        // don't log a second, generic "Compilation failed" after a failed
+        // build (the stream already reported the real error).
+        let streamedError = false
         const result = await compiler.compileProgram(
           {
             projectData: freshProjectData,
@@ -276,6 +280,9 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
                 .getState()
                 .deviceActions.setPlcRuntimeStatus(event.plcStatus as NonNullable<RuntimeConnection['plcStatus']>)
             }
+            if (event.level === 'error' || event.stage === 'error') {
+              streamedError = true
+            }
             logCompilerEvent(event, addLog)
             if (event.firmwarePath && isSimulatorBoard) {
               void simulator.loadFirmware(event.firmwarePath).then((loadResult) => {
@@ -305,7 +312,7 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
           },
         )
 
-        if (!result.success) {
+        if (!result.success && !streamedError) {
           addLog({ id: crypto.randomUUID(), level: 'error', message: result.error ?? 'Compilation failed' })
         }
       } catch (err: unknown) {

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -1235,7 +1235,14 @@ class MainProcessBridge implements MainIpcModule {
 
   handleRunCompileProgram = (event: IpcMainEvent, args: Array<string | PLCProjectData>) => {
     const mainProcessPort = event.ports[0]
-    void this.compilerModule.compileProgram(args, mainProcessPort, this)
+    void this.compilerModule.compileProgram(args, mainProcessPort, this).catch((error) => {
+      mainProcessPort.postMessage({
+        logLevel: 'error',
+        message: `${getErrorMessage(error)}\nStopping compilation process.`,
+      })
+      mainProcessPort.postMessage({ closePort: true })
+      mainProcessPort.close()
+    })
   }
 
   handleRunDebugCompilation = (event: IpcMainEvent, args: Array<string | PLCProjectData>) => {

--- a/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
@@ -278,6 +278,29 @@ describe('createEditorCompilerAdapter', () => {
 
       expect(result).toEqual({ success: false, error: 'Compilation failed: missing file' })
       expect(progressEvents.some((e) => e.stage === 'error')).toBe(true)
+      expect(progressEvents.some((e) => e.stage === 'done' && e.message === 'Compilation complete')).toBe(false)
+    })
+
+    it('ignores duplicate closePort events after an error', async () => {
+      const progressEvents: CompileProgressEvent[] = []
+      const promise = adapter.compileProgram(
+        {
+          projectData: mockProjectData,
+          boardTarget: 'Arduino Mega',
+          projectPath: '/path',
+        },
+        (event) => progressEvents.push(event),
+      )
+
+      await flushMicrotasks()
+      compileCallback!({ message: 'Board not found', logLevel: 'error' })
+      compileCallback!({ closePort: true })
+      compileCallback!({ closePort: true })
+
+      const result = await promise
+
+      expect(result).toEqual({ success: false, error: 'Board not found' })
+      expect(progressEvents).toEqual([{ stage: 'error', message: 'Board not found', level: 'error' }])
     })
 
     it('captures simulatorFirmwarePath as hexPath', async () => {

--- a/src/middleware/adapters/editor/compiler-adapter.ts
+++ b/src/middleware/adapters/editor/compiler-adapter.ts
@@ -204,6 +204,7 @@ export function createEditorCompilerAdapter(): CompilerPort {
         let hasError = false
         let lastError = ''
         let hexPath: string | undefined
+        let settled = false
 
         window.bridge.runCompileProgram(
           [
@@ -233,7 +234,11 @@ export function createEditorCompilerAdapter(): CompilerPort {
             }
 
             if (data.closePort) {
-              onProgress({ stage: 'done', message: 'Compilation complete' })
+              if (settled) return
+              settled = true
+              if (!hasError) {
+                onProgress({ stage: 'done', message: 'Compilation complete' })
+              }
               resolve(
                 hasError
                   ? { success: false, error: lastError }


### PR DESCRIPTION
## Summary
- Stop emitting a misleading `Compilation complete` progress event and a  duplicate generic `Compilation failed` log when a build fails, the stream already reports the real error.
- Make the compiler IPC handler resilient to unexpected rejections so a throw before board selection (e.g. corrupt `hals.json`) still terminates the build cleanly instead of leaving the renderer pending.

## Background
This is a focused re-implementation of the relevant part of #792 on top of current `development`. The board-resolution hang that #792 targeted is already fixed on `development` via the `resolveBoardSelection` refactor (failure logs the error and closes the port; the renderer bridge turns the port `close` into a `closePort` message that resolves the compile
promise). So the compiler-module change from #792 is redundant here and was intentionally dropped, this PR keeps only the still-relevant pieces.

## Changes
- `compiler-adapter.ts`: `settled` guard on `closePort` + skip `Compilation complete` when `hasError`.
- `workspace-activity-bar/default.tsx`: `streamedError` flag to suppress the duplicate generic failure log.
- `main.ts`: `.catch` backstop on `compileProgram` (posts error + `closePort` + closes the port).
- `compiler-adapter.test.ts`: regression test for duplicate `closePort` after an error.

## Out of scope
The broader bridge-resilience refactor from #792 (optional-chaining fallbacks across ~9 adapters, webpack react alias, SVG attribute fixes) is **not** included, including the `system-adapter` `matchMedia` fallback (and its latent `?.matches` TypeError). If we want that, it should be a separate PR.

## Validation
- `npx jest src/middleware/adapters/editor --runInBand --no-coverage` → 16 suites / 313 tests passing
- `tsc --noEmit` clean on the changed files



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compilation error handling so only the most relevant error message is shown.
  * Prevented duplicate completion messages after a failed compile.
  * Ensured compilation stops cleanly when an error occurs.
  * Ignored repeated close events to avoid inconsistent final status updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->