### PR TITLE
fix(debug): resolve alias-bound locations before debug compilation

### DIFF
--- a/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
@@ -791,10 +791,14 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
         return
       }
 
-      // Debug compilation
+      // Debug compilation. Resolve alias-bound locations to concrete
+      // addresses first (same pre-compile snapshot the build/upload paths
+      // use) — the compiler only understands `%…` literals, not alias names.
+      const freshProjectData = useOpenPLCStore.getState().projectActions.getCompileReadyProjectData()
       consoleActions.addLog({ id: crypto.randomUUID(), level: 'info', message: 'Starting debug compilation...' })
-      const debugCompileResult = await compiler.compileForDebug({ projectData, boardTarget, projectPath }, (event) =>
-        logCompilerEvent(event, consoleActions.addLog),
+      const debugCompileResult = await compiler.compileForDebug(
+        { projectData: freshProjectData, boardTarget, projectPath },
+        (event) => logCompilerEvent(event, consoleActions.addLog),
       )
       if (!debugCompileResult.success) {
         consoleActions.addLog({


### PR DESCRIPTION
## Summary
The debug-compile path (`handleDebugger` in the workspace activity bar) passed **raw** project data to `compileForDebug`, so alias-bound variable locations were emitted as alias identifiers in the generated `_config.st`:

```
start_pb AT in_0 : BOOL;   ← in_0 is a pin alias, not a %address
motor    AT out_0 : BOOL;
```

STruC++ rejects these: `error: Expected DirectAddress, found identifier IN_0`. The normal **build** and **upload** paths already resolve aliases → concrete `%` addresses via `projectActions.getCompileReadyProjectData()`; this wires the same pre-compile snapshot into the debug-compile call.

**Regression** from the single-field variable-location refactor (#915 / #575): alias resolution was added to build/upload but the debug path was missed. Program compile + upload work; only debug compilation failed.

## Testing
`tsc` + `eslint` clean; surface byte-identical between repos. Reproduced from a desktop debug-compile log (P1AM-100, pin-aliased BOOLs) and confirmed the debug path now resolves `in_0 → %IX…`, matching the build path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the debugger’s compile flow to use the latest project snapshot, helping ensure debug compilation runs on up-to-date data.
  * Added clearer status logging when debug compilation starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->