### PR TITLE
Promote development → main (APP_VERSION 4.2.8 parity)

### DIFF
--- a/src/frontend/data/constants/app-version.ts
+++ b/src/frontend/data/constants/app-version.ts
@@ -18,4 +18,4 @@
  * compares a per-deploy `BUILD_ID` (git commit SHA), not this version, so a
  * stale tab is detected on every deploy even without a version bump.
  */
-export const APP_VERSION = '4.2.6'
+export const APP_VERSION = '4.2.8'


### PR DESCRIPTION
Promotes the `APP_VERSION` bump (openplc-editor#924) to main for shared-surface parity with openplc-web production. Desktop version is tag-driven, so this only aligns the shared constant — **no tag, no desktop release.** Pairs with openplc-web#586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)