### PR TITLE
fix: keep sidebar size on context switch and hide stray activity-bar divider

### DIFF
--- a/src/frontend/components/_features/[workspace]/source-control/source-control-panel.tsx
+++ b/src/frontend/components/_features/[workspace]/source-control/source-control-panel.tsx
@@ -1,94 +1,79 @@
 import { GitBranch } from 'lucide-react'
-import { LegacyRef, useCallback, useState } from 'react'
-import { ImperativePanelHandle } from 'react-resizable-panels'
+import { useCallback, useState } from 'react'
 
 import { useOpenPLCStore } from '../../../../store'
 import { cn } from '../../../../utils/cn'
-import { ResizablePanel } from '../../../_organisms/panel'
 import { ChangesSection } from './changes-section'
 import { HistorySection } from './history-section'
 import { StashSection } from './stash-section'
 
 type SourceControlPanelProps = {
-  collapse: LegacyRef<ImperativePanelHandle> | undefined
-  defaultSize?: number
   projectId: string
 }
 
 type ActiveView = 'changes' | 'history' | 'stash'
 
-const SourceControlPanel = ({ collapse, defaultSize = 16, projectId }: SourceControlPanelProps) => {
+const SourceControlPanel = ({ projectId }: SourceControlPanelProps) => {
   const [activeView, setActiveView] = useState<ActiveView>('changes')
   const pendingChangesCount = useOpenPLCStore(useCallback((s) => s.versionControl.pendingChangesCount, []))
 
   return (
-    <ResizablePanel
-      ref={collapse}
-      id='sourceControlPanel'
-      order={1}
-      collapsible={true}
-      minSize={13}
-      defaultSize={defaultSize}
-      maxSize={80}
-      className="flex h-full w-full max-w-lg flex-col overflow-auto rounded-lg border-2 border-inherit border-neutral-200 bg-white data-[panel-size='0.0']:hidden dark:border-neutral-850 dark:bg-neutral-950"
-    >
-      <div className='flex h-full w-full flex-col'>
-        {/* Header */}
-        <div className='shrink-0 px-2 py-2'>
-          <div className='flex h-8 w-full cursor-default select-none items-center justify-start rounded-lg bg-neutral-100 px-1.5 dark:bg-brand-dark'>
-            <GitBranch className='h-3.5 w-3.5 text-[#0464FB]' />
-            <span className='pl-1.5 font-caption text-xs font-medium text-neutral-1000 duration-500 ease-in-out dark:text-neutral-50'>
-              Source Control
-            </span>
-          </div>
-        </div>
-
-        {/* Tab switcher */}
-        <div className='flex px-2 pb-2'>
-          <button
-            onClick={() => setActiveView('changes')}
-            className={cn(
-              'h-7 flex-1 rounded-s-md text-xs font-medium transition-colors duration-150',
-              activeView === 'changes'
-                ? 'bg-blue-500 text-white'
-                : 'bg-neutral-100 text-neutral-500 hover:text-neutral-700 dark:bg-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200',
-            )}
-          >
-            Changes
-            {pendingChangesCount > 0 && <span className='ml-1 inline-block h-1.5 w-1.5 rounded-full bg-blue-500' />}
-          </button>
-          <button
-            onClick={() => setActiveView('stash')}
-            className={cn(
-              'h-7 flex-1 text-xs font-medium transition-colors duration-150',
-              activeView === 'stash'
-                ? 'bg-blue-500 text-white'
-                : 'bg-neutral-100 text-neutral-500 hover:text-neutral-700 dark:bg-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200',
-            )}
-          >
-            Stash
-          </button>
-          <button
-            onClick={() => setActiveView('history')}
-            className={cn(
-              'h-7 flex-1 rounded-e-md text-xs font-medium transition-colors duration-150',
-              activeView === 'history'
-                ? 'bg-blue-500 text-white'
-                : 'bg-neutral-100 text-neutral-500 hover:text-neutral-700 dark:bg-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200',
-            )}
-          >
-            History
-          </button>
-        </div>
-
-        {/* Content */}
-        <div className='flex min-h-0 flex-1 flex-col overflow-hidden'>
-          {activeView === 'changes' && <ChangesSection projectId={projectId} />}
-          {activeView === 'stash' && <StashSection projectId={projectId} />}
-          {activeView === 'history' && <HistorySection projectId={projectId} />}
+    <div className='flex h-full w-full flex-col'>
+      {/* Header */}
+      <div className='shrink-0 px-2 py-2'>
+        <div className='flex h-8 w-full cursor-default select-none items-center justify-start rounded-lg bg-neutral-100 px-1.5 dark:bg-brand-dark'>
+          <GitBranch className='h-3.5 w-3.5 text-[#0464FB]' />
+          <span className='pl-1.5 font-caption text-xs font-medium text-neutral-1000 duration-500 ease-in-out dark:text-neutral-50'>
+            Source Control
+          </span>
         </div>
       </div>
-    </ResizablePanel>
+
+      {/* Tab switcher */}
+      <div className='flex px-2 pb-2'>
+        <button
+          onClick={() => setActiveView('changes')}
+          className={cn(
+            'h-7 flex-1 rounded-s-md text-xs font-medium transition-colors duration-150',
+            activeView === 'changes'
+              ? 'bg-blue-500 text-white'
+              : 'bg-neutral-100 text-neutral-500 hover:text-neutral-700 dark:bg-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200',
+          )}
+        >
+          Changes
+          {pendingChangesCount > 0 && <span className='ml-1 inline-block h-1.5 w-1.5 rounded-full bg-blue-500' />}
+        </button>
+        <button
+          onClick={() => setActiveView('stash')}
+          className={cn(
+            'h-7 flex-1 text-xs font-medium transition-colors duration-150',
+            activeView === 'stash'
+              ? 'bg-blue-500 text-white'
+              : 'bg-neutral-100 text-neutral-500 hover:text-neutral-700 dark:bg-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200',
+          )}
+        >
+          Stash
+        </button>
+        <button
+          onClick={() => setActiveView('history')}
+          className={cn(
+            'h-7 flex-1 rounded-e-md text-xs font-medium transition-colors duration-150',
+            activeView === 'history'
+              ? 'bg-blue-500 text-white'
+              : 'bg-neutral-100 text-neutral-500 hover:text-neutral-700 dark:bg-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200',
+          )}
+        >
+          History
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className='flex min-h-0 flex-1 flex-col overflow-hidden'>
+        {activeView === 'changes' && <ChangesSection projectId={projectId} />}
+        {activeView === 'stash' && <StashSection projectId={projectId} />}
+        {activeView === 'history' && <HistorySection projectId={projectId} />}
+      </div>
+    </div>
   )
 }
 

--- a/src/frontend/components/_organisms/explorer/index.tsx
+++ b/src/frontend/components/_organisms/explorer/index.tsx
@@ -1,5 +1,4 @@
-import { LegacyRef, ReactElement, useMemo, useState } from 'react'
-import { ImperativePanelHandle } from 'react-resizable-panels'
+import { ReactElement, useMemo, useState } from 'react'
 
 import { useOpenPLCStore } from '../../../store'
 import type { BlockVariant } from '../../_atoms/graphical-editor/types/block'
@@ -9,12 +8,7 @@ import { Info } from './info'
 import { Library } from './library'
 import { Project } from './project'
 
-type ExplorerProps = {
-  collapse: LegacyRef<ImperativePanelHandle> | undefined
-  defaultSize?: number
-}
-
-const Explorer = ({ collapse, defaultSize = 16 }: ExplorerProps): ReactElement => {
+const Explorer = (): ReactElement => {
   const {
     editor,
     project: {
@@ -96,16 +90,7 @@ const Explorer = ({ collapse, defaultSize = 16 }: ExplorerProps): ReactElement =
   }, [selectedFileKey, system, pous])
 
   return (
-    <ResizablePanel
-      ref={collapse}
-      id='explorerPanel'
-      order={1}
-      collapsible={true}
-      minSize={13}
-      defaultSize={defaultSize}
-      maxSize={80}
-      className="flex h-full w-[200px] max-w-lg flex-col overflow-auto rounded-lg border-2 border-inherit border-neutral-200 bg-white data-[panel-size='0.0']:hidden dark:border-neutral-850 dark:bg-neutral-950"
-    >
+    <>
       <ResizablePanelGroup id='explorerPanelGroup' direction='vertical' className='h-full flex-1'>
         <ResizablePanel id='projectExplorerPanel' order={1} defaultSize={50} minSize={25} collapsible>
           <Project />
@@ -126,7 +111,7 @@ const Explorer = ({ collapse, defaultSize = 16 }: ExplorerProps): ReactElement =
         </ResizablePanel>
       </ResizablePanelGroup>
       <Info selectedPouDocumentation={selectedPouDocumentation} />
-    </ResizablePanel>
+    </>
   )
 }
 

--- a/src/frontend/components/_organisms/workspace-activity-bar/index.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/index.tsx
@@ -87,7 +87,7 @@ export const WorkspaceActivityBar = ({ defaultActivityBar, explorer, sourceContr
             </button>
           </TooltipSidebarWrapperButton>
         )}
-        <DividerActivityBar />
+        {(explorer || sourceControl) && <DividerActivityBar />}
         <div className='flex w-full flex-col items-center gap-5'>
           <DefaultWorkspaceActivityBar {...defaultActivityBar} />
         </div>

--- a/src/frontend/screens/workspace-screen.tsx
+++ b/src/frontend/screens/workspace-screen.tsx
@@ -146,8 +146,6 @@ const WorkspaceScreen = () => {
   // for now — git-on-library is plausible but out of scope and
   // would re-introduce the same UI churn we just removed.
   const hasVersionControl = capabilities.hasVersionControl && projectCaps.hasVersionControl
-  const sourceControlPanelRef = useRef<ImperativePanelHandle | null>(null)
-  const [leftPanelSize, setLeftPanelSize] = useState(16)
 
   // Start global runtime polling for status and logs
   useRuntimePolling()
@@ -311,7 +309,7 @@ const WorkspaceScreen = () => {
   } & ImperativePanelHandle
 
   const panelRef = useRef<ImperativePanelHandle | null>(null)
-  const explorerPanelRef = useRef<PanelMethods | null>(null)
+  const leftPanelRef = useRef<PanelMethods | null>(null)
   const workspacePanelRef = useRef<PanelMethods | null>(null)
   const consolePanelRef = useRef<PanelMethods | null>(null)
   const [activeTab, setActiveTab] = useState('console')
@@ -348,7 +346,7 @@ const WorkspaceScreen = () => {
 
   useEffect(() => {
     const action = isCollapsed ? 'collapse' : 'expand'
-    ;[explorerPanelRef, workspacePanelRef, consolePanelRef, sourceControlPanelRef].forEach((ref) => {
+    ;[leftPanelRef, workspacePanelRef, consolePanelRef].forEach((ref) => {
       if (ref.current && typeof ref.current[action] === 'function') {
         ref.current[action]()
       }
@@ -457,13 +455,7 @@ const WorkspaceScreen = () => {
               hasVersionControl
                 ? {
                     isActive: activePanel === 'explorer',
-                    onClick: () => {
-                      if (activePanel !== 'explorer') {
-                        const size = sourceControlPanelRef.current?.getSize()
-                        if (size) setLeftPanelSize(size)
-                      }
-                      setActivePanel('explorer')
-                    },
+                    onClick: () => setActivePanel('explorer'),
                   }
                 : undefined
             }
@@ -472,13 +464,7 @@ const WorkspaceScreen = () => {
                 ? {
                     isActive: activePanel === 'source-control',
                     pendingCount: pendingChangesCount,
-                    onClick: () => {
-                      if (activePanel !== 'source-control') {
-                        const size = explorerPanelRef.current?.getSize()
-                        if (size) setLeftPanelSize(size)
-                      }
-                      setActivePanel('source-control')
-                    },
+                    onClick: () => setActivePanel('source-control'),
                   }
                 : undefined
             }
@@ -490,15 +476,26 @@ const WorkspaceScreen = () => {
             direction='horizontal'
             className='relative flex h-full w-full'
           >
-            {hasVersionControl && activePanel === 'source-control' ? (
-              <SourceControlPanel
-                collapse={sourceControlPanelRef}
-                defaultSize={leftPanelSize}
-                projectId={projectPath}
-              />
-            ) : (
-              <Explorer collapse={explorerPanelRef} defaultSize={leftPanelSize} />
-            )}
+            {/* The left panel must stay mounted across context switches: swapping
+                the ResizablePanel itself makes react-resizable-panels rebuild the
+                layout from defaultSize and re-normalize, growing the sidebar on
+                every switch. Only the children swap. */}
+            <ResizablePanel
+              ref={leftPanelRef}
+              id='leftPanel'
+              order={1}
+              collapsible={true}
+              minSize={13}
+              defaultSize={16}
+              maxSize={80}
+              className="flex h-full w-full max-w-lg flex-col overflow-auto rounded-lg border-2 border-inherit border-neutral-200 bg-white data-[panel-size='0.0']:hidden dark:border-neutral-850 dark:bg-neutral-950"
+            >
+              {hasVersionControl && activePanel === 'source-control' ? (
+                <SourceControlPanel projectId={projectPath} />
+              ) : (
+                <Explorer />
+              )}
+            </ResizablePanel>
             <ResizableHandle
               id='workspaceHandle'
               hitAreaMargins={{ coarse: 12, fine: 3 }}


### PR DESCRIPTION
## Summary

Fixes two visual bugs around the sidebar context-switch buttons (Explorer / Source Control):

1. **Sidebar grows on every context switch (web).** Each context mounted its own `ResizablePanel` (`explorerPanel` / `sourceControlPanel`). Swapping panel ids forces react-resizable-panels to rebuild the layout from `defaultSize` and re-normalize it — and since the group's declared sizes (`leftPanelSize + 68`) sum to less than 100, every rebuild scaled the left panel up (`L → 100·L/(L+68)`), with the inflated `getSize()` captured and re-applied on the next switch, converging at the 32% fixed point. The left slot is now a **single always-mounted `ResizablePanel`** owned by the workspace screen; only its children swap, so the width (including manual resizes) is preserved natively. `Explorer` and `SourceControlPanel` no longer render their own panels, and the `getSize()`-capture plumbing (`leftPanelSize`, second panel ref) is removed.

2. **Stray divider on desktop.** The activity-bar divider below the context buttons rendered unconditionally, so on desktop — where `hasVersionControl` is false and the buttons are hidden — a lone separator appeared at the top of the bar. It now renders only when at least one context button is present: `{(explorer || sourceControl) && <DividerActivityBar />}`. No visual change on web.

On desktop the context buttons are hidden (`hasVersionControl: false`), so the visible fix here is the divider; the panel restructure keeps the shared frontend byte-identical with the web repo.

Repro recording (web): https://jam.dev/c/3b3fc37a-06b2-4bca-8946-5c6ea958c69d

## Test plan

- [ ] No stray divider at the top of the activity bar
- [ ] Explorer renders and resizes normally; zoom/collapse button still collapses/expands the sidebar
- [ ] Web (mirror): sidebar width stays constant across Explorer ↔ Source Control switches

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/594

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fpthmAmQoNX8WMYyb68Qi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the workspace sidebar layout so the Explorer and Source Control views now switch within a single consistent panel.
  * Streamlined sidebar interactions, making panel switching and collapse/expand behavior more predictable.

* **Bug Fixes**
  * Improved divider visibility in the activity bar so separators only appear when relevant panels are available.
  * Preserved the pending changes count display while updating the Source Control view layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->