### PR TITLE
fix(ci): install strucpp in the unit-tests job

### DIFF
--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -20,6 +20,14 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      # --ignore-scripts skips the postinstall, so strucpp (a GitHub-release
+      # package, not an npm dep) is never fetched — yet the TS sources import
+      # `strucpp/libs/iec-types.json` and its runtime headers. Install just
+      # strucpp (no xml2st platform binary, no native rebuild) so the suites
+      # can load and the coverage gate actually runs.
+      - name: Install strucpp
+        run: npm run setup:strucpp
+
       - name: Run tests with coverage
         run: npx jest --config jest.config.json --collectCoverage --ci
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "format": "cross-env NODE_ENV=development prettier --write \"./src/**/*.{ts,tsx}\"",
     "postinstall": "ts-node scripts/download-binaries.ts && ts-node scripts/check-native-dep.js && electron-builder install-app-deps && npm run build:dll",
     "setup:binaries": "ts-node scripts/download-binaries.ts",
+    "setup:strucpp": "ts-node scripts/download-binaries.ts --strucpp-only",
     "package": "ts-node scripts/clean.js dist && npm run build && electron-builder build --publish never && npm run build:dll",
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir release/app",
     "prestart": "ts-node scripts/download-binaries.ts && cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./configs/webpack/webpack.config.main.dev.ts",

--- a/scripts/download-binaries.ts
+++ b/scripts/download-binaries.ts
@@ -54,11 +54,17 @@ function cacheFile(platform: Platform, arch: Arch): string {
 // CLI argument parsing
 // ---------------------------------------------------------------------------
 
-function parseArgs(): { platform: Platform; arch: Arch; force: boolean } {
+function parseArgs(): { platform: Platform; arch: Arch; force: boolean; strucppOnly: boolean } {
   const args = process.argv.slice(2)
   let platform = process.platform as string
   let arch = process.arch as string
   let force = false
+  // strucpp-only: install just the platform-independent strucpp package (its
+  // libs/ + runtime headers are imported by the TS sources). Skips the xml2st
+  // platform binary — used by the unit-test CI job, which runs `npm ci
+  // --ignore-scripts` (so the postinstall never fetched strucpp) but doesn't
+  // need the heavyweight platform binaries or a native rebuild.
+  let strucppOnly = false
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--platform' && args[i + 1]) {
@@ -67,6 +73,8 @@ function parseArgs(): { platform: Platform; arch: Arch; force: boolean } {
       arch = args[++i]
     } else if (args[i] === '--force') {
       force = true
+    } else if (args[i] === '--strucpp-only') {
+      strucppOnly = true
     }
   }
 
@@ -79,7 +87,7 @@ function parseArgs(): { platform: Platform; arch: Arch; force: boolean } {
     process.exit(1)
   }
 
-  return { platform: platform as Platform, arch: arch as Arch, force }
+  return { platform: platform as Platform, arch: arch as Arch, force, strucppOnly }
 }
 
 // ---------------------------------------------------------------------------
@@ -289,7 +297,7 @@ async function downloadStrucpp(tool: ToolEntry): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  const { platform, arch, force } = parseArgs()
+  const { platform, arch, force, strucppOnly } = parseArgs()
 
   if (!fs.existsSync(VERSIONS_FILE)) {
     console.error(`binary-versions.json not found at ${VERSIONS_FILE}`)
@@ -298,31 +306,31 @@ async function main(): Promise<void> {
 
   const versions: BinaryVersions = JSON.parse(fs.readFileSync(VERSIONS_FILE, 'utf-8'))
 
-  console.log(`[download-binaries] platform=${platform} arch=${arch} force=${force}`)
+  console.log(`[download-binaries] platform=${platform} arch=${arch} force=${force} strucppOnly=${strucppOnly}`)
+
+  // strucpp is platform-independent (its libs/ + runtime headers are imported
+  // by the TS sources) — download it whenever it's missing or outdated.
+  if (force || needsStrucpp(versions)) {
+    await downloadStrucpp(versions.strucpp)
+  } else {
+    console.log(`  strucpp ${versions.strucpp.version} already installed, skipping.`)
+  }
+
+  // --strucpp-only stops here: the caller (e.g. the unit-test CI job) needs the
+  // strucpp package but not the platform binary or the platform cache marker.
+  if (strucppOnly) {
+    console.log(`[download-binaries] strucpp-only: skipped xml2st platform binary.`)
+    return
+  }
 
   const targetBinDir = binDir(platform, arch)
   fs.mkdirSync(targetBinDir, { recursive: true })
 
   const cached = force ? null : getCachedMetadata(platform, arch)
-  const downloadXml2stNeeded = force || needsXml2st(versions, cached, platform, arch)
-  const downloadStrucppNeeded = force || needsStrucpp(versions)
-
-  if (!downloadXml2stNeeded && !downloadStrucppNeeded) {
-    console.log(`[download-binaries] All tools up to date, skipping.`)
-    return
-  }
-
-  if (downloadXml2stNeeded) {
+  if (force || needsXml2st(versions, cached, platform, arch)) {
     await downloadXml2st(versions.xml2st, platform, arch, targetBinDir)
   } else {
     console.log(`  xml2st ${versions.xml2st.version} already installed, skipping.`)
-  }
-
-  // strucpp is platform-independent — only download once regardless of platform/arch
-  if (downloadStrucppNeeded) {
-    await downloadStrucpp(versions.strucpp)
-  } else {
-    console.log(`  strucpp ${versions.strucpp.version} already installed, skipping.`)
   }
 
   writeCache(versions, platform, arch)


### PR DESCRIPTION
The `ci-unit-tests` workflow runs `npm ci --ignore-scripts`, which skips the postinstall that fetches **strucpp** (a GitHub-release package, not an npm dependency). The TS sources import `strucpp/libs/iec-types.json` and its runtime headers, so every suite failed to load with `Cannot find module 'strucpp'` — the job has been red on **every** run since it was added (workflow_dispatch-only, so it went unnoticed).

**Fix:** add a `--strucpp-only` mode to `download-binaries` (installs just the platform-independent strucpp package — no xml2st platform binary, no native rebuild) + a `setup:strucpp` script, and run it after install in the workflow.

**Verified** via a dispatched run on this branch: 0 `Cannot find module 'strucpp'` errors; the suite now executes (4930/4934 pass).

### Not addressed here (pre-existing, surfaced now that the job runs — see the follow-up report)
- 3 `backend/shared` test files fail to compile against renamed APIs (`transpileXmlToSt` → `transpileToSt`; changed `PrepareXmlOutcome` shape).
- 1 real assertion failure in the VPP alias-sync test (`setAvailableOptions` not adopting an alias on SLM-RP4).

These are separate subsystems (compiler/library/VPP) and are left for separate triage; this PR only unblocks the strucpp-load infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI unit tests now install the required StruCPP tooling before running, helping ensure the test suite and coverage checks can complete successfully.
  * Improved the binary setup flow so the required tooling is prepared consistently, reducing skipped or missing test prerequisites.

* **Chores**
  * Added a dedicated setup command for installing StruCPP on its own, making the test environment setup more explicit and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->