### PR TITLE
feat(opcua-client): OPC-UA Client support

### DIFF
--- a/src/backend/shared/compile/__tests__/generate-confs.test.ts
+++ b/src/backend/shared/compile/__tests__/generate-confs.test.ts
@@ -49,6 +49,7 @@ jest.mock('../../../../frontend/utils/opcua', () => {
   }
   return {
     generateOpcUaConfig: jest.fn(),
+    generateOpcUaClientConfig: jest.fn(() => null),
     OpcUaConfigError,
   }
 })
@@ -111,6 +112,7 @@ describe('generateRuntimeConfs — happy path', () => {
       modbusMaster: '{"modbus_master":{}}',
       s7Comm: '{"s7":{}}',
       opcUa: '{"opcua":{}}',
+      opcUaClient: null,
       ethercat: '{"ethercat":{}}',
     })
   })
@@ -158,6 +160,7 @@ describe('generateRuntimeConfs — happy path', () => {
       modbusMaster: null,
       s7Comm: null,
       opcUa: null,
+      opcUaClient: null,
       ethercat: null,
     })
   })

--- a/src/backend/shared/compile/pipeline.ts
+++ b/src/backend/shared/compile/pipeline.ts
@@ -529,6 +529,7 @@ async function runCompilePipelineInner(
         modbusMaster: confs.modbusMaster,
         s7Comm: confs.s7Comm,
         opcUa: confs.opcUa,
+        opcUaClient: confs.opcUaClient,
         // `generateRuntimeConfs` validated EtherCAT before returning;
         // null here means "no EtherCAT devices" → composer skips.
         ethercat: confs.ethercat ?? '',

--- a/src/backend/shared/compile/steps/generate-confs.ts
+++ b/src/backend/shared/compile/steps/generate-confs.ts
@@ -37,7 +37,7 @@
 // → frontend`) but functional, see the build-pipeline refactor plan.
 import { getErrorMessage } from '../../../../frontend/utils/get-error-message'
 import { generateModbusSlaveConfig } from '../../../../frontend/utils/modbus/generate-modbus-slave-config'
-import { generateOpcUaConfig, OpcUaConfigError } from '../../../../frontend/utils/opcua'
+import { generateOpcUaClientConfig, generateOpcUaConfig, OpcUaConfigError } from '../../../../frontend/utils/opcua'
 import { generateS7CommConfig } from '../../../../frontend/utils/s7comm'
 import { generateEthercatConfig } from '../../ethercat/generate-ethercat-config'
 import { validateEthercatConfig } from '../../ethercat/validate-ethercat-config'
@@ -87,6 +87,8 @@ export interface GenerateConfsOutput {
   modbusMaster: string | null
   s7Comm: string | null
   opcUa: string | null
+  /** OPC-UA Client (remote device). Same resolver/error semantics as opcUa. */
+  opcUaClient: string | null
   /** EtherCAT is gated on `validateEthercatConfig`; this function
    *  throws BEFORE returning when validation fails.  Successful
    *  return guarantees either `null` (no devices) or a string that
@@ -142,6 +144,21 @@ export function generateRuntimeConfs(input: GenerateConfsInput): GenerateConfsOu
     throw error
   }
 
+  // OPC-UA Client: aggregates every enabled 'opc-ua-client' remote device
+  // into one conf/opcua_client.json. Same fail-fast gate as the OPC-UA server
+  // (a renamed/deleted local variable in a mapping throws OpcUaConfigError).
+  let opcUaClient: string | null = null
+  try {
+    opcUaClient = generateOpcUaClientConfig(remoteDevices, debugMapContent, instances)
+  } catch (error) {
+    if (error instanceof OpcUaConfigError) {
+      log(`OPC-UA Client Configuration Error:\n${error.message}`, 'error')
+    } else {
+      log(`Failed to generate OPC-UA client config: ${getErrorMessage(error)}`, 'error')
+    }
+    throw error
+  }
+
   // EtherCAT: validate BEFORE returning so a bad config aborts the
   // compile before the composer runs.  Validation failures throw a
   // plain `Error` — caller's try/catch wraps it with the runtime-v4
@@ -152,5 +169,5 @@ export function generateRuntimeConfs(input: GenerateConfsInput): GenerateConfsOu
     throw new Error(`EtherCAT configuration is invalid: ${ethercatErrors.join('; ')}`)
   }
 
-  return { modbusSlave, modbusMaster, s7Comm, opcUa, ethercat }
+  return { modbusSlave, modbusMaster, s7Comm, opcUa, opcUaClient, ethercat }
 }

--- a/src/backend/shared/types/PLC/open-plc.ts
+++ b/src/backend/shared/types/PLC/open-plc.ts
@@ -607,7 +607,13 @@ const ModbusTcpConfigSchema = z.object({
 })
 type ModbusTcpConfig = z.infer<typeof ModbusTcpConfigSchema>
 
-const PLCRemoteDeviceProtocolSchema = z.enum(['modbus-tcp', 'ethernet-ip', 'ethercat', 'profinet'])
+const PLCRemoteDeviceProtocolSchema = z.enum([
+  'modbus-tcp',
+  'ethernet-ip',
+  'ethercat',
+  'profinet',
+  'opc-ua-client',
+])
 type PLCRemoteDeviceProtocol = z.infer<typeof PLCRemoteDeviceProtocolSchema>
 
 // ---- EtherCAT Configuration Schemas ----
@@ -738,11 +744,58 @@ const EthercatConfigSchema = z.object({
 })
 type EthercatConfig = z.infer<typeof EthercatConfigSchema>
 
+// ---- OPC-UA Client Configuration Schemas ----
+// The runtime acts as an OPC-UA client connecting OUT to a remote server.
+// Policies must match the runtime's shared.opcua_common SECURITY_POLICY_MAPPING.
+
+const OpcUaClientSecurityPolicySchema = z.enum([
+  'None',
+  'Basic256Sha256',
+  'Aes128_Sha256_RsaOaep',
+  'Aes256_Sha256_RsaPss',
+])
+
+const OpcUaClientAuthModeSchema = z.enum(['anonymous', 'username', 'certificate'])
+
+const OpcUaClientDirectionSchema = z.enum(['remote_to_plc', 'plc_to_remote'])
+
+const OpcUaClientSecuritySchema = z.object({
+  securityPolicy: OpcUaClientSecurityPolicySchema,
+  securityMode: OpcUaSecurityModeSchema,
+  authMode: OpcUaClientAuthModeSchema,
+  username: z.string().nullable(),
+  password: z.string().nullable(),
+  clientCertPem: z.string().nullable(),
+  clientKeyPem: z.string().nullable(),
+  serverCertPem: z.string().nullable(),
+})
+
+const OpcUaClientMappingSchema = z.object({
+  id: z.string(),
+  pouName: z.string(),
+  variablePath: z.string(),
+  variableType: z.string(),
+  remoteNodeId: z.string(),
+  direction: OpcUaClientDirectionSchema,
+  cycleTimeMs: z.number().int().min(1),
+})
+
+const OpcUaClientConfigSchema = z.object({
+  enabled: z.boolean(),
+  endpointUrl: z.string(),
+  sessionTimeoutMs: z.number().int().min(0),
+  reconnect: z.boolean(),
+  security: OpcUaClientSecuritySchema,
+  mappings: z.array(OpcUaClientMappingSchema),
+})
+type OpcUaClientConfig = z.infer<typeof OpcUaClientConfigSchema>
+
 const PLCRemoteDeviceSchema = z.object({
   name: z.string(),
   protocol: PLCRemoteDeviceProtocolSchema,
   modbusTcpConfig: ModbusTcpConfigSchema.optional(),
   ethercatConfig: EthercatConfigSchema.optional(),
+  opcuaClientConfig: OpcUaClientConfigSchema.optional(),
 })
 type PLCRemoteDevice = z.infer<typeof PLCRemoteDeviceSchema>
 
@@ -866,6 +919,7 @@ export {
   ModbusTransportTypeSchema,
   OpcUaAddressSpaceConfigSchema,
   OpcUaAuthMethodSchema,
+  OpcUaClientConfigSchema,
   OpcUaFieldConfigSchema,
   OpcUaNodeConfigSchema,
   OpcUaPermissionsSchema,
@@ -929,6 +983,7 @@ export type {
   ModbusTransportType,
   OpcUaAddressSpaceConfig,
   OpcUaAuthMethod,
+  OpcUaClientConfig,
   OpcUaFieldConfig,
   OpcUaNodeConfig,
   OpcUaPermissions,

--- a/src/backend/shared/types/PLC/open-plc.ts
+++ b/src/backend/shared/types/PLC/open-plc.ts
@@ -607,13 +607,7 @@ const ModbusTcpConfigSchema = z.object({
 })
 type ModbusTcpConfig = z.infer<typeof ModbusTcpConfigSchema>
 
-const PLCRemoteDeviceProtocolSchema = z.enum([
-  'modbus-tcp',
-  'ethernet-ip',
-  'ethercat',
-  'profinet',
-  'opc-ua-client',
-])
+const PLCRemoteDeviceProtocolSchema = z.enum(['modbus-tcp', 'ethernet-ip', 'ethercat', 'profinet', 'opc-ua-client'])
 type PLCRemoteDeviceProtocol = z.infer<typeof PLCRemoteDeviceProtocolSchema>
 
 // ---- EtherCAT Configuration Schemas ----

--- a/src/frontend/components/_features/[workspace]/create-element/element-card/index.tsx
+++ b/src/frontend/components/_features/[workspace]/create-element/element-card/index.tsx
@@ -49,7 +49,7 @@ type CreateServerFormProps = {
 
 type CreateRemoteDeviceFormProps = {
   name: string
-  protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet'
+  protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet' | 'opc-ua-client'
 }
 
 const ServerProtocolSources = [
@@ -61,6 +61,7 @@ const ServerProtocolSources = [
 
 const RemoteDeviceProtocolSources = [
   { value: 'modbus-tcp', label: 'Modbus', disabled: false },
+  { value: 'opc-ua-client', label: 'OPC-UA Client', disabled: false },
   { value: 'ethernet-ip', label: 'EtherNet/IP', disabled: true },
   { value: 'ethercat', label: 'EtherCAT', disabled: false },
   { value: 'profinet', label: 'PROFINET', disabled: true },

--- a/src/frontend/components/_features/[workspace]/editor/device/opcua-client/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/opcua-client/index.tsx
@@ -10,6 +10,7 @@ import { useMemo, useState } from 'react'
 import { useOpenPLCStore } from '../../../../../../store'
 import { cn } from '../../../../../../utils/cn'
 import { InputWithRef } from '../../../../../_atoms/input'
+import { Label } from '../../../../../_atoms/label'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '../../../../../_atoms/select'
 import {
   Modal,
@@ -20,21 +21,41 @@ import {
 } from '../../../../../_molecules/modal'
 import { useProjectVariables, type VariableTreeNode } from '../../server/opcua-server/hooks/use-project-variables'
 
+// Shared field styles — matched to the OPC-UA Server editor.
 const inputStyles =
   'h-[30px] w-full rounded-md border border-neutral-300 bg-white px-2 py-1 font-caption text-xs font-medium text-neutral-850 outline-none focus:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
+const selectTriggerStyles =
+  'flex h-[30px] w-full items-center justify-between gap-1 rounded-md border border-neutral-300 bg-white px-2 py-1 font-caption text-xs font-medium text-neutral-850 outline-none data-[state=open]:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
+const selectContentStyles =
+  'h-fit max-h-[240px] w-[--radix-select-trigger-width] overflow-y-auto rounded-lg border border-neutral-300 bg-white outline-none drop-shadow-lg dark:border-brand-medium-dark dark:bg-neutral-950'
+const selectItemStyles = cn(
+  'data-[state=checked]:[&:not(:hover)]:bg-neutral-100 data-[state=checked]:dark:[&:not(:hover)]:bg-neutral-900',
+  'flex w-full cursor-pointer items-center justify-start px-2 py-1 outline-none hover:bg-neutral-100 dark:hover:bg-neutral-800',
+)
+const selectItemTextStyles =
+  'text-start font-caption text-xs font-normal text-neutral-700 dark:text-neutral-100'
+const labelStyles = 'w-32 whitespace-nowrap text-xs text-neutral-950 dark:text-white'
 
-const SECURITY_POLICIES: OpcUaClientConfig['security']['securityPolicy'][] = [
+const SECURITY_POLICIES: OpcUaClientSecurity['securityPolicy'][] = [
   'None',
   'Basic256Sha256',
   'Aes128_Sha256_RsaOaep',
   'Aes256_Sha256_RsaPss',
 ]
 const SECURITY_MODES: OpcUaClientSecurity['securityMode'][] = ['None', 'Sign', 'SignAndEncrypt']
-const AUTH_MODES: OpcUaClientSecurity['authMode'][] = ['anonymous', 'username', 'certificate']
+const AUTH_MODES: { value: OpcUaClientSecurity['authMode']; label: string }[] = [
+  { value: 'anonymous', label: 'Anonymous' },
+  { value: 'username', label: 'Username / Password' },
+  { value: 'certificate', label: 'Certificate' },
+]
 const DIRECTIONS: { value: OpcUaClientDirection; label: string }[] = [
   { value: 'remote_to_plc', label: 'Remote -> PLC (read)' },
   { value: 'plc_to_remote', label: 'PLC -> Remote (write)' },
 ]
+
+// ---------------------------------------------------------------------------
+// Layout primitives (mirror the OPC-UA Server editor)
+// ---------------------------------------------------------------------------
 
 const TabItem = ({ value, label, isActive }: { value: string; label: string; isActive: boolean }) => (
   <Tabs.Trigger
@@ -52,10 +73,88 @@ const TabItem = ({ value, label, isActive }: { value: string; label: string; isA
   </Tabs.Trigger>
 )
 
-const FieldLabel = ({ children }: { children: React.ReactNode }) => (
-  <label className='mb-1 block font-caption text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+const SectionCard = ({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description?: string
+  children: React.ReactNode
+}) => (
+  <div className='flex flex-col gap-4 rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900'>
+    <h3 className='font-caption text-sm font-semibold text-neutral-950 dark:text-white'>{title}</h3>
+    {description && <p className='text-xs text-neutral-600 dark:text-neutral-400'>{description}</p>}
     {children}
-  </label>
+  </div>
+)
+
+const Row = ({
+  label,
+  hint,
+  fieldClassName = 'w-64',
+  children,
+}: {
+  label: string
+  hint?: string
+  fieldClassName?: string
+  children: React.ReactNode
+}) => (
+  <div className='flex items-center gap-4'>
+    <Label className={labelStyles}>{label}</Label>
+    <div className={fieldClassName}>{children}</div>
+    {hint && <span className='text-xs text-neutral-500 dark:text-neutral-400'>{hint}</span>}
+  </div>
+)
+
+const Toggle = ({
+  label,
+  checked,
+  status,
+  onChange,
+}: {
+  label: string
+  checked: boolean
+  status: string
+  onChange: (checked: boolean) => void
+}) => (
+  <div className='flex items-center gap-4'>
+    <Label className={labelStyles}>{label}</Label>
+    <label className='relative inline-flex cursor-pointer items-center'>
+      <input type='checkbox' checked={checked} onChange={(e) => onChange(e.target.checked)} className='peer sr-only' />
+      <div
+        className={cn(
+          'h-6 w-11 rounded-full bg-neutral-300 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-all after:content-[""]',
+          'peer-checked:bg-brand peer-checked:after:translate-x-full',
+          'dark:bg-neutral-700 dark:peer-checked:bg-brand',
+        )}
+      />
+    </label>
+    <span className='text-xs text-neutral-600 dark:text-neutral-400'>{status}</span>
+  </div>
+)
+
+const SimpleSelect = ({
+  value,
+  placeholder,
+  options,
+  onValueChange,
+}: {
+  value: string
+  placeholder: string
+  options: { value: string; label: string }[]
+  onValueChange: (value: string) => void
+}) => (
+  <Select value={value} onValueChange={onValueChange}>
+    <SelectTrigger withIndicator placeholder={placeholder} className={selectTriggerStyles} />
+    <SelectContent className={selectContentStyles}>
+      {options.map((o) => (
+        <SelectItem key={o.value} value={o.value} className={selectItemStyles}>
+          <span className={selectItemTextStyles}>{o.label}</span>
+        </SelectItem>
+      ))}
+    </SelectContent>
+  </Select>
 )
 
 /** Flatten the project variable tree to its selectable leaves. */
@@ -95,7 +194,6 @@ const MappingModal = ({ open, onClose, onSave, variables, existing }: MappingMod
     () => variables.find((v) => `${v.pouName}:${v.variablePath}` === variableKey),
     [variables, variableKey],
   )
-
   const isValid = Boolean(selected) && remoteNodeId.trim().length > 0 && cycleTimeMs > 0
 
   const handleSave = () => {
@@ -112,6 +210,11 @@ const MappingModal = ({ open, onClose, onSave, variables, existing }: MappingMod
     onClose()
   }
 
+  const variableOptions = variables.map((v) => ({
+    value: `${v.pouName}:${v.variablePath}`,
+    label: `${v.pouName}.${v.variablePath}${v.variableType ? ` (${v.variableType})` : ''}`,
+  }))
+
   return (
     <Modal open={open} onOpenChange={(o) => !o && onClose()}>
       <ModalContent className='h-auto max-h-[90vh] w-[560px]' onClose={onClose}>
@@ -120,25 +223,18 @@ const MappingModal = ({ open, onClose, onSave, variables, existing }: MappingMod
         </ModalHeader>
 
         <div className='flex flex-1 flex-col gap-3 overflow-y-auto py-2'>
-          <div>
-            <FieldLabel>Local PLC variable</FieldLabel>
-            <Select value={variableKey} onValueChange={setVariableKey}>
-              <SelectTrigger className={inputStyles} placeholder='Select a variable' />
-              <SelectContent className='max-h-[260px] overflow-y-auto'>
-                {variables.map((v) => {
-                  const key = `${v.pouName}:${v.variablePath}`
-                  return (
-                    <SelectItem key={key} value={key}>
-                      {`${v.pouName}.${v.variablePath}${v.variableType ? ` (${v.variableType})` : ''}`}
-                    </SelectItem>
-                  )
-                })}
-              </SelectContent>
-            </Select>
+          <div className='flex flex-col gap-1'>
+            <Label className='text-xs text-neutral-950 dark:text-white'>Local PLC variable</Label>
+            <SimpleSelect
+              value={variableKey}
+              placeholder='Select a variable'
+              options={variableOptions}
+              onValueChange={setVariableKey}
+            />
           </div>
 
-          <div>
-            <FieldLabel>Remote NodeId</FieldLabel>
+          <div className='flex flex-col gap-1'>
+            <Label className='text-xs text-neutral-950 dark:text-white'>Remote NodeId</Label>
             <InputWithRef
               className={inputStyles}
               placeholder='e.g. ns=2;s=Tag or ns=2;i=5'
@@ -147,22 +243,18 @@ const MappingModal = ({ open, onClose, onSave, variables, existing }: MappingMod
             />
           </div>
 
-          <div>
-            <FieldLabel>Direction</FieldLabel>
-            <Select value={direction} onValueChange={(v) => setDirection(v as OpcUaClientDirection)}>
-              <SelectTrigger className={inputStyles} placeholder='Select direction' />
-              <SelectContent>
-                {DIRECTIONS.map((d) => (
-                  <SelectItem key={d.value} value={d.value}>
-                    {d.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+          <div className='flex flex-col gap-1'>
+            <Label className='text-xs text-neutral-950 dark:text-white'>Direction</Label>
+            <SimpleSelect
+              value={direction}
+              placeholder='Select direction'
+              options={DIRECTIONS}
+              onValueChange={(v) => setDirection(v as OpcUaClientDirection)}
+            />
           </div>
 
-          <div>
-            <FieldLabel>Cycle time (ms)</FieldLabel>
+          <div className='flex flex-col gap-1'>
+            <Label className='text-xs text-neutral-950 dark:text-white'>Cycle time (ms)</Label>
             <InputWithRef
               className={inputStyles}
               type='number'
@@ -226,6 +318,14 @@ export const OpcUaClientEditor = () => {
   const selectableVariables = useMemo(() => flattenSelectable(allVariables), [allVariables])
 
   const touch = () => handleFileAndWorkspaceSavedState(deviceName)
+  const setConn = (updates: Partial<OpcUaClientConfig>) => {
+    updateOpcUaClientConnection(deviceName, updates)
+    touch()
+  }
+  const setSec = (updates: Partial<OpcUaClientSecurity>) => {
+    updateOpcUaClientSecurity(deviceName, updates)
+    touch()
+  }
 
   if (!config) {
     return (
@@ -240,9 +340,7 @@ export const OpcUaClientEditor = () => {
   return (
     <div aria-label='OPC-UA client container' className='flex h-full w-full flex-col overflow-hidden p-4'>
       <div className='mb-4'>
-        <h2 className='text-lg font-semibold text-neutral-1000 dark:text-neutral-100'>
-          OPC-UA Client: {deviceName}
-        </h2>
+        <h2 className='text-lg font-semibold text-neutral-1000 dark:text-neutral-100'>OPC-UA Client: {deviceName}</h2>
         <p className='text-sm text-neutral-600 dark:text-neutral-400'>Connects to a remote OPC-UA server</p>
       </div>
 
@@ -254,255 +352,226 @@ export const OpcUaClientEditor = () => {
         </Tabs.List>
 
         {/* Connection */}
-        <Tabs.Content value='connection' className='min-h-0 flex-1 overflow-auto pt-4 data-[state=inactive]:hidden'>
-          <div className='flex max-w-xl flex-col gap-3'>
-            <label className='flex items-center gap-2 text-xs font-medium text-neutral-700 dark:text-neutral-300'>
-              <input
-                type='checkbox'
-                checked={config.enabled}
-                onChange={(e) => {
-                  updateOpcUaClientConnection(deviceName, { enabled: e.target.checked })
-                  touch()
-                }}
-              />
-              Enabled
-            </label>
-            <div>
-              <FieldLabel>Endpoint URL</FieldLabel>
-              <InputWithRef
-                className={inputStyles}
-                placeholder='opc.tcp://host:4840/path'
-                value={config.endpointUrl}
-                onChange={(e) => {
-                  updateOpcUaClientConnection(deviceName, { endpointUrl: e.target.value })
-                  touch()
-                }}
-              />
+        <Tabs.Content
+          value='connection'
+          className='flex min-h-0 flex-1 flex-col overflow-hidden pt-4 data-[state=inactive]:hidden'
+        >
+          <div className='min-h-0 flex-1 overflow-auto pb-4'>
+            <div className='flex flex-col gap-6'>
+              <SectionCard title='Connection'>
+                <Toggle
+                  label='Enable Client'
+                  checked={config.enabled}
+                  status={config.enabled ? 'Client will connect when PLC runs' : 'Client is disabled'}
+                  onChange={(enabled) => setConn({ enabled })}
+                />
+                <Row label='Endpoint URL' fieldClassName='w-96'>
+                  <InputWithRef
+                    className={inputStyles}
+                    placeholder='opc.tcp://host:4840/path'
+                    value={config.endpointUrl}
+                    onChange={(e) => setConn({ endpointUrl: e.target.value })}
+                  />
+                </Row>
+                <Row label='Session timeout' hint='milliseconds (default: 60000)'>
+                  <InputWithRef
+                    className={inputStyles}
+                    type='number'
+                    min={0}
+                    value={String(config.sessionTimeoutMs)}
+                    onChange={(e) => setConn({ sessionTimeoutMs: Number(e.target.value) })}
+                  />
+                </Row>
+                <Toggle
+                  label='Auto-reconnect'
+                  checked={config.reconnect}
+                  status={config.reconnect ? 'Reconnects if the server drops' : 'Reconnect disabled'}
+                  onChange={(reconnect) => setConn({ reconnect })}
+                />
+              </SectionCard>
             </div>
-            <div>
-              <FieldLabel>Session timeout (ms)</FieldLabel>
-              <InputWithRef
-                className={inputStyles}
-                type='number'
-                min={0}
-                value={String(config.sessionTimeoutMs)}
-                onChange={(e) => {
-                  updateOpcUaClientConnection(deviceName, { sessionTimeoutMs: Number(e.target.value) })
-                  touch()
-                }}
-              />
-            </div>
-            <label className='flex items-center gap-2 text-xs font-medium text-neutral-700 dark:text-neutral-300'>
-              <input
-                type='checkbox'
-                checked={config.reconnect}
-                onChange={(e) => {
-                  updateOpcUaClientConnection(deviceName, { reconnect: e.target.checked })
-                  touch()
-                }}
-              />
-              Reconnect automatically
-            </label>
           </div>
         </Tabs.Content>
 
         {/* Security */}
-        <Tabs.Content value='security' className='min-h-0 flex-1 overflow-auto pt-4 data-[state=inactive]:hidden'>
-          <div className='flex max-w-xl flex-col gap-3'>
-            <div>
-              <FieldLabel>Security policy</FieldLabel>
-              <Select
-                value={sec.securityPolicy}
-                onValueChange={(v) => {
-                  updateOpcUaClientSecurity(deviceName, {
-                    securityPolicy: v as OpcUaClientSecurity['securityPolicy'],
-                  })
-                  touch()
-                }}
+        <Tabs.Content
+          value='security'
+          className='flex min-h-0 flex-1 flex-col overflow-hidden pt-4 data-[state=inactive]:hidden'
+        >
+          <div className='min-h-0 flex-1 overflow-auto pb-4'>
+            <div className='flex flex-col gap-6'>
+              <SectionCard
+                title='Secure Channel'
+                description='How the client secures the connection to the remote server.'
               >
-                <SelectTrigger className={inputStyles} placeholder='Policy' />
-                <SelectContent>
-                  {SECURITY_POLICIES.map((p) => (
-                    <SelectItem key={p} value={p}>
-                      {p}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <FieldLabel>Security mode</FieldLabel>
-              <Select
-                value={sec.securityMode}
-                onValueChange={(v) => {
-                  updateOpcUaClientSecurity(deviceName, { securityMode: v as OpcUaClientSecurity['securityMode'] })
-                  touch()
-                }}
+                <Row label='Security Policy'>
+                  <SimpleSelect
+                    value={sec.securityPolicy}
+                    placeholder='Policy'
+                    options={SECURITY_POLICIES.map((p) => ({ value: p, label: p }))}
+                    onValueChange={(v) => setSec({ securityPolicy: v as OpcUaClientSecurity['securityPolicy'] })}
+                  />
+                </Row>
+                <Row label='Security Mode'>
+                  <SimpleSelect
+                    value={sec.securityMode}
+                    placeholder='Mode'
+                    options={SECURITY_MODES.map((m) => ({ value: m, label: m }))}
+                    onValueChange={(v) => setSec({ securityMode: v as OpcUaClientSecurity['securityMode'] })}
+                  />
+                </Row>
+              </SectionCard>
+
+              <SectionCard
+                title='Authentication'
+                description='How the client identifies itself to the remote server.'
               >
-                <SelectTrigger className={inputStyles} placeholder='Mode' />
-                <SelectContent>
-                  {SECURITY_MODES.map((m) => (
-                    <SelectItem key={m} value={m}>
-                      {m}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                <Row label='Auth Method'>
+                  <SimpleSelect
+                    value={sec.authMode}
+                    placeholder='Auth method'
+                    options={AUTH_MODES}
+                    onValueChange={(v) => setSec({ authMode: v as OpcUaClientSecurity['authMode'] })}
+                  />
+                </Row>
+
+                {sec.authMode === 'username' && (
+                  <>
+                    <Row label='Username'>
+                      <InputWithRef
+                        className={inputStyles}
+                        value={sec.username ?? ''}
+                        onChange={(e) => setSec({ username: e.target.value || null })}
+                      />
+                    </Row>
+                    <Row label='Password'>
+                      <InputWithRef
+                        className={inputStyles}
+                        type='password'
+                        value={sec.password ?? ''}
+                        onChange={(e) => setSec({ password: e.target.value || null })}
+                      />
+                    </Row>
+                  </>
+                )}
+
+                {sec.authMode === 'certificate' && (
+                  <>
+                    <div className='flex items-start gap-4'>
+                      <Label className={cn(labelStyles, 'pt-2')}>Client Certificate</Label>
+                      <textarea
+                        className={cn(inputStyles, 'h-24 w-96 py-2 font-mono')}
+                        placeholder='-----BEGIN CERTIFICATE-----'
+                        value={sec.clientCertPem ?? ''}
+                        onChange={(e) => setSec({ clientCertPem: e.target.value || null })}
+                      />
+                    </div>
+                    <div className='flex items-start gap-4'>
+                      <Label className={cn(labelStyles, 'pt-2')}>Client Private Key</Label>
+                      <textarea
+                        className={cn(inputStyles, 'h-24 w-96 py-2 font-mono')}
+                        placeholder='-----BEGIN PRIVATE KEY-----'
+                        value={sec.clientKeyPem ?? ''}
+                        onChange={(e) => setSec({ clientKeyPem: e.target.value || null })}
+                      />
+                    </div>
+                  </>
+                )}
+              </SectionCard>
+
+              {sec.securityMode !== 'None' && (
+                <SectionCard
+                  title='Server Certificate'
+                  description='Optional. The remote server certificate to trust for Sign / SignAndEncrypt.'
+                >
+                  <div className='flex items-start gap-4'>
+                    <Label className={cn(labelStyles, 'pt-2')}>Server Certificate</Label>
+                    <textarea
+                      className={cn(inputStyles, 'h-24 w-96 py-2 font-mono')}
+                      placeholder='-----BEGIN CERTIFICATE-----'
+                      value={sec.serverCertPem ?? ''}
+                      onChange={(e) => setSec({ serverCertPem: e.target.value || null })}
+                    />
+                  </div>
+                </SectionCard>
+              )}
             </div>
-            <div>
-              <FieldLabel>Authentication</FieldLabel>
-              <Select
-                value={sec.authMode}
-                onValueChange={(v) => {
-                  updateOpcUaClientSecurity(deviceName, { authMode: v as OpcUaClientSecurity['authMode'] })
-                  touch()
-                }}
-              >
-                <SelectTrigger className={inputStyles} placeholder='Auth mode' />
-                <SelectContent>
-                  {AUTH_MODES.map((a) => (
-                    <SelectItem key={a} value={a}>
-                      {a}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            {sec.authMode === 'username' && (
-              <>
-                <div>
-                  <FieldLabel>Username</FieldLabel>
-                  <InputWithRef
-                    className={inputStyles}
-                    value={sec.username ?? ''}
-                    onChange={(e) => {
-                      updateOpcUaClientSecurity(deviceName, { username: e.target.value || null })
-                      touch()
-                    }}
-                  />
-                </div>
-                <div>
-                  <FieldLabel>Password</FieldLabel>
-                  <InputWithRef
-                    className={inputStyles}
-                    type='password'
-                    value={sec.password ?? ''}
-                    onChange={(e) => {
-                      updateOpcUaClientSecurity(deviceName, { password: e.target.value || null })
-                      touch()
-                    }}
-                  />
-                </div>
-              </>
-            )}
-
-            {sec.authMode === 'certificate' && (
-              <>
-                <div>
-                  <FieldLabel>Client certificate (PEM)</FieldLabel>
-                  <textarea
-                    className={cn(inputStyles, 'h-24 py-2 font-mono')}
-                    value={sec.clientCertPem ?? ''}
-                    onChange={(e) => {
-                      updateOpcUaClientSecurity(deviceName, { clientCertPem: e.target.value || null })
-                      touch()
-                    }}
-                  />
-                </div>
-                <div>
-                  <FieldLabel>Client private key (PEM)</FieldLabel>
-                  <textarea
-                    className={cn(inputStyles, 'h-24 py-2 font-mono')}
-                    value={sec.clientKeyPem ?? ''}
-                    onChange={(e) => {
-                      updateOpcUaClientSecurity(deviceName, { clientKeyPem: e.target.value || null })
-                      touch()
-                    }}
-                  />
-                </div>
-              </>
-            )}
-
-            {sec.securityMode !== 'None' && (
-              <div>
-                <FieldLabel>Server certificate (PEM, optional)</FieldLabel>
-                <textarea
-                  className={cn(inputStyles, 'h-24 py-2 font-mono')}
-                  value={sec.serverCertPem ?? ''}
-                  onChange={(e) => {
-                    updateOpcUaClientSecurity(deviceName, { serverCertPem: e.target.value || null })
-                    touch()
-                  }}
-                />
-              </div>
-            )}
           </div>
         </Tabs.Content>
 
         {/* Mappings */}
-        <Tabs.Content value='mappings' className='min-h-0 flex-1 overflow-auto pt-4 data-[state=inactive]:hidden'>
-          <div className='mb-3 flex justify-end'>
-            <button
-              onClick={() => {
-                setEditingMapping(null)
-                setModalOpen(true)
-              }}
-              className='rounded-md bg-brand px-3 py-1 text-xs font-medium text-white'
+        <Tabs.Content
+          value='mappings'
+          className='flex min-h-0 flex-1 flex-col overflow-hidden pt-4 data-[state=inactive]:hidden'
+        >
+          <div className='min-h-0 flex-1 overflow-auto pb-4'>
+            <SectionCard
+              title='Variable Mappings'
+              description='Bind a remote OPC-UA node to a local PLC variable. Direction sets read (remote to PLC) or write (PLC to remote).'
             >
-              Add Mapping
-            </button>
-          </div>
+              <div className='flex justify-end'>
+                <button
+                  onClick={() => {
+                    setEditingMapping(null)
+                    setModalOpen(true)
+                  }}
+                  className='rounded-md bg-brand px-3 py-1 text-xs font-medium text-white'
+                >
+                  Add Mapping
+                </button>
+              </div>
 
-          {config.mappings.length === 0 ? (
-            <p className='py-8 text-center text-xs text-neutral-500 dark:text-neutral-400'>
-              No mappings yet. Add one to bridge a remote node to a local PLC variable.
-            </p>
-          ) : (
-            <table className='w-full text-xs'>
-              <thead>
-                <tr className='border-b border-neutral-200 text-left dark:border-neutral-700'>
-                  <th className='px-2 py-1 font-medium'>Local variable</th>
-                  <th className='px-2 py-1 font-medium'>Remote NodeId</th>
-                  <th className='px-2 py-1 font-medium'>Direction</th>
-                  <th className='px-2 py-1 font-medium'>Cycle (ms)</th>
-                  <th className='px-2 py-1' />
-                </tr>
-              </thead>
-              <tbody>
-                {config.mappings.map((m) => (
-                  <tr key={m.id} className='border-b border-neutral-100 dark:border-neutral-800'>
-                    <td className='px-2 py-1'>{`${m.pouName}.${m.variablePath}`}</td>
-                    <td className='px-2 py-1 font-mono'>{m.remoteNodeId}</td>
-                    <td className='px-2 py-1'>
-                      {m.direction === 'remote_to_plc' ? 'Remote -> PLC' : 'PLC -> Remote'}
-                    </td>
-                    <td className='px-2 py-1'>{m.cycleTimeMs}</td>
-                    <td className='px-2 py-1 text-right'>
-                      <button
-                        className='mr-2 text-brand-medium hover:underline dark:text-brand-light'
-                        onClick={() => {
-                          setEditingMapping(m)
-                          setModalOpen(true)
-                        }}
-                      >
-                        Edit
-                      </button>
-                      <button
-                        className='text-red-500 hover:underline'
-                        onClick={() => {
-                          removeOpcUaClientMapping(deviceName, m.id)
-                          touch()
-                        }}
-                      >
-                        Remove
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
+              {config.mappings.length === 0 ? (
+                <p className='py-8 text-center text-xs text-neutral-500 dark:text-neutral-400'>
+                  No mappings yet. Add one to bridge a remote node to a local PLC variable.
+                </p>
+              ) : (
+                <table className='w-full text-xs'>
+                  <thead>
+                    <tr className='border-b border-neutral-200 text-left text-neutral-600 dark:border-neutral-700 dark:text-neutral-400'>
+                      <th className='px-2 py-1 font-medium'>Local variable</th>
+                      <th className='px-2 py-1 font-medium'>Remote NodeId</th>
+                      <th className='px-2 py-1 font-medium'>Direction</th>
+                      <th className='px-2 py-1 font-medium'>Cycle (ms)</th>
+                      <th className='px-2 py-1' />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {config.mappings.map((m) => (
+                      <tr key={m.id} className='border-b border-neutral-100 dark:border-neutral-800'>
+                        <td className='px-2 py-1 text-neutral-950 dark:text-white'>{`${m.pouName}.${m.variablePath}`}</td>
+                        <td className='px-2 py-1 font-mono text-neutral-700 dark:text-neutral-300'>{m.remoteNodeId}</td>
+                        <td className='px-2 py-1 text-neutral-700 dark:text-neutral-300'>
+                          {m.direction === 'remote_to_plc' ? 'Remote -> PLC' : 'PLC -> Remote'}
+                        </td>
+                        <td className='px-2 py-1 text-neutral-700 dark:text-neutral-300'>{m.cycleTimeMs}</td>
+                        <td className='px-2 py-1 text-right'>
+                          <button
+                            className='mr-2 text-brand-medium hover:underline dark:text-brand-light'
+                            onClick={() => {
+                              setEditingMapping(m)
+                              setModalOpen(true)
+                            }}
+                          >
+                            Edit
+                          </button>
+                          <button
+                            className='text-red-500 hover:underline'
+                            onClick={() => {
+                              removeOpcUaClientMapping(deviceName, m.id)
+                              touch()
+                            }}
+                          >
+                            Remove
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </SectionCard>
+          </div>
         </Tabs.Content>
       </Tabs.Root>
 

--- a/src/frontend/components/_features/[workspace]/editor/device/opcua-client/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/opcua-client/index.tsx
@@ -1,0 +1,527 @@
+import * as Tabs from '@radix-ui/react-tabs'
+import type {
+  OpcUaClientConfig,
+  OpcUaClientDirection,
+  OpcUaClientMapping,
+  OpcUaClientSecurity,
+} from '@root/middleware/shared/ports/types'
+import { useMemo, useState } from 'react'
+
+import { useOpenPLCStore } from '../../../../../../store'
+import { cn } from '../../../../../../utils/cn'
+import { InputWithRef } from '../../../../../_atoms/input'
+import { Select, SelectContent, SelectItem, SelectTrigger } from '../../../../../_atoms/select'
+import {
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from '../../../../../_molecules/modal'
+import { useProjectVariables, type VariableTreeNode } from '../../server/opcua-server/hooks/use-project-variables'
+
+const inputStyles =
+  'h-[30px] w-full rounded-md border border-neutral-300 bg-white px-2 py-1 font-caption text-xs font-medium text-neutral-850 outline-none focus:border-brand-medium-dark dark:border-neutral-850 dark:bg-neutral-950 dark:text-neutral-300'
+
+const SECURITY_POLICIES: OpcUaClientConfig['security']['securityPolicy'][] = [
+  'None',
+  'Basic256Sha256',
+  'Aes128_Sha256_RsaOaep',
+  'Aes256_Sha256_RsaPss',
+]
+const SECURITY_MODES: OpcUaClientSecurity['securityMode'][] = ['None', 'Sign', 'SignAndEncrypt']
+const AUTH_MODES: OpcUaClientSecurity['authMode'][] = ['anonymous', 'username', 'certificate']
+const DIRECTIONS: { value: OpcUaClientDirection; label: string }[] = [
+  { value: 'remote_to_plc', label: 'Remote -> PLC (read)' },
+  { value: 'plc_to_remote', label: 'PLC -> Remote (write)' },
+]
+
+const TabItem = ({ value, label, isActive }: { value: string; label: string; isActive: boolean }) => (
+  <Tabs.Trigger
+    value={value}
+    className={cn(
+      'px-4 py-2 font-caption text-xs font-medium transition-colors',
+      'border-b-2 border-transparent',
+      'hover:text-brand-medium dark:hover:text-brand-light',
+      isActive
+        ? 'border-brand-medium text-brand-medium dark:border-brand-light dark:text-brand-light'
+        : 'text-neutral-500 dark:text-neutral-400',
+    )}
+  >
+    {label}
+  </Tabs.Trigger>
+)
+
+const FieldLabel = ({ children }: { children: React.ReactNode }) => (
+  <label className='mb-1 block font-caption text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+    {children}
+  </label>
+)
+
+/** Flatten the project variable tree to its selectable leaves. */
+const flattenSelectable = (nodes: VariableTreeNode[]): VariableTreeNode[] => {
+  const out: VariableTreeNode[] = []
+  const walk = (list: VariableTreeNode[]) => {
+    for (const n of list) {
+      if (n.isSelectable && n.type !== 'program' && n.type !== 'function_block' && n.type !== 'global') {
+        out.push(n)
+      }
+      if (n.children) walk(n.children)
+    }
+  }
+  walk(nodes)
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Mapping modal
+// ---------------------------------------------------------------------------
+
+interface MappingModalProps {
+  open: boolean
+  onClose: () => void
+  onSave: (mapping: OpcUaClientMapping) => void
+  variables: VariableTreeNode[]
+  existing?: OpcUaClientMapping | null
+}
+
+const MappingModal = ({ open, onClose, onSave, variables, existing }: MappingModalProps) => {
+  const [variableKey, setVariableKey] = useState(existing ? `${existing.pouName}:${existing.variablePath}` : '')
+  const [remoteNodeId, setRemoteNodeId] = useState(existing?.remoteNodeId ?? '')
+  const [direction, setDirection] = useState<OpcUaClientDirection>(existing?.direction ?? 'remote_to_plc')
+  const [cycleTimeMs, setCycleTimeMs] = useState<number>(existing?.cycleTimeMs ?? 100)
+
+  const selected = useMemo(
+    () => variables.find((v) => `${v.pouName}:${v.variablePath}` === variableKey),
+    [variables, variableKey],
+  )
+
+  const isValid = Boolean(selected) && remoteNodeId.trim().length > 0 && cycleTimeMs > 0
+
+  const handleSave = () => {
+    if (!selected) return
+    onSave({
+      id: existing?.id ?? crypto.randomUUID(),
+      pouName: selected.pouName,
+      variablePath: selected.variablePath,
+      variableType: selected.variableType ?? '',
+      remoteNodeId: remoteNodeId.trim(),
+      direction,
+      cycleTimeMs,
+    })
+    onClose()
+  }
+
+  return (
+    <Modal open={open} onOpenChange={(o) => !o && onClose()}>
+      <ModalContent className='h-auto max-h-[90vh] w-[560px]' onClose={onClose}>
+        <ModalHeader>
+          <ModalTitle>{existing ? 'Edit Mapping' : 'Add Mapping'}</ModalTitle>
+        </ModalHeader>
+
+        <div className='flex flex-1 flex-col gap-3 overflow-y-auto py-2'>
+          <div>
+            <FieldLabel>Local PLC variable</FieldLabel>
+            <Select value={variableKey} onValueChange={setVariableKey}>
+              <SelectTrigger className={inputStyles} placeholder='Select a variable' />
+              <SelectContent className='max-h-[260px] overflow-y-auto'>
+                {variables.map((v) => {
+                  const key = `${v.pouName}:${v.variablePath}`
+                  return (
+                    <SelectItem key={key} value={key}>
+                      {`${v.pouName}.${v.variablePath}${v.variableType ? ` (${v.variableType})` : ''}`}
+                    </SelectItem>
+                  )
+                })}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <FieldLabel>Remote NodeId</FieldLabel>
+            <InputWithRef
+              className={inputStyles}
+              placeholder='e.g. ns=2;s=Tag or ns=2;i=5'
+              value={remoteNodeId}
+              onChange={(e) => setRemoteNodeId(e.target.value)}
+            />
+          </div>
+
+          <div>
+            <FieldLabel>Direction</FieldLabel>
+            <Select value={direction} onValueChange={(v) => setDirection(v as OpcUaClientDirection)}>
+              <SelectTrigger className={inputStyles} placeholder='Select direction' />
+              <SelectContent>
+                {DIRECTIONS.map((d) => (
+                  <SelectItem key={d.value} value={d.value}>
+                    {d.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <FieldLabel>Cycle time (ms)</FieldLabel>
+            <InputWithRef
+              className={inputStyles}
+              type='number'
+              min={1}
+              value={String(cycleTimeMs)}
+              onChange={(e) => setCycleTimeMs(Number(e.target.value))}
+            />
+          </div>
+        </div>
+
+        <ModalFooter className='mt-2 flex justify-end gap-2'>
+          <button
+            onClick={onClose}
+            className='rounded-md border border-neutral-300 bg-white px-3 py-1 text-xs font-medium text-neutral-700 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300'
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!isValid}
+            className='rounded-md bg-brand px-3 py-1 text-xs font-medium text-white disabled:opacity-50'
+          >
+            {existing ? 'Save' : 'Add'}
+          </button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Editor
+// ---------------------------------------------------------------------------
+
+export const OpcUaClientEditor = () => {
+  const {
+    editor,
+    project,
+    projectActions: {
+      updateOpcUaClientConnection,
+      updateOpcUaClientSecurity,
+      addOpcUaClientMapping,
+      updateOpcUaClientMapping,
+      removeOpcUaClientMapping,
+    },
+    sharedWorkspaceActions: { handleFileAndWorkspaceSavedState },
+  } = useOpenPLCStore()
+
+  const [activeTab, setActiveTab] = useState('connection')
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editingMapping, setEditingMapping] = useState<OpcUaClientMapping | null>(null)
+
+  const deviceName = editor.type === 'plc-remote-device' ? editor.meta.name : ''
+  const device = useMemo(
+    () => project.data.remoteDevices?.find((d) => d.name === deviceName),
+    [project.data.remoteDevices, deviceName],
+  )
+  const config = device?.opcuaClientConfig
+
+  const allVariables = useProjectVariables()
+  const selectableVariables = useMemo(() => flattenSelectable(allVariables), [allVariables])
+
+  const touch = () => handleFileAndWorkspaceSavedState(deviceName)
+
+  if (!config) {
+    return (
+      <div className='flex h-full w-full items-center justify-center'>
+        <p className='text-neutral-500 dark:text-neutral-400'>Loading OPC-UA client configuration...</p>
+      </div>
+    )
+  }
+
+  const sec = config.security
+
+  return (
+    <div aria-label='OPC-UA client container' className='flex h-full w-full flex-col overflow-hidden p-4'>
+      <div className='mb-4'>
+        <h2 className='text-lg font-semibold text-neutral-1000 dark:text-neutral-100'>
+          OPC-UA Client: {deviceName}
+        </h2>
+        <p className='text-sm text-neutral-600 dark:text-neutral-400'>Connects to a remote OPC-UA server</p>
+      </div>
+
+      <Tabs.Root value={activeTab} onValueChange={setActiveTab} className='flex min-h-0 flex-1 flex-col'>
+        <Tabs.List className='flex shrink-0 border-b border-neutral-200 dark:border-neutral-700'>
+          <TabItem value='connection' label='Connection' isActive={activeTab === 'connection'} />
+          <TabItem value='security' label='Security' isActive={activeTab === 'security'} />
+          <TabItem value='mappings' label='Mappings' isActive={activeTab === 'mappings'} />
+        </Tabs.List>
+
+        {/* Connection */}
+        <Tabs.Content value='connection' className='min-h-0 flex-1 overflow-auto pt-4 data-[state=inactive]:hidden'>
+          <div className='flex max-w-xl flex-col gap-3'>
+            <label className='flex items-center gap-2 text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+              <input
+                type='checkbox'
+                checked={config.enabled}
+                onChange={(e) => {
+                  updateOpcUaClientConnection(deviceName, { enabled: e.target.checked })
+                  touch()
+                }}
+              />
+              Enabled
+            </label>
+            <div>
+              <FieldLabel>Endpoint URL</FieldLabel>
+              <InputWithRef
+                className={inputStyles}
+                placeholder='opc.tcp://host:4840/path'
+                value={config.endpointUrl}
+                onChange={(e) => {
+                  updateOpcUaClientConnection(deviceName, { endpointUrl: e.target.value })
+                  touch()
+                }}
+              />
+            </div>
+            <div>
+              <FieldLabel>Session timeout (ms)</FieldLabel>
+              <InputWithRef
+                className={inputStyles}
+                type='number'
+                min={0}
+                value={String(config.sessionTimeoutMs)}
+                onChange={(e) => {
+                  updateOpcUaClientConnection(deviceName, { sessionTimeoutMs: Number(e.target.value) })
+                  touch()
+                }}
+              />
+            </div>
+            <label className='flex items-center gap-2 text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+              <input
+                type='checkbox'
+                checked={config.reconnect}
+                onChange={(e) => {
+                  updateOpcUaClientConnection(deviceName, { reconnect: e.target.checked })
+                  touch()
+                }}
+              />
+              Reconnect automatically
+            </label>
+          </div>
+        </Tabs.Content>
+
+        {/* Security */}
+        <Tabs.Content value='security' className='min-h-0 flex-1 overflow-auto pt-4 data-[state=inactive]:hidden'>
+          <div className='flex max-w-xl flex-col gap-3'>
+            <div>
+              <FieldLabel>Security policy</FieldLabel>
+              <Select
+                value={sec.securityPolicy}
+                onValueChange={(v) => {
+                  updateOpcUaClientSecurity(deviceName, {
+                    securityPolicy: v as OpcUaClientSecurity['securityPolicy'],
+                  })
+                  touch()
+                }}
+              >
+                <SelectTrigger className={inputStyles} placeholder='Policy' />
+                <SelectContent>
+                  {SECURITY_POLICIES.map((p) => (
+                    <SelectItem key={p} value={p}>
+                      {p}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <FieldLabel>Security mode</FieldLabel>
+              <Select
+                value={sec.securityMode}
+                onValueChange={(v) => {
+                  updateOpcUaClientSecurity(deviceName, { securityMode: v as OpcUaClientSecurity['securityMode'] })
+                  touch()
+                }}
+              >
+                <SelectTrigger className={inputStyles} placeholder='Mode' />
+                <SelectContent>
+                  {SECURITY_MODES.map((m) => (
+                    <SelectItem key={m} value={m}>
+                      {m}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <FieldLabel>Authentication</FieldLabel>
+              <Select
+                value={sec.authMode}
+                onValueChange={(v) => {
+                  updateOpcUaClientSecurity(deviceName, { authMode: v as OpcUaClientSecurity['authMode'] })
+                  touch()
+                }}
+              >
+                <SelectTrigger className={inputStyles} placeholder='Auth mode' />
+                <SelectContent>
+                  {AUTH_MODES.map((a) => (
+                    <SelectItem key={a} value={a}>
+                      {a}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {sec.authMode === 'username' && (
+              <>
+                <div>
+                  <FieldLabel>Username</FieldLabel>
+                  <InputWithRef
+                    className={inputStyles}
+                    value={sec.username ?? ''}
+                    onChange={(e) => {
+                      updateOpcUaClientSecurity(deviceName, { username: e.target.value || null })
+                      touch()
+                    }}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Password</FieldLabel>
+                  <InputWithRef
+                    className={inputStyles}
+                    type='password'
+                    value={sec.password ?? ''}
+                    onChange={(e) => {
+                      updateOpcUaClientSecurity(deviceName, { password: e.target.value || null })
+                      touch()
+                    }}
+                  />
+                </div>
+              </>
+            )}
+
+            {sec.authMode === 'certificate' && (
+              <>
+                <div>
+                  <FieldLabel>Client certificate (PEM)</FieldLabel>
+                  <textarea
+                    className={cn(inputStyles, 'h-24 py-2 font-mono')}
+                    value={sec.clientCertPem ?? ''}
+                    onChange={(e) => {
+                      updateOpcUaClientSecurity(deviceName, { clientCertPem: e.target.value || null })
+                      touch()
+                    }}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Client private key (PEM)</FieldLabel>
+                  <textarea
+                    className={cn(inputStyles, 'h-24 py-2 font-mono')}
+                    value={sec.clientKeyPem ?? ''}
+                    onChange={(e) => {
+                      updateOpcUaClientSecurity(deviceName, { clientKeyPem: e.target.value || null })
+                      touch()
+                    }}
+                  />
+                </div>
+              </>
+            )}
+
+            {sec.securityMode !== 'None' && (
+              <div>
+                <FieldLabel>Server certificate (PEM, optional)</FieldLabel>
+                <textarea
+                  className={cn(inputStyles, 'h-24 py-2 font-mono')}
+                  value={sec.serverCertPem ?? ''}
+                  onChange={(e) => {
+                    updateOpcUaClientSecurity(deviceName, { serverCertPem: e.target.value || null })
+                    touch()
+                  }}
+                />
+              </div>
+            )}
+          </div>
+        </Tabs.Content>
+
+        {/* Mappings */}
+        <Tabs.Content value='mappings' className='min-h-0 flex-1 overflow-auto pt-4 data-[state=inactive]:hidden'>
+          <div className='mb-3 flex justify-end'>
+            <button
+              onClick={() => {
+                setEditingMapping(null)
+                setModalOpen(true)
+              }}
+              className='rounded-md bg-brand px-3 py-1 text-xs font-medium text-white'
+            >
+              Add Mapping
+            </button>
+          </div>
+
+          {config.mappings.length === 0 ? (
+            <p className='py-8 text-center text-xs text-neutral-500 dark:text-neutral-400'>
+              No mappings yet. Add one to bridge a remote node to a local PLC variable.
+            </p>
+          ) : (
+            <table className='w-full text-xs'>
+              <thead>
+                <tr className='border-b border-neutral-200 text-left dark:border-neutral-700'>
+                  <th className='px-2 py-1 font-medium'>Local variable</th>
+                  <th className='px-2 py-1 font-medium'>Remote NodeId</th>
+                  <th className='px-2 py-1 font-medium'>Direction</th>
+                  <th className='px-2 py-1 font-medium'>Cycle (ms)</th>
+                  <th className='px-2 py-1' />
+                </tr>
+              </thead>
+              <tbody>
+                {config.mappings.map((m) => (
+                  <tr key={m.id} className='border-b border-neutral-100 dark:border-neutral-800'>
+                    <td className='px-2 py-1'>{`${m.pouName}.${m.variablePath}`}</td>
+                    <td className='px-2 py-1 font-mono'>{m.remoteNodeId}</td>
+                    <td className='px-2 py-1'>
+                      {m.direction === 'remote_to_plc' ? 'Remote -> PLC' : 'PLC -> Remote'}
+                    </td>
+                    <td className='px-2 py-1'>{m.cycleTimeMs}</td>
+                    <td className='px-2 py-1 text-right'>
+                      <button
+                        className='mr-2 text-brand-medium hover:underline dark:text-brand-light'
+                        onClick={() => {
+                          setEditingMapping(m)
+                          setModalOpen(true)
+                        }}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        className='text-red-500 hover:underline'
+                        onClick={() => {
+                          removeOpcUaClientMapping(deviceName, m.id)
+                          touch()
+                        }}
+                      >
+                        Remove
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </Tabs.Content>
+      </Tabs.Root>
+
+      {modalOpen && (
+        <MappingModal
+          open={modalOpen}
+          onClose={() => setModalOpen(false)}
+          variables={selectableVariables}
+          existing={editingMapping}
+          onSave={(mapping) => {
+            if (editingMapping) {
+              updateOpcUaClientMapping(deviceName, editingMapping.id, mapping)
+            } else {
+              addOpcUaClientMapping(deviceName, mapping)
+            }
+            touch()
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/frontend/components/_features/[workspace]/editor/device/opcua-client/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/opcua-client/index.tsx
@@ -12,13 +12,7 @@ import { cn } from '../../../../../../utils/cn'
 import { InputWithRef } from '../../../../../_atoms/input'
 import { Label } from '../../../../../_atoms/label'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '../../../../../_atoms/select'
-import {
-  Modal,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalTitle,
-} from '../../../../../_molecules/modal'
+import { Modal, ModalContent, ModalFooter, ModalHeader, ModalTitle } from '../../../../../_molecules/modal'
 import { useProjectVariables, type VariableTreeNode } from '../../server/opcua-server/hooks/use-project-variables'
 
 // Shared field styles — matched to the OPC-UA Server editor.
@@ -32,8 +26,7 @@ const selectItemStyles = cn(
   'data-[state=checked]:[&:not(:hover)]:bg-neutral-100 data-[state=checked]:dark:[&:not(:hover)]:bg-neutral-900',
   'flex w-full cursor-pointer items-center justify-start px-2 py-1 outline-none hover:bg-neutral-100 dark:hover:bg-neutral-800',
 )
-const selectItemTextStyles =
-  'text-start font-caption text-xs font-normal text-neutral-700 dark:text-neutral-100'
+const selectItemTextStyles = 'text-start font-caption text-xs font-normal text-neutral-700 dark:text-neutral-100'
 const labelStyles = 'w-32 whitespace-nowrap text-xs text-neutral-950 dark:text-white'
 
 const SECURITY_POLICIES: OpcUaClientSecurity['securityPolicy'][] = [
@@ -422,10 +415,7 @@ export const OpcUaClientEditor = () => {
                 </Row>
               </SectionCard>
 
-              <SectionCard
-                title='Authentication'
-                description='How the client identifies itself to the remote server.'
-              >
+              <SectionCard title='Authentication' description='How the client identifies itself to the remote server.'>
                 <Row label='Auth Method'>
                   <SimpleSelect
                     value={sec.authMode}

--- a/src/frontend/screens/workspace-screen.tsx
+++ b/src/frontend/screens/workspace-screen.tsx
@@ -18,6 +18,7 @@ import { BranchStatusBar } from '../components/_features/[workspace]/branches'
 import { DataTypeEditor } from '../components/_features/[workspace]/data-type'
 import { DeviceEditor } from '../components/_features/[workspace]/editor/device'
 import { EtherCATDeviceEditor, EtherCATEditor } from '../components/_features/[workspace]/editor/device/ethercat'
+import { OpcUaClientEditor } from '../components/_features/[workspace]/editor/device/opcua-client'
 import { RemoteDeviceEditor } from '../components/_features/[workspace]/editor/device/remote-device'
 import { DiffViewerEditor } from '../components/_features/[workspace]/editor/diff-viewer'
 import { GraphicalEditor } from '../components/_features/[workspace]/editor/graphical'
@@ -530,9 +531,12 @@ const WorkspaceScreen = () => {
                         {editor['type'] === 'plc-remote-device' && editor.meta.protocol === 'ethercat' && (
                           <EtherCATEditor />
                         )}
-                        {editor['type'] === 'plc-remote-device' && editor.meta.protocol !== 'ethercat' && (
-                          <RemoteDeviceEditor />
+                        {editor['type'] === 'plc-remote-device' && editor.meta.protocol === 'opc-ua-client' && (
+                          <OpcUaClientEditor />
                         )}
+                        {editor['type'] === 'plc-remote-device' &&
+                          editor.meta.protocol !== 'ethercat' &&
+                          editor.meta.protocol !== 'opc-ua-client' && <RemoteDeviceEditor />}
                         {editor['type'] === 'plc-server' && editor.meta.protocol === 'modbus-tcp' && (
                           <ModbusServerEditor />
                         )}

--- a/src/frontend/store/slices/editor/types.ts
+++ b/src/frontend/store/slices/editor/types.ts
@@ -158,7 +158,7 @@ export type EditorModel = EditorModelBase &
         type: 'plc-remote-device'
         meta: {
           name: string
-          protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet'
+          protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet' | 'opc-ua-client'
         }
       }
     | {

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -5,8 +5,6 @@ import { StateCreator } from 'zustand'
 import type {
   ModbusIOPoint,
   OpcUaClientConfig,
-  OpcUaClientMapping,
-  OpcUaClientSecurity,
   OpcUaServerConfig,
   PLCServer,
   PLCVariable,

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -4,6 +4,9 @@ import { StateCreator } from 'zustand'
 
 import type {
   ModbusIOPoint,
+  OpcUaClientConfig,
+  OpcUaClientMapping,
+  OpcUaClientSecurity,
   OpcUaServerConfig,
   PLCServer,
   PLCVariable,
@@ -92,6 +95,24 @@ const DEFAULT_OPCUA_SERVER_CONFIG: OpcUaServerConfig = {
     namespaceUri: 'urn:openplc:opcua:namespace',
     nodes: [],
   },
+}
+
+const DEFAULT_OPCUA_CLIENT_CONFIG: OpcUaClientConfig = {
+  enabled: false,
+  endpointUrl: 'opc.tcp://127.0.0.1:4840',
+  sessionTimeoutMs: 60000,
+  reconnect: true,
+  security: {
+    securityPolicy: 'None',
+    securityMode: 'None',
+    authMode: 'anonymous',
+    username: null,
+    password: null,
+    clientCertPem: null,
+    clientKeyPem: null,
+    serverCertPem: null,
+  },
+  mappings: [],
 }
 
 function initializeServerProtocolConfig(serverData: PLCServer): PLCServer {
@@ -1429,6 +1450,13 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
           if (device.protocol === 'modbus-tcp' && !device.modbusTcpConfig) {
             device.modbusTcpConfig = { host: '127.0.0.1', port: 502, slaveId: 1, timeout: 1000, ioGroups: [] }
           }
+          if (device.protocol === 'opc-ua-client' && !device.opcuaClientConfig) {
+            device.opcuaClientConfig = {
+              ...DEFAULT_OPCUA_CLIENT_CONFIG,
+              security: { ...DEFAULT_OPCUA_CLIENT_CONFIG.security },
+              mappings: [],
+            }
+          }
           slice.project.data.remoteDevices.push(device)
 
           // EtherCAT bus is driven by a dedicated thread inside the
@@ -1486,6 +1514,64 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
           // Common fields
           if (config.slaveId !== undefined) device.modbusTcpConfig.slaveId = config.slaveId
           if (config.timeout !== undefined) device.modbusTcpConfig.timeout = config.timeout
+        }),
+      )
+      return ok()
+    },
+    updateOpcUaClientConnection: (name, config) => {
+      setState(
+        produce((slice: ProjectSlice) => {
+          const device = slice.project.data.remoteDevices?.find((d) => d.name === name)
+          if (!device?.opcuaClientConfig) return
+          const c = device.opcuaClientConfig
+          if (config.enabled !== undefined) c.enabled = config.enabled
+          if (config.endpointUrl !== undefined) c.endpointUrl = config.endpointUrl
+          if (config.sessionTimeoutMs !== undefined) c.sessionTimeoutMs = config.sessionTimeoutMs
+          if (config.reconnect !== undefined) c.reconnect = config.reconnect
+        }),
+      )
+      return ok()
+    },
+    updateOpcUaClientSecurity: (name, security) => {
+      setState(
+        produce((slice: ProjectSlice) => {
+          const device = slice.project.data.remoteDevices?.find((d) => d.name === name)
+          if (!device?.opcuaClientConfig) return
+          device.opcuaClientConfig.security = { ...device.opcuaClientConfig.security, ...security }
+        }),
+      )
+      return ok()
+    },
+    addOpcUaClientMapping: (name, mapping) => {
+      setState(
+        produce((slice: ProjectSlice) => {
+          const device = slice.project.data.remoteDevices?.find((d) => d.name === name)
+          if (!device?.opcuaClientConfig) return
+          device.opcuaClientConfig.mappings.push(mapping)
+        }),
+      )
+      return ok()
+    },
+    updateOpcUaClientMapping: (name, mappingId, mapping) => {
+      setState(
+        produce((slice: ProjectSlice) => {
+          const device = slice.project.data.remoteDevices?.find((d) => d.name === name)
+          if (!device?.opcuaClientConfig) return
+          const existing = device.opcuaClientConfig.mappings.find((m) => m.id === mappingId)
+          if (!existing) return
+          Object.assign(existing, mapping)
+        }),
+      )
+      return ok()
+    },
+    removeOpcUaClientMapping: (name, mappingId) => {
+      setState(
+        produce((slice: ProjectSlice) => {
+          const device = slice.project.data.remoteDevices?.find((d) => d.name === name)
+          if (!device?.opcuaClientConfig) return
+          device.opcuaClientConfig.mappings = device.opcuaClientConfig.mappings.filter(
+            (m) => m.id !== mappingId,
+          )
         }),
       )
       return ok()

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -1567,9 +1567,7 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
         produce((slice: ProjectSlice) => {
           const device = slice.project.data.remoteDevices?.find((d) => d.name === name)
           if (!device?.opcuaClientConfig) return
-          device.opcuaClientConfig.mappings = device.opcuaClientConfig.mappings.filter(
-            (m) => m.id !== mappingId,
-          )
+          device.opcuaClientConfig.mappings = device.opcuaClientConfig.mappings.filter((m) => m.id !== mappingId)
         }),
       )
       return ok()

--- a/src/frontend/store/slices/project/types.ts
+++ b/src/frontend/store/slices/project/types.ts
@@ -2,6 +2,9 @@ import type {
   EthercatConfig,
   ModbusBufferMapping,
   ModbusIOGroup,
+  OpcUaClientConfig,
+  OpcUaClientMapping,
+  OpcUaClientSecurity,
   OpcUaNodeConfig,
   OpcUaSecurityProfile,
   OpcUaTrustedCertificate,
@@ -290,6 +293,20 @@ export type ProjectActions = {
   deleteIOGroup: (deviceName: string, groupId: string) => ProjectResponse
   updateIOPointAlias: (deviceName: string, groupId: string, pointId: string, alias: string) => ProjectResponse
   updateEthercatConfig: (deviceName: string, ethercatConfig: EthercatConfig) => ProjectResponse
+
+  // OPC-UA Client (remote device)
+  updateOpcUaClientConnection: (
+    name: string,
+    config: Partial<Pick<OpcUaClientConfig, 'enabled' | 'endpointUrl' | 'sessionTimeoutMs' | 'reconnect'>>,
+  ) => ProjectResponse
+  updateOpcUaClientSecurity: (name: string, security: Partial<OpcUaClientSecurity>) => ProjectResponse
+  addOpcUaClientMapping: (name: string, mapping: OpcUaClientMapping) => ProjectResponse
+  updateOpcUaClientMapping: (
+    name: string,
+    mappingId: string,
+    mapping: Partial<OpcUaClientMapping>,
+  ) => ProjectResponse
+  removeOpcUaClientMapping: (name: string, mappingId: string) => ProjectResponse
 }
 
 // ---------------------------------------------------------------------------

--- a/src/frontend/store/slices/project/types.ts
+++ b/src/frontend/store/slices/project/types.ts
@@ -301,11 +301,7 @@ export type ProjectActions = {
   ) => ProjectResponse
   updateOpcUaClientSecurity: (name: string, security: Partial<OpcUaClientSecurity>) => ProjectResponse
   addOpcUaClientMapping: (name: string, mapping: OpcUaClientMapping) => ProjectResponse
-  updateOpcUaClientMapping: (
-    name: string,
-    mappingId: string,
-    mapping: Partial<OpcUaClientMapping>,
-  ) => ProjectResponse
+  updateOpcUaClientMapping: (name: string, mappingId: string, mapping: Partial<OpcUaClientMapping>) => ProjectResponse
   removeOpcUaClientMapping: (name: string, mappingId: string) => ProjectResponse
 }
 

--- a/src/frontend/store/slices/shared/types.ts
+++ b/src/frontend/store/slices/shared/types.ts
@@ -103,7 +103,10 @@ export type ServerActions = {
 }
 
 export type RemoteDeviceActions = {
-  create: (args: { name: string; protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet' }) => SharedResponse
+  create: (args: {
+    name: string
+    protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet' | 'opc-ua-client'
+  }) => SharedResponse
   deleteRequest: (name: string) => void
   delete: (name: string) => SharedResponse
   rename: (oldName: string, newName: string) => SharedResponse

--- a/src/frontend/store/slices/shared/utils.ts
+++ b/src/frontend/store/slices/shared/utils.ts
@@ -157,7 +157,7 @@ export function createEditorObjectForServer(
 
 export function createEditorObjectForRemoteDevice(
   name: string,
-  protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet',
+  protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet' | 'opc-ua-client',
 ): EditorModel {
   return {
     type: 'plc-remote-device',

--- a/src/frontend/store/slices/tabs/types.ts
+++ b/src/frontend/store/slices/tabs/types.ts
@@ -13,7 +13,7 @@ export type TabsProps = {
     | { type: 'resource' }
     | { type: 'device'; derivation: 'configuration' | 'pin-mapping' | 'orchestrators' }
     | { type: 'server'; protocol: 'modbus-tcp' | 's7comm' | 'ethernet-ip' | 'opcua' }
-    | { type: 'remote-device'; protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet' }
+    | { type: 'remote-device'; protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet' | 'opc-ua-client' }
     | { type: 'vendor-screen'; screenName: string }
     | { type: 'package-manager' }
     | { type: 'library-manager' }

--- a/src/frontend/store/slices/tabs/utils.ts
+++ b/src/frontend/store/slices/tabs/utils.ts
@@ -93,7 +93,7 @@ const CreateDeviceEditor = (
 
 const CreateRemoteDeviceEditor = (
   name: string,
-  protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet',
+  protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet' | 'opc-ua-client',
 ): EditorModel => ({
   type: 'plc-remote-device',
   meta: { name, protocol },

--- a/src/frontend/utils/opcua/__tests__/generate-opcua-client-config.test.ts
+++ b/src/frontend/utils/opcua/__tests__/generate-opcua-client-config.test.ts
@@ -195,10 +195,7 @@ describe('generateOpcUaClientConfig', () => {
 
   it('aggregates multiple enabled client devices into servers[]', () => {
     const a = makeDevice(baseClientConfig({ mappings: [makeMapping()] }), 'A')
-    const b = makeDevice(
-      baseClientConfig({ endpointUrl: 'opc.tcp://other:4840/y', mappings: [makeMapping()] }),
-      'B',
-    )
+    const b = makeDevice(baseClientConfig({ endpointUrl: 'opc.tcp://other:4840/y', mappings: [makeMapping()] }), 'B')
     const json = generateOpcUaClientConfig(
       [a, b],
       debugMapJson([{ path: 'COUNTER', type: 'INT', arr: 0, elem: 0, size: 2 }]),
@@ -211,11 +208,7 @@ describe('generateOpcUaClientConfig', () => {
   it('throws OpcUaConfigError when a mapping local variable cannot be resolved', () => {
     const device = makeDevice(baseClientConfig({ mappings: [makeMapping({ variablePath: 'MISSING' })] }))
     expect(() =>
-      generateOpcUaClientConfig(
-        [device],
-        debugMapJson([{ path: 'COUNTER', type: 'INT', arr: 0, elem: 0 }]),
-        instances,
-      ),
+      generateOpcUaClientConfig([device], debugMapJson([{ path: 'COUNTER', type: 'INT', arr: 0, elem: 0 }]), instances),
     ).toThrow(OpcUaConfigError)
   })
 })

--- a/src/frontend/utils/opcua/__tests__/generate-opcua-client-config.test.ts
+++ b/src/frontend/utils/opcua/__tests__/generate-opcua-client-config.test.ts
@@ -1,0 +1,272 @@
+import type {
+  OpcUaClientConfig,
+  OpcUaClientMapping,
+  OpcUaClientSecurity,
+  PLCRemoteDevice,
+} from '@root/middleware/shared/ports/open-plc-types'
+
+import {
+  generateOpcUaClientConfig,
+  OPCUA_CLIENT_CONFIG_FORMAT_VERSION,
+  validateOpcUaClientConfig,
+} from '../generate-opcua-client-config'
+import { OpcUaConfigError } from '../resolve-indices'
+import type { PLCInstanceInfo } from '../types'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal debug-map.json string. GVL leaves resolve by uppercased path. */
+const debugMapJson = (
+  leaves: Array<{ path: string; type: string; arr: number; elem: number; size?: number }>,
+): string =>
+  JSON.stringify({
+    version: 2,
+    md5: 'deadbeef',
+    typeTags: { BOOL: 0, INT: 3, REAL: 9, DINT: 5 },
+    arrays: [{ index: 0, count: leaves.length }],
+    leaves: leaves.map((l) => ({
+      arrayIdx: l.arr,
+      elemIdx: l.elem,
+      path: l.path,
+      type: l.type,
+      size: l.size ?? 2,
+    })),
+  })
+
+const baseSecurity = (): OpcUaClientSecurity => ({
+  securityPolicy: 'None',
+  securityMode: 'None',
+  authMode: 'anonymous',
+  username: null,
+  password: null,
+  clientCertPem: null,
+  clientKeyPem: null,
+  serverCertPem: null,
+})
+
+const makeMapping = (overrides: Partial<OpcUaClientMapping> = {}): OpcUaClientMapping => ({
+  id: 'm1',
+  pouName: 'GVL',
+  variablePath: 'COUNTER',
+  variableType: 'INT',
+  remoteNodeId: 'ns=2;s=Counter',
+  direction: 'remote_to_plc',
+  cycleTimeMs: 100,
+  ...overrides,
+})
+
+const baseClientConfig = (overrides: Partial<OpcUaClientConfig> = {}): OpcUaClientConfig => ({
+  enabled: true,
+  endpointUrl: 'opc.tcp://192.168.0.50:4840/x',
+  sessionTimeoutMs: 60000,
+  reconnect: true,
+  security: baseSecurity(),
+  mappings: [],
+  ...overrides,
+})
+
+const makeDevice = (config: OpcUaClientConfig, name = 'RemotePLC_A'): PLCRemoteDevice => ({
+  name,
+  protocol: 'opc-ua-client',
+  opcuaClientConfig: config,
+})
+
+const instances: PLCInstanceInfo[] = [{ name: 'INSTANCE0', task: 'TASK0', program: 'MAIN' }]
+
+// ---------------------------------------------------------------------------
+// generateOpcUaClientConfig
+// ---------------------------------------------------------------------------
+
+describe('generateOpcUaClientConfig', () => {
+  it('returns null when remoteDevices is undefined', () => {
+    expect(generateOpcUaClientConfig(undefined, debugMapJson([]), [])).toBeNull()
+  })
+
+  it('returns null when remoteDevices is empty', () => {
+    expect(generateOpcUaClientConfig([], debugMapJson([]), [])).toBeNull()
+  })
+
+  it('returns null when no opc-ua-client device is enabled', () => {
+    const device = makeDevice(baseClientConfig({ enabled: false, mappings: [makeMapping()] }))
+    expect(generateOpcUaClientConfig([device], debugMapJson([]), [])).toBeNull()
+  })
+
+  it('throws when debug map is empty but mappings exist', () => {
+    const device = makeDevice(baseClientConfig({ mappings: [makeMapping()] }))
+    expect(() => generateOpcUaClientConfig([device], debugMapJson([]), instances)).toThrow(OpcUaConfigError)
+  })
+
+  it('stamps the contract format_version and protocol envelope', () => {
+    const device = makeDevice(baseClientConfig())
+    const json = generateOpcUaClientConfig([device], debugMapJson([]), [])!
+    const parsed = JSON.parse(json) as Array<{ name: string; protocol: string; config: { format_version: number } }>
+    expect(parsed[0].name).toBe('opcua_client')
+    expect(parsed[0].protocol).toBe('OPC-UA-Client')
+    expect(parsed[0].config.format_version).toBe(OPCUA_CLIENT_CONFIG_FORMAT_VERSION)
+  })
+
+  it('resolves a mapping local variable to canonical (arr, elem, datatype, size) from the debug map', () => {
+    // Stored variableType is INT, but the compiler says the leaf is a
+    // 4-byte DINT — the emitted datatype/size come from the debug map.
+    const device = makeDevice(
+      baseClientConfig({
+        mappings: [
+          makeMapping({
+            pouName: 'GVL',
+            variablePath: 'COUNTER',
+            variableType: 'INT',
+            remoteNodeId: 'ns=2;s=Counter',
+            direction: 'remote_to_plc',
+            cycleTimeMs: 250,
+          }),
+        ],
+      }),
+    )
+    const json = generateOpcUaClientConfig(
+      [device],
+      debugMapJson([{ path: 'COUNTER', type: 'DINT', arr: 0, elem: 3, size: 4 }]),
+      [],
+    )!
+    const parsed = JSON.parse(json) as Array<{
+      config: {
+        servers: Array<{
+          endpoint_url: string
+          session_timeout_ms: number
+          reconnect: boolean
+          mappings: Array<{
+            remote_node_id: string
+            arr: number
+            elem: number
+            datatype: string
+            size: number
+            direction: string
+            cycle_time_ms: number
+          }>
+        }>
+      }
+    }>
+    const server = parsed[0].config.servers[0]
+    expect(server.endpoint_url).toBe('opc.tcp://192.168.0.50:4840/x')
+    expect(server.session_timeout_ms).toBe(60000)
+    expect(server.reconnect).toBe(true)
+    expect(server.mappings[0]).toMatchObject({
+      remote_node_id: 'ns=2;s=Counter',
+      arr: 0,
+      elem: 3,
+      datatype: 'DINT',
+      size: 4,
+      direction: 'remote_to_plc',
+      cycle_time_ms: 250,
+    })
+  })
+
+  it('passes security through to snake_case', () => {
+    const device = makeDevice(
+      baseClientConfig({
+        security: {
+          securityPolicy: 'Basic256Sha256',
+          securityMode: 'SignAndEncrypt',
+          authMode: 'username',
+          username: 'operator',
+          password: 'secret',
+          clientCertPem: null,
+          clientKeyPem: null,
+          serverCertPem: null,
+        },
+      }),
+    )
+    const json = generateOpcUaClientConfig([device], debugMapJson([]), [])!
+    const parsed = JSON.parse(json) as Array<{
+      config: { servers: Array<{ security: Record<string, unknown> }> }
+    }>
+    expect(parsed[0].config.servers[0].security).toEqual({
+      security_policy: 'Basic256Sha256',
+      security_mode: 'SignAndEncrypt',
+      auth_mode: 'username',
+      username: 'operator',
+      password: 'secret',
+      client_cert_pem: null,
+      client_key_pem: null,
+      server_cert_pem: null,
+    })
+  })
+
+  it('aggregates multiple enabled client devices into servers[]', () => {
+    const a = makeDevice(baseClientConfig({ mappings: [makeMapping()] }), 'A')
+    const b = makeDevice(
+      baseClientConfig({ endpointUrl: 'opc.tcp://other:4840/y', mappings: [makeMapping()] }),
+      'B',
+    )
+    const json = generateOpcUaClientConfig(
+      [a, b],
+      debugMapJson([{ path: 'COUNTER', type: 'INT', arr: 0, elem: 0, size: 2 }]),
+      [],
+    )!
+    const parsed = JSON.parse(json) as Array<{ config: { servers: Array<{ name: string }> } }>
+    expect(parsed[0].config.servers.map((s) => s.name)).toEqual(['A', 'B'])
+  })
+
+  it('throws OpcUaConfigError when a mapping local variable cannot be resolved', () => {
+    const device = makeDevice(baseClientConfig({ mappings: [makeMapping({ variablePath: 'MISSING' })] }))
+    expect(() =>
+      generateOpcUaClientConfig(
+        [device],
+        debugMapJson([{ path: 'COUNTER', type: 'INT', arr: 0, elem: 0 }]),
+        instances,
+      ),
+    ).toThrow(OpcUaConfigError)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateOpcUaClientConfig
+// ---------------------------------------------------------------------------
+
+describe('validateOpcUaClientConfig', () => {
+  it('is valid for a resolvable anonymous config', () => {
+    const config = baseClientConfig({ mappings: [makeMapping()] })
+    const result = validateOpcUaClientConfig(
+      config,
+      debugMapJson([{ path: 'COUNTER', type: 'INT', arr: 0, elem: 0 }]),
+      [],
+    )
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it('flags username auth without a username', () => {
+    const config = baseClientConfig({
+      security: { ...baseSecurity(), authMode: 'username', username: null },
+    })
+    const result = validateOpcUaClientConfig(config, debugMapJson([]), [])
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.toLowerCase().includes('username'))).toBe(true)
+  })
+
+  it('flags certificate auth without a client certificate', () => {
+    const config = baseClientConfig({
+      security: { ...baseSecurity(), authMode: 'certificate' },
+    })
+    const result = validateOpcUaClientConfig(config, debugMapJson([]), [])
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.toLowerCase().includes('certificate'))).toBe(true)
+  })
+
+  it('flags an empty endpoint URL', () => {
+    const config = baseClientConfig({ endpointUrl: '' })
+    const result = validateOpcUaClientConfig(config, debugMapJson([]), [])
+    expect(result.valid).toBe(false)
+  })
+
+  it('flags an unresolvable mapping', () => {
+    const config = baseClientConfig({ mappings: [makeMapping({ variablePath: 'MISSING' })] })
+    const result = validateOpcUaClientConfig(
+      config,
+      debugMapJson([{ path: 'COUNTER', type: 'INT', arr: 0, elem: 0 }]),
+      instances,
+    )
+    expect(result.valid).toBe(false)
+  })
+})

--- a/src/frontend/utils/opcua/generate-opcua-client-config.ts
+++ b/src/frontend/utils/opcua/generate-opcua-client-config.ts
@@ -187,9 +187,7 @@ export const generateOpcUaClientConfig = (
     return null
   }
 
-  const clients = remoteDevices.filter(
-    (d) => d.protocol === 'opc-ua-client' && d.opcuaClientConfig?.enabled,
-  )
+  const clients = remoteDevices.filter((d) => d.protocol === 'opc-ua-client' && d.opcuaClientConfig?.enabled)
   if (clients.length === 0) {
     return null
   }

--- a/src/frontend/utils/opcua/generate-opcua-client-config.ts
+++ b/src/frontend/utils/opcua/generate-opcua-client-config.ts
@@ -1,0 +1,276 @@
+import type {
+  OpcUaClientConfig,
+  OpcUaClientMapping,
+  OpcUaNodeConfig,
+  PLCRemoteDevice,
+} from '@root/middleware/shared/ports/open-plc-types'
+
+import { buildLeafInfoMap, type DebugLeafInfo, parseDebugMap as parseDebugMapJson } from '../debug-parser'
+import { getErrorMessage } from '../get-error-message'
+import { OpcUaConfigError, resolveVariableAddress } from './resolve-indices'
+import type { PLCInstanceInfo } from './types'
+
+/**
+ * opcua_client.json contract version. Mirrors OPCUA_CLIENT_CONFIG_MIN_FORMAT_VERSION
+ * in the runtime's shared.plugin_config_decode.opcua_client_config_model. v1
+ * already carries the compiler-canonical per-leaf `datatype` + `size` (from
+ * debug-map.json) so the runtime encodes the exact byte width instead of
+ * re-deriving it. A runtime that requires >= 1 gracefully refuses an older
+ * (unversioned) config instead of writing the wrong number of bytes.
+ */
+export const OPCUA_CLIENT_CONFIG_FORMAT_VERSION = 1
+
+/**
+ * Runtime configuration interfaces (snake_case) — the JSON the OpenPLC
+ * OPC-UA Client plugin consumes. See the runtime's opcua_client_config_model.
+ */
+
+interface RuntimeClientSecurity {
+  security_policy: string
+  security_mode: string
+  auth_mode: string
+  username: string | null
+  password: string | null
+  client_cert_pem: string | null
+  client_key_pem: string | null
+  server_cert_pem: string | null
+}
+
+interface RuntimeClientMapping {
+  remote_node_id: string
+  // Local PLC leaf address — resolved from the compiler's debug map, NOT the
+  // stored project-model datatype (which can drift from the compiled layout).
+  arr: number
+  elem: number
+  datatype: string
+  size: number
+  direction: string
+  cycle_time_ms: number
+}
+
+interface RuntimeClientServer {
+  name: string
+  endpoint_url: string
+  security: RuntimeClientSecurity
+  session_timeout_ms: number
+  reconnect: boolean
+  mappings: RuntimeClientMapping[]
+}
+
+interface RuntimeClientPluginConfig {
+  /** opcua_client.json contract version — see OPCUA_CLIENT_CONFIG_FORMAT_VERSION. */
+  format_version: number
+  servers: RuntimeClientServer[]
+}
+
+interface RuntimeClientConfig {
+  name: string
+  protocol: 'OPC-UA-Client'
+  config: RuntimeClientPluginConfig
+}
+
+/**
+ * Parse debug-map.json into the uppercase-path → leaf-info Map the resolver
+ * consumes (shared with the OPC-UA server generator). Empty Map on
+ * malformed/missing input; the caller distinguishes "no program" from
+ * "no mappings".
+ */
+const parseDebugMapToInfoMap = (content: string): Map<string, DebugLeafInfo> => {
+  const map = parseDebugMapJson(content)
+  if (!map) return new Map()
+  return buildLeafInfoMap(map)
+}
+
+const buildSecurity = (config: OpcUaClientConfig): RuntimeClientSecurity => {
+  const { security } = config
+  return {
+    security_policy: security.securityPolicy,
+    security_mode: security.securityMode,
+    auth_mode: security.authMode,
+    username: security.username,
+    password: security.password,
+    client_cert_pem: security.clientCertPem,
+    client_key_pem: security.clientKeyPem,
+    server_cert_pem: security.serverCertPem,
+  }
+}
+
+/**
+ * Resolve one mapping's LOCAL PLC variable to its (arr, elem) address and
+ * canonical datatype/size, then assemble the runtime mapping. Throws
+ * OpcUaConfigError when the local variable can't be resolved (renamed/deleted
+ * after configuring) — same hard-error semantics as the server's top-level
+ * variables.
+ */
+const buildMapping = (
+  mapping: OpcUaClientMapping,
+  pathToAddr: Map<string, DebugLeafInfo>,
+  instances: PLCInstanceInfo[],
+): RuntimeClientMapping => {
+  // resolveVariableAddress only reads pouName/variablePath off the node.
+  const addr = resolveVariableAddress(
+    { pouName: mapping.pouName, variablePath: mapping.variablePath } as OpcUaNodeConfig,
+    pathToAddr,
+    instances,
+  )
+
+  return {
+    remote_node_id: mapping.remoteNodeId,
+    arr: addr.arr,
+    elem: addr.elem,
+    datatype: addr.type,
+    size: addr.size,
+    direction: mapping.direction,
+    cycle_time_ms: mapping.cycleTimeMs,
+  }
+}
+
+const buildServer = (
+  device: PLCRemoteDevice,
+  config: OpcUaClientConfig,
+  pathToAddr: Map<string, DebugLeafInfo>,
+  instances: PLCInstanceInfo[],
+): RuntimeClientServer => {
+  const mappings: RuntimeClientMapping[] = []
+  const errors: OpcUaConfigError[] = []
+
+  for (const mapping of config.mappings) {
+    try {
+      mappings.push(buildMapping(mapping, pathToAddr, instances))
+    } catch (error) {
+      if (error instanceof OpcUaConfigError) {
+        errors.push(error)
+      } else {
+        throw error
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    const errorMessages = errors.map((e) => e.message).join('\n\n')
+    throw new OpcUaConfigError(
+      device.name,
+      'multiple',
+      `Failed to resolve ${errors.length} OPC-UA client mapping(s) for "${device.name}":\n\n${errorMessages}`,
+    )
+  }
+
+  return {
+    name: device.name,
+    endpoint_url: config.endpointUrl,
+    security: buildSecurity(config),
+    session_timeout_ms: config.sessionTimeoutMs,
+    reconnect: config.reconnect,
+    mappings,
+  }
+}
+
+/**
+ * Generates the OPC-UA Client configuration JSON for the runtime plugin.
+ *
+ * Every enabled remote device with protocol 'opc-ua-client' becomes one entry
+ * in the runtime's servers[] array. Local variable addresses (arr/elem/size/
+ * datatype) are resolved from STruC++'s debug-map.json — the same resolution
+ * the OPC-UA server uses — so a renamed/deleted local variable is a hard error.
+ *
+ * @param remoteDevices - Array of configured PLC remote devices
+ * @param debugMapContent - Content of the generated debug-map.json file
+ * @param instances - Array of PLC instances from Resources configuration
+ * @returns JSON string for opcua_client.json, or null if no enabled client
+ */
+export const generateOpcUaClientConfig = (
+  remoteDevices: PLCRemoteDevice[] | undefined,
+  debugMapContent: string,
+  instances: PLCInstanceInfo[],
+): string | null => {
+  if (!remoteDevices || remoteDevices.length === 0) {
+    return null
+  }
+
+  const clients = remoteDevices.filter(
+    (d) => d.protocol === 'opc-ua-client' && d.opcuaClientConfig?.enabled,
+  )
+  if (clients.length === 0) {
+    return null
+  }
+
+  // Parse the debug map once for all clients.
+  const pathToAddr = parseDebugMapToInfoMap(debugMapContent)
+
+  const totalMappings = clients.reduce((n, d) => n + (d.opcuaClientConfig?.mappings.length ?? 0), 0)
+  if (pathToAddr.size === 0 && totalMappings > 0) {
+    throw new OpcUaConfigError(
+      'debug-map.json',
+      'leaves[]',
+      'Cannot resolve OPC-UA client variable addresses: debug-map.json is empty or invalid.\n' +
+        'This may happen if the PLC program compilation failed.',
+    )
+  }
+
+  const servers: RuntimeClientServer[] = clients.map((device) =>
+    buildServer(device, device.opcuaClientConfig as OpcUaClientConfig, pathToAddr, instances),
+  )
+
+  const runtimeConfig: RuntimeClientConfig = {
+    name: 'opcua_client',
+    protocol: 'OPC-UA-Client',
+    config: {
+      format_version: OPCUA_CLIENT_CONFIG_FORMAT_VERSION,
+      servers,
+    },
+  }
+
+  return JSON.stringify([runtimeConfig], null, 2)
+}
+
+/**
+ * Validates the OPC-UA client configuration without throwing. Mirrors
+ * validateOpcUaConfig: checks auth requirements and that every mapping's
+ * local variable resolves.
+ */
+export const validateOpcUaClientConfig = (
+  config: OpcUaClientConfig,
+  debugMapContent: string,
+  instances: PLCInstanceInfo[],
+): { valid: boolean; errors: string[] } => {
+  const errors: string[] = []
+
+  if (!config.endpointUrl.trim()) {
+    errors.push('Endpoint URL is required')
+  }
+
+  const { security } = config
+  if (security.authMode === 'username' && !security.username) {
+    errors.push('Username authentication is selected but no username is configured')
+  }
+  if (security.authMode === 'certificate' && !(security.clientCertPem && security.clientKeyPem)) {
+    errors.push('Certificate authentication requires a client certificate and private key')
+  }
+
+  const pathToAddr = parseDebugMapToInfoMap(debugMapContent)
+  for (const mapping of config.mappings) {
+    try {
+      resolveVariableAddress(
+        { pouName: mapping.pouName, variablePath: mapping.variablePath } as OpcUaNodeConfig,
+        pathToAddr,
+        instances,
+      )
+    } catch (error) {
+      if (error instanceof OpcUaConfigError) {
+        errors.push(error.message)
+      } else {
+        errors.push(getErrorMessage(error))
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors }
+}
+
+export type {
+  RuntimeClientConfig,
+  RuntimeClientMapping,
+  RuntimeClientPluginConfig,
+  RuntimeClientSecurity,
+  RuntimeClientServer,
+}

--- a/src/frontend/utils/opcua/index.ts
+++ b/src/frontend/utils/opcua/index.ts
@@ -21,6 +21,18 @@ export type {
   RuntimeVariablePermissions,
 } from './generate-opcua-config'
 export { generateOpcUaConfig, validateOpcUaConfig } from './generate-opcua-config'
+export type {
+  RuntimeClientConfig,
+  RuntimeClientMapping,
+  RuntimeClientPluginConfig,
+  RuntimeClientSecurity,
+  RuntimeClientServer,
+} from './generate-opcua-client-config'
+export {
+  generateOpcUaClientConfig,
+  OPCUA_CLIENT_CONFIG_FORMAT_VERSION,
+  validateOpcUaClientConfig,
+} from './generate-opcua-client-config'
 export {
   type LeafAddress,
   OpcUaConfigError,

--- a/src/frontend/utils/opcua/index.ts
+++ b/src/frontend/utils/opcua/index.ts
@@ -6,6 +6,18 @@
  */
 
 export type {
+  RuntimeClientConfig,
+  RuntimeClientMapping,
+  RuntimeClientPluginConfig,
+  RuntimeClientSecurity,
+  RuntimeClientServer,
+} from './generate-opcua-client-config'
+export {
+  generateOpcUaClientConfig,
+  OPCUA_CLIENT_CONFIG_FORMAT_VERSION,
+  validateOpcUaClientConfig,
+} from './generate-opcua-client-config'
+export type {
   RuntimeAddressSpace,
   RuntimeArray,
   RuntimeConfig,
@@ -21,18 +33,6 @@ export type {
   RuntimeVariablePermissions,
 } from './generate-opcua-config'
 export { generateOpcUaConfig, validateOpcUaConfig } from './generate-opcua-config'
-export type {
-  RuntimeClientConfig,
-  RuntimeClientMapping,
-  RuntimeClientPluginConfig,
-  RuntimeClientSecurity,
-  RuntimeClientServer,
-} from './generate-opcua-client-config'
-export {
-  generateOpcUaClientConfig,
-  OPCUA_CLIENT_CONFIG_FORMAT_VERSION,
-  validateOpcUaClientConfig,
-} from './generate-opcua-client-config'
 export {
   type LeafAddress,
   OpcUaConfigError,

--- a/src/middleware/shared/ports/open-plc-types.ts
+++ b/src/middleware/shared/ports/open-plc-types.ts
@@ -6,6 +6,12 @@
  */
 
 import type {
+  OpcUaClientAuthMode,
+  OpcUaClientConfig,
+  OpcUaClientDirection,
+  OpcUaClientMapping,
+  OpcUaClientSecurity,
+  OpcUaClientSecurityPolicy,
   OpcUaFieldConfig,
   OpcUaNodeConfig,
   OpcUaPermissions,
@@ -122,6 +128,12 @@ export interface PLCProject {
 // ---------------------------------------------------------------------------
 
 export type {
+  OpcUaClientAuthMode,
+  OpcUaClientConfig,
+  OpcUaClientDirection,
+  OpcUaClientMapping,
+  OpcUaClientSecurity,
+  OpcUaClientSecurityPolicy,
   OpcUaFieldConfig,
   OpcUaNodeConfig,
   OpcUaPermissions,

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -394,11 +394,7 @@ export interface OpcUaServerConfig {
 
 // Security policies the runtime's OPC-UA client supports (must match the
 // keys of SECURITY_POLICY_MAPPING in the runtime's shared.opcua_common).
-export type OpcUaClientSecurityPolicy =
-  | 'None'
-  | 'Basic256Sha256'
-  | 'Aes128_Sha256_RsaOaep'
-  | 'Aes256_Sha256_RsaPss'
+export type OpcUaClientSecurityPolicy = 'None' | 'Basic256Sha256' | 'Aes128_Sha256_RsaOaep' | 'Aes256_Sha256_RsaPss'
 
 export type OpcUaClientAuthMode = 'anonymous' | 'username' | 'certificate'
 

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -163,7 +163,7 @@ export interface PLCGlobalVariable extends Omit<PLCVariable, 'class'> {
 // ---------------------------------------------------------------------------
 
 export type ServerProtocol = 'modbus-tcp' | 's7comm' | 'ethernet-ip' | 'opcua'
-export type RemoteDeviceProtocol = 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet'
+export type RemoteDeviceProtocol = 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet' | 'opc-ua-client'
 
 // Modbus
 export interface ModbusSlaveConfig {
@@ -387,6 +387,57 @@ export interface OpcUaServerConfig {
   addressSpace: OpcUaAddressSpaceConfig
 }
 
+// OPC-UA Client (remote device — the runtime connects OUT to a remote
+// OPC-UA server and bridges nodes to local PLC variables). One client
+// remote device == one remote endpoint; the editor aggregates all of
+// them into a single conf/opcua_client.json (servers[]) at compile time.
+
+// Security policies the runtime's OPC-UA client supports (must match the
+// keys of SECURITY_POLICY_MAPPING in the runtime's shared.opcua_common).
+export type OpcUaClientSecurityPolicy =
+  | 'None'
+  | 'Basic256Sha256'
+  | 'Aes128_Sha256_RsaOaep'
+  | 'Aes256_Sha256_RsaPss'
+
+export type OpcUaClientAuthMode = 'anonymous' | 'username' | 'certificate'
+
+// Mapping direction relative to the PLC.
+export type OpcUaClientDirection = 'remote_to_plc' | 'plc_to_remote'
+
+export interface OpcUaClientSecurity {
+  securityPolicy: OpcUaClientSecurityPolicy
+  securityMode: OpcUaSecurityModeType
+  authMode: OpcUaClientAuthMode
+  username: string | null
+  password: string | null
+  clientCertPem: string | null
+  clientKeyPem: string | null
+  serverCertPem: string | null
+}
+
+export interface OpcUaClientMapping {
+  id: string
+  // Local PLC variable. arr/elem/size/datatype are resolved from the
+  // compiler's debug map at build time (same resolution as the server).
+  pouName: string
+  variablePath: string
+  variableType: string
+  // Remote OPC-UA NodeId string, entered by the user (e.g. "ns=2;s=Tag").
+  remoteNodeId: string
+  direction: OpcUaClientDirection
+  cycleTimeMs: number
+}
+
+export interface OpcUaClientConfig {
+  enabled: boolean
+  endpointUrl: string
+  sessionTimeoutMs: number
+  reconnect: boolean
+  security: OpcUaClientSecurity
+  mappings: OpcUaClientMapping[]
+}
+
 // PLCServer
 export interface PLCServer {
   name: string
@@ -416,6 +467,7 @@ export interface PLCRemoteDevice {
   protocol: RemoteDeviceProtocol
   modbusTcpConfig?: ModbusRemoteTcpConfig
   ethercatConfig?: EthercatConfig
+  opcuaClientConfig?: OpcUaClientConfig
 }
 
 // ---------------------------------------------------------------------------

--- a/src/middleware/shared/utils/library/__tests__/compose-runtime-v4-bundle.test.ts
+++ b/src/middleware/shared/utils/library/__tests__/compose-runtime-v4-bundle.test.ts
@@ -24,6 +24,7 @@ function baseInput(overrides: Partial<ComposeRuntimeV4BundleInput> = {}): Compos
       modbusMaster: null,
       s7Comm: null,
       opcUa: null,
+      opcUaClient: null,
       ethercat: '{"masters":[]}',
     },
     ...overrides,
@@ -95,6 +96,7 @@ describe('composeRuntimeV4Bundle', () => {
           modbusMaster: '{"masters":[]}',
           s7Comm: '{"servers":[]}',
           opcUa: '{"endpoints":[]}',
+          opcUaClient: '{"servers":[]}',
           ethercat: '{"masters":[]}',
         },
       }),
@@ -103,6 +105,7 @@ describe('composeRuntimeV4Bundle', () => {
     expect(files['conf/modbus_master.json']).toBe('{"masters":[]}')
     expect(files['conf/s7comm.json']).toBe('{"servers":[]}')
     expect(files['conf/opcua.json']).toBe('{"endpoints":[]}')
+    expect(files['conf/opcua_client.json']).toBe('{"servers":[]}')
     expect(files['conf/ethercat.json']).toBe('{"masters":[]}')
   })
 

--- a/src/middleware/shared/utils/library/compose-runtime-v4-bundle.ts
+++ b/src/middleware/shared/utils/library/compose-runtime-v4-bundle.ts
@@ -86,6 +86,10 @@ export interface ComposeRuntimeV4BundleInput {
      *  Caller catches `OpcUaConfigError` and surfaces it before
      *  calling the composer — passing `null` skips the file. */
     opcUa: string | null
+    /** From `generateOpcUaClientConfig(remoteDevices, debug-map, instances)`.
+     *  Caller catches `OpcUaConfigError` and surfaces it before calling the
+     *  composer — passing `null` skips the file. */
+    opcUaClient: string | null
     /** From `generateEthercatConfig(remoteDevices)`.  Caller should
      *  run `validateEthercatConfig` first and abort the compile (not
      *  call the composer) when validation produces errors. */
@@ -142,6 +146,7 @@ export function composeRuntimeV4Bundle(input: ComposeRuntimeV4BundleInput): Reco
   if (input.confs.modbusMaster) files['conf/modbus_master.json'] = input.confs.modbusMaster
   if (input.confs.s7Comm) files['conf/s7comm.json'] = input.confs.s7Comm
   if (input.confs.opcUa) files['conf/opcua.json'] = input.confs.opcUa
+  if (input.confs.opcUaClient) files['conf/opcua_client.json'] = input.confs.opcUaClient
   files['conf/ethercat.json'] = input.confs.ethercat
 
   return files


### PR DESCRIPTION
## Summary

Adds **OPC-UA Client** support: OpenPLC connects out to remote OPC-UA servers and maps remote nodes to local PLC variables (remote→PLC via subscription; PLC→remote via poll + change-detect), modeled as a Remote Device with Connection / Security / Mappings tabs.

The whole feature lives in the **byte-identical shared surface** (`frontend/`, `middleware/shared/`, `backend/shared/`), so it is mirrored verbatim into **openplc-web**.

## Cross-repo sync

Paired with openplc-web PR (branch `feat/opcua-client-plugin`). The 21 shared-surface files are byte-identical across both repos (verified via `git hash-object`). The `surface-sync` check on each PR matches against the other.

## Validation

- 39 unit tests pass (jest), `prettier --check` and `eslint` clean on the changed surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)