### PR TITLE
fix(ai): mirror shared-surface AI autocomplete fixes from openplc-web

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,27 @@ When adding new code to covered directories, you must add corresponding tests to
 
 ## Important Patterns
 
+### When bumping the app version:
+`APP_VERSION` in `src/frontend/data/constants/app-version.ts` is the **single
+source of truth** for the human-facing version, shared **byte-for-byte** between
+openplc-editor and openplc-web (enforced by the mirror gate / `compare-surfaces.py`).
+The About modal renders it directly; the web build writes it into `version.json`.
+
+**Bump `APP_VERSION` — never `package.json` alone.** Make the identical one-line
+edit in BOTH repos, and set `package.json.version` to the same value in both so
+they can't drift. Roles: `APP_VERSION` is what the user sees in the About dialog;
+`package.json.version` is what electron-builder stamps on the desktop binary and
+what the release tag `vX.Y.Z` must match. Bumping only `package.json` leaves the
+About dialog stuck on the old version — **this mistake shipped 4.2.7 and 4.2.8
+with About still showing 4.2.6.** If the two ever disagree, `APP_VERSION` is
+authoritative; fix it to match.
+
+Release order: bump `APP_VERSION` + `package.json` (both repos, same value) → PR
+to `development` → merge → promote `development`→`main` on both → tag `vX.Y.Z` on
+the editor's `main` to trigger the "Build and Release" workflow. Web auto-deploys
+on its `main` push. (Ideally `package.json.version` should be derived from
+`APP_VERSION` in the release workflow so a single bump can never drift.)
+
 ### When adding a new port:
 1. Define the interface in `src/middleware/shared/ports/`
 2. Add it to `PlatformPorts` in `src/middleware/shared/providers/types.ts`

--- a/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
@@ -1245,6 +1245,17 @@ void loop()
     minimap: { enabled: false },
     dropIntoEditor: { enabled: true },
     readOnly: isDebuggerVisible,
+    // Force Monaco's classic hidden-<textarea> input instead of the newer
+    // EditContext-API surface (a plain `<div class="native-edit-context">`).
+    // Monaco 0.54 enables EditContext by default wherever the browser exposes
+    // the API, but WebKit/Safari's EditContext support is immature: the Tab
+    // `keydown` on that surface never reaches Monaco's keybinding service, so
+    // Tab-accept of AI inline suggestions silently no-ops on Safari (mouse
+    // "Accept" works because it's a direct widget action). The textarea path is
+    // mature and consistent across Chrome/Safari, restoring Tab-accept. (It also
+    // makes the surface a real input element that @xyflow's `isInputDOMNode`
+    // recognises — see the `.nokey` workaround note in the render below.)
+    editContext: false,
     // Lock indentation to 4 spaces across every language Monaco
     // hosts (ST / IL / Python / C++).  Without this Monaco's
     // `detectIndentation` heuristic kicks in on the existing model
@@ -1287,7 +1298,18 @@ void loop()
         // Keep the LSP dropdown visible alongside the AI ghost text instead of
         // suppressing it — coexistence is the whole point here.
         suppressSuggestions: false,
-      },
+        // Render the AI ghost text EVEN WHILE the LSP suggest widget is open
+        // with a highlighted item. Monaco defaults `showOnSuggestConflict` to
+        // 'never', which hides the ghost the instant the dropdown auto-selects
+        // an entry (which it does on almost every keystroke) — so the ghost
+        // that Tab is meant to accept would flicker away exactly when the user
+        // reaches for it. 'always' keeps both surfaces visible; acceptance stays
+        // split by key (Enter/arrows commit the LSP item, Tab commits the AI
+        // ghost — see `installAiLspCoexistenceKeybindings`). `experimental` is
+        // not yet in Monaco's public `IInlineSuggestOptions` type but is read at
+        // runtime (editorOptions.js), hence the cast.
+        experimental: { showOnSuggestConflict: 'always' },
+      } as monacoEditorOptionsType['inlineSuggest'],
     }),
   }
 

--- a/src/middleware/shared/ports/ai-port.ts
+++ b/src/middleware/shared/ports/ai-port.ts
@@ -57,6 +57,7 @@ export type AITelemetryEventName =
   | 'completion_dismissed'
   | 'completion_error'
   | 'completion_timeout'
+  | 'completion_empty'
   | 'chat_message'
   | 'chat_rating'
   | 'conversation_created'


### PR DESCRIPTION
## Summary
Byte-identical mirror of the shared frontend / middleware changes landing in **openplc-web#583** (`fix/ai-autocomplete-empty-completions`), kept in sync by the mirror gate.

## Changes (shared surface only)
- **`monaco/index.tsx`:** `editContext: false` (Safari Tab-accept fix) and `inlineSuggest.experimental.showOnSuggestConflict: 'always'` so AI ghost text renders alongside the STruC++ LSP suggest widget.
- **`middleware/shared/ports/ai-port.ts`:** new `completion_empty` telemetry event name.
- **CLAUDE.md:** documents the app-version bump procedure.

## No desktop release
The empty-completion behavioural fixes live in the web-only AI adapter and the autonomy-edge backend. This PR only keeps the shared surface identical — **no version bump, no tag, no new build.** Merge to `development` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved AI suggestion behavior in the editor so inline completions stay visible more reliably alongside the suggestion list.

- **Bug Fixes**
  - Fixed Tab key handling for accepting inline AI suggestions in supported browsers.
  - Added support for tracking empty AI completion results for better telemetry coverage.

- **Documentation**
  - Clarified version-bumping and release ordering guidance for app updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->