### PR TITLE
fix(modbus/opcua): editable IO groups, per-row actions, table contrast

### DIFF
--- a/src/frontend/components/_features/[workspace]/editor/device/remote-device/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/remote-device/index.tsx
@@ -1,10 +1,10 @@
+import { Pencil1Icon, TrashIcon } from '@radix-ui/react-icons'
 import type { ModbusIOGroup, ModbusIOPoint } from '@root/middleware/shared/ports/types'
 import { useRuntime } from '@root/middleware/shared/providers/platform-context'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
 import { ArrowIcon } from '../../../../../../assets/icons/interface/Arrow'
-import { MinusIcon } from '../../../../../../assets/icons/interface/Minus'
 import { PlusIcon } from '../../../../../../assets/icons/interface/Plus'
 import { useOpenPLCStore } from '../../../../../../store'
 import { cn } from '../../../../../../utils/cn'
@@ -348,21 +348,12 @@ type IOGroupRowProps = {
   ioGroup: ModbusIOGroup
   isExpanded: boolean
   onToggleExpand: () => void
-  isSelected: boolean
-  onSelect: () => void
   onEdit: () => void
+  onDelete: () => void
   onUpdateAlias: (ioPointId: string, alias: string) => void
 }
 
-const IOGroupRow = ({
-  ioGroup,
-  isExpanded,
-  onToggleExpand,
-  isSelected,
-  onSelect,
-  onEdit,
-  onUpdateAlias,
-}: IOGroupRowProps) => {
+const IOGroupRow = ({ ioGroup, isExpanded, onToggleExpand, onEdit, onDelete, onUpdateAlias }: IOGroupRowProps) => {
   const firstIOPoint = ioGroup.ioPoints?.[0]
   const groupType = firstIOPoint?.type || '-'
   const groupAddress = firstIOPoint?.iecLocation || '-'
@@ -370,22 +361,9 @@ const IOGroupRow = ({
 
   return (
     <>
-      <tr
-        onClick={onSelect}
-        onDoubleClick={onEdit}
-        className={cn(
-          'cursor-pointer border-b border-neutral-200 dark:border-neutral-800',
-          isSelected && 'bg-brand/10 dark:bg-brand/20',
-        )}
-      >
+      <tr className='border-b border-neutral-200 dark:border-neutral-800'>
         <td className='px-2 py-2'>
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              onToggleExpand()
-            }}
-            className='flex items-center justify-center'
-          >
+          <button onClick={onToggleExpand} className='flex items-center justify-center'>
             <ArrowIcon
               direction='right'
               className={cn('h-4 w-4 stroke-brand-light transition-all', isExpanded && 'rotate-270 stroke-brand')}
@@ -400,6 +378,28 @@ const IOGroupRow = ({
           {getFunctionCodeLabel(ioGroup.functionCode)}
         </td>
         <td className='px-2 py-2 text-sm text-neutral-700 dark:text-neutral-300'>-</td>
+        <td className='px-2 py-2'>
+          <div className='flex justify-end gap-2'>
+            <button
+              type='button'
+              onClick={onEdit}
+              className='rounded p-1 text-neutral-500 hover:bg-neutral-100 hover:text-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-200'
+              title='Edit'
+              aria-label={`Edit ${ioGroup.name}`}
+            >
+              <Pencil1Icon className='h-4 w-4' />
+            </button>
+            <button
+              type='button'
+              onClick={onDelete}
+              className='rounded p-1 text-neutral-500 hover:bg-red-100 hover:text-red-600 dark:text-neutral-400 dark:hover:bg-red-900/30 dark:hover:text-red-400'
+              title='Delete'
+              aria-label={`Delete ${ioGroup.name}`}
+            >
+              <TrashIcon className='h-4 w-4' />
+            </button>
+          </div>
+        </td>
       </tr>
       {isExpanded &&
         (ioGroup.ioPoints ?? []).map((ioPoint: ModbusIOPoint, index: number) => (
@@ -446,6 +446,7 @@ const IOPointRow = ({ ioPoint, offset, onUpdateAlias }: IOPointRowProps) => {
           className='h-6 w-full rounded border border-neutral-200 bg-white px-1 text-xs text-neutral-700 outline-none focus:border-brand dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300'
         />
       </td>
+      <td className='px-2 py-1'></td>
     </tr>
   )
 }
@@ -490,7 +491,6 @@ const RemoteDeviceEditor = () => {
 
   // UI state
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
-  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [editingGroup, setEditingGroup] = useState<ModbusIOGroup | null>(null)
 
@@ -737,13 +737,13 @@ const RemoteDeviceEditor = () => {
     [deviceName, projectActions, editingGroup, sharedWorkspaceActions],
   )
 
-  const handleDeleteIOGroup = useCallback(() => {
-    if (selectedGroupId) {
-      projectActions.deleteIOGroup(deviceName, selectedGroupId)
-      setSelectedGroupId(null)
+  const handleDeleteIOGroup = useCallback(
+    (groupId: string) => {
+      projectActions.deleteIOGroup(deviceName, groupId)
       sharedWorkspaceActions.handleFileAndWorkspaceSavedState(deviceName)
-    }
-  }, [deviceName, selectedGroupId, projectActions, sharedWorkspaceActions])
+    },
+    [deviceName, projectActions, sharedWorkspaceActions],
+  )
 
   const handleUpdateAlias = useCallback(
     (ioGroupId: string, ioPointId: string, alias: string) => {
@@ -951,13 +951,6 @@ const RemoteDeviceEditor = () => {
                 icon: <PlusIcon className='h-4 w-4 stroke-brand' />,
                 id: 'add-io-group-button',
               },
-              {
-                ariaLabel: 'Remove IO Group',
-                onClick: handleDeleteIOGroup,
-                disabled: !selectedGroupId,
-                icon: <MinusIcon className='h-4 w-4 stroke-brand' />,
-                id: 'remove-io-group-button',
-              },
             ]}
             buttonProps={{
               className:
@@ -983,18 +976,21 @@ const RemoteDeviceEditor = () => {
                 <th className='w-[8%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                   Offset
                 </th>
-                <th className='w-[22%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                <th className='w-[20%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                   Function Code
                 </th>
                 <th className='px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                   Alias
+                </th>
+                <th className='w-20 px-2 py-2 text-right text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                  Actions
                 </th>
               </tr>
             </thead>
             <tbody>
               {ioGroups.length === 0 ? (
                 <tr>
-                  <td colSpan={7} className='px-4 py-8 text-center text-sm text-neutral-500 dark:text-neutral-400'>
+                  <td colSpan={8} className='px-4 py-8 text-center text-sm text-neutral-500 dark:text-neutral-400'>
                     No IO groups configured. Click the + button to add one.
                   </td>
                 </tr>
@@ -1005,9 +1001,8 @@ const RemoteDeviceEditor = () => {
                     ioGroup={ioGroup}
                     isExpanded={expandedGroups.has(ioGroup.id)}
                     onToggleExpand={() => handleToggleExpand(ioGroup.id)}
-                    isSelected={selectedGroupId === ioGroup.id}
-                    onSelect={() => setSelectedGroupId(ioGroup.id)}
                     onEdit={() => handleOpenEditModal(ioGroup.id)}
+                    onDelete={() => handleDeleteIOGroup(ioGroup.id)}
                     onUpdateAlias={(ioPointId, alias) => handleUpdateAlias(ioGroup.id, ioPointId, alias)}
                   />
                 ))

--- a/src/frontend/components/_features/[workspace]/editor/server/opcua-server/components/certificates-tab.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/server/opcua-server/components/certificates-tab.tsx
@@ -265,19 +265,19 @@ MIIEvgIBADANBg...
         ) : (
           <div className='overflow-hidden rounded-md border border-neutral-200 dark:border-neutral-700'>
             <table className='w-full'>
-              <thead className='bg-neutral-50 dark:bg-neutral-800'>
+              <thead className='bg-neutral-100 dark:bg-neutral-900'>
                 <tr>
-                  <th className='px-3 py-2 text-left text-xs font-medium text-neutral-600 dark:text-neutral-400'>ID</th>
-                  <th className='px-3 py-2 text-left text-xs font-medium text-neutral-600 dark:text-neutral-400'>
+                  <th className='px-3 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>ID</th>
+                  <th className='px-3 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                     Subject
                   </th>
-                  <th className='px-3 py-2 text-left text-xs font-medium text-neutral-600 dark:text-neutral-400'>
+                  <th className='px-3 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                     Valid
                   </th>
-                  <th className='px-3 py-2 text-left text-xs font-medium text-neutral-600 dark:text-neutral-400'>
+                  <th className='px-3 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                     Fingerprint
                   </th>
-                  <th className='px-3 py-2 text-right text-xs font-medium text-neutral-600 dark:text-neutral-400'>
+                  <th className='px-3 py-2 text-right text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                     Actions
                   </th>
                 </tr>

--- a/src/frontend/components/_features/[workspace]/editor/server/opcua-server/components/security-profiles-tab.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/server/opcua-server/components/security-profiles-tab.tsx
@@ -115,20 +115,20 @@ export const SecurityProfilesTab = ({ config, serverName, onConfigChange }: Secu
       {config.securityProfiles.length > 0 ? (
         <div className='overflow-hidden rounded-md border border-neutral-200 dark:border-neutral-700'>
           <table className='w-full'>
-            <thead className='bg-neutral-50 dark:bg-neutral-800'>
+            <thead className='bg-neutral-100 dark:bg-neutral-900'>
               <tr>
-                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-600 dark:text-neutral-400'>
+                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                   Enabled
                 </th>
-                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-600 dark:text-neutral-400'>Name</th>
-                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-600 dark:text-neutral-400'>
+                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>Name</th>
+                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                   Policy
                 </th>
-                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-600 dark:text-neutral-400'>Mode</th>
-                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-600 dark:text-neutral-400'>
+                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>Mode</th>
+                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                   Authentication
                 </th>
-                <th className='px-3 py-2 text-right text-xs font-medium text-neutral-600 dark:text-neutral-400'>
+                <th className='px-3 py-2 text-right text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                   Actions
                 </th>
               </tr>

--- a/src/frontend/components/_features/[workspace]/editor/server/opcua-server/components/users-tab.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/server/opcua-server/components/users-tab.tsx
@@ -125,12 +125,12 @@ export const UsersTab = ({ config, serverName, onConfigChange }: UsersTabProps) 
       ) : (
         <div className='overflow-hidden rounded-md border border-neutral-200 dark:border-neutral-700'>
           <table className='w-full'>
-            <thead className='bg-neutral-50 dark:bg-neutral-800'>
+            <thead className='bg-neutral-100 dark:bg-neutral-900'>
               <tr>
-                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-600 dark:text-neutral-400'>Name</th>
-                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-600 dark:text-neutral-400'>Type</th>
-                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-600 dark:text-neutral-400'>Role</th>
-                <th className='px-3 py-2 text-right text-xs font-medium text-neutral-600 dark:text-neutral-400'>
+                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>Name</th>
+                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>Type</th>
+                <th className='px-3 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>Role</th>
+                <th className='px-3 py-2 text-right text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                   Actions
                 </th>
               </tr>

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -2386,6 +2386,61 @@ describe('createProjectSlice', () => {
       const result = store.getState().projectActions.updateIOGroup('EtherCAT', 'g1', { name: 'x' })
       expect(result.ok).toBe(true)
     })
+
+    it('regenerates ioPoints when the length grows (edit size)', () => {
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 2))
+      expect(store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups[0].ioPoints).toHaveLength(2)
+
+      store.getState().projectActions.updateIOGroup('Dev1', 'g1', { length: 4 })
+      const points = store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups[0].ioPoints!
+      expect(points).toHaveLength(4)
+      expect(points.map((p) => p.iecLocation)).toEqual(['%IW0', '%IW1', '%IW2', '%IW3'])
+    })
+
+    it('regenerates ioPoints when the length shrinks (edit size)', () => {
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 4))
+      store.getState().projectActions.updateIOGroup('Dev1', 'g1', { length: 1 })
+      const points = store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups[0].ioPoints!
+      expect(points).toHaveLength(1)
+      expect(points[0].iecLocation).toBe('%IW0')
+    })
+
+    it('re-derives addresses under the new prefix when the function code changes', () => {
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 2)) // FC3 -> %IW
+      store.getState().projectActions.updateIOGroup('Dev1', 'g1', { functionCode: '1' }) // FC1 -> %IX
+      const points = store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups[0].ioPoints!
+      expect(points.map((p) => p.iecLocation)).toEqual(['%IX0.0', '%IX0.1'])
+    })
+
+    it('regenerates only the edited group, leaving sibling groups untouched (no project-wide recompaction)', () => {
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 2)) // %IW0,1
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g2', '3', 2)) // %IW2,3
+
+      // Grow g1. Because this edit is localized (it does NOT recompact the
+      // whole project), g1 reuses its own freed %IW0/%IW1 and its third
+      // point takes the next free slot after g2's untouched %IW2/%IW3.
+      store.getState().projectActions.updateIOGroup('Dev1', 'g1', { length: 3 })
+      const groups = store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups
+      expect(groups[0].ioPoints!.map((p) => p.iecLocation)).toEqual(['%IW0', '%IW1', '%IW4'])
+      expect(groups[1].ioPoints!.map((p) => p.iecLocation)).toEqual(['%IW2', '%IW3']) // sibling untouched
+    })
+
+    it('preserves point aliases positionally when regenerating', () => {
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 2))
+      const pointId = store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups[0].ioPoints![0].id
+      store.getState().projectActions.updateIOPointAlias('Dev1', 'g1', pointId, 'Temp')
+
+      store.getState().projectActions.updateIOGroup('Dev1', 'g1', { length: 3 })
+      const points = store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups[0].ioPoints!
+      expect(points).toHaveLength(3)
+      expect(points[0].alias).toBe('Temp') // survived the reshuffle
+      expect(points[2].alias).toBe('') // freshly allocated slot
+    })
   })
 
   describe('deleteIOGroup', () => {

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -158,6 +158,10 @@ function generateIOPoints(
    * without needing to rebuild the pool inside the loop. */
   pool: Parameters<typeof nextFreeAddress>[0],
   pending: Set<string>,
+  /* Points that previously occupied this group (edit flow). Their
+   * aliases are carried over positionally so resizing / editing a
+   * group doesn't wipe the aliases the user attached to each slot. */
+  existingPoints: ModbusIOPoint[] = [],
 ): ModbusIOPoint[] {
   const { type, iecPrefix, isBit } = getFunctionCodeInfo(functionCode)
   const points: ModbusIOPoint[] = []
@@ -165,7 +169,13 @@ function generateIOPoints(
   for (let i = 0; i < length; i++) {
     const iecLocation = nextFreeAddress(pool, iecPrefix, isBit, undefined, pending)
     pending.add(iecLocation)
-    points.push({ id: `${groupName}_${i}`, name: `${groupName}_${i}`, type, iecLocation, alias: '' })
+    points.push({
+      id: `${groupName}_${i}`,
+      name: `${groupName}_${i}`,
+      type,
+      iecLocation,
+      alias: existingPoints[i]?.alias ?? '',
+    })
   }
 
   return points
@@ -1531,12 +1541,63 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       return ok()
     },
     updateIOGroup: (deviceName, groupId, updates) => {
+      // Editing a group's length / function code / name must regenerate
+      // its I/O points — the previous implementation only `Object.assign`ed
+      // the metadata, so the point list (and therefore the effective size
+      // shown in the table) never changed (bug: "size stays as originally
+      // set"). We regenerate ONLY this group's points here — no
+      // project-wide reallocation. To let the group reuse its own freed
+      // addresses, the pool is built from every producer EXCEPT this
+      // group's current points (all other Modbus groups, pin-mapping, VPP
+      // and EtherCAT claims are still honoured). Existing aliases are
+      // carried over positionally.
+      const live = getState()
+      const boardInfo = live.deviceAvailableOptions.availableBoards.get(
+        live.deviceDefinitions.configuration.deviceBoard ?? '',
+      )
+      const ioMapping =
+        (
+          live.deviceDefinitions.configuration.vendorScreenData?.['io-mapping'] as
+            | { entries?: Array<{ iecAddress: string; alias?: string; slot: number; channelName: string }> }
+            | undefined
+        )?.entries ?? []
+
+      // Clone remoteDevices with the edited group's points cleared so its
+      // own addresses are free for re-allocation without disturbing the
+      // rest of the project.
+      const remoteDevicesForPool = live.project.data.remoteDevices?.map((d) =>
+        d.name !== deviceName || !d.modbusTcpConfig
+          ? d
+          : {
+              ...d,
+              modbusTcpConfig: {
+                ...d.modbusTcpConfig,
+                ioGroups: d.modbusTcpConfig.ioGroups.map((g) => (g.id === groupId ? { ...g, ioPoints: [] } : g)),
+              },
+            },
+      )
+
+      const pool = buildAddressPool(
+        {
+          pinMapping: {
+            pins: live.deviceDefinitions.pinMapping.pinsByBoard[live.deviceDefinitions.configuration.deviceBoard] ?? [],
+          },
+          vendorIoMapping: { entries: ioMapping },
+          remoteDevices: remoteDevicesForPool,
+        },
+        resolveTargetCapabilities(boardInfo),
+      )
+
       setState(
         produce((slice: ProjectSlice) => {
           const device = slice.project.data.remoteDevices?.find((d) => d.name === deviceName)
           if (!device?.modbusTcpConfig) return
           const group = device.modbusTcpConfig.ioGroups.find((g) => g.id === groupId)
-          if (group) Object.assign(group, updates)
+          if (!group) return
+          const existingPoints = group.ioPoints ?? []
+          Object.assign(group, updates)
+          const pending = new Set<string>()
+          group.ioPoints = generateIOPoints(group.functionCode, group.length, group.name, pool, pending, existingPoints)
         }),
       )
       return ok()


### PR DESCRIPTION
## Summary

Fixes three UI/UX issues in the remote-device (Modbus master) and OPC-UA server editors. (Shared surface — a matching PR lands on `openplc-web` simultaneously.)

### 1. Modbus IO Group size could not be edited
`updateIOGroup` only reassigned group metadata via `Object.assign`, so the underlying `ioPoints` list (and the size shown in the table) never changed. It now regenerates the edited group's I/O points to match the new length / function code, reusing the group's own freed addresses (pool built from every other producer) and preserving each point's alias positionally. The change is **localized to the edited group** — no project-wide reallocation.

### 2. IO Group table edit/remove UX
Replaced double-click-to-edit with per-row **Edit / Delete** icon buttons (mirroring the OPC-UA Security Profiles pattern) and removed the redundant `-` toolbar button, keeping only `+` to add.

### 3. OPC-UA table header contrast
Fixed low-contrast headers on the OPC-UA Security Profiles, Users, and Certificates tables (hard to read in dark mode) by adopting the Modbus IO table's header styling.

## Not included
Project-wide IEC address recompaction (reclaiming gaps on delete) is intentionally **deferred** to a follow-up that centralizes address allocation across all producers.

## Testing
- `npm run test` (project-slice suite): all green, added tests for the edit-size flow (grow/shrink, function-code change, alias preservation, sibling groups untouched).
- `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Editing a Modbus IO group now correctly refreshes its point addresses when length or function code changes.
  * Existing point aliases are preserved during group resizing, and newly added points start blank.
  * Deleting or editing IO groups now uses clear per-row actions instead of requiring selection.

* **Style**
  * Updated table header styling across several server editor views for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->