### PR TITLE
fix(ai): mirror inline-completion idle re-trigger from openplc-web

### DIFF
--- a/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
@@ -1320,6 +1320,46 @@ void loop()
     coexistenceRef.current?.setActive(inlineCompletionsActive)
   }, [inlineCompletionsActive, editorInstanceId])
 
+  // AI inline-completion idle re-trigger.
+  //
+  // Monaco only auto-triggers inline completions on a content change and renders
+  // just the latest call's result, so a request can complete without ever
+  // painting (a late/superseded result is silently dropped) — after which
+  // nothing re-requests until the next keystroke, and the suggestion appears to
+  // "give up". This re-arms it: once the user has been idle for 2s with AI on and
+  // no ghost text currently visible, we explicitly re-trigger inline suggest so
+  // the editor always eventually offers something for a settled cursor. The 2s
+  // window keeps this from firing needless requests during active editing; it
+  // fires at most once per idle period (triggering does not change content, so
+  // the timer is not re-armed by its own action).
+  useEffect(() => {
+    if (!inlineCompletionsActive) return
+    const editor = editorRef.current
+    if (!editor) return
+
+    const IDLE_MS = 2000
+    let idleTimer: ReturnType<typeof setTimeout> | undefined
+
+    const scheduleIdleRetrigger = () => {
+      if (idleTimer) clearTimeout(idleTimer)
+      idleTimer = setTimeout(() => {
+        if (!editor.hasTextFocus()) return
+        const model = editor.getModel()
+        if (!model || model.getValueLength() === 0) return
+        // Skip if a ghost is already showing (avoid a redundant request).
+        const dom = editor.getDomNode()
+        if (dom?.querySelector('.ghost-text-decoration, .ghost-text, [class*="ghost-text"]')) return
+        editor.trigger('openplc-ai-idle', 'editor.action.inlineSuggest.trigger', {})
+      }, IDLE_MS)
+    }
+
+    const changeDisposable = editor.onDidChangeModelContent(scheduleIdleRetrigger)
+    return () => {
+      if (idleTimer) clearTimeout(idleTimer)
+      changeDisposable.dispose()
+    }
+  }, [inlineCompletionsActive, editorInstanceId])
+
   // -----------------------------------------------------------------------
   // Drag-and-drop
   // -----------------------------------------------------------------------


### PR DESCRIPTION
Byte-identical mirror of the shared `monaco/index.tsx` change in openplc-web#589: after 2s idle with AI on and no ghost visible, re-trigger inline suggest so completions don't "give up" after a late/dropped result.

The debounce + token-guard halves of the fix are web-only (AI adapter), so this is purely the shared editor wiring. **No version bump, no tag, no desktop release.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved AI inline completions in the editor by automatically rechecking for suggestions after a short idle period when you keep typing.
  * Inline suggestions now reappear more reliably when the editor is focused and there’s still content to work with.
* **Bug Fixes**
  * Reduced cases where ghost text would fail to show again after content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->