### PR TITLE
chore(version): bump APP_VERSION to 4.2.8 (mirror)

### DIFF
--- a/src/frontend/data/constants/app-version.ts
+++ b/src/frontend/data/constants/app-version.ts
@@ -18,4 +18,4 @@
  * compares a per-deploy `BUILD_ID` (git commit SHA), not this version, so a
  * stale tab is detected on every deploy even without a version bump.
  */
-export const APP_VERSION = '4.2.6'
+export const APP_VERSION = '4.2.8'


### PR DESCRIPTION
Byte-identical mirror of openplc-web's `APP_VERSION` bump (openplc-web#585) to keep the shared surface in sync. Desktop's displayed version is tag-driven via CD, so this only aligns the shared constant — **no tag, no desktop release.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to **4.2.8** across the frontend and editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->