### PR TITLE
fix(debugger): resolve + force shared/located globals (#653)

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -4,7 +4,7 @@
     "repository": "Autonomy-Logic/xml2st"
   },
   "strucpp": {
-    "version": "v0.5.10",
+    "version": "v0.5.13",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }

--- a/src/frontend/hooks/useDebugPolling.ts
+++ b/src/frontend/hooks/useDebugPolling.ts
@@ -95,11 +95,19 @@ interface LeafMeta {
 }
 
 /**
- * Collect ALL leaf indexes from a tree (ignoring expansion state).
- * Used to build the full index→metadata lookup for parsing responses.
+ * Collect ALL leaf metadata from a tree (ignoring expansion state), grouped by
+ * debug index. Used to build the full index→metadata lookup for parsing
+ * responses.
+ *
+ * One index can map to MANY composite keys: a shared CONFIGURATION VAR_GLOBAL is
+ * referenced (as VAR_EXTERNAL) by every program that uses it, so `main:start_pb`
+ * and `another_test:start_pb` resolve to the same address. The value read from
+ * that address must fan out to every composite key, or the variable displays on
+ * only one POU (the last one walked). Hence `LeafMeta[]` per index, not a single
+ * `LeafMeta`.
  */
-function collectAllLeafMeta(nodes: DebugTreeNode[]): Map<number, LeafMeta> {
-  const result = new Map<number, LeafMeta>()
+function collectAllLeafMeta(nodes: DebugTreeNode[]): Map<number, LeafMeta[]> {
+  const result = new Map<number, LeafMeta[]>()
 
   function walk(node: DebugTreeNode) {
     if (node.isComplex && node.children) {
@@ -109,7 +117,9 @@ function collectAllLeafMeta(nodes: DebugTreeNode[]): Map<number, LeafMeta> {
     } else if (node.debugIndex !== undefined) {
       const meta: LeafMeta = { compositeKey: node.compositeKey, type: node.type }
       if (node.enumValues) meta.enumValues = node.enumValues
-      result.set(node.debugIndex, meta)
+      const existing = result.get(node.debugIndex)
+      if (existing) existing.push(meta)
+      else result.set(node.debugIndex, [meta])
     }
   }
 
@@ -158,7 +168,8 @@ export function useDebugPolling({ debugTreesRef }: UseDebugPollingOptions): void
   const batchSizeRef = useRef(TCP_BATCH_SIZE)
 
   // Full leaf index→metadata map — computed once when debugger starts.
-  const allLeavesRef = useRef<Map<number, LeafMeta> | null>(null)
+  // One index → many leaves (a shared global appears under each POU's key).
+  const allLeavesRef = useRef<Map<number, LeafMeta[]> | null>(null)
 
   // Cached active indexes — rebuilt only when invalidation triggers change.
   const activeIndexesRef = useRef<number[] | null>(null)
@@ -183,11 +194,13 @@ export function useDebugPolling({ debugTreesRef }: UseDebugPollingOptions): void
     if (allLeavesRef.current) return allLeavesRef.current
 
     const allTrees = debugTreesRef.current
-    const allLeaves = new Map<number, LeafMeta>()
+    const allLeaves = new Map<number, LeafMeta[]>()
     for (const pouTrees of Object.values(allTrees)) {
       const leaves = collectAllLeafMeta(pouTrees)
-      for (const [index, meta] of leaves) {
-        allLeaves.set(index, meta)
+      for (const [index, metas] of leaves) {
+        const existing = allLeaves.get(index)
+        if (existing) existing.push(...metas)
+        else allLeaves.set(index, [...metas])
       }
     }
 
@@ -297,8 +310,8 @@ export function useDebugPolling({ debugTreesRef }: UseDebugPollingOptions): void
         }
 
         const index = batch[pos]
-        const meta = allLeaves.get(index)
-        if (!meta) {
+        const metas = allLeaves.get(index)
+        if (!metas || metas.length === 0) {
           // No leaf metadata — the runtime still consumed the position
           // (it doesn't know our index→type map).  Count it consumed and
           // press on; the value bytes for this slot are forfeit.
@@ -306,6 +319,10 @@ export function useDebugPolling({ debugTreesRef }: UseDebugPollingOptions): void
           continue
         }
 
+        // Every leaf at one index is the same underlying variable/address, so
+        // they share type/size; parse once off the first, then fan the value
+        // out to every composite key (a shared global lives under each POU's).
+        const meta = metas[0]
         const typeSize = getTypeSizeByName(meta.type)
         if (bufferOffset + typeSize > responseBuffer.length) {
           // Response buffer ran out before we reached every position the
@@ -334,12 +351,15 @@ export function useDebugPolling({ debugTreesRef }: UseDebugPollingOptions): void
           // Out-of-range falls back to the raw integer.
           const stored = meta.enumValues !== undefined ? (meta.enumValues[Number(value)] ?? value) : value
           const current = isBool ? currentBool : currentNonBool
-          if (current.get(meta.compositeKey) !== stored) {
-            ;(isBool ? changedBool : changedNonBool).set(meta.compositeKey, stored)
+          const changed = isBool ? changedBool : changedNonBool
+          // Fan out to every composite key sharing this address (shared globals).
+          for (const m of metas) {
+            if (current.get(m.compositeKey) !== stored) changed.set(m.compositeKey, stored)
           }
           bufferOffset += bytesRead
         } catch {
-          ;(isBool ? changedBool : changedNonBool).set(meta.compositeKey, 'ERR')
+          const changed = isBool ? changedBool : changedNonBool
+          for (const m of metas) changed.set(m.compositeKey, 'ERR')
           bufferOffset += typeSize
         }
         positionsConsumed = pos + 1

--- a/src/frontend/hooks/useDebugSession.ts
+++ b/src/frontend/hooks/useDebugSession.ts
@@ -19,8 +19,8 @@ import { parseDebugMap } from '../utils/debug-parser'
 import {
   buildDebugVariableTreeMap,
   buildFbInstanceMap,
-  buildVariableIndexMap,
   debugMapToEntries,
+  deriveVariableIndexMap,
 } from '../utils/debugger-session'
 import { encodeForceValue } from '../utils/variable-sizes'
 
@@ -88,7 +88,6 @@ export function useDebugSession(): UseDebugSessionReturn {
           return { success: false, error }
         }
 
-        const { indexMap, warnings } = buildVariableIndexMap(project.data.pous, instances, debugMap)
         const entriesForTree = debugMapToEntries(debugMap)
         logActions.addLog({
           id: crypto.randomUUID(),
@@ -96,11 +95,10 @@ export function useDebugSession(): UseDebugSessionReturn {
           message: `Debug map: ${debugMap.leaves.length} leaves across ${debugMap.arrays.length} arrays.`,
         })
 
-        for (const w of warnings) {
-          logActions.addLog({ id: crypto.randomUUID(), level: 'warning', message: w })
-        }
-
-        // Build debug variable tree
+        // Build the debug variable tree — the single enumeration walk. The
+        // composite-key → index map (used by the LD/FBD editors and the poller)
+        // is derived from this same tree, so every consumer resolves a
+        // variable's address identically.
         let treeMap = new Map<string, DebugTreeNode>()
         const pouTrees: Record<string, DebugTreeNode[]> = {}
         try {
@@ -120,6 +118,10 @@ export function useDebugSession(): UseDebugSessionReturn {
             pouTrees[pouName].push(node)
           }
 
+          for (const w of treeResult.warnings) {
+            logActions.addLog({ id: crypto.randomUUID(), level: 'warning', message: w })
+          }
+
           logActions.addLog({
             id: crypto.randomUUID(),
             level: 'info',
@@ -134,6 +136,9 @@ export function useDebugSession(): UseDebugSessionReturn {
         }
 
         debugTreesRef.current = pouTrees
+
+        // Derive the composite-key → packed-address map from the tree leaves.
+        const indexMap = deriveVariableIndexMap(treeMap, debugMap)
 
         // Build FB instance map
         const fbDebugInstancesMap = buildFbInstanceMap(project.data.pous, instances)

--- a/src/frontend/utils/__tests__/debug-polling-filter.test.ts
+++ b/src/frontend/utils/__tests__/debug-polling-filter.test.ts
@@ -103,7 +103,7 @@ function makeState(overrides: {
 describe('buildActiveIndexSet', () => {
   it('returns empty indexes when there are no active variables', () => {
     const state = makeState({})
-    const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+    const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
     const { activeIndexes, cacheResult } = buildActiveIndexSet(state, allLeaves, null)
     expect(activeIndexes).toEqual([])
     expect(cacheResult).toBeNull()
@@ -117,7 +117,7 @@ describe('buildActiveIndexSet', () => {
       ])
       const indexMap = new Map([['Main:SPEED', 10]])
       const state = makeState({ pous: [pou], debugVariableIndexes: indexMap })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([10])
@@ -147,7 +147,7 @@ describe('buildActiveIndexSet', () => {
         fbSelectedInstance: fbSelected,
         fbDebugInstances: fbInstances,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([5])
@@ -156,7 +156,7 @@ describe('buildActiveIndexSet', () => {
     it('skips FB watched variables when no instance is selected', () => {
       const fbPou = makePou('MyFB', 'function-block', [makeVariable('OUT', 'output', true)])
       const state = makeState({ pous: [fbPou] })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -184,7 +184,7 @@ describe('buildActiveIndexSet', () => {
         fbSelectedInstance: fbSelected,
         fbDebugInstances: fbInstances,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -197,7 +197,7 @@ describe('buildActiveIndexSet', () => {
         body: { language: 'st', value: '' },
       }
       const state = makeState({ pous: [pou] })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -209,7 +209,7 @@ describe('buildActiveIndexSet', () => {
       const forced = new Map([['Main:FORCED_VAR', { value: 42 }]])
       const indexMap = new Map([['Main:FORCED_VAR', 7]])
       const state = makeState({ debugForcedVariables: forced, debugVariableIndexes: indexMap })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([7])
@@ -220,7 +220,7 @@ describe('buildActiveIndexSet', () => {
     it('includes graph-listed variable indexes', () => {
       const indexMap = new Map([['Main:PLOTTED', 3]])
       const state = makeState({ debugGraphList: ['Main:PLOTTED'], debugVariableIndexes: indexMap })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([3])
@@ -240,8 +240,8 @@ describe('buildActiveIndexSet', () => {
         debugVariableIndexes: indexMap,
         debugExpandedNodes: expandedNodes,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [11, { compositeKey: 'Main:MyStruct.field1', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [11, [{ compositeKey: 'Main:MyStruct.field1', type: 'INT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -259,8 +259,8 @@ describe('buildActiveIndexSet', () => {
         pous: [pou],
         debugVariableIndexes: indexMap,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [11, { compositeKey: 'Main:MyStruct.field1', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [11, [{ compositeKey: 'Main:MyStruct.field1', type: 'INT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -269,8 +269,8 @@ describe('buildActiveIndexSet', () => {
 
     it('skips leaf entry with no colon in compositeKey', () => {
       const state = makeState({})
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [99, { compositeKey: 'no-colon-key', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [99, [{ compositeKey: 'no-colon-key', type: 'INT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -294,10 +294,10 @@ describe('buildActiveIndexSet', () => {
         debugVariableIndexes: indexMap,
         debugExpandedNodes: expandedNodes,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [101, { compositeKey: 'Main:MY_ARRAY[1]', type: 'DINT' }],
-        [102, { compositeKey: 'Main:MY_ARRAY[2]', type: 'DINT' }],
-        [103, { compositeKey: 'Main:MY_ARRAY[3]', type: 'DINT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [101, [{ compositeKey: 'Main:MY_ARRAY[1]', type: 'DINT' }]],
+        [102, [{ compositeKey: 'Main:MY_ARRAY[2]', type: 'DINT' }]],
+        [103, [{ compositeKey: 'Main:MY_ARRAY[3]', type: 'DINT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -315,8 +315,8 @@ describe('buildActiveIndexSet', () => {
         pous: [pou],
         debugVariableIndexes: indexMap,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [101, { compositeKey: 'Main:MY_ARRAY[1]', type: 'DINT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [101, [{ compositeKey: 'Main:MY_ARRAY[1]', type: 'DINT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -332,9 +332,9 @@ describe('buildActiveIndexSet', () => {
         ['Main:FB.ARR[1]', 21],
         ['Main:FB.ARR[2]', 22],
       ])
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [21, { compositeKey: 'Main:FB.ARR[1]', type: 'INT' }],
-        [22, { compositeKey: 'Main:FB.ARR[2]', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [21, [{ compositeKey: 'Main:FB.ARR[1]', type: 'INT' }]],
+        [22, [{ compositeKey: 'Main:FB.ARR[2]', type: 'INT' }]],
       ])
 
       // Only FB expanded — array root is collapsed → elements stay hidden
@@ -372,13 +372,13 @@ describe('buildActiveIndexSet', () => {
         ['Main:FB_ARR[3].Q', 81],
         ['Main:FB_ARR[3].ET', 82],
       ])
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [61, { compositeKey: 'Main:FB_ARR[1].Q', type: 'BOOL' }],
-        [62, { compositeKey: 'Main:FB_ARR[1].ET', type: 'TIME' }],
-        [71, { compositeKey: 'Main:FB_ARR[2].Q', type: 'BOOL' }],
-        [72, { compositeKey: 'Main:FB_ARR[2].ET', type: 'TIME' }],
-        [81, { compositeKey: 'Main:FB_ARR[3].Q', type: 'BOOL' }],
-        [82, { compositeKey: 'Main:FB_ARR[3].ET', type: 'TIME' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [61, [{ compositeKey: 'Main:FB_ARR[1].Q', type: 'BOOL' }]],
+        [62, [{ compositeKey: 'Main:FB_ARR[1].ET', type: 'TIME' }]],
+        [71, [{ compositeKey: 'Main:FB_ARR[2].Q', type: 'BOOL' }]],
+        [72, [{ compositeKey: 'Main:FB_ARR[2].ET', type: 'TIME' }]],
+        [81, [{ compositeKey: 'Main:FB_ARR[3].Q', type: 'BOOL' }]],
+        [82, [{ compositeKey: 'Main:FB_ARR[3].ET', type: 'TIME' }]],
       ])
 
       // Array expanded, only element [2] expanded → only [2]'s leaves poll
@@ -406,10 +406,10 @@ describe('buildActiveIndexSet', () => {
         ['Main:BOOLS[1]', 92],
         ['Main:BOOLS[2]', 93],
       ])
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [91, { compositeKey: 'Main:BOOLS[0]', type: 'BOOL' }],
-        [92, { compositeKey: 'Main:BOOLS[1]', type: 'BOOL' }],
-        [93, { compositeKey: 'Main:BOOLS[2]', type: 'BOOL' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [91, [{ compositeKey: 'Main:BOOLS[0]', type: 'BOOL' }]],
+        [92, [{ compositeKey: 'Main:BOOLS[1]', type: 'BOOL' }]],
+        [93, [{ compositeKey: 'Main:BOOLS[2]', type: 'BOOL' }]],
       ])
       const state = makeState({
         pous: [pou],
@@ -423,8 +423,8 @@ describe('buildActiveIndexSet', () => {
       const pou = makePou('Main', 'program', [makeVariable('X', 'local', true)])
       const indexMap = new Map([['Main:X', 1]])
       const state = makeState({ pous: [pou], debugVariableIndexes: indexMap })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [1, { compositeKey: 'Main:X', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [1, [{ compositeKey: 'Main:X', type: 'INT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -437,8 +437,8 @@ describe('buildActiveIndexSet', () => {
         debugGraphList: ['Main:MyStruct.field1'],
         debugVariableIndexes: new Map([['Main:MyStruct.field1', 11]]),
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [11, { compositeKey: 'Main:MyStruct.field1', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [11, [{ compositeKey: 'Main:MyStruct.field1', type: 'INT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -449,8 +449,8 @@ describe('buildActiveIndexSet', () => {
       const state = makeState({
         debugExpandedNodes: new Map([['Main:A', true]]),
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [20, { compositeKey: 'Main:A.B.C', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [20, [{ compositeKey: 'Main:A.B.C', type: 'INT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -473,8 +473,8 @@ describe('buildActiveIndexSet', () => {
         debugVariableIndexes: indexMap,
         debugExpandedNodes: expandedNodes,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [11, { compositeKey: 'Main:FB0.Q', type: 'BOOL' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [11, [{ compositeKey: 'Main:FB0.Q', type: 'BOOL' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -499,7 +499,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'st',
         debugVariableIndexes: indexMap,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes, cacheResult } = buildActiveIndexSet(state, allLeaves, cached)
       expect(activeIndexes).toContain(99)
@@ -519,7 +519,7 @@ describe('buildActiveIndexSet', () => {
         editorName: 'Main',
         editorLanguage: 'st',
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { cacheResult } = buildActiveIndexSet(state, allLeaves, cached)
       // Cache should have been replaced
@@ -529,7 +529,7 @@ describe('buildActiveIndexSet', () => {
 
     it('skips diagram/source scan when currentPou is not found', () => {
       const state = makeState({ editorName: 'Nonexistent' })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes, cacheResult } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -566,7 +566,7 @@ describe('buildActiveIndexSet', () => {
         fbSelectedInstance: fbSelected,
         fbDebugInstances: fbInstances,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { cacheResult } = buildActiveIndexSet(state, allLeaves, cached)
       // Cache should still be valid because fbContextKey matches
@@ -579,8 +579,8 @@ describe('buildActiveIndexSet', () => {
       const pou = makePou('Main', 'program', [makeVariable('A', 'local', true)])
       // A is watched but NOT in debugVariableIndexes
       const state = makeState({ pous: [pou] })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [42, { compositeKey: 'Main:A', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [42, [{ compositeKey: 'Main:A', type: 'INT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -599,7 +599,7 @@ describe('buildActiveIndexSet', () => {
         ['Main:B', 20],
       ])
       const state = makeState({ pous: [pou], debugVariableIndexes: indexMap })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([10, 20, 30])
@@ -609,8 +609,8 @@ describe('buildActiveIndexSet', () => {
       const forced = new Map([['Main:X', { value: 0 }]])
       const indexMap = new Map([['Main:X', 5]])
       const state = makeState({ debugForcedVariables: forced, debugVariableIndexes: indexMap })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [5, { compositeKey: 'Main:X', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [5, [{ compositeKey: 'Main:X', type: 'INT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -629,7 +629,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'st',
         debugVariableIndexes: indexMap,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toContain(15)
@@ -652,8 +652,8 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'st',
         debugVariableIndexes: indexMap,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [20, { compositeKey: 'Main:MyTimer.ET', type: 'TIME' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [20, [{ compositeKey: 'Main:MyTimer.ET', type: 'TIME' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -670,7 +670,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'st',
         debugVariableIndexes: indexMap,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).not.toContain(50)
@@ -686,7 +686,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'il',
         debugVariableIndexes: indexMap,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toContain(8)
@@ -702,7 +702,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'st',
         debugVariableIndexes: indexMap,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).not.toContain(8)
@@ -718,7 +718,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'st',
         debugVariableIndexes: indexMap,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).not.toContain(8)
@@ -750,7 +750,7 @@ describe('buildActiveIndexSet', () => {
         debugVariableIndexes: indexMap,
         ladderFlows: [ldFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toContain(1)
@@ -775,7 +775,7 @@ describe('buildActiveIndexSet', () => {
         debugVariableIndexes: indexMap,
         ladderFlows: [ldFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toContain(3)
@@ -801,7 +801,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'ld',
         ladderFlows: [ldFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -831,8 +831,8 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'ld',
         ladderFlows: [ldFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [50, { compositeKey: 'Main:MyTimer.Q', type: 'BOOL' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [50, [{ compositeKey: 'Main:MyTimer.Q', type: 'BOOL' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -863,8 +863,8 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'ld',
         ladderFlows: [ldFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [60, { compositeKey: 'Main:_TMP_ADD3_OUT', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [60, [{ compositeKey: 'Main:_TMP_ADD3_OUT', type: 'INT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -887,7 +887,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'ld',
         ladderFlows: [ldFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -901,7 +901,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'ld',
         ladderFlows: [{ name: 'OtherPou', rungs: [] }],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -933,7 +933,7 @@ describe('buildActiveIndexSet', () => {
         debugVariableIndexes: indexMap,
         fbdFlows: [fbdFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([1, 2, 3])
@@ -961,8 +961,8 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'fbd',
         fbdFlows: [fbdFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [70, { compositeKey: 'Main:Timer1.ET', type: 'TIME' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [70, [{ compositeKey: 'Main:Timer1.ET', type: 'TIME' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -986,7 +986,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'fbd',
         fbdFlows: [fbdFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -1000,7 +1000,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'fbd',
         fbdFlows: [{ name: 'OtherPou', rung: { nodes: [] } }],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -1028,8 +1028,8 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'fbd',
         fbdFlows: [fbdFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [80, { compositeKey: 'Main:_TMP_MUL7_OUT', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [80, [{ compositeKey: 'Main:_TMP_MUL7_OUT', type: 'INT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -1050,7 +1050,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'fbd',
         fbdFlows: [fbdFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -1085,7 +1085,7 @@ describe('buildActiveIndexSet', () => {
         fbDebugInstances: fbInstances,
         debugVariableIndexes: indexMap,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toContain(25)
@@ -1100,7 +1100,7 @@ describe('buildActiveIndexSet', () => {
         editorName: 'MyFB',
         editorLanguage: 'st',
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -1118,7 +1118,7 @@ describe('buildActiveIndexSet', () => {
       })
       // Remove the language property from meta
       delete (state as unknown as { editor: { meta: Record<string, unknown> } }).editor.meta.language
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { cacheResult } = buildActiveIndexSet(state, allLeaves, null)
       expect(cacheResult?.language).toBe('')
@@ -1135,7 +1135,7 @@ describe('buildActiveIndexSet', () => {
         fbSelectedInstance: fbSelected,
         fbDebugInstances: new Map(),
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       // No matching instance found in the empty list -> no variables added
@@ -1153,7 +1153,7 @@ describe('buildActiveIndexSet', () => {
         editorName: 'NoInterface',
         editorLanguage: 'st',
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       // No interface -> ?? [] -> no variables to scan
@@ -1174,7 +1174,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'ld',
         ladderFlows: [{ name: 'Main', rungs: [] }],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { cacheResult } = buildActiveIndexSet(state, allLeaves, cached)
       expect(cacheResult).not.toBe(cached)
@@ -1196,7 +1196,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'st',
         fbSelectedInstance: fbSelected,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { cacheResult } = buildActiveIndexSet(state, allLeaves, cached)
       expect(cacheResult).not.toBe(cached)
@@ -1217,8 +1217,8 @@ describe('buildActiveIndexSet', () => {
         debugVariableIndexes: indexMap,
         debugExpandedNodes: expandedNodes,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [2, { compositeKey: 'Main:A.B.C', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [2, [{ compositeKey: 'Main:A.B.C', type: 'INT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -1240,8 +1240,8 @@ describe('buildActiveIndexSet', () => {
         debugVariableIndexes: indexMap,
         debugExpandedNodes: expandedNodes,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [2, { compositeKey: 'Main:A.B.C', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [2, [{ compositeKey: 'Main:A.B.C', type: 'INT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -1259,7 +1259,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'python',
         debugVariableIndexes: indexMap,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       // Python is not ld/fbd/st/il -> no visible variables collected
@@ -1303,7 +1303,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'ld',
         ladderFlows: [ldFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       // makeKey returns null for all -> no keys added
@@ -1342,7 +1342,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'fbd',
         fbdFlows: [fbdFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -1363,7 +1363,7 @@ describe('buildActiveIndexSet', () => {
         editorName: 'UnresolvedFB',
         editorLanguage: 'st',
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -1393,8 +1393,8 @@ describe('buildActiveIndexSet', () => {
         debugVariableIndexes: indexMap,
         debugExpandedNodes: expandedNodes,
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [11, { compositeKey: 'Main:FB0.Q', type: 'BOOL' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [11, [{ compositeKey: 'Main:FB0.Q', type: 'BOOL' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -1419,7 +1419,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'ld',
         ladderFlows: [ldFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -1449,7 +1449,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'fbd',
         fbdFlows: [fbdFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -1481,8 +1481,8 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'ld',
         ladderFlows: [ldFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [50, { compositeKey: 'something:Timer1.Q', type: 'BOOL' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [50, [{ compositeKey: 'something:Timer1.Q', type: 'BOOL' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -1508,8 +1508,8 @@ describe('buildActiveIndexSet', () => {
         editorName: 'UnresolvedFB',
         editorLanguage: 'st',
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [90, { compositeKey: 'something:MyTimer.ET', type: 'TIME' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [90, [{ compositeKey: 'something:MyTimer.ET', type: 'TIME' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
@@ -1538,7 +1538,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'ld',
         ladderFlows: [ldFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -1564,7 +1564,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'fbd',
         fbdFlows: [fbdFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -1596,7 +1596,7 @@ describe('buildActiveIndexSet', () => {
         editorLanguage: 'ld',
         ladderFlows: [ldFlow],
       })
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>()
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>()
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)
       expect(activeIndexes).toEqual([])
@@ -1629,8 +1629,8 @@ describe('buildActiveIndexSet', () => {
         ladderFlows: [ldFlow],
       })
       // allLeaves has entries that DON'T match the prefix
-      const allLeaves = new Map<number, { compositeKey: string; type: string }>([
-        [99, { compositeKey: 'Main:UNRELATED', type: 'INT' }],
+      const allLeaves = new Map<number, { compositeKey: string; type: string }[]>([
+        [99, [{ compositeKey: 'Main:UNRELATED', type: 'INT' }]],
       ])
 
       const { activeIndexes } = buildActiveIndexSet(state, allLeaves, null)

--- a/src/frontend/utils/__tests__/debugger-session.test.ts
+++ b/src/frontend/utils/__tests__/debugger-session.test.ts
@@ -5,7 +5,8 @@ import { packDebugAddr } from '../debug-parser'
 import {
   buildDebugVariableTreeMap,
   buildFbInstanceMap,
-  buildVariableIndexMap,
+  debugMapToEntries,
+  deriveVariableIndexMap,
   logCompilerEvent,
 } from '../debugger-session'
 
@@ -203,7 +204,7 @@ describe('logCompilerEvent', () => {
 })
 
 // ---------------------------------------------------------------------------
-// buildVariableIndexMap
+// deriveVariableIndexMap
 // ---------------------------------------------------------------------------
 
 function makeMap(leaves: Array<{ path: string; type: string; size: number }>): DebugMap {
@@ -220,7 +221,21 @@ function addr(arrayIdx: number, elemIdx: number): number {
   return packDebugAddr({ arrayIdx, elemIdx })
 }
 
-describe('buildVariableIndexMap', () => {
+describe('deriveVariableIndexMap', () => {
+  // The index map is now DERIVED from the debug tree (the single enumeration
+  // walk) rather than a parallel walk — so these tests drive the real flow:
+  // build the tree via buildDebugVariableTreeMap, then derive.
+  function derive(
+    pous: PLCPou[],
+    instances: PLCInstance[],
+    map: DebugMap,
+    dataTypes: PLCDataType[] = [],
+  ): { indexMap: Map<string, number>; warnings: string[] } {
+    const entries = debugMapToEntries(map)
+    const { treeMap, warnings } = buildDebugVariableTreeMap(pous, instances, entries, { dataTypes, pous }, SYSTEM_LIBS)
+    return { indexMap: deriveVariableIndexMap(treeMap, map), warnings }
+  }
+
   it('builds index map for simple base-type variables', () => {
     const pou = makePou('Main', 'program', [makeBaseVariable('SPEED', 'INT'), makeBaseVariable('TEMP', 'REAL')])
     const instances = [makeInstance('INSTANCE0', 'Main')]
@@ -229,7 +244,7 @@ describe('buildVariableIndexMap', () => {
       { path: 'INSTANCE0.TEMP', type: 'REAL', size: 4 },
     ])
 
-    const { indexMap, warnings } = buildVariableIndexMap([pou], instances, map)
+    const { indexMap, warnings } = derive([pou], instances, map)
 
     expect(indexMap.get('Main:SPEED')).toBe(addr(0, 0))
     expect(indexMap.get('Main:TEMP')).toBe(addr(0, 1))
@@ -238,7 +253,7 @@ describe('buildVariableIndexMap', () => {
 
   it('warns when no instance is found for a program POU', () => {
     const pou = makePou('Orphan', 'program', [makeBaseVariable('X', 'INT')])
-    const { warnings } = buildVariableIndexMap([pou], [], makeMap([]))
+    const { warnings } = derive([pou], [], makeMap([]))
 
     expect(warnings).toHaveLength(1)
     expect(warnings[0]).toContain('Orphan')
@@ -246,7 +261,7 @@ describe('buildVariableIndexMap', () => {
 
   it('skips non-program POUs', () => {
     const fb = makePou('MyFB', 'function-block', [makeBaseVariable('Q', 'BOOL')])
-    const { indexMap } = buildVariableIndexMap([fb], [makeInstance('INSTANCE0', 'Main')], makeMap([]))
+    const { indexMap } = derive([fb], [makeInstance('INSTANCE0', 'Main')], makeMap([]))
 
     expect(indexMap.size).toBe(0)
   })
@@ -260,7 +275,7 @@ describe('buildVariableIndexMap', () => {
       { path: 'INSTANCE0.ARR[2]', type: 'INT', size: 2 },
     ])
 
-    const { indexMap } = buildVariableIndexMap([pou], instances, map)
+    const { indexMap } = derive([pou], instances, map)
 
     expect(indexMap.get('Main:ARR[0]')).toBe(addr(0, 0))
     expect(indexMap.get('Main:ARR[1]')).toBe(addr(0, 1))
@@ -276,11 +291,49 @@ describe('buildVariableIndexMap', () => {
       { path: 'INSTANCE0.NEG[1]', type: 'BOOL', size: 1 },
     ])
 
-    const { indexMap } = buildVariableIndexMap([pou], instances, map)
+    const { indexMap } = derive([pou], instances, map)
 
     expect(indexMap.get('Main:NEG[-1]')).toBe(addr(0, 0))
     expect(indexMap.get('Main:NEG[0]')).toBe(addr(0, 1))
     expect(indexMap.get('Main:NEG[1]')).toBe(addr(0, 2))
+  })
+
+  it('resolves VAR_EXTERNAL globals by their bare (unprefixed) debug path', () => {
+    // A CONFIGURATION VAR_GLOBAL is emitted under its bare uppercase name, not
+    // the program-instance path. The tree resolves the external via the global
+    // path, so the composite key gets an index (force/release then work from
+    // the LD/FBD editors).
+    const pou = makePou('Main', 'program', [
+      makeBaseVariable('START_PB', 'BOOL', 'external'),
+      makeBaseVariable('LOCAL_X', 'INT'),
+    ])
+    const instances = [makeInstance('INSTANCE0', 'Main')]
+    const map = makeMap([
+      { path: 'START_PB', type: 'BOOL', size: 1 },
+      { path: 'INSTANCE0.LOCAL_X', type: 'INT', size: 2 },
+    ])
+
+    const { indexMap } = derive([pou], instances, map)
+
+    expect(indexMap.get('Main:START_PB')).toBe(addr(0, 0))
+    expect(indexMap.get('Main:LOCAL_X')).toBe(addr(0, 1))
+    // The instance-prefixed path must NOT resolve the global.
+    expect(indexMap.has('INSTANCE0.START_PB')).toBe(false)
+  })
+
+  it('maps a global shared by two programs to the same index under both keys', () => {
+    // The regression this whole refactor targets: a VAR_GLOBAL referenced (as
+    // VAR_EXTERNAL) by two programs must resolve to ONE address under BOTH
+    // composite keys, so force + value display work on every referencing POU.
+    const main = makePou('Main', 'program', [makeBaseVariable('START_PB', 'BOOL', 'external')])
+    const another = makePou('Another', 'program', [makeBaseVariable('START_PB', 'BOOL', 'external')])
+    const instances = [makeInstance('INSTANCE0', 'Main'), makeInstance('INSTANCE1', 'Another')]
+    const map = makeMap([{ path: 'START_PB', type: 'BOOL', size: 1 }])
+
+    const { indexMap } = derive([main, another], instances, map)
+
+    expect(indexMap.get('Main:START_PB')).toBe(addr(0, 0))
+    expect(indexMap.get('Another:START_PB')).toBe(addr(0, 0))
   })
 
   it('falls back to raw debug path for unmatched leaves (nested fields)', () => {
@@ -288,7 +341,7 @@ describe('buildVariableIndexMap', () => {
     const instances = [makeInstance('INSTANCE0', 'Main')]
     const map = makeMap([{ path: 'INSTANCE0.FB.FIELD', type: 'INT', size: 2 }])
 
-    const { indexMap } = buildVariableIndexMap([pou], instances, map)
+    const { indexMap } = derive([pou], instances, map)
 
     expect(indexMap.get('INSTANCE0.FB.FIELD')).toBe(addr(0, 0))
   })
@@ -310,7 +363,7 @@ describe('buildVariableIndexMap', () => {
       ],
     }
 
-    const { indexMap } = buildVariableIndexMap([pou], instances, map)
+    const { indexMap } = derive([pou], instances, map)
 
     expect(indexMap.get('Main:X')).toBe(addr(0, 0))
     expect(indexMap.get('INSTANCE0.OTHER')).toBe(addr(1, 0))

--- a/src/frontend/utils/debug-polling-filter.ts
+++ b/src/frontend/utils/debug-polling-filter.ts
@@ -62,13 +62,14 @@ export type VisibleVarsCache = {
  * Build a sorted array of debug indexes to poll this tick.
  *
  * @param state        - Current Zustand store snapshot
- * @param allLeaves    - Full index→{compositeKey,type} map (all debug tree leaves)
+ * @param allLeaves    - Full index→{compositeKey,type}[] map (all debug tree
+ *                       leaves; one index maps to many leaves for shared globals)
  * @param cachedResult - Previous diagram/source scan cache (or null)
  * @returns activeIndexes (sorted) and updated cache
  */
 export function buildActiveIndexSet(
   state: DebugPollingState,
-  allLeaves: Map<number, { compositeKey: string; type: string }>,
+  allLeaves: Map<number, { compositeKey: string; type: string }[]>,
   cachedResult: VisibleVarsCache,
 ): { activeIndexes: number[]; cacheResult: VisibleVarsCache } {
   const activeKeys = new Set<string>()
@@ -126,18 +127,20 @@ export function buildActiveIndexSet(
   //    — and include them if they have a watched/forced/graphed ancestor
   //    AND every node in the hierarchy from that ancestor down is expanded.
   // -----------------------------------------------------------------------
-  for (const [, meta] of allLeaves) {
-    const key = meta.compositeKey
-    const colonIdx = key.indexOf(':')
-    if (colonIdx === -1) continue
-    const pouName = key.slice(0, colonIdx)
-    const varName = key.slice(colonIdx + 1)
-    // Only nested leaves (struct fields, FB fields, array elements) need
-    // ancestor-resolution; flat leaves are handled by the watched-key path.
-    if (!varName.includes('.') && !varName.includes('[')) continue
+  for (const [, metas] of allLeaves) {
+    for (const meta of metas) {
+      const key = meta.compositeKey
+      const colonIdx = key.indexOf(':')
+      if (colonIdx === -1) continue
+      const pouName = key.slice(0, colonIdx)
+      const varName = key.slice(colonIdx + 1)
+      // Only nested leaves (struct fields, FB fields, array elements) need
+      // ancestor-resolution; flat leaves are handled by the watched-key path.
+      if (!varName.includes('.') && !varName.includes('[')) continue
 
-    if (shouldPollNestedVariable(varName, pouName, activeKeys, debugExpandedNodes, debugGraphList)) {
-      activeKeys.add(key)
+      if (shouldPollNestedVariable(varName, pouName, activeKeys, debugExpandedNodes, debugGraphList)) {
+        activeKeys.add(key)
+      }
     }
   }
 
@@ -179,9 +182,10 @@ export function buildActiveIndexSet(
   }
 
   // Also include by scanning allLeaves (handles cases where debugVariableIndexes
-  // doesn't have the key but the tree does, e.g. deeply nested fields)
-  for (const [index, meta] of allLeaves) {
-    if (activeKeys.has(meta.compositeKey)) {
+  // doesn't have the key but the tree does, e.g. deeply nested fields). One
+  // index can carry several keys (shared globals) — active if ANY is active.
+  for (const [index, metas] of allLeaves) {
+    if (metas.some((m) => activeKeys.has(m.compositeKey))) {
       indexSet.add(index)
     }
   }
@@ -284,7 +288,7 @@ function shouldPollNestedVariable(
 function computeVisibleVariableKeys(
   state: DebugPollingState,
   currentPou: PLCPou,
-  allLeaves: Map<number, { compositeKey: string; type: string }>,
+  allLeaves: Map<number, { compositeKey: string; type: string }[]>,
 ): Set<string> {
   const keys = new Set<string>()
   const language = currentPou.body.language
@@ -304,9 +308,11 @@ function computeVisibleVariableKeys(
 
   // Helper to find all leaf keys matching a prefix in the debug tree
   const addLeavesWithPrefix = (prefix: string) => {
-    for (const [, meta] of allLeaves) {
-      if (meta.compositeKey.startsWith(prefix)) {
-        keys.add(meta.compositeKey)
+    for (const [, metas] of allLeaves) {
+      for (const meta of metas) {
+        if (meta.compositeKey.startsWith(prefix)) {
+          keys.add(meta.compositeKey)
+        }
       }
     }
   }

--- a/src/frontend/utils/debug-tree-builder.ts
+++ b/src/frontend/utils/debug-tree-builder.ts
@@ -10,7 +10,7 @@ import type { DebugTreeNode, PLCPou, PLCVariable } from '../../middleware/shared
 import type { DebugVariableEntry } from './debug-parser'
 import type { DebugNodeVisitor, TraversalContext } from './debug-tree-traversal'
 import { traverseVariable } from './debug-tree-traversal'
-import { buildDebugPath, buildGlobalDebugPath } from './debug-variable-finder'
+import { buildGlobalDebugPath, buildVariableDebugPath } from './debug-variable-finder'
 
 /**
  * Project data shape expected by the debug tree builder.
@@ -198,8 +198,5 @@ export function buildDebugTree(
  * External variables use CONFIG0__ prefix, local variables use RES0__INSTANCE. prefix.
  */
 export function buildVariableBasePath(variableName: string, instanceName: string, variableClass?: string): string {
-  if (variableClass === 'external') {
-    return buildGlobalDebugPath(variableName)
-  }
-  return buildDebugPath(instanceName, variableName)
+  return buildVariableDebugPath(variableClass === 'external', instanceName, variableName)
 }

--- a/src/frontend/utils/debug-tree-traversal.ts
+++ b/src/frontend/utils/debug-tree-traversal.ts
@@ -9,12 +9,7 @@
 import type { SystemLibrary } from '../../middleware/shared/ports/library-types'
 import type { PLCDataType, PLCPou, PLCVariable } from '../../middleware/shared/ports/types'
 import type { DebugVariableEntry } from './debug-parser'
-import {
-  buildDebugPath,
-  buildGlobalDebugPath,
-  findDebugVariable,
-  findDebugVariableForField,
-} from './debug-variable-finder'
+import { buildVariableDebugPath, findDebugVariable, findDebugVariableForField } from './debug-variable-finder'
 import { findFunctionBlockVariables, findStructureVariables, normalizeTypeString } from './pou-helpers'
 
 /**
@@ -405,9 +400,8 @@ export function traverseVariable<T>(variable: PLCVariable, context: TraversalCon
   const { debugVariables, projectPous, pouName, instanceName, systemLibraries } = context
   const compositeKey = `${pouName}:${variable.name}`
 
-  // Build the base path
-  const fullPath =
-    variable.class === 'external' ? buildGlobalDebugPath(variable.name) : buildDebugPath(instanceName, variable.name)
+  // Build the base path (single rule — see buildVariableDebugPath)
+  const fullPath = buildVariableDebugPath(variable.class === 'external', instanceName, variable.name)
 
   if (variable.type.definition === 'base-type') {
     const baseType = variable.type.value.toUpperCase()

--- a/src/frontend/utils/debug-variable-finder.ts
+++ b/src/frontend/utils/debug-variable-finder.ts
@@ -86,12 +86,24 @@ export function buildDebugPath(
 }
 
 /**
- * Build the debug path for a global variable. STruC++ does not currently
- * emit globals into debug-map.json; this helper returns the unprefixed
- * name so future support lines up naturally.
+ * Build the debug path for a global variable. STruC++ emits CONFIGURATION
+ * VAR_GLOBALs into debug-map.json under their bare (unprefixed) uppercase name,
+ * so a VAR_EXTERNAL reference resolves to the same address from every program.
  */
 export function buildGlobalDebugPath(variablePath: string): string {
   return variablePath.toUpperCase()
+}
+
+/**
+ * The single path rule for a program variable: a shared global (VAR_EXTERNAL →
+ * CONFIGURATION VAR_GLOBAL) addresses by its bare name; everything else is
+ * instance-prefixed. Both the tree traversal and the base-path shim resolve
+ * through here so the "is this a global?" decision (and thus the address) can't
+ * drift between them. OPC-UA reaches the same two primitives but derives
+ * global-ness from its own node model (pouName GVL/CONFIG), not variable class.
+ */
+export function buildVariableDebugPath(isGlobal: boolean, instanceName: string, variableName: string): string {
+  return isGlobal ? buildGlobalDebugPath(variableName) : buildDebugPath(instanceName, variableName)
 }
 
 /**

--- a/src/frontend/utils/debugger-session.ts
+++ b/src/frontend/utils/debugger-session.ts
@@ -16,7 +16,7 @@ import type {
   PLCVariable,
 } from '../../middleware/shared/ports/types'
 import type { DebugMap, DebugVariableEntry } from './debug-parser'
-import { buildLeafPathMap, packDebugAddr } from './debug-parser'
+import { packDebugAddr } from './debug-parser'
 import { buildDebugTree } from './debug-tree-builder'
 import { buildDebugPathPrefix, findInstanceName, type PLCInstanceMapping } from './debug-variable-finder'
 
@@ -79,88 +79,47 @@ export function logCompilerEvent(
 }
 
 // ---------------------------------------------------------------------------
-// 1. buildVariableIndexMap — composite-key -> packed-DebugAddr
+// 1. deriveVariableIndexMap — composite-key -> packed-DebugAddr (from the tree)
 // ---------------------------------------------------------------------------
 
-export interface VariableIndexMapResult {
-  indexMap: Map<string, number>
-  warnings: string[]
-}
-
 /**
- * Build a composite-key -> packed-DebugAddr map from a DebugMap.
+ * Derive the composite-key -> packed-DebugAddr map from the debug tree, which
+ * is the single enumeration walk (`traverseVariable`, via
+ * `buildDebugVariableTreeMap`).
  *
- * The map addresses variables as (arrayIdx, elemIdx) pairs; we pack those
- * into a single number `(arr << 16) | elem` so downstream store types and
- * the polling loop see a plain `number` key.
+ * The tree already resolved every variable's debug address exactly once,
+ * applying the one path convention (external globals by their bare name,
+ * program-locals instance-prefixed, `.FIELD` for struct/FB fields, `[idx]` for
+ * array elements). Flattening its leaves here guarantees the LD/FBD editors,
+ * the watch panel, and the poller all address a variable identically — there is
+ * no second walk that can drift. (A divergent inline walk here is exactly how
+ * force silently no-op'd on located globals: it missed the external case.)
  *
- * Path convention emitted by STruC++:
- *   INSTANCE_NAME.VAR_NAME            (scalar)
- *   INSTANCE_NAME.VAR_NAME[5]         (array element, IEC-indexed)
- *   INSTANCE_NAME.FB_INST.FIELD       (nested struct/FB field)
+ * Addresses are (arrayIdx, elemIdx) pairs packed into a single number
+ * `(arr << 16) | elem`. `treeMap` is the flat compositeKey -> node map that
+ * `buildDebugVariableTreeMap` returns (every node, nested included).
  */
-export function buildVariableIndexMap(pous: PLCPou[], instances: PLCInstance[], map: DebugMap): VariableIndexMapResult {
+export function deriveVariableIndexMap(treeMap: Map<string, DebugTreeNode>, map: DebugMap): Map<string, number> {
   const indexMap = new Map<string, number>()
-  const warnings: string[] = []
 
-  // Single source of truth for path → packed-address (case-insensitive).
-  // Same lookup the OPC-UA resolver uses.
-  const pathToAddr = buildLeafPathMap(map)
-
-  const instanceMappings: PLCInstanceMapping[] = instances.map((inst) => ({
-    name: inst.name,
-    program: inst.program,
-  }))
-
-  pous.forEach((pou) => {
-    if (pou.pouType !== 'program') return
-
-    const instanceName = findInstanceName(pou.name, instanceMappings)
-    if (!instanceName) {
-      warnings.push(`No instance found for program '${pou.name}', skipping debug variable parsing.`)
-      return
+  // Every resolved leaf in the tree, keyed by its composite key. Complex nodes
+  // (structs / FBs / arrays) carry no address of their own — only their leaves
+  // do (debugIndex === undefined on the parents).
+  for (const [compositeKey, node] of treeMap) {
+    if (node.debugIndex !== undefined) {
+      indexMap.set(compositeKey, node.debugIndex)
     }
+  }
 
-    const upperInstance = instanceName.toUpperCase()
-    const variables = pou.interface?.variables ?? []
-
-    variables.forEach((v: PLCVariable) => {
-      if (v.type.definition === 'array' && v.type.data) {
-        const dimensions = v.type.data.dimensions
-        if (dimensions.length > 0) {
-          const dimMatch = dimensions[0].dimension.match(/^(-?\d+)\.\.(-?\d+)$/)
-          if (dimMatch) {
-            const startIdx = parseInt(dimMatch[1], 10)
-            const endIdx = parseInt(dimMatch[2], 10)
-            for (let i = 0; i <= endIdx - startIdx; i++) {
-              const iecIdx = startIdx + i
-              const path = `${upperInstance}.${v.name.toUpperCase()}[${iecIdx}]`
-              const addr = pathToAddr.get(path)
-              if (addr !== undefined) {
-                indexMap.set(`${pou.name}:${v.name}[${iecIdx}]`, addr)
-              }
-            }
-          }
-        }
-      } else {
-        const path = `${upperInstance}.${v.name.toUpperCase()}`
-        const addr = pathToAddr.get(path)
-        if (addr !== undefined) {
-          indexMap.set(`${pou.name}:${v.name}`, addr)
-        }
-      }
-    })
-  })
-
-  // Fallback: also key by the raw debug path so any leaves we didn't cover
-  // (nested fields, FB internals) remain reachable by path.
+  // Fallback: also key by the raw debug path so any leaves the tree didn't
+  // surface (e.g. library-FB internals) remain reachable by path.
   for (const leaf of map.leaves) {
     if (!indexMap.has(leaf.path)) {
       indexMap.set(leaf.path, packDebugAddr(leaf))
     }
   }
 
-  return { indexMap, warnings }
+  return indexMap
 }
 
 /**
@@ -183,12 +142,16 @@ export interface DebugVariableTreeMapResult {
   treeMap: Map<string, DebugTreeNode>
   trees: DebugTreeNode[]
   complexCount: number
+  warnings: string[]
 }
 
 /**
  * Build a flat compositeKey -> DebugTreeNode map by traversing all program
- * POU variables. Pure function — swallows per-variable errors to match
- * existing behaviour.
+ * POU variables. This is the single enumeration walk (`traverseVariable`);
+ * `deriveVariableIndexMap` and the poller's leaf collection both project off
+ * its output rather than re-walking. Pure function — swallows per-variable
+ * errors to match existing behaviour; `warnings` collects programs with no
+ * instance in Resources (same diagnostic the old index-map walk emitted).
  */
 export function buildDebugVariableTreeMap(
   pous: PLCPou[],
@@ -199,6 +162,7 @@ export function buildDebugVariableTreeMap(
 ): DebugVariableTreeMapResult {
   const trees: DebugTreeNode[] = []
   const treeMap = new Map<string, DebugTreeNode>()
+  const warnings: string[] = []
   let complexCount = 0
 
   const instanceMappings: PLCInstanceMapping[] = instances.map((inst) => ({
@@ -219,7 +183,10 @@ export function buildDebugVariableTreeMap(
     if (pou.pouType !== 'program') return
 
     const instanceName = findInstanceName(pou.name, instanceMappings)
-    if (!instanceName) return
+    if (!instanceName) {
+      warnings.push(`No instance found for program '${pou.name}', skipping debug variable parsing.`)
+      return
+    }
 
     const variables = pou.interface?.variables ?? []
     variables.forEach((v: PLCVariable) => {
@@ -262,7 +229,7 @@ export function buildDebugVariableTreeMap(
     }
   })
 
-  return { treeMap, trees, complexCount }
+  return { treeMap, trees, complexCount, warnings }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/frontend/utils/opcua/generate-opcua-config.ts
+++ b/src/frontend/utils/opcua/generate-opcua-config.ts
@@ -387,8 +387,8 @@ const buildAddressSpace = (
 
 /**
  * Parse debug-map.json content into the uppercase-path → packed-addr
- * Map the resolver consumes. The same lookup table the debugger's
- * buildVariableIndexMap builds — single source of truth.
+ * Map the resolver consumes. The same path→address lookup table the
+ * debugger derives its index map from — single source of truth.
  *
  * Returns an empty Map on malformed/missing input; caller checks
  * `addressSpace.nodes.length > 0 && map.size === 0` to distinguish


### PR DESCRIPTION
Fixes editor #653 — located `VAR_GLOBAL` forcing/I-O and shared globals across IEC tasks. The compiler/runtime side lands via strucpp v0.5.13 (pinned here); this PR is the editor/debugger side.

- **Single-source variable→address:** the composite-key→index map is now derived from the debug tree (the one `traverseVariable` enumeration walk) instead of a divergent inline walk. LD/FBD force, the watch panel, and the poller resolve a variable's address identically.
- **Fan-out:** a polled value now propagates to every composite key sharing an address, so a global referenced by multiple programs displays on all of them (index→leaf map is 1:many).
- Names the single path rule (`buildVariableDebugPath`); OPC-UA keeps the shared path primitives + address map.
- Pins strucpp v0.5.13.

Shared-surface files are byte-identical with openplc-web (same branch name). HIL-validated: P1AM-100 (baremetal) + SLM-RP4 (threaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Debug variable handling now supports multiple entries sharing the same runtime address, improving visibility for shared globals and composite variables.
  * Variable paths are now resolved more consistently for both instance-based and global variables.

* **Bug Fixes**
  * Fixed debug polling so values and errors are correctly applied to all matching variables instead of only one.
  * Improved handling of missing or unmatched debug metadata during polling and session startup.

* **Chores**
  * Updated the bundled `strucpp` version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->