### PR TITLE
fix(alias): persist location warning on select; orphan bound vars on alias clear (4.2.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-plc-editor",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "license": "GPL-3.0",
   "author": {
     "name": "Autonomy Logic"

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/io-table-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/io-table-layout.tsx
@@ -21,6 +21,33 @@ type IoTableLayoutProps = {
   moduleSystem: ModuleSystem
 }
 
+/**
+ * Alias cell with local state so the value commits on blur (focus change),
+ * not on every keystroke. Committing per keystroke fires the alias-rename
+ * cascade for every intermediate string while editing — e.g. clearing "flow"
+ * would cascade through "flo", "fl", "f" onto bound variables. Committing on
+ * blur means a single rename (old → final) reaches the store, and clearing the
+ * field to empty leaves bound variables orphaned rather than partially renamed.
+ */
+function AliasInputCell({ value, onCommit }: { value: string; onCommit: (next: string) => void }) {
+  const [local, setLocal] = useState(value)
+  useEffect(() => {
+    setLocal(value)
+  }, [value])
+  return (
+    <input
+      type='text'
+      value={local}
+      onChange={(e) => setLocal(e.target.value)}
+      onBlur={() => {
+        if (local !== value) onCommit(local)
+      }}
+      placeholder='Alias...'
+      className='h-[26px] w-full rounded border border-neutral-100 bg-white px-2 font-caption text-cp-sm text-neutral-850 outline-none placeholder:text-neutral-400 focus:border-brand-medium-dark dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300 dark:placeholder:text-neutral-600'
+    />
+  )
+}
+
 function IoTableLayout({ section, moduleSystem }: IoTableLayoutProps) {
   // See `getSectionPersistenceKey` in ../index.tsx — the single
   // source of truth for the per-section storage key.  Falls back to
@@ -335,12 +362,9 @@ function IoTableLayout({ section, moduleSystem }: IoTableLayoutProps) {
                         {entry.iecAddress}
                       </td>
                       <td className='px-1 py-1'>
-                        <input
-                          type='text'
-                          value={entry.alias}
-                          onChange={(e) => handleAliasChange(entry.globalIndex, e.target.value)}
-                          placeholder='Alias...'
-                          className='h-[26px] w-full rounded border border-neutral-100 bg-white px-2 font-caption text-cp-sm text-neutral-850 outline-none placeholder:text-neutral-400 focus:border-brand-medium-dark dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300 dark:placeholder:text-neutral-600'
+                        <AliasInputCell
+                          value={entry.alias ?? ''}
+                          onCommit={(next) => handleAliasChange(entry.globalIndex, next)}
                         />
                       </td>
                     </tr>

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
@@ -88,6 +88,33 @@ type ConfigScreenDefinition = {
 // Walk a screen definition and return every field that contributes
 // to the configuration form. The screen JSON is a vendor artifact —
 // be tolerant of missing/oddly-shaped fragments rather than crash.
+/**
+ * Alias cell with local state so the value commits on blur (focus change),
+ * not on every keystroke. Committing per keystroke fires the alias-rename
+ * cascade for every intermediate string while editing — e.g. clearing "flow"
+ * would cascade through "flo", "fl", "f" onto bound variables. Committing on
+ * blur means a single rename (old → final) reaches the store, and clearing the
+ * field to empty leaves bound variables orphaned rather than partially renamed.
+ */
+function AliasInputCell({ value, onCommit }: { value: string; onCommit: (next: string) => void }) {
+  const [local, setLocal] = useState(value)
+  useEffect(() => {
+    setLocal(value)
+  }, [value])
+  return (
+    <input
+      type='text'
+      value={local}
+      onChange={(e) => setLocal(e.target.value)}
+      onBlur={() => {
+        if (local !== value) onCommit(local)
+      }}
+      placeholder='Alias...'
+      className='h-[26px] w-full rounded border border-neutral-100 bg-white px-2 font-caption text-cp-sm text-neutral-850 outline-none placeholder:text-neutral-400 focus:border-brand-medium-dark dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300 dark:placeholder:text-neutral-600'
+    />
+  )
+}
+
 function collectConfigFields(def: ConfigScreenDefinition | undefined | null): ConfigFieldDef[] {
   if (!def?.sections) return []
   const out: ConfigFieldDef[] = []
@@ -993,12 +1020,9 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
                                 {entry.iecAddress}
                               </td>
                               <td className='px-1 py-1'>
-                                <input
-                                  type='text'
-                                  value={entry.alias}
-                                  onChange={(e) => handleAliasChange(entry.slot, entry.channelName, e.target.value)}
-                                  placeholder='Alias...'
-                                  className='h-[26px] w-full rounded border border-neutral-100 bg-white px-2 font-caption text-cp-sm text-neutral-850 outline-none placeholder:text-neutral-400 focus:border-brand-medium-dark dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300 dark:placeholder:text-neutral-600'
+                                <AliasInputCell
+                                  value={entry.alias ?? ''}
+                                  onCommit={(next) => handleAliasChange(entry.slot, entry.channelName, next)}
                                 />
                               </td>
                             </tr>

--- a/src/frontend/components/_molecules/global-variables-table/editable-cell.tsx
+++ b/src/frontend/components/_molecules/global-variables-table/editable-cell.tsx
@@ -389,18 +389,33 @@ const EditableLocationCell = ({
       ? `Address ${cellValue} conflicts with alias "${locationConflict.aliasName}" assigned to "${locationConflict.variableName}". Two variables cannot share a location.`
       : undefined
 
+  // The warning glyph must stay visible whether or not the row is selected.
+  // The editable branch renders a combobox; previously the glyph lived only in
+  // the display branch, so an active conflict/orphan looked unflagged the
+  // moment the row was selected. Render it in both branches.
+  const warningGlyph =
+    hasLocationWarning && warningTooltip ? (
+      <LocationWarningGlyph
+        label={isManualConflict ? 'Address conflicts with an alias' : 'Orphaned alias'}
+        tooltip={warningTooltip}
+      />
+    ) : null
+
   return editable ? (
-    <GenericComboboxCell
-      value={cellValue}
-      displayLabel={cellValue}
-      onValueChange={(value) => {
-        onBlur(value)
-      }}
-      selectValues={selectableValues()}
-      selected={editable}
-      openOnSelectedOption
-      canAddACustomOption
-    />
+    <div className='flex w-full flex-1 items-center gap-1'>
+      {warningGlyph}
+      <GenericComboboxCell
+        value={cellValue}
+        displayLabel={cellValue}
+        onValueChange={(value) => {
+          onBlur(value)
+        }}
+        selectValues={selectableValues()}
+        selected={editable}
+        openOnSelectedOption
+        canAddACustomOption
+      />
+    </div>
   ) : (
     <div
       className={cn(
@@ -410,12 +425,7 @@ const EditableLocationCell = ({
         },
       )}
     >
-      {hasLocationWarning && warningTooltip && (
-        <LocationWarningGlyph
-          label={isManualConflict ? 'Address conflicts with an alias' : 'Orphaned alias'}
-          tooltip={warningTooltip}
-        />
-      )}
+      {warningGlyph}
       <HighlightedText
         text={cellValue}
         searchQuery={searchQuery}

--- a/src/frontend/components/_molecules/variables-table/editable-cell.tsx
+++ b/src/frontend/components/_molecules/variables-table/editable-cell.tsx
@@ -556,21 +556,36 @@ const EditableLocationCell = ({
       ? `Address ${cellValue} conflicts with alias "${locationConflict.aliasName}" assigned to "${locationConflict.variableName}". Two variables cannot share a location.`
       : undefined
 
+  // The warning glyph must stay visible whether or not the row is selected.
+  // The selected branch renders an editable combobox; previously the glyph
+  // lived only in the display branch, so an active conflict/orphan looked
+  // unflagged the moment the row was selected. Render it in both branches.
+  const warningGlyph =
+    hasLocationWarning && warningTooltip ? (
+      <LocationWarningGlyph
+        label={isManualConflict ? 'Address conflicts with an alias' : 'Orphaned alias'}
+        tooltip={warningTooltip}
+      />
+    ) : null
+
   return selected ? (
-    <GenericComboboxCell
-      value={cellValue}
-      displayLabel={cellValue}
-      onValueChange={(value) => {
-        onBlur(value)
-      }}
-      selectValues={selectableValues()}
-      selected={selected}
-      openOnSelectedOption
-      canAddACustomOption
-      // An orphaned alias name resolves to nothing at compile; keep "Clear"
-      // enabled even when empty so the user can drop it.
-      allowClearWhenEmpty={id === 'location' && isOrphaned}
-    />
+    <div className='flex w-full flex-1 items-center gap-1'>
+      {warningGlyph}
+      <GenericComboboxCell
+        value={cellValue}
+        displayLabel={cellValue}
+        onValueChange={(value) => {
+          onBlur(value)
+        }}
+        selectValues={selectableValues()}
+        selected={selected}
+        openOnSelectedOption
+        canAddACustomOption
+        // An orphaned alias name resolves to nothing at compile; keep "Clear"
+        // enabled even when empty so the user can drop it.
+        allowClearWhenEmpty={id === 'location' && isOrphaned}
+      />
+    </div>
   ) : (
     <div
       className={cn(
@@ -581,12 +596,7 @@ const EditableLocationCell = ({
         },
       )}
     >
-      {hasLocationWarning && warningTooltip && (
-        <LocationWarningGlyph
-          label={isManualConflict ? 'Address conflicts with an alias' : 'Orphaned alias'}
-          tooltip={warningTooltip}
-        />
-      )}
+      {warningGlyph}
       <HighlightedText
         text={cellValue}
         searchQuery={searchQuery}

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -2771,11 +2771,14 @@ describe('createProjectSlice', () => {
       expect(store.getState().project.data.pous[0].interface!.variables![0].location).toBe('relay')
     })
 
-    it('clears bound variable locations when the alias is renamed to empty', () => {
+    it('leaves bound variable locations untouched (orphaned) when the alias is cleared', () => {
       seedPou(store, makePou('Prog', 'program', [locVar('bound', 'relay_1')]))
       const result = store.getState().projectActions.renameAlias('relay_1', '')
-      expect(result.renamed).toBe(1)
-      expect(store.getState().project.data.pous[0].interface!.variables![0].location).toBe('')
+      // Clearing an alias is a deletion, not a rename: the bound variable keeps
+      // the now-missing alias name and orphans (surfaces the warning glyph),
+      // rather than being silently wiped. Same behavior as deleting the device.
+      expect(result.renamed).toBe(0)
+      expect(store.getState().project.data.pous[0].interface!.variables![0].location).toBe('relay_1')
     })
 
     it('is a no-op when the old alias is empty', () => {

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -887,6 +887,14 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       // mapping screen on first-time alias write where there's no
       // prior text to cascade.
       if (trimmedOld.length === 0) return { renamed: 0 }
+      // Clearing an alias at its producer (empty newAlias) is a DELETION, not a
+      // rename. We deliberately do NOT cascade the empty string onto bound
+      // variables: they keep the old alias name in `location`, so they surface
+      // as orphaned (amber warning) and resolve to unlocated at compile time —
+      // exactly like deleting the whole producer/device. Cascading '' here
+      // would silently wipe the user's I/O mapping with no trace, which is the
+      // bug this guard prevents.
+      if (trimmedNew.length === 0) return { renamed: 0 }
       // True no-op only when the name is unchanged. A CASE change must still
       // cascade — the alias registry is case-sensitive, so `location` has to
       // match the producer alias exactly to resolve at compile time.
@@ -899,9 +907,9 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
         // and never equal a (non-`%`) alias name, so they're left untouched.
         if (variable.location !== trimmedOld) return variable
         renamed += 1
-        // When the producer CLEARS its alias (newAlias empty), the bound
-        // variable becomes unlocated — `location` clears, matching the
-        // compile-time "missing alias → empty location" rule.
+        // A genuine rename (both names non-empty): the bound variable follows
+        // to the new alias so it stays located. (The empty-newAlias case is
+        // handled above and never reaches here.)
         return { ...variable, location: trimmedNew }
       }
 


### PR DESCRIPTION
## Editor bugs fixed (found during EtherCAT/Modbus alias stress test)

**#1 — Location-warning glyph vanished when the row was selected.** The variable-location cell rendered the amber conflict/orphan glyph only in its display branch; selecting the row swapped to the editable combobox, which had no glyph, so an active conflict/orphan looked unflagged while editing. The glyph now renders in both branches (program + global variables tables).

**#2 — Clearing an alias silently wiped bound variables' locations.** Clearing an alias at its producer cascaded the empty string onto bound variables via `renameAlias`, blanking their `location` with no trace. An empty rename is now treated as a deletion: bound variables keep the (now-missing) alias name and surface as **orphaned** (amber warning), matching the behavior of deleting the whole device. The VPP io-table / module-slots alias inputs now commit on **blur** (local state) rather than per keystroke, so a single rename reaches the store instead of one per intermediate string.

## Validation
- All unit tests pass; `renameAlias` test updated to assert the orphan-preserving behavior; coverage on `slice.ts` unchanged (verified with/without the change).
- Verified on dev:local browser: selected conflicting row keeps its glyph (#1); clearing a Modbus alias leaves the bound variable orphaned with a warning instead of blank (#2).
- Shared surface byte-identical with openplc-web (same commit).

Bumps version to 4.2.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alias edits in I/O and module mapping tables now save only when you leave the field, reducing accidental updates while typing.
  * Location warning indicators now appear consistently in both editable and read-only states.
  * Clearing an alias now behaves like a delete without unexpectedly changing related locations.

* **Chores**
  * Updated the app version to 4.2.8.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->