### PR TITLE
refactor(combobox): unify all device pickers on GenericComboboxCell

### DIFF
--- a/src/frontend/components/_atoms/generic-table-inputs/__tests__/generic-combobox-cell.test.tsx
+++ b/src/frontend/components/_atoms/generic-table-inputs/__tests__/generic-combobox-cell.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { GenericComboboxCell } from '../generic-combobox-cell'
+
+const OPTIONS = [
+  { id: 'a', value: 'Alpha', label: 'Alpha' },
+  { id: 'b', value: 'Beta', label: 'Beta' },
+  { id: 'g', value: 'Gamma', label: 'Gamma' },
+]
+
+const renderCell = (props?: Partial<React.ComponentProps<typeof GenericComboboxCell>>) =>
+  render(<GenericComboboxCell value='' onValueChange={() => {}} selectValues={OPTIONS} {...props} />)
+
+// Radix DropdownMenu's trigger opens on Enter — deterministic across runners.
+const open = () => fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' })
+const type = (text: string) =>
+  fireEvent.change(screen.getByPlaceholderText('Enter a value...'), { target: { value: text } })
+
+describe('GenericComboboxCell', () => {
+  it('filters options case-insensitively (uppercase query matches mixed-case label)', () => {
+    renderCell()
+    open()
+    type('ALP')
+
+    expect(screen.getByText('Alpha')).toBeTruthy()
+    expect(screen.queryByText('Beta')).toBeNull()
+    expect(screen.queryByText('Gamma')).toBeNull()
+  })
+
+  it('filters options case-insensitively (lowercase query matches mixed-case label)', () => {
+    renderCell()
+    open()
+    type('bet')
+
+    expect(screen.getByText('Beta')).toBeTruthy()
+    expect(screen.queryByText('Alpha')).toBeNull()
+  })
+
+  it('keeps the full list visible when disableFilter is set, regardless of typed text', () => {
+    renderCell({ disableFilter: true })
+    open()
+    type('zzz')
+
+    expect(screen.getByText('Alpha')).toBeTruthy()
+    expect(screen.getByText('Beta')).toBeTruthy()
+    expect(screen.getByText('Gamma')).toBeTruthy()
+  })
+})

--- a/src/frontend/components/_atoms/generic-table-inputs/generic-combobox-cell.tsx
+++ b/src/frontend/components/_atoms/generic-table-inputs/generic-combobox-cell.tsx
@@ -1,6 +1,7 @@
 import * as PrimitiveDropdown from '@radix-ui/react-dropdown-menu'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
+import { ArrowIcon } from '../../../assets/icons/interface/Arrow'
 import { CloseIcon } from '../../../assets/icons/interface/Close'
 import { PlusIcon } from '../../../assets/icons/interface/Plus'
 import { cn } from '../../../utils/cn'
@@ -18,6 +19,11 @@ type SelectGroup = {
   options: Array<SelectOption>
 }
 
+// Default trigger look = the table-cell style (centered, borderless). Field-style
+// callers (device pickers) override it via `triggerClassName`.
+const DEFAULT_TRIGGER_CLASS =
+  'w-full flex-1 items-center justify-center p-2 font-caption text-cp-sm font-medium text-neutral-700 outline-none dark:text-neutral-500'
+
 export const GenericComboboxCell = ({
   value,
   onValueChange,
@@ -27,6 +33,16 @@ export const GenericComboboxCell = ({
   canAddACustomOption = false,
   allowClearWhenEmpty = false,
   displayLabel,
+  // --- consolidation props (all optional; defaults preserve current behavior) ---
+  disableFilter = false,
+  placeholder = 'Enter a value...',
+  emptyMessage = 'No options available',
+  customValueLabel = 'Add custom value',
+  clearLabel = 'Clear location',
+  showClearOption = true,
+  disabled = false,
+  triggerClassName,
+  showChevron = false,
 }: {
   value: string
   onValueChange: (value: string) => void
@@ -44,6 +60,28 @@ export const GenericComboboxCell = ({
    *  variable cells to render `alias (address)` so the bound alias
    *  stays visible alongside the raw address the combobox edits. */
   displayLabel?: string
+  /** When true the option list is shown in full and never narrowed by the typed
+   *  text — the input only feeds the "add custom value" path. Used by pickers
+   *  (e.g. EtherCAT interface) where the discovered list must stay fully visible
+   *  and typing means "enter a custom value". Default false keeps filtering on. */
+  disableFilter?: boolean
+  /** Filter / custom-value input placeholder. */
+  placeholder?: string
+  /** Message shown when the (filtered) option list is empty. */
+  emptyMessage?: string
+  /** Label for the "add custom value" affordance. */
+  customValueLabel?: string
+  /** Label for the clear affordance. */
+  clearLabel?: string
+  /** Show the clear affordance alongside the custom-value button. Default true
+   *  preserves the variable-location cell behavior. */
+  showClearOption?: boolean
+  /** Render the trigger non-interactive (locked field). */
+  disabled?: boolean
+  /** Override the trigger layout/look (field-style vs the default table cell). */
+  triggerClassName?: string
+  /** Render a dropdown chevron in the trigger (field-style pickers). */
+  showChevron?: boolean
 }) => {
   const [selectIsOpen, setSelectIsOpen] = useState(false)
   const selectRef = useRef<HTMLDivElement>(null)
@@ -137,7 +175,7 @@ export const GenericComboboxCell = ({
           return null
         } else {
           const label = item.label || item.value
-          if (label.includes(input)) {
+          if (label.toLowerCase().includes(input.toLowerCase())) {
             return item
           }
           return null
@@ -147,8 +185,12 @@ export const GenericComboboxCell = ({
   }
 
   // Flatten filtered options for navigation
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const filteredOptions = useMemo(() => filterOptions(selectValues, inputValue), [selectValues, inputValue])
+
+  const filteredOptions = useMemo(
+    () => (disableFilter ? selectValues : filterOptions(selectValues, inputValue)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectValues, inputValue, disableFilter],
+  )
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const flatFilteredOptions = useMemo(() => flattenOptions(filteredOptions), [filteredOptions])
 
@@ -177,8 +219,9 @@ export const GenericComboboxCell = ({
   // Keyboard navigation handler
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     const showButton = canAddACustomOption && !isButtonDisabled
-    const showClearButton = canAddACustomOption && !isClearButtonDisabled
-    const totalOptions = flatFilteredOptions.length + (canAddACustomOption ? 2 : 0)
+    const showClearButton = canAddACustomOption && showClearOption && !isClearButtonDisabled
+    const totalOptions =
+      flatFilteredOptions.length + (canAddACustomOption ? 1 : 0) + (canAddACustomOption && showClearOption ? 1 : 0)
     if (e.key === 'ArrowDown') {
       e.preventDefault()
       setHighlightedIndex((prev) => {
@@ -215,12 +258,25 @@ export const GenericComboboxCell = ({
   return (
     <PrimitiveDropdown.Root open={selectIsOpen} onOpenChange={handleOnOpenChange}>
       <PrimitiveDropdown.Trigger
+        disabled={disabled}
         className={cn(
-          'w-full flex-1 items-center justify-center p-2 font-caption text-cp-sm font-medium text-neutral-700 outline-none dark:text-neutral-500',
+          triggerClassName ?? DEFAULT_TRIGGER_CLASS,
           { 'pointer-events-none': !selected },
+          disabled && 'cursor-not-allowed opacity-60',
+          showChevron && 'flex items-center justify-between gap-1',
         )}
       >
-        {displayLabel ?? value ?? ''}
+        {showChevron ? (
+          <>
+            <span className='truncate'>{displayLabel ?? value ?? ''}</span>
+            <ArrowIcon
+              size='sm'
+              className={cn('rotate-270 stroke-brand transition-all', selectIsOpen && 'rotate-90')}
+            />
+          </>
+        ) : (
+          (displayLabel ?? value ?? '')
+        )}
       </PrimitiveDropdown.Trigger>
       <PrimitiveDropdown.Content
         sideOffset={12}
@@ -238,7 +294,7 @@ export const GenericComboboxCell = ({
               e.stopPropagation()
               handleInputKeyDown(e)
             }}
-            placeholder='Enter a value...'
+            placeholder={placeholder}
             className='w-full rounded-md border border-neutral-200 px-2 py-1 text-xs text-neutral-700 outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-500'
           />
         </div>
@@ -305,7 +361,7 @@ export const GenericComboboxCell = ({
                 renderOptions(filteredOptions, 0)
               ) : (
                 <div className='flex h-full w-full items-center justify-center py-2 opacity-60'>
-                  <span className='text-neutral-500'>No options available</span>
+                  <span className='text-neutral-500'>{emptyMessage}</span>
                 </div>
               )
             })()}
@@ -337,33 +393,35 @@ export const GenericComboboxCell = ({
               }}
             >
               <PlusIcon className='h-3 w-3 stroke-brand' />
-              <div className='ml-2'>Add custom value</div>
+              <div className='ml-2'>{customValueLabel}</div>
             </div>
-            <div
-              className={cn(
-                'flex h-fit min-h-8 w-full cursor-pointer flex-row items-center justify-center border-t border-neutral-200 p-1 dark:border-neutral-800',
-                'hover:bg-neutral-600 dark:hover:bg-neutral-900',
-                'bg-white dark:bg-neutral-950',
-                'rounded-b-lg',
-                isClearButtonDisabled ? 'pointer-events-none cursor-not-allowed opacity-50' : '',
-                !isClearButtonDisabled && highlightedIndex === flatFilteredOptions.length + 1
-                  ? 'bg-neutral-100 dark:bg-neutral-900'
-                  : '',
-              )}
-              tabIndex={0}
-              role='button'
-              aria-disabled={isClearButtonDisabled}
-              onMouseEnter={() => !isClearButtonDisabled && setHighlightedIndex(flatFilteredOptions.length + 1)}
-              onClick={() => {
-                if (!isClearButtonDisabled) {
-                  handleOnValueChange('')
-                  handleOnOpenChange(false)
-                }
-              }}
-            >
-              <CloseIcon className='h-3 w-3 stroke-red-500' />
-              <div className='ml-2'>Clear location</div>
-            </div>
+            {showClearOption && (
+              <div
+                className={cn(
+                  'flex h-fit min-h-8 w-full cursor-pointer flex-row items-center justify-center border-t border-neutral-200 p-1 dark:border-neutral-800',
+                  'hover:bg-neutral-600 dark:hover:bg-neutral-900',
+                  'bg-white dark:bg-neutral-950',
+                  'rounded-b-lg',
+                  isClearButtonDisabled ? 'pointer-events-none cursor-not-allowed opacity-50' : '',
+                  !isClearButtonDisabled && highlightedIndex === flatFilteredOptions.length + 1
+                    ? 'bg-neutral-100 dark:bg-neutral-900'
+                    : '',
+                )}
+                tabIndex={0}
+                role='button'
+                aria-disabled={isClearButtonDisabled}
+                onMouseEnter={() => !isClearButtonDisabled && setHighlightedIndex(flatFilteredOptions.length + 1)}
+                onClick={() => {
+                  if (!isClearButtonDisabled) {
+                    handleOnValueChange('')
+                    handleOnOpenChange(false)
+                  }
+                }}
+              >
+                <CloseIcon className='h-3 w-3 stroke-red-500' />
+                <div className='ml-2'>{clearLabel}</div>
+              </div>
+            )}
           </>
         )}
       </PrimitiveDropdown.Content>

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
@@ -3,6 +3,7 @@ import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } 
 import { CSS } from '@dnd-kit/utilities'
 import { DragHandleIcon } from '@root/frontend/assets/icons/interface/DragHandle'
 import { Checkbox } from '@root/frontend/components/_atoms/checkbox'
+import { GenericComboboxCell } from '@root/frontend/components/_atoms/generic-table-inputs/generic-combobox-cell'
 import { Label } from '@root/frontend/components/_atoms/label'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@root/frontend/components/_atoms/select'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@root/frontend/components/_atoms/tooltip'
@@ -168,6 +169,67 @@ function SortableSlotButton({ idx, moduleName, ioSummary, isSelected, draggable,
         </span>
       </button>
     </div>
+  )
+}
+
+// Field-style trigger matching the other vendor-screen pickers.
+const MODULE_PICKER_TRIGGER_CLASS =
+  'flex h-[32px] w-80 cursor-pointer items-center justify-between gap-1 rounded-md border border-neutral-100 bg-white px-3 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none data-[state=open]:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
+
+// Sentinel value for the "-- Empty --" choice. Translated to '' (clear the slot)
+// at the onChange boundary so callers never see it.
+const EMPTY_SLOT_VALUE = '__empty__'
+
+type ModuleSlotPickerProps = {
+  slotNumber: number
+  /** Modules offered in the list (already scoped: fixed-only when locked). */
+  modules: ModuleDefinition[]
+  selectedModule: ModuleDefinition | undefined
+  /** Offer the "-- Empty --" choice (physical mode, unlocked slots). */
+  includeEmpty: boolean
+  /** Locked (built-in) slot — picker is non-interactive. */
+  disabled: boolean
+  /** Receives the module id, or '' when the slot is cleared. */
+  onChange: (moduleId: string) => void
+}
+
+/**
+ * Per-slot module picker.
+ *
+ * A thin wrapper over the shared GenericComboboxCell — the single combobox in
+ * the app. It maps the module list to options (sorted alphabetically, with an
+ * optional "-- Empty --" entry), translates the empty sentinel back to '' for
+ * the caller, and renders the field-style trigger. The combobox provides the
+ * search filter for free; custom values are disabled (only known modules).
+ */
+const ModuleSlotPicker = ({
+  slotNumber,
+  modules,
+  selectedModule,
+  includeEmpty,
+  disabled,
+  onChange,
+}: ModuleSlotPickerProps) => {
+  const selectValues = useMemo(() => {
+    const sorted = [...modules]
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((m) => ({ id: m.id, value: m.id, label: m.name }))
+    return includeEmpty ? [{ id: EMPTY_SLOT_VALUE, value: EMPTY_SLOT_VALUE, label: '-- Empty --' }, ...sorted] : sorted
+  }, [modules, includeEmpty])
+
+  return (
+    <GenericComboboxCell
+      value={selectedModule ? selectedModule.id : EMPTY_SLOT_VALUE}
+      onValueChange={(v) => onChange(v === EMPTY_SLOT_VALUE ? '' : v)}
+      selectValues={selectValues}
+      displayLabel={selectedModule ? selectedModule.name : '-- Empty --'}
+      disabled={disabled}
+      showClearOption={false}
+      showChevron
+      triggerClassName={MODULE_PICKER_TRIGGER_CLASS}
+      placeholder={`Search modules… (slot ${slotNumber})`}
+      emptyMessage='No modules available'
+    />
   )
 }
 
@@ -802,47 +864,14 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
                         <Label className='w-20 shrink-0 text-xs font-medium text-neutral-950 dark:text-white'>
                           Module
                         </Label>
-                        <Select
-                          value={selectedModule ? selectedModule.id : '__empty__'}
-                          onValueChange={(v) => handleSlotChange(selectedSlot, v === '__empty__' ? '' : v)}
+                        <ModuleSlotPicker
+                          slotNumber={selectedSlot + 1}
+                          modules={dropdownModules}
+                          selectedModule={selectedModule}
+                          includeEmpty={!stackable && !locked}
                           disabled={locked}
-                        >
-                          <SelectTrigger
-                            aria-label={`Module for slot ${selectedSlot + 1}`}
-                            placeholder='-- Empty --'
-                            withIndicator
-                            className='flex h-[32px] w-80 cursor-pointer items-center justify-between gap-1 rounded-md border border-neutral-100 bg-white px-3 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none data-[disabled]:cursor-not-allowed data-[state=open]:border-brand-medium-dark data-[disabled]:opacity-60 dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
-                          />
-                          <SelectContent
-                            className='h-fit max-h-[280px] w-[--radix-select-trigger-width] overflow-y-auto rounded-lg border border-neutral-100 bg-white outline-none drop-shadow-lg dark:border-brand-medium-dark dark:bg-neutral-950'
-                            sideOffset={5}
-                            position='popper'
-                            align='center'
-                            side='bottom'
-                          >
-                            {!stackable && !locked && (
-                              <SelectItem
-                                value='__empty__'
-                                className='flex w-full cursor-pointer items-center px-2 py-[6px] outline-none hover:bg-neutral-200 dark:hover:bg-neutral-850'
-                              >
-                                <span className='font-caption text-cp-sm font-medium italic text-neutral-500 dark:text-neutral-400'>
-                                  -- Empty --
-                                </span>
-                              </SelectItem>
-                            )}
-                            {dropdownModules.map((mod) => (
-                              <SelectItem
-                                key={mod.id}
-                                value={mod.id}
-                                className='flex w-full cursor-pointer items-center px-2 py-[6px] outline-none hover:bg-neutral-200 dark:hover:bg-neutral-850'
-                              >
-                                <span className='font-caption text-cp-sm font-medium text-neutral-850 dark:text-neutral-300'>
-                                  {mod.name}
-                                </span>
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
+                          onChange={(moduleId) => handleSlotChange(selectedSlot, moduleId)}
+                        />
                         {stackable && selectedModule && !locked && (
                           <button
                             type='button'

--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/__tests__/interface-selector.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/__tests__/interface-selector.test.tsx
@@ -22,41 +22,59 @@ const renderSelector = (overrides?: Partial<React.ComponentProps<typeof Interfac
     />,
   )
 
+// Radix DropdownMenu's trigger opens on Enter — drive it with a keydown so the
+// test stays dependency-free and deterministic across both repos' runners
+// (jsdom's PointerEvent support varies between Jest and Vitest).
+const openDropdown = () => {
+  fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' })
+}
+
+// Each adapter renders as `name — description` (the GenericComboboxCell option label).
+const adapterOption = (name: string) => screen.getByText(new RegExp(`^${name} —`))
+
 describe('InterfaceSelector', () => {
   it('lists every scanned interface when the dropdown opens', () => {
     renderSelector()
-    fireEvent.click(screen.getByRole('button'))
+    openDropdown()
 
-    expect(screen.getByText('eth0')).toBeTruthy()
-    expect(screen.getByText('eth1')).toBeTruthy()
-    expect(screen.getByText('wlan0')).toBeTruthy()
+    expect(adapterOption('eth0')).toBeTruthy()
+    expect(adapterOption('eth1')).toBeTruthy()
+    expect(adapterOption('wlan0')).toBeTruthy()
   })
 
-  it('does NOT filter the adapter list as the user types', () => {
+  it('does NOT filter the adapter list as the user types (disableFilter)', () => {
     renderSelector()
-    fireEvent.click(screen.getByRole('button'))
+    openDropdown()
 
-    // Type text that, under the old behavior, would have hidden eth0/eth1.
+    // Type text that, under a filtering combobox, would have hidden eth0/eth1.
     fireEvent.change(screen.getByPlaceholderText('eth0'), { target: { value: 'wlan' } })
 
     // All adapters remain visible — the scan list is never narrowed.
-    expect(screen.getByText('eth0')).toBeTruthy()
-    expect(screen.getByText('eth1')).toBeTruthy()
-    expect(screen.getByText('wlan0')).toBeTruthy()
+    expect(adapterOption('eth0')).toBeTruthy()
+    expect(adapterOption('eth1')).toBeTruthy()
+    expect(adapterOption('wlan0')).toBeTruthy()
   })
 
   it('still allows entering a custom interface name not in the scan', () => {
     const onSelectInterface = vi.fn()
     renderSelector({ onSelectInterface })
-    fireEvent.click(screen.getByRole('button'))
+    openDropdown()
 
     const input = screen.getByPlaceholderText('eth0')
     fireEvent.change(input, { target: { value: 'enp3s0' } })
 
-    // The "Use ..." affordance for a custom value is present...
-    expect(screen.getByText('Use "enp3s0"')).toBeTruthy()
-    // ...and Enter commits the custom value.
+    // The custom-value affordance is present...
+    expect(screen.getByText('Use custom interface')).toBeTruthy()
+    // ...and Enter commits the typed value verbatim through onSelectInterface.
     fireEvent.keyDown(input, { key: 'Enter' })
     expect(onSelectInterface).toHaveBeenCalledWith('enp3s0')
+  })
+
+  it('shows a loading message and no adapters while a scan is in flight', () => {
+    renderSelector({ isLoading: true })
+    openDropdown()
+
+    expect(screen.getByText('Loading interfaces...')).toBeTruthy()
+    expect(screen.queryByText(/^eth0 —/)).toBeNull()
   })
 })

--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/interface-selector.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/components/interface-selector.tsx
@@ -1,11 +1,7 @@
-import * as Popover from '@radix-ui/react-popover'
-import { ArrowIcon } from '@root/frontend/assets/icons/interface/Arrow'
-import { PlusIcon } from '@root/frontend/assets/icons/interface/Plus'
-import { InputWithRef } from '@root/frontend/components/_atoms/input'
+import { GenericComboboxCell } from '@root/frontend/components/_atoms/generic-table-inputs/generic-combobox-cell'
 import { Label } from '@root/frontend/components/_atoms/label'
-import { cn } from '@root/frontend/utils/cn'
 import type { NetworkInterface } from '@root/middleware/shared/ports/ethercat-types'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo } from 'react'
 
 type InterfaceSelectorProps = {
   interfaces: NetworkInterface[]
@@ -15,10 +11,17 @@ type InterfaceSelectorProps = {
   error: string | null
 }
 
+// Field-style trigger (bordered dropdown), distinct from the default table-cell look.
+const FIELD_TRIGGER_CLASS =
+  'flex h-[30px] w-full min-w-[200px] max-w-[300px] items-center justify-between gap-1 rounded-md border border-neutral-300 bg-white px-2 py-1 font-caption text-xs font-normal text-neutral-700 outline-none data-[state=open]:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-100'
+
 /**
- * Editable combobox for network interface selection.
- * Shows a dropdown with available interfaces from runtime, but also allows typing custom values.
- * Follows the same pattern as the Modbus RTU SerialPortCombobox.
+ * Network-interface picker for the EtherCAT screen.
+ *
+ * A thin wrapper over the shared GenericComboboxCell — the single combobox in
+ * the app. The runtime returns the full set of adapters and that list is shown
+ * in full (`disableFilter`), while the user can still type a custom interface
+ * name (`canAddACustomOption`) that propagates verbatim through onSelectInterface.
  */
 const InterfaceSelector = ({
   interfaces,
@@ -27,177 +30,41 @@ const InterfaceSelector = ({
   isLoading,
   error,
 }: InterfaceSelectorProps) => {
-  const [isOpen, setIsOpen] = useState(false)
-  const [inputValue, setInputValue] = useState(selectedInterface)
-  const inputRef = useRef<HTMLInputElement>(null)
-  const optionRefs = useRef<Array<HTMLDivElement | null>>([])
-  const [highlightedIndex, setHighlightedIndex] = useState(-1)
-
-  // Sync input value with external value changes
-  useEffect(() => {
-    setInputValue(selectedInterface)
-  }, [selectedInterface])
-
-  // Build options from interfaces
-  const options = useMemo(
-    () => interfaces.map((iface) => ({ value: iface.name, label: iface.description || iface.name })),
-    [interfaces],
+  // While a scan is in flight, present an empty list so the "Loading…" message
+  // shows (mirrors the previous behavior); otherwise map adapters to options
+  // keyed by interface name (the value that propagates).
+  const selectValues = useMemo(
+    () =>
+      isLoading
+        ? []
+        : interfaces.map((iface) => ({
+            id: iface.name,
+            value: iface.name,
+            label:
+              iface.description && iface.description !== iface.name
+                ? `${iface.name} — ${iface.description}`
+                : iface.name,
+          })),
+    [interfaces, isLoading],
   )
-
-  // No typed-text filtering: the scan returns the full set of adapters the
-  // runtime can see, and that list should always be shown in full. The input
-  // is for entering a custom interface name (e.g. one not yet up), not for
-  // narrowing the discovered list — narrowing only hid valid choices.
-
-  // Focus input and select all text when dropdown opens
-  useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => {
-        inputRef.current?.focus()
-        inputRef.current?.select()
-        const currentIndex = options.findIndex((opt) => opt.value === selectedInterface)
-        setHighlightedIndex(currentIndex >= 0 ? currentIndex : -1)
-      }, 0)
-    }
-  }, [isOpen, options, selectedInterface])
-
-  // Scroll highlighted option into view
-  useEffect(() => {
-    if (highlightedIndex >= 0 && highlightedIndex < options.length && optionRefs.current[highlightedIndex]) {
-      optionRefs.current[highlightedIndex]?.scrollIntoView({ block: 'nearest' })
-    }
-  }, [highlightedIndex, options.length])
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value)
-    setHighlightedIndex(-1)
-  }
-
-  const handleInputBlur = () => {
-    if (inputValue !== selectedInterface) {
-      onSelectInterface(inputValue)
-    }
-  }
-
-  const handleSelectOption = useCallback(
-    (optionValue: string) => {
-      setInputValue(optionValue)
-      onSelectInterface(optionValue)
-      setIsOpen(false)
-    },
-    [onSelectInterface],
-  )
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault()
-      setHighlightedIndex((prev) => (prev < options.length - 1 ? prev + 1 : 0))
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault()
-      setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : options.length - 1))
-    } else if (e.key === 'Enter') {
-      e.preventDefault()
-      if (highlightedIndex >= 0 && highlightedIndex < options.length) {
-        handleSelectOption(options[highlightedIndex].value)
-      } else if (inputValue.trim()) {
-        onSelectInterface(inputValue.trim())
-        setIsOpen(false)
-      }
-    } else if (e.key === 'Escape') {
-      setIsOpen(false)
-    }
-  }
-
-  const handleOpenChange = (open: boolean) => {
-    if (!open && inputValue.trim() !== selectedInterface) {
-      onSelectInterface(inputValue.trim())
-    }
-    setIsOpen(open)
-  }
 
   return (
     <div className='flex flex-col gap-1'>
       <Label className='text-xs text-neutral-950 dark:text-white'>Network Interface</Label>
-      <Popover.Root open={isOpen} onOpenChange={handleOpenChange}>
-        <Popover.Trigger asChild>
-          <button
-            type='button'
-            className='flex h-[30px] w-full min-w-[200px] max-w-[300px] items-center justify-between gap-1 rounded-md border border-neutral-300 bg-white px-2 py-1 font-caption font-medium text-neutral-850 outline-none data-[state=open]:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
-          >
-            <span className='truncate text-xs font-normal text-neutral-700 dark:text-neutral-100'>
-              {selectedInterface || 'Select interface'}
-            </span>
-            <ArrowIcon size='sm' className={cn('rotate-270 stroke-brand transition-all', isOpen && 'rotate-90')} />
-          </button>
-        </Popover.Trigger>
-        <Popover.Portal>
-          <Popover.Content
-            sideOffset={5}
-            align='start'
-            className='z-50 w-[--radix-popover-trigger-width] min-w-[200px] rounded-lg border border-neutral-300 bg-white shadow-lg outline-none dark:border-brand-medium-dark dark:bg-neutral-950'
-          >
-            <div className='p-2'>
-              <InputWithRef
-                ref={inputRef}
-                value={inputValue}
-                onChange={handleInputChange}
-                onBlur={handleInputBlur}
-                onKeyDown={handleKeyDown}
-                placeholder='eth0'
-                className='h-[28px] w-full rounded-md border border-neutral-200 bg-white px-2 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none focus:border-brand-medium-dark dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300'
-              />
-            </div>
-            <div className='max-h-[200px] overflow-y-auto'>
-              {isLoading ? (
-                <div className='flex items-center justify-center py-2 text-xs text-neutral-500'>
-                  Loading interfaces...
-                </div>
-              ) : options.length > 0 ? (
-                options.map((option, index) => (
-                  <div
-                    key={option.value}
-                    ref={(el) => (optionRefs.current[index] = el)}
-                    className={cn(
-                      'flex w-full cursor-pointer flex-col px-2 py-1 outline-none hover:bg-neutral-100 dark:hover:bg-neutral-800',
-                      (selectedInterface === option.value || highlightedIndex === index) &&
-                        'bg-neutral-100 dark:bg-neutral-800',
-                    )}
-                    onMouseEnter={() => setHighlightedIndex(index)}
-                    onClick={() => handleSelectOption(option.value)}
-                    role='option'
-                    aria-selected={highlightedIndex === index}
-                  >
-                    <span className='text-start font-caption text-xs font-normal text-neutral-700 dark:text-neutral-100'>
-                      {option.value}
-                    </span>
-                    {option.label !== option.value && (
-                      <span className='text-start font-caption text-[10px] font-normal text-neutral-500 dark:text-neutral-400'>
-                        {option.label}
-                      </span>
-                    )}
-                  </div>
-                ))
-              ) : (
-                <div className='px-2 py-2 text-center text-xs text-neutral-500'>
-                  No interfaces available. Type a custom value.
-                </div>
-              )}
-            </div>
-            {inputValue.trim() && !options.some((opt) => opt.value === inputValue.trim()) && (
-              <div
-                className='flex cursor-pointer items-center gap-2 border-t border-neutral-200 px-2 py-1 hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800'
-                onClick={() => handleSelectOption(inputValue.trim())}
-              >
-                <PlusIcon className='h-3 w-3 stroke-brand' />
-                <span className='font-caption text-xs font-normal text-neutral-700 dark:text-neutral-100'>
-                  Use "{inputValue.trim()}"
-                </span>
-              </div>
-            )}
-          </Popover.Content>
-        </Popover.Portal>
-      </Popover.Root>
-
+      <GenericComboboxCell
+        value={selectedInterface}
+        onValueChange={onSelectInterface}
+        selectValues={selectValues}
+        displayLabel={selectedInterface || 'Select interface'}
+        disableFilter
+        canAddACustomOption
+        showClearOption={false}
+        showChevron
+        triggerClassName={FIELD_TRIGGER_CLASS}
+        placeholder='eth0'
+        customValueLabel='Use custom interface'
+        emptyMessage={isLoading ? 'Loading interfaces...' : 'No interfaces available. Type a custom value.'}
+      />
       {error && <p className='text-xs text-red-500 dark:text-red-400'>{error}</p>}
     </div>
   )

--- a/src/frontend/components/_features/[workspace]/editor/device/remote-device/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/remote-device/index.tsx
@@ -1,7 +1,6 @@
-import * as Popover from '@radix-ui/react-popover'
 import type { ModbusIOGroup, ModbusIOPoint } from '@root/middleware/shared/ports/types'
 import { useRuntime } from '@root/middleware/shared/providers/platform-context'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
 import { ArrowIcon } from '../../../../../../assets/icons/interface/Arrow'
@@ -10,12 +9,12 @@ import { PlusIcon } from '../../../../../../assets/icons/interface/Plus'
 import { useOpenPLCStore } from '../../../../../../store'
 import { cn } from '../../../../../../utils/cn'
 import { getErrorMessage } from '../../../../../../utils/get-error-message'
+import { GenericComboboxCell } from '../../../../../_atoms/generic-table-inputs/generic-combobox-cell'
 import { InputWithRef } from '../../../../../_atoms/input'
 import { Label } from '../../../../../_atoms/label'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '../../../../../_atoms/select'
 import TableActions from '../../../../../_atoms/table-actions'
 import { Modal, ModalContent, ModalFooter, ModalHeader, ModalTitle } from '../../../../../_molecules/modal'
-import ScrollAreaComponent from '../../../../../ui/scroll-area'
 
 type FunctionCodeOption = {
   value: '1' | '2' | '3' | '4' | '5' | '6' | '15' | '16'
@@ -92,12 +91,19 @@ type SerialPortComboboxProps = {
   options: SerialPortOption[]
   isLoading?: boolean
   placeholder?: string
-  className?: string
 }
 
+// Field-style trigger (bordered, chevron) matching the other RTU config fields.
+const SERIAL_PORT_TRIGGER_CLASS =
+  'flex h-[30px] w-full max-w-[200px] items-center justify-between gap-1 rounded-md border border-neutral-300 bg-white px-2 py-1 font-caption text-xs font-normal text-neutral-700 outline-none data-[state=open]:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-100'
+
 /**
- * Editable combobox for serial port selection.
- * Shows a dropdown with available ports from runtime, but also allows typing custom values.
+ * Editable serial-port picker for RTU devices.
+ *
+ * A thin wrapper over the shared GenericComboboxCell — the single combobox in the
+ * app. Runtime-discovered ports populate the list (filterable, case-insensitive),
+ * and the user can still type a custom device path (`canAddACustomOption`) that
+ * propagates verbatim through onValueChange to the device config.
  */
 const SerialPortCombobox = ({
   value,
@@ -106,176 +112,34 @@ const SerialPortCombobox = ({
   isLoading = false,
   placeholder = '/dev/ttyUSB0',
 }: SerialPortComboboxProps) => {
-  const [isOpen, setIsOpen] = useState(false)
-  const [inputValue, setInputValue] = useState(value)
-  const inputRef = useRef<HTMLInputElement>(null)
-  const optionRefs = useRef<Array<HTMLDivElement | null>>([])
-  const [highlightedIndex, setHighlightedIndex] = useState(-1)
-
-  // Sync input value with external value changes
-  useEffect(() => {
-    setInputValue(value)
-  }, [value])
-
-  // Filter options based on input
-  const filteredOptions = useMemo(() => {
-    if (!inputValue.trim()) return options
-    const lowerInput = inputValue.toLowerCase()
-    return options.filter(
-      (opt) => opt.value.toLowerCase().includes(lowerInput) || opt.label.toLowerCase().includes(lowerInput),
-    )
-  }, [options, inputValue])
-
-  // Focus input when dropdown opens
-  useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => {
-        inputRef.current?.focus()
-        // Find and highlight current value in list
-        const currentIndex = filteredOptions.findIndex((opt) => opt.value === value)
-        setHighlightedIndex(currentIndex >= 0 ? currentIndex : -1)
-      }, 0)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen])
-
-  // Scroll highlighted option into view
-  useEffect(() => {
-    if (highlightedIndex >= 0 && highlightedIndex < filteredOptions.length && optionRefs.current[highlightedIndex]) {
-      optionRefs.current[highlightedIndex]?.scrollIntoView({ block: 'nearest' })
-    }
-  }, [highlightedIndex, filteredOptions.length])
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value)
-    setHighlightedIndex(-1)
-  }
-
-  const handleInputBlur = () => {
-    // Commit the value on blur if it changed
-    if (inputValue !== value) {
-      onValueChange(inputValue)
-    }
-  }
-
-  const handleSelectOption = (optionValue: string) => {
-    setInputValue(optionValue)
-    onValueChange(optionValue)
-    setIsOpen(false)
-  }
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault()
-      setHighlightedIndex((prev) => (prev < filteredOptions.length - 1 ? prev + 1 : 0))
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault()
-      setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : filteredOptions.length - 1))
-    } else if (e.key === 'Enter') {
-      e.preventDefault()
-      if (highlightedIndex >= 0 && highlightedIndex < filteredOptions.length) {
-        handleSelectOption(filteredOptions[highlightedIndex].value)
-      } else if (inputValue.trim()) {
-        onValueChange(inputValue.trim())
-        setIsOpen(false)
-      }
-    } else if (e.key === 'Escape') {
-      setIsOpen(false)
-    }
-  }
-
-  // Handle popover open/close - commit pending value when closing
-  const handleOpenChange = (open: boolean) => {
-    // When closing, commit any pending value before the input unmounts
-    // This handles the case where user types a value and clicks outside
-    if (!open && inputValue.trim() !== value) {
-      onValueChange(inputValue.trim())
-    }
-    setIsOpen(open)
-  }
+  // Map runtime ports to options. The device path is the value that propagates;
+  // the human description (when distinct) is appended to the visible label.
+  const selectValues = useMemo(
+    () =>
+      isLoading
+        ? []
+        : options.map((opt) => ({
+            id: opt.value,
+            value: opt.value,
+            label: opt.label && opt.label !== opt.value ? `${opt.value} — ${opt.label}` : opt.value,
+          })),
+    [options, isLoading],
+  )
 
   return (
-    <Popover.Root open={isOpen} onOpenChange={handleOpenChange}>
-      <Popover.Trigger asChild>
-        <button
-          type='button'
-          className='flex h-[30px] w-full max-w-[200px] items-center justify-between gap-1 rounded-md border border-neutral-300 bg-white px-2 py-1 font-caption font-medium text-neutral-850 outline-none data-[state=open]:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
-        >
-          <span className='truncate text-xs font-normal text-neutral-700 dark:text-neutral-100'>
-            {value || placeholder}
-          </span>
-          <ArrowIcon size='sm' className={cn('rotate-270 stroke-brand transition-all', isOpen && 'rotate-90')} />
-        </button>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content
-          sideOffset={5}
-          align='start'
-          className='z-50 w-[--radix-popover-trigger-width] min-w-[200px] rounded-lg border border-neutral-300 bg-white shadow-lg outline-none dark:border-brand-medium-dark dark:bg-neutral-950'
-        >
-          <div className='p-2'>
-            <InputWithRef
-              ref={inputRef}
-              value={inputValue}
-              onChange={handleInputChange}
-              onBlur={handleInputBlur}
-              onKeyDown={handleKeyDown}
-              placeholder={placeholder}
-              className='h-[28px] w-full rounded-md border border-neutral-200 bg-white px-2 py-1 font-caption text-cp-sm font-medium text-neutral-850 outline-none focus:border-brand-medium-dark dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300'
-            />
-          </div>
-          <ScrollAreaComponent.Root type='always'>
-            <ScrollAreaComponent.Viewport className='max-h-[200px]'>
-              {isLoading ? (
-                <div className='flex items-center justify-center py-2 text-xs text-neutral-500'>Loading ports...</div>
-              ) : filteredOptions.length > 0 ? (
-                filteredOptions.map((option, index) => (
-                  <div
-                    key={option.value}
-                    ref={(el) => (optionRefs.current[index] = el)}
-                    className={cn(
-                      'flex w-full cursor-pointer flex-col px-2 py-1 outline-none hover:bg-neutral-100 dark:hover:bg-neutral-800',
-                      (value === option.value || highlightedIndex === index) && 'bg-neutral-100 dark:bg-neutral-800',
-                    )}
-                    onMouseEnter={() => setHighlightedIndex(index)}
-                    onClick={() => handleSelectOption(option.value)}
-                    role='option'
-                    aria-selected={highlightedIndex === index}
-                  >
-                    <span className='text-start font-caption text-xs font-normal text-neutral-700 dark:text-neutral-100'>
-                      {option.value}
-                    </span>
-                    {option.label !== option.value && (
-                      <span className='text-start font-caption text-[10px] font-normal text-neutral-500 dark:text-neutral-400'>
-                        {option.label}
-                      </span>
-                    )}
-                  </div>
-                ))
-              ) : (
-                <div className='px-2 py-2 text-center text-xs text-neutral-500'>
-                  {options.length === 0
-                    ? 'No ports available. Type a custom value.'
-                    : 'No matches. Type a custom value.'}
-                </div>
-              )}
-            </ScrollAreaComponent.Viewport>
-            <ScrollAreaComponent.ScrollBar />
-          </ScrollAreaComponent.Root>
-          {inputValue.trim() && !filteredOptions.some((opt) => opt.value === inputValue.trim()) && (
-            <div
-              className='flex cursor-pointer items-center gap-2 border-t border-neutral-200 px-2 py-1 hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800'
-              onClick={() => handleSelectOption(inputValue.trim())}
-            >
-              <PlusIcon className='h-3 w-3 stroke-brand' />
-              <span className='font-caption text-xs font-normal text-neutral-700 dark:text-neutral-100'>
-                Use "{inputValue.trim()}"
-              </span>
-            </div>
-          )}
-        </Popover.Content>
-      </Popover.Portal>
-    </Popover.Root>
+    <GenericComboboxCell
+      value={value}
+      onValueChange={onValueChange}
+      selectValues={selectValues}
+      displayLabel={value || placeholder}
+      canAddACustomOption
+      showClearOption={false}
+      showChevron
+      triggerClassName={SERIAL_PORT_TRIGGER_CLASS}
+      placeholder={placeholder}
+      customValueLabel='Use custom port'
+      emptyMessage={isLoading ? 'Loading ports...' : 'No ports available. Type a custom value.'}
+    />
   )
 }
 

--- a/src/jest-vi-shim.ts
+++ b/src/jest-vi-shim.ts
@@ -2,6 +2,25 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ;(globalThis as any).vi = jest
 
+// Radix UI primitives (DropdownMenu, Select, …) rely on Pointer Capture and
+// scrollIntoView, which jsdom doesn't implement — without these, the menus
+// never open in tests. Polyfill as no-ops so combobox/dropdown components are
+// exercisable. (Editor-private setup; the web Vitest run has its own mirror.)
+if (typeof Element !== 'undefined') {
+  if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false
+  if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => undefined
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => undefined
+}
+// Radix ScrollArea (inside the combobox menu) instantiates a ResizeObserver,
+// which jsdom doesn't provide. A no-op stub is enough for tests.
+if (typeof (globalThis as { ResizeObserver?: unknown }).ResizeObserver === 'undefined') {
+  ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}
+
 // jsdom 24+ ships `structuredClone` on the window, but the jest
 // jsdom environment we ship doesn't expose it on the test global
 // scope.  Production code that runs through this shim (e.g.


### PR DESCRIPTION
## Summary

Makes **`GenericComboboxCell` the single combobox implementation** in the app and migrates the bespoke device pickers onto it as thin wrappers, eliminating duplicated dropdown / filter / keyboard / custom-value logic that had drifted between copies.

`GenericComboboxCell` gains optional, **backward-compatible** props (defaults preserve current behavior, so pin-mapping and variable cells are unaffected): `disableFilter`, `placeholder`, `emptyMessage`, `customValueLabel`, `clearLabel`, `showClearOption`, `disabled`, `triggerClassName`, `showChevron`. Filtering is now **case-insensitive**.

## Migrated pickers (behavior preserved)

| Picker | Notes |
|---|---|
| EtherCAT `InterfaceSelector` | full list shown (`disableFilter`) + custom interface typeable; keeps Label + error chrome |
| Modbus RTU `SerialPortCombobox` | filterable (now case-insensitive) + custom device path commits verbatim to JSON |
| VPP backplane module picker | was a raw `<Select>` → now sorted + filterable; `-- Empty --` clears the slot; locked slots disabled |

The pickers stay as **thin, domain-named wrappers** — they hold only the data→options mapping and field chrome; all combobox behavior is delegated to the single component (so they can't drift). Call-site signatures are unchanged, keeping the diff contained.

## Tests

- New `generic-combobox-cell.test.tsx`: case-insensitive filtering + `disableFilter`.
- `interface-selector.test.tsx` reworked to the new markup (full list, no narrowing, custom-value commit, loading state).
- Adds Radix-in-jsdom polyfills (pointer capture, `scrollIntoView`, `ResizeObserver`) to the jest shim so the dropdown opens under the runner.
- `tsc` ✓, eslint ✓, prettier ✓, webpack renderer build ✓.

## Cross-repo

Shared-surface files are **byte-identical** with the web PR on the matching branch `refactor/unify-combobox-generic` (Shared Surface Sync). Supersedes the standalone Bug #5 module-combobox PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dropdown selectors across device configuration screens with clearer labels, optional chevrons, and better handling of empty or custom entries.
  * Added support for adding custom interface and serial port values directly from the picker.

* **Bug Fixes**
  * Search/filtering in option lists is now case-insensitive.
  * Disabled filtering now keeps the full list visible while typing.

* **Tests**
  * Expanded automated coverage for combobox filtering, custom-value entry, and dropdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->