### PR TITLE
fix: eliminate phantom source-control diffs in graphical editors

### DIFF
--- a/src/frontend/components/_atoms/graphical-editor/ladder/block.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/block.tsx
@@ -879,6 +879,9 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
             handleSubmit={() => handleSubmitBlockVariableOnTextareaBlur(blockVariableValue, false)}
             onFocus={(e) => {
               e.target.select()
+              const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+                nodeId: id,
+              })
               if (!node || !rung) return
               // Drag-lock while typing is UI state, not an edit — transient
               // so focusing the input never marks the flow as modified.
@@ -895,6 +898,9 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
               return
             }}
             onBlur={() => {
+              const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+                nodeId: id,
+              })
               if (!node || !rung) return
               updateNode({
                 editorName: pouName,

--- a/src/frontend/components/_atoms/graphical-editor/ladder/block.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/block.tsx
@@ -556,6 +556,16 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
       return
     }
 
+    // Blur with an unchanged name is not an edit — skip the write so merely
+    // clicking in and out of a block never marks the POU as modified. The
+    // autocomplete's explicit create action (createIfNotFound) still proceeds.
+    if (
+      !createIfNotFound &&
+      variableNameToSubmit === (node.data as { variable?: { name?: string } }).variable?.name
+    ) {
+      return
+    }
+
     const blockType = (node.data as BlockNodeData<BlockVariant>).variant.name
 
     const findMatchingVariable = () =>
@@ -873,6 +883,8 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
             onFocus={(e) => {
               e.target.select()
               if (!node || !rung) return
+              // Drag-lock while typing is UI state, not an edit — transient
+              // so focusing the input never marks the flow as modified.
               updateNode({
                 editorName: pouName,
                 nodeId: node.id,
@@ -881,6 +893,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
                   ...node,
                   draggable: false,
                 },
+                transient: true,
               })
               return
             }}
@@ -894,6 +907,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
                   ...node,
                   draggable: node.data.draggable as boolean,
                 },
+                transient: true,
               })
               return
             }}

--- a/src/frontend/components/_atoms/graphical-editor/ladder/block.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/block.tsx
@@ -559,10 +559,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
     // Blur with an unchanged name is not an edit — skip the write so merely
     // clicking in and out of a block never marks the POU as modified. The
     // autocomplete's explicit create action (createIfNotFound) still proceeds.
-    if (
-      !createIfNotFound &&
-      variableNameToSubmit === (node.data as { variable?: { name?: string } }).variable?.name
-    ) {
+    if (!createIfNotFound && variableNameToSubmit === (node.data as { variable?: { name?: string } }).variable?.name) {
       return
     }
 

--- a/src/frontend/components/_atoms/graphical-editor/ladder/coil.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/coil.tsx
@@ -155,6 +155,10 @@ export const Coil = (block: CoilProps) => {
     })
     if (!rung || !node) return
 
+    // Blur with an unchanged name is not an edit — skip the write so merely
+    // clicking in and out of a coil never marks the POU as modified.
+    if (variableNameToSubmit === (node.data as { variable?: { name?: string } }).variable?.name) return
+
     // Persist whatever the user typed; the validation effect resolves and
     // type-checks it against the full project scope and drives the red state.
     updateNode({
@@ -215,6 +219,8 @@ export const Coil = (block: CoilProps) => {
                 nodeId: id ?? '',
               })
               if (!node || !rung) return
+              // Drag-lock while typing is UI state, not an edit — transient
+              // so focusing the input never marks the flow as modified.
               updateNode({
                 editorName: pouName,
                 nodeId: node.id,
@@ -223,6 +229,7 @@ export const Coil = (block: CoilProps) => {
                   ...node,
                   draggable: false,
                 },
+                transient: true,
               })
               return
             }}
@@ -239,6 +246,7 @@ export const Coil = (block: CoilProps) => {
                   ...node,
                   draggable: node.data.draggable as boolean,
                 },
+                transient: true,
               })
               return
             }}

--- a/src/frontend/components/_atoms/graphical-editor/ladder/contact.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/contact.tsx
@@ -156,6 +156,10 @@ export const Contact = (block: ContactProps) => {
     })
     if (!rung || !node) return
 
+    // Blur with an unchanged name is not an edit — skip the write so merely
+    // clicking in and out of a contact never marks the POU as modified.
+    if (variableNameToSubmit === (node.data as { variable?: { name?: string } }).variable?.name) return
+
     // Persist whatever the user typed; the validation effect resolves and
     // type-checks it against the full project scope and drives the red state.
     updateNode({
@@ -216,6 +220,8 @@ export const Contact = (block: ContactProps) => {
                 nodeId: id ?? '',
               })
               if (!node || !rung) return
+              // Drag-lock while typing is UI state, not an edit — transient
+              // so focusing the input never marks the flow as modified.
               updateNode({
                 editorName: pouName,
                 nodeId: node.id,
@@ -224,6 +230,7 @@ export const Contact = (block: ContactProps) => {
                   ...node,
                   draggable: false,
                 },
+                transient: true,
               })
               return
             }}
@@ -240,6 +247,7 @@ export const Contact = (block: ContactProps) => {
                   ...node,
                   draggable: node.data.draggable as boolean,
                 },
+                transient: true,
               })
               return
             }}

--- a/src/frontend/components/_features/[workspace]/editor/diff-viewer/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/diff-viewer/index.tsx
@@ -13,7 +13,11 @@
  *     serialized form for files edited this session — keeping the diff live.
  *
  * The HEAD `before` map is cached in the version-control slice (`headContent`)
- * and invalidated on project load / commit / in-place reload.
+ * and invalidated on project load / commit / in-place reload, plus pruned
+ * per-path on save (`recordSavedFiles`). The fetch below refires whenever the
+ * open path has no cached entry, so a viewer that stayed mounted across a
+ * commit (which empties the pending set) picks up the new HEAD on the next
+ * change instead of diffing against a stale snapshot.
  */
 
 import { useEffect, useMemo } from 'react'
@@ -61,28 +65,51 @@ export function DiffViewerEditor() {
 
   const filePath = editor.type === 'diff-viewer' ? editor.meta.filePath : ''
 
+  // The cached snapshot serves this diff only when it has an entry for the
+  // open path. A missing entry means the cache predates the change being
+  // viewed (e.g. it was rebuilt while a commit had emptied the pending set),
+  // so it must be refetched — rendering it would diff against a wrong HEAD.
+  const headReady = headContent !== null && (!filePath || headContent[filePath] !== undefined)
+
   // Lazily fetch the HEAD content of all pending files via the backend's
   // content-bearing /changes call (authoritative against the real HEAD), and
-  // cache the `before` map. Invalidated on load / commit / reload.
+  // cache the `before` map. Invalidated on load / commit / reload and pruned
+  // per-path on save.
   useEffect(() => {
-    if (headContent !== null || !projectId || !versionControl) return
+    if (headReady || !projectId || !versionControl) return
     let cancelled = false
+    // Snapshot the working-tree bytes before fetching: if `filePath` turns
+    // out to have no pending change, its working tree equals HEAD, so these
+    // bytes ARE its HEAD content. Caching them keeps `headReady` from
+    // refetching in a loop and gives later diffs the correct original side.
+    let workingTreeSnapshot = ''
+    if (filePath) {
+      try {
+        workingTreeSnapshot = buildAllProjectFileContents()[filePath] ?? ''
+      } catch {
+        workingTreeSnapshot = ''
+      }
+    }
     void (async () => {
       try {
         const { changes } = await versionControl.getChanges(projectId, undefined, true)
         const map: Record<string, string> = {}
         for (const c of changes) map[c.path] = c.before ?? ''
+        if (filePath && map[filePath] === undefined) map[filePath] = workingTreeSnapshot
         if (!cancelled) setHeadContent(map)
       } catch {
-        if (!cancelled) setHeadContent({})
+        // Cache an (empty) entry for the open path even on failure so
+        // `headReady` doesn't retry in a tight loop; the next mount or path
+        // change triggers a fresh attempt.
+        if (!cancelled) setHeadContent(filePath ? { [filePath]: '' } : {})
       }
     })()
     return () => {
       cancelled = true
     }
-  }, [headContent, projectId, versionControl, setHeadContent])
+  }, [headReady, filePath, projectId, versionControl, setHeadContent])
 
-  const original = headContent && filePath ? (headContent[filePath] ?? '') : ''
+  const original = headReady && headContent && filePath ? (headContent[filePath] ?? '') : ''
 
   // The working-tree side: raw loaded bytes for files untouched this session,
   // freshly serialized for edited ones. Recomputed when `project` changes.
@@ -111,7 +138,7 @@ export function DiffViewerEditor() {
       <div className='flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border-2 border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950'>
         <div className='flex shrink-0 items-center gap-2 border-b border-neutral-200 px-3 py-2 dark:border-neutral-800'>
           <p className='flex-1 truncate font-mono text-xs text-neutral-600 dark:text-neutral-400'>{filePath}</p>
-          {headContent !== null && (
+          {headReady && (
             <span
               className={cn(
                 'shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold',
@@ -123,7 +150,7 @@ export function DiffViewerEditor() {
           )}
         </div>
         <div className='min-h-0 flex-1'>
-          {headContent === null ? (
+          {!headReady ? (
             <div className='flex h-full items-center justify-center'>
               <div className='flex flex-col items-center gap-3'>
                 <div className='h-5 w-5 animate-spin rounded-full border-2 border-brand-light border-t-transparent' />

--- a/src/frontend/components/_features/[workspace]/editor/diff-viewer/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/diff-viewer/index.tsx
@@ -62,6 +62,7 @@ export function DiffViewerEditor() {
   // of each diff. `null` = not yet loaded → fetched lazily below.
   const headContent = useOpenPLCStore((s) => s.versionControl.headContent)
   const setHeadContent = useOpenPLCStore((s) => s.versionControlActions.setHeadContent)
+  const mergeHeadContent = useOpenPLCStore((s) => s.versionControlActions.mergeHeadContent)
 
   const filePath = editor.type === 'diff-viewer' ? editor.meta.filePath : ''
 
@@ -101,13 +102,13 @@ export function DiffViewerEditor() {
         // Cache an (empty) entry for the open path even on failure so
         // `headReady` doesn't retry in a tight loop; the next mount or path
         // change triggers a fresh attempt.
-        if (!cancelled) setHeadContent(filePath ? { [filePath]: '' } : {})
+        if (!cancelled) mergeHeadContent(filePath ? { [filePath]: '' } : {})
       }
     })()
     return () => {
       cancelled = true
     }
-  }, [headReady, filePath, projectId, versionControl, setHeadContent])
+  }, [headReady, filePath, projectId, versionControl, setHeadContent, mergeHeadContent])
 
   const original = headReady && headContent && filePath ? (headContent[filePath] ?? '') : ''
 

--- a/src/frontend/components/_features/[workspace]/editor/graphical/FBD/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/FBD/index.tsx
@@ -82,19 +82,27 @@ export default function FbdEditor() {
   }, [flow?.rung.nodes, userLibraries, pous])
 
   /**
-   * Update the flow state to project JSON
+   * Update the flow state to project JSON.
+   *
+   * Validate the flow with Zod but persist the raw object (minus the
+   * transient `updated` flag). Using the parsed result would silently strip
+   * every field not declared in `zodFBDFlowSchema` and reorder keys to
+   * schema order, which makes `serializeGraphicalPouToString` produce
+   * byte-drift vs. the loaded disk copy — surfacing as phantom "Modified"
+   * entries in Source Control for POUs the user never edited.
    */
   useEffect(() => {
-    if (!flowUpdated) return
+    if (!flowUpdated || !flow) return
 
     const flowSchema = zodFBDFlowSchema.safeParse(flow)
     if (!flowSchema.success) return
 
+    const { updated: _updated, ...flowBody } = flow
     updatePou({
       name: pouName,
       content: {
         language: 'fbd',
-        value: flowSchema.data,
+        value: structuredClone(flowBody),
       },
     })
 

--- a/src/frontend/components/_features/[workspace]/editor/graphical/ladder/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/ladder/index.tsx
@@ -92,18 +92,27 @@ export default function LadderEditor() {
 
   /**
    * Update the flow state to project JSON.
+   *
+   * Validate the flow with Zod but persist the raw object (minus the
+   * transient `updated` flag). Using the parsed result would silently strip
+   * every field not declared in `zodLadderFlowSchema` (e.g. `handleBranches`,
+   * `positionAbsolute`, `zIndex`) and reorder keys to schema order, which
+   * makes `serializeGraphicalPouToString` produce byte-drift vs. the loaded
+   * disk copy — surfacing as phantom "Modified" entries in Source Control
+   * for POUs the user never edited.
    */
   useEffect(() => {
-    if (!flowUpdated) return
+    if (!flowUpdated || !flow) return
 
     const flowSchema = zodLadderFlowSchema.safeParse(flow)
     if (!flowSchema.success) return
 
+    const { updated: _updated, ...flowBody } = flow
     updatePou({
       name: pouName,
       content: {
         language: 'ld',
-        value: flowSchema.data,
+        value: structuredClone(flowBody),
       },
     })
 

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/diagram/index.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/diagram/index.ts
@@ -396,6 +396,10 @@ const applyDynamicBlockHandleOffsets = (rung: RungLadderState): Node[] => {
 export const updateDiagramElementsPosition = (
   rung: RungLadderState,
   defaultBounds: [number, number],
+  /** Fallback identity source for the variable-node rebuild — pass the
+   *  pre-strip node set when `rung.nodes` had its variable nodes removed
+   *  earlier in the pipeline (see updateVariableBlockPosition). */
+  previousNodes?: Node[],
 ): { nodes: Node[]; edges: Edge[] } => {
   // Pre-expand block dimensions BEFORE the main layout loop. findAllParallelsDepthAndNodes
   // and the parallel-path Y formulas both read block.height; if blocks haven't been
@@ -689,10 +693,13 @@ export const updateDiagramElementsPosition = (
     defaultBounds,
   )
 
-  const variablesNodes = updateVariableBlockPosition({
-    ...rung,
-    nodes: changedRailNodes,
-  })
+  const variablesNodes = updateVariableBlockPosition(
+    {
+      ...rung,
+      nodes: changedRailNodes,
+    },
+    previousNodes,
+  )
 
   return { nodes: variablesNodes.nodes, edges: variablesNodes.edges }
 }

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/diagram/index.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/diagram/index.ts
@@ -454,14 +454,17 @@ export const updateDiagramElementsPosition = (
     /**
      * Find the previous nodes and edges of the current node
      */
-    const { nodes: previousNodes, edges: previousEdges } = getPreviousElementsByEdge({ ...rung, nodes: newNodes }, node)
-    if (!previousNodes || !previousEdges) return { nodes: rung.nodes, edges: rung.edges }
+    const { nodes: previousLinkedNodes, edges: previousEdges } = getPreviousElementsByEdge(
+      { ...rung, nodes: newNodes },
+      node,
+    )
+    if (!previousLinkedNodes || !previousEdges) return { nodes: rung.nodes, edges: rung.edges }
 
-    if (previousNodes.all.length === 1) {
+    if (previousLinkedNodes.all.length === 1) {
       /**
        * Nodes that only have one edge connecting to them
        */
-      const previousNode = previousNodes.all[0]
+      const previousNode = previousLinkedNodes.all[0]
       if (
         isNodeOfType(previousNode, 'parallel') &&
         (previousNode as ParallelNode).data.type === 'open' &&
@@ -486,8 +489,8 @@ export const updateDiagramElementsPosition = (
        * This is used to calculate the position of the new node
        */
       let acc = newNodePosition
-      for (let j = 0; j < previousNodes.all.length; j++) {
-        const previousNode = previousNodes.all[j]
+      for (let j = 0; j < previousLinkedNodes.all.length; j++) {
+        const previousNode = previousLinkedNodes.all[j]
         const position = getNodePositionBasedOnPreviousNode(previousNode, node, 'serial')
         acc = {
           posX: Math.max(acc.posX, position.posX),

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/drag-n-drop/handlers.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/drag-n-drop/handlers.ts
@@ -178,6 +178,10 @@ function layoutAndReturn(
       ...(handleBranches && { handleBranches }),
     },
     oldStateRung.defaultBounds as [number, number],
+    // `nodes` may have had its variable nodes stripped by prepareDropState;
+    // the pre-drop rung still holds them, so pass it as the identity source
+    // to keep variable-node ids stable across the rebuild.
+    oldStateRung.nodes,
   )
   return { nodes: diagramNodes, edges: diagramEdges, handleBranches }
 }
@@ -252,10 +256,13 @@ export function handleMainParallel(ctx: DropContext, sourceIsBranch: boolean): D
     ctx.node,
   )
 
-  // Remove the copycat node
+  // Remove the copycat node. `parallelNodes` derives from preparedNodes
+  // (variables stripped) — pass the pre-drop rung as identity source so the
+  // variable-node rebuild keeps stable ids.
   const { nodes: cleanedNodes, edges: cleanedEdges } = removeElement(
     { ...ctx.rung, nodes: parallelNodes, edges: parallelEdges },
     ctx.copycatNode,
+    ctx.oldStateRung.nodes,
   )
 
   return { nodes: cleanedNodes, edges: cleanedEdges }
@@ -380,10 +387,13 @@ export function handleMainSerial(ctx: DropContext, sourceIsBranch: boolean): Dro
     ctx.node,
   )
 
-  // Remove the copycat node
+  // Remove the copycat node. `serialNodes` derives from preparedNodes
+  // (variables stripped) — pass the pre-drop rung as identity source so the
+  // variable-node rebuild keeps stable ids.
   const { nodes: cleanedNodes, edges: cleanedEdges } = removeElement(
     { ...ctx.rung, nodes: serialNodes, edges: serialEdges },
     ctx.copycatNode,
+    ctx.oldStateRung.nodes,
   )
 
   return { nodes: cleanedNodes, edges: cleanedEdges }

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/index.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/index.ts
@@ -208,6 +208,10 @@ export const addNewElement = <T>(
 export const removeElement = (
   rung: RungLadderState,
   element: Node,
+  /** Fallback identity source for the variable-node rebuild — pass the
+   *  pre-strip node set when `rung.nodes` had its variable nodes removed
+   *  earlier in the pipeline (see updateVariableBlockPosition). */
+  previousNodes?: Node[],
 ): { nodes: Node[]; edges: Edge[]; handleBranches?: HandleBranch[] } => {
   let newNodes: Node[]
   let newEdges: Edge[]
@@ -317,6 +321,7 @@ export const removeElement = (
       ...(handleBranches && { handleBranches }),
     },
     rung.defaultBounds as [number, number],
+    previousNodes,
   )
   newNodes = updatedDiagramNodes
   newEdges = updatedDiagramEdges

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/variable-block/__tests__/variable-block.test.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/variable-block/__tests__/variable-block.test.ts
@@ -1,0 +1,160 @@
+/**
+ * updateVariableBlockPosition destroys and rebuilds every variable node on
+ * each layout pass. These tests pin the identity-reuse contract: a rebuilt
+ * variable node for an unchanged attachment point (block id + handle id +
+ * side) must keep its previous `id` and `data.numericId`, so a net-identical
+ * graph stays byte-identical when serialized (no phantom source-control
+ * modifications after drag-away-and-back).
+ */
+import type { RungLadderState } from '@root/frontend/store/slices'
+import type { Node } from '@xyflow/react'
+
+import { updateVariableBlockPosition } from '../index'
+
+const makeHandle = (id: string, x: number, y: number) => ({
+  id,
+  glbPosition: { x, y },
+})
+
+const makeBlockNode = (): Node =>
+  ({
+    id: 'BLOCK_1',
+    type: 'block',
+    position: { x: 200, y: 40 },
+    data: {
+      variant: { name: 'CTU', type: 'function-block', variables: [] },
+      inputHandles: [makeHandle('EN', 200, 50), makeHandle('CU', 200, 70), makeHandle('PV', 200, 90)],
+      outputHandles: [makeHandle('ENO', 300, 50), makeHandle('CV', 300, 70)],
+      connectedVariables: [],
+    },
+  }) as unknown as Node
+
+const makeVariableNode = (id: string, handleId: string, variant: 'input' | 'output', numericId: number): Node =>
+  ({
+    id,
+    type: 'variable',
+    position: { x: 0, y: 0 },
+    data: {
+      variant,
+      block: { id: 'BLOCK_1', handleId },
+      numericId,
+    },
+  }) as unknown as Node
+
+const makeRung = (nodes: Node[]): RungLadderState =>
+  ({
+    id: 'rung-1',
+    comment: '',
+    defaultBounds: [800, 200],
+    reactFlowViewport: [800, 200],
+    selectedNodes: [],
+    nodes,
+    edges: [],
+  }) as unknown as RungLadderState
+
+describe('updateVariableBlockPosition identity reuse', () => {
+  it('reuses id and numericId for unchanged attachment points', () => {
+    const rung = makeRung([
+      makeBlockNode(),
+      makeVariableNode('VARIABLE_prev_cu', 'CU', 'input', 111),
+      makeVariableNode('VARIABLE_prev_pv', 'PV', 'input', 222),
+      makeVariableNode('VARIABLE_prev_cv', 'CV', 'output', 333),
+    ])
+
+    const { nodes } = updateVariableBlockPosition(rung)
+    const variables = nodes.filter((n) => n.type === 'variable')
+
+    expect(variables).toHaveLength(3)
+    const byHandle = new Map(
+      variables.map((n) => [(n.data as { block: { handleId: string } }).block.handleId, n]),
+    )
+    expect(byHandle.get('CU')?.id).toBe('VARIABLE_prev_cu')
+    expect((byHandle.get('CU')?.data as { numericId: number }).numericId).toBe(111)
+    expect(byHandle.get('PV')?.id).toBe('VARIABLE_prev_pv')
+    expect((byHandle.get('PV')?.data as { numericId: number }).numericId).toBe(222)
+    expect(byHandle.get('CV')?.id).toBe('VARIABLE_prev_cv')
+    expect((byHandle.get('CV')?.data as { numericId: number }).numericId).toBe(333)
+  })
+
+  it('is idempotent: a second rebuild produces identical variable identities', () => {
+    const rung = makeRung([makeBlockNode()])
+
+    const first = updateVariableBlockPosition(rung)
+    const second = updateVariableBlockPosition(makeRung(first.nodes))
+
+    const identity = (ns: Node[]) =>
+      ns
+        .filter((n) => n.type === 'variable')
+        .map((n) => `${n.id}::${(n.data as { numericId: number }).numericId}`)
+        .sort()
+    expect(identity(second.nodes)).toEqual(identity(first.nodes))
+  })
+
+  it('mints fresh ids for attachment points with no previous variable node', () => {
+    const rung = makeRung([makeBlockNode(), makeVariableNode('VARIABLE_prev_cu', 'CU', 'input', 111)])
+
+    const { nodes } = updateVariableBlockPosition(rung)
+    const variables = nodes.filter((n) => n.type === 'variable')
+
+    expect(variables).toHaveLength(3)
+    const cu = variables.find((n) => (n.data as { block: { handleId: string } }).block.handleId === 'CU')
+    const pv = variables.find((n) => (n.data as { block: { handleId: string } }).block.handleId === 'PV')
+    expect(cu?.id).toBe('VARIABLE_prev_cu')
+    expect(pv?.id).toMatch(/^VARIABLE_/)
+    expect(pv?.id).not.toBe('VARIABLE_prev_pv')
+  })
+
+  it('reuses identities from previousNodes when the rung was stripped upstream', () => {
+    // Simulates the drag-drop pipeline: prepareDropState removes variable
+    // nodes before layout, so the rung reaching the rebuild has none — the
+    // pre-drop node set is passed separately as the identity source.
+    const strippedRung = makeRung([makeBlockNode()])
+    const preDropNodes = [
+      makeBlockNode(),
+      makeVariableNode('VARIABLE_prev_cu', 'CU', 'input', 111),
+      makeVariableNode('VARIABLE_prev_pv', 'PV', 'input', 222),
+      makeVariableNode('VARIABLE_prev_cv', 'CV', 'output', 333),
+    ]
+
+    const { nodes } = updateVariableBlockPosition(strippedRung, preDropNodes)
+    const variables = nodes.filter((n) => n.type === 'variable')
+
+    expect(variables).toHaveLength(3)
+    const byHandle = new Map(
+      variables.map((n) => [(n.data as { block: { handleId: string } }).block.handleId, n]),
+    )
+    expect(byHandle.get('CU')?.id).toBe('VARIABLE_prev_cu')
+    expect(byHandle.get('PV')?.id).toBe('VARIABLE_prev_pv')
+    expect(byHandle.get('CV')?.id).toBe('VARIABLE_prev_cv')
+    expect((byHandle.get('CV')?.data as { numericId: number }).numericId).toBe(333)
+  })
+
+  it('prefers identities from the rung itself over previousNodes', () => {
+    const rung = makeRung([makeBlockNode(), makeVariableNode('VARIABLE_current_cu', 'CU', 'input', 999)])
+    const preDropNodes = [makeVariableNode('VARIABLE_stale_cu', 'CU', 'input', 111)]
+
+    const { nodes } = updateVariableBlockPosition(rung, preDropNodes)
+    const cu = nodes.find(
+      (n) => n.type === 'variable' && (n.data as { block: { handleId: string } }).block.handleId === 'CU',
+    )
+
+    expect(cu?.id).toBe('VARIABLE_current_cu')
+    expect((cu?.data as { numericId: number }).numericId).toBe(999)
+  })
+
+  it('ignores previous variable nodes with incomplete identity data', () => {
+    const brokenVariable = {
+      id: 'VARIABLE_broken',
+      type: 'variable',
+      position: { x: 0, y: 0 },
+      data: { variant: 'input', block: { id: 'BLOCK_1' } },
+    } as unknown as Node
+
+    const rung = makeRung([makeBlockNode(), brokenVariable])
+    const { nodes } = updateVariableBlockPosition(rung)
+    const variables = nodes.filter((n) => n.type === 'variable')
+
+    expect(variables).toHaveLength(3)
+    expect(variables.every((n) => n.id !== 'VARIABLE_broken')).toBe(true)
+  })
+})

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/variable-block/__tests__/variable-block.test.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/variable-block/__tests__/variable-block.test.ts
@@ -65,9 +65,7 @@ describe('updateVariableBlockPosition identity reuse', () => {
     const variables = nodes.filter((n) => n.type === 'variable')
 
     expect(variables).toHaveLength(3)
-    const byHandle = new Map(
-      variables.map((n) => [(n.data as { block: { handleId: string } }).block.handleId, n]),
-    )
+    const byHandle = new Map(variables.map((n) => [(n.data as { block: { handleId: string } }).block.handleId, n]))
     expect(byHandle.get('CU')?.id).toBe('VARIABLE_prev_cu')
     expect((byHandle.get('CU')?.data as { numericId: number }).numericId).toBe(111)
     expect(byHandle.get('PV')?.id).toBe('VARIABLE_prev_pv')
@@ -120,9 +118,7 @@ describe('updateVariableBlockPosition identity reuse', () => {
     const variables = nodes.filter((n) => n.type === 'variable')
 
     expect(variables).toHaveLength(3)
-    const byHandle = new Map(
-      variables.map((n) => [(n.data as { block: { handleId: string } }).block.handleId, n]),
-    )
+    const byHandle = new Map(variables.map((n) => [(n.data as { block: { handleId: string } }).block.handleId, n]))
     expect(byHandle.get('CU')?.id).toBe('VARIABLE_prev_cu')
     expect(byHandle.get('PV')?.id).toBe('VARIABLE_prev_pv')
     expect(byHandle.get('CV')?.id).toBe('VARIABLE_prev_cv')

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/variable-block/index.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/variable-block/index.ts
@@ -10,7 +10,42 @@ import { BlockNode, BlockVariant } from '../../../../../../../_atoms/graphical-e
 import { buildEdge } from '../../edges'
 import { hasBranchOnHandle } from '../handle-branch'
 
-export const renderVariableBlock = <T extends BlockVariant>(rung: RungLadderState, block: Node) => {
+/**
+ * Identity of a rebuilt variable node, keyed by its attachment point
+ * (block id + handle id + input/output side). The layout pass destroys and
+ * rebuilds every variable node — reusing the previous node's `id` and
+ * `data.numericId` keeps a net-identical graph byte-identical on disk, so
+ * dragging a block away and back doesn't leave a phantom "Modified" file.
+ */
+type VariableIdentity = { id: string; numericId: number | string }
+
+const variableIdentityKey = (blockId: string, handleId: string, variant: 'input' | 'output') =>
+  `${blockId}::${handleId}::${variant}`
+
+/** Collect the identities of a rung's existing variable nodes before a rebuild. */
+const collectVariableIdentities = (nodes: Node[]): Map<string, VariableIdentity> => {
+  const identities = new Map<string, VariableIdentity>()
+  for (const node of nodes) {
+    if (node.type !== 'variable') continue
+    const data = node.data as {
+      variant?: 'input' | 'output'
+      block?: { id?: string; handleId?: string }
+      numericId?: number | string
+    }
+    if (!data?.block?.id || !data.block.handleId || !data.variant || data.numericId === undefined) continue
+    identities.set(variableIdentityKey(data.block.id, data.block.handleId, data.variant), {
+      id: node.id,
+      numericId: data.numericId,
+    })
+  }
+  return identities
+}
+
+export const renderVariableBlock = <T extends BlockVariant>(
+  rung: RungLadderState,
+  block: Node,
+  previousIdentities?: Map<string, VariableIdentity>,
+) => {
   const variableElements: Node[] = []
   const variableEdges: Edge[] = []
   const variableElementStyle = defaultCustomNodesStyles.variable
@@ -50,8 +85,9 @@ export const renderVariableBlock = <T extends BlockVariant>(rung: RungLadderStat
       if (variable.name === inputHandle.id) variableType = variable
     })
 
+    const previous = previousIdentities?.get(variableIdentityKey(blockElement.id, inputHandle.id as string, 'input'))
     const variableElement = nodesBuilder.variable({
-      id: newGraphicalEditorNodeID('variable'),
+      id: previous?.id ?? newGraphicalEditorNodeID('variable'),
       posX: inputHandle.glbPosition.x - (variableElementStyle.width + variableElementStyle.gap),
       posY: inputHandle.glbPosition.y - variableElementStyle.handle.y,
       handleX: inputHandle.glbPosition.x - variableElementStyle.gap,
@@ -64,6 +100,7 @@ export const renderVariableBlock = <T extends BlockVariant>(rung: RungLadderStat
       },
       variable: connectedVariable ? connectedVariable.variable : undefined,
     })
+    if (previous) (variableElement.data as { numericId: number | string }).numericId = previous.numericId
     const variableEdge = buildEdge(variableElement.id, blockElement.id, {
       sourceHandle: 'output',
       targetHandle: inputHandle.id,
@@ -92,8 +129,9 @@ export const renderVariableBlock = <T extends BlockVariant>(rung: RungLadderStat
       if (variable.name === outputHandle.id) variableType = variable
     })
 
+    const previous = previousIdentities?.get(variableIdentityKey(blockElement.id, outputHandle.id as string, 'output'))
     const variableElement = nodesBuilder.variable({
-      id: newGraphicalEditorNodeID('variable'),
+      id: previous?.id ?? newGraphicalEditorNodeID('variable'),
       posX: outputHandle.glbPosition.x + variableElementStyle.gap,
       posY: outputHandle.glbPosition.y - variableElementStyle.handle.y,
       handleX: outputHandle.glbPosition.x + variableElementStyle.gap,
@@ -106,6 +144,7 @@ export const renderVariableBlock = <T extends BlockVariant>(rung: RungLadderStat
       },
       variable: connectedVariable ? connectedVariable.variable : undefined,
     })
+    if (previous) (variableElement.data as { numericId: number | string }).numericId = previous.numericId
     const variableEdge = buildEdge(blockElement.id, variableElement.id, {
       sourceHandle: outputHandle.id,
       targetHandle: 'input',
@@ -126,9 +165,18 @@ export const removeVariableBlock = (rung: RungLadderState) => {
   return { nodes: newNodes, edges: newEdges }
 }
 
-export const updateVariableBlockPosition = (rung: RungLadderState) => {
+export const updateVariableBlockPosition = (rung: RungLadderState, previousNodes?: Node[]) => {
   let newNodes = [...rung.nodes]
   let newEdges = [...rung.edges]
+
+  // Remember each variable node's identity before the rebuild so unchanged
+  // attachment points keep their ids (and therefore their edge ids).
+  // `previousNodes` is a fallback identity source for pipelines that strip
+  // variable nodes before layout (the drag-drop flow removes them in
+  // `prepareDropState`) — entries from `rung.nodes` win when both exist.
+  const previousIdentities = collectVariableIdentities(
+    previousNodes ? [...previousNodes, ...rung.nodes] : rung.nodes,
+  )
 
   const { nodes: removedVariableNodes, edges: removedVariableEdges } = removeVariableBlock(rung)
   newNodes = removedVariableNodes
@@ -144,6 +192,7 @@ export const updateVariableBlockPosition = (rung: RungLadderState) => {
         edges: newEdges,
       },
       blockElement,
+      previousIdentities,
     )
     newNodes = nodes
     newEdges = edges

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/variable-block/index.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/variable-block/index.ts
@@ -174,9 +174,7 @@ export const updateVariableBlockPosition = (rung: RungLadderState, previousNodes
   // `previousNodes` is a fallback identity source for pipelines that strip
   // variable nodes before layout (the drag-drop flow removes them in
   // `prepareDropState`) — entries from `rung.nodes` win when both exist.
-  const previousIdentities = collectVariableIdentities(
-    previousNodes ? [...previousNodes, ...rung.nodes] : rung.nodes,
-  )
+  const previousIdentities = collectVariableIdentities(previousNodes ? [...previousNodes, ...rung.nodes] : rung.nodes)
 
   const { nodes: removedVariableNodes, edges: removedVariableEdges } = removeVariableBlock(rung)
   newNodes = removedVariableNodes

--- a/src/frontend/store/__tests__/ladder-slice.test.ts
+++ b/src/frontend/store/__tests__/ladder-slice.test.ts
@@ -498,9 +498,12 @@ describe('createLadderFlowSlice', () => {
     seedFlowWithRung(store, 'editor-1', rung)
     store.getState().ladderFlowActions.setFlowUpdated({ editorName: 'editor-1', updated: false })
 
-    store
-      .getState()
-      .ladderFlowActions.updateNode({ editorName: 'editor-1', rungId: 'rung-1', nodeId: 'n1', node: makeNode({ id: 'n1' }) })
+    store.getState().ladderFlowActions.updateNode({
+      editorName: 'editor-1',
+      rungId: 'rung-1',
+      nodeId: 'n1',
+      node: makeNode({ id: 'n1' }),
+    })
 
     expect(store.getState().ladderFlows[0].updated).toBe(true)
   })

--- a/src/frontend/store/__tests__/ladder-slice.test.ts
+++ b/src/frontend/store/__tests__/ladder-slice.test.ts
@@ -493,6 +493,35 @@ describe('createLadderFlowSlice', () => {
     expect(store.getState().ladderFlows[0].rungs[0].nodes).toHaveLength(2)
   })
 
+  it('updateNode marks the flow as updated', () => {
+    const rung = makeRung({ nodes: [makeNode({ id: 'n1' })] })
+    seedFlowWithRung(store, 'editor-1', rung)
+    store.getState().ladderFlowActions.setFlowUpdated({ editorName: 'editor-1', updated: false })
+
+    store
+      .getState()
+      .ladderFlowActions.updateNode({ editorName: 'editor-1', rungId: 'rung-1', nodeId: 'n1', node: makeNode({ id: 'n1' }) })
+
+    expect(store.getState().ladderFlows[0].updated).toBe(true)
+  })
+
+  it('updateNode with transient replaces the node without marking the flow as updated', () => {
+    const rung = makeRung({ nodes: [makeNode({ id: 'n1', data: { label: 'old' } })] })
+    seedFlowWithRung(store, 'editor-1', rung)
+    store.getState().ladderFlowActions.setFlowUpdated({ editorName: 'editor-1', updated: false })
+
+    store.getState().ladderFlowActions.updateNode({
+      editorName: 'editor-1',
+      rungId: 'rung-1',
+      nodeId: 'n1',
+      node: makeNode({ id: 'n1', data: { label: 'new' } }),
+      transient: true,
+    })
+
+    expect(store.getState().ladderFlows[0].rungs[0].nodes.find((n) => n.id === 'n1')?.data.label).toBe('new')
+    expect(store.getState().ladderFlows[0].updated).toBe(false)
+  })
+
   // -------------------------------------------------------------------------
   // addNode
   // -------------------------------------------------------------------------

--- a/src/frontend/store/__tests__/version-control-slice.test.ts
+++ b/src/frontend/store/__tests__/version-control-slice.test.ts
@@ -55,6 +55,19 @@ describe('createVersionControlSlice', () => {
     })
   })
 
+  describe('mergeHeadContent', () => {
+    it('creates the snapshot from null', () => {
+      actions().mergeHeadContent({ 'a.st': 'head-a' })
+      expect(vc().headContent).toEqual({ 'a.st': 'head-a' })
+    })
+
+    it('merges entries without dropping the rest of the map', () => {
+      actions().setHeadContent({ 'a.st': 'head-a', 'b.st': 'head-b' })
+      actions().mergeHeadContent({ 'b.st': 'updated', 'c.st': 'head-c' })
+      expect(vc().headContent).toEqual({ 'a.st': 'head-a', 'b.st': 'updated', 'c.st': 'head-c' })
+    })
+  })
+
   it('initBaseline resets the cached HEAD snapshot to null', () => {
     actions().setHeadContent({ 'a.st': 'x' })
     actions().initBaseline({

--- a/src/frontend/store/__tests__/version-control-slice.test.ts
+++ b/src/frontend/store/__tests__/version-control-slice.test.ts
@@ -139,6 +139,29 @@ describe('createVersionControlSlice', () => {
       expect(vc().changedPaths).toContain('tracked.st')
       expect(vc().changedPaths).not.toContain('session.st')
     })
+
+    it('prunes saved and deleted paths from the cached HEAD snapshot', () => {
+      actions().initBaseline({ initialPending: [], baselineContent: { 'gone.st': 'g' } })
+      actions().setHeadContent({ 'saved.st': 'old-head', 'gone.st': 'old-head', 'untouched.st': 'head' })
+
+      actions().recordSavedFiles({
+        saved: [{ path: 'saved.st', content: 'new' }],
+        deleted: ['gone.st'],
+      })
+
+      expect(vc().headContent).toEqual({ 'untouched.st': 'head' })
+    })
+
+    it('leaves the HEAD snapshot null when it was never fetched', () => {
+      actions().initBaseline({ initialPending: [], baselineContent: {} })
+
+      actions().recordSavedFiles({
+        saved: [{ path: 'saved.st', content: 'new' }],
+        deleted: [],
+      })
+
+      expect(vc().headContent).toBeNull()
+    })
   })
 
   it('commitBaseline refreshes baseline, clears pending, and invalidates HEAD', () => {

--- a/src/frontend/store/slices/ladder/slice.ts
+++ b/src/frontend/store/slices/ladder/slice.ts
@@ -294,7 +294,7 @@ export const createLadderFlowSlice: StateCreator<LadderFlowSlice, [], [], Ladder
         }),
       )
     },
-    updateNode({ editorName, node, nodeId, rungId }) {
+    updateNode({ editorName, node, nodeId, rungId, transient }) {
       setState(
         produce(({ ladderFlows }: LadderFlowState) => {
           const flow = ladderFlows.find((flow) => flow.name === editorName)
@@ -307,7 +307,7 @@ export const createLadderFlowSlice: StateCreator<LadderFlowSlice, [], [], Ladder
           if (nodeIndex === -1) return
 
           rung.nodes[nodeIndex] = node
-          flow.updated = true
+          if (!transient) flow.updated = true
         }),
       )
     },

--- a/src/frontend/store/slices/ladder/types.ts
+++ b/src/frontend/store/slices/ladder/types.ts
@@ -98,11 +98,16 @@ type LadderFlowActions = {
     nodeId,
     rungId,
     editorName,
+    transient,
   }: {
     node: Node
     nodeId: string
     rungId: string
     editorName: string
+    /** UI-only update (e.g. drag-lock while a variable input is focused) —
+     *  writes the node without marking the flow as edited, so merely
+     *  focusing/blurring an element never dirties the POU. */
+    transient?: boolean
   }) => void
   addNode: ({ node, rungId, editorName }: { node: Node; rungId: string; editorName: string }) => void
   removeNodes: ({ nodes, rungId, editorName }: { nodes: Node[]; rungId: string; editorName: string }) => void

--- a/src/frontend/store/slices/version-control/slice.ts
+++ b/src/frontend/store/slices/version-control/slice.ts
@@ -58,6 +58,13 @@ const createVersionControlSlice: StateCreator<VersionControlSlice, [], [], Versi
         }),
       ),
 
+    mergeHeadContent: (entries: Record<string, string>) =>
+      setState(
+        produce<VersionControlSlice>((draft) => {
+          draft.versionControl.headContent = { ...(draft.versionControl.headContent ?? {}), ...entries }
+        }),
+      ),
+
     initBaseline: ({ initialPending, baselineContent, rawLoadedContent, loadedSerialized }) =>
       setState(
         produce<VersionControlSlice>((draft) => {

--- a/src/frontend/store/slices/version-control/slice.ts
+++ b/src/frontend/store/slices/version-control/slice.ts
@@ -96,6 +96,16 @@ const createVersionControlSlice: StateCreator<VersionControlSlice, [], [], Versi
           const initialMap = new Map(draft.versionControl.initialPending.map((e) => [e.path, e.status]))
           const changedSet = new Set(draft.versionControl.changedPaths)
 
+          // Drop the cached HEAD snapshot for every path this save touched.
+          // A save doesn't move HEAD, but the cached entry may predate it
+          // wrongly (e.g. a fetch that raced a commit), and the diff view
+          // can't tell a stale entry from a fresh one — pruning forces it to
+          // refetch authoritative content the next time the path is viewed.
+          if (draft.versionControl.headContent) {
+            for (const { path } of saved) delete draft.versionControl.headContent[path]
+            for (const path of deleted) delete draft.versionControl.headContent[path]
+          }
+
           for (const { path, content } of saved) {
             // Track S3's current state for this path so future "clean"
             // saves echo back what's now in S3 (instead of the original

--- a/src/frontend/store/slices/version-control/types.ts
+++ b/src/frontend/store/slices/version-control/types.ts
@@ -58,10 +58,11 @@ export type VersionControlState = {
      * `/changes?includeContent=true` `before` field (authoritative against the
      * real HEAD). `null` until lazily fetched by the diff view; reset to `null`
      * on project load / commit / in-place reload so it refetches against the
-     * current HEAD. Unlike `baselineContent` (which reflects the loaded working
-     * tree and so already includes pre-existing pending changes), this is the
-     * committed content, so it can show a diff for changes made before the
-     * current session.
+     * current HEAD, and pruned per-path by `recordSavedFiles` so a re-edited
+     * file never diffs against a stale snapshot. Unlike `baselineContent`
+     * (which reflects the loaded working tree and so already includes
+     * pre-existing pending changes), this is the committed content, so it can
+     * show a diff for changes made before the current session.
      */
     headContent: Record<string, string> | null
   }
@@ -96,7 +97,10 @@ export type VersionControlActions = {
    * Update `changedPaths` based on what the save just sent. Files matching
    * baseline are removed; files differing are added; deletions are folded
    * back into initialPending or changedPaths depending on their original
-   * status (see slice implementation for the case-by-case logic).
+   * status (see slice implementation for the case-by-case logic). Also prunes
+   * the saved/deleted paths from the cached `headContent` snapshot so the
+   * diff view refetches their HEAD side instead of trusting a possibly-stale
+   * entry.
    */
   recordSavedFiles: (args: { saved: SavedFileRecord[]; deleted: string[] }) => void
   /**

--- a/src/frontend/store/slices/version-control/types.ts
+++ b/src/frontend/store/slices/version-control/types.ts
@@ -76,6 +76,8 @@ export type VersionControlActions = {
   /** Set (or clear, with `null`) the lazily-fetched HEAD snapshot used as the
    *  "original" side of source-control diffs. */
   setHeadContent: (content: Record<string, string> | null) => void
+  /** Merge entries into the HEAD snapshot without dropping the rest of the map (creates it when `null`). */
+  mergeHeadContent: (entries: Record<string, string>) => void
   /**
    * Snapshot baseline + initial pending at the last "in-sync" point
    * (project load, after restore, after discard).

--- a/src/frontend/utils/__tests__/save-project.test.ts
+++ b/src/frontend/utils/__tests__/save-project.test.ts
@@ -118,14 +118,18 @@ describe('graphical node sanitization', () => {
 
   it('clears selection state and resets selectedNodes on LD rungs', () => {
     const pou = makeLdPou([{ id: 'n1', selected: true, dragging: true, draggable: true, data: { draggable: true } }])
-    const value = sanitizePou(pou, undefined).body.value as { rungs: { selectedNodes: unknown[]; nodes: Record<string, unknown>[] }[] }
+    const value = sanitizePou(pou, undefined).body.value as {
+      rungs: { selectedNodes: unknown[]; nodes: Record<string, unknown>[] }[]
+    }
     expect(value.rungs[0].selectedNodes).toEqual([])
     expect(value.rungs[0].nodes[0].selected).toBe(false)
     expect(value.rungs[0].nodes[0].dragging).toBe(false)
   })
 
   it('strips the hasDivergence render decoration from LD node data', () => {
-    const pou = makeLdPou([{ id: 'n1', draggable: true, data: { draggable: true, hasDivergence: false, variable: { name: 'X' } } }])
+    const pou = makeLdPou([
+      { id: 'n1', draggable: true, data: { draggable: true, hasDivergence: false, variable: { name: 'X' } } },
+    ])
     const value = sanitizePou(pou, undefined).body.value as { rungs: { nodes: { data: Record<string, unknown> }[] }[] }
     expect('hasDivergence' in value.rungs[0].nodes[0].data).toBe(false)
     expect(value.rungs[0].nodes[0].data.variable).toEqual({ name: 'X' })
@@ -161,7 +165,15 @@ describe('graphical node sanitization', () => {
         value: {
           name: 'MyFbd',
           rung: {
-            nodes: [{ id: 'n1', selected: true, dragging: true, draggable: false, data: { draggable: true, hasDivergence: true } }],
+            nodes: [
+              {
+                id: 'n1',
+                selected: true,
+                dragging: true,
+                draggable: false,
+                data: { draggable: true, hasDivergence: true },
+              },
+            ],
             edges: [],
             selectedNodes: [{ id: 'ghost' }],
           },
@@ -170,7 +182,10 @@ describe('graphical node sanitization', () => {
       documentation: '',
     } as unknown as PLCPou
     const value = sanitizePou(pou, undefined).body.value as {
-      rung: { selectedNodes: unknown[]; nodes: { selected: boolean; dragging: boolean; draggable: boolean; data: Record<string, unknown> }[] }
+      rung: {
+        selectedNodes: unknown[]
+        nodes: { selected: boolean; dragging: boolean; draggable: boolean; data: Record<string, unknown> }[]
+      }
     }
     expect(value.rung.selectedNodes).toEqual([])
     expect(value.rung.nodes[0].selected).toBe(false)

--- a/src/frontend/utils/__tests__/save-project.test.ts
+++ b/src/frontend/utils/__tests__/save-project.test.ts
@@ -97,6 +97,205 @@ describe('sanitizePou', () => {
 })
 
 // ---------------------------------------------------------------------------
+// graphical node sanitization (via sanitizePou → stripGraphicalSelections)
+// ---------------------------------------------------------------------------
+
+describe('graphical node sanitization', () => {
+  const makeLdPou = (nodes: unknown[], rungExtras?: Record<string, unknown>): PLCPou =>
+    ({
+      name: 'MyLadder',
+      pouType: 'program',
+      interface: { variables: [] },
+      body: {
+        language: 'ld',
+        value: {
+          name: 'MyLadder',
+          rungs: [{ id: 'rung-1', nodes, edges: [], selectedNodes: [{ id: 'ghost' }], ...rungExtras }],
+        },
+      },
+      documentation: '',
+    }) as unknown as PLCPou
+
+  it('clears selection state and resets selectedNodes on LD rungs', () => {
+    const pou = makeLdPou([{ id: 'n1', selected: true, dragging: true, draggable: true, data: { draggable: true } }])
+    const value = sanitizePou(pou, undefined).body.value as { rungs: { selectedNodes: unknown[]; nodes: Record<string, unknown>[] }[] }
+    expect(value.rungs[0].selectedNodes).toEqual([])
+    expect(value.rungs[0].nodes[0].selected).toBe(false)
+    expect(value.rungs[0].nodes[0].dragging).toBe(false)
+  })
+
+  it('strips the hasDivergence render decoration from LD node data', () => {
+    const pou = makeLdPou([{ id: 'n1', draggable: true, data: { draggable: true, hasDivergence: false, variable: { name: 'X' } } }])
+    const value = sanitizePou(pou, undefined).body.value as { rungs: { nodes: { data: Record<string, unknown> }[] }[] }
+    expect('hasDivergence' in value.rungs[0].nodes[0].data).toBe(false)
+    expect(value.rungs[0].nodes[0].data.variable).toEqual({ name: 'X' })
+  })
+
+  it('normalizes top-level draggable to the design-time data.draggable', () => {
+    const pou = makeLdPou([
+      { id: 'locked', draggable: false, data: { draggable: true } },
+      { id: 'rail', draggable: true, data: { draggable: false } },
+      { id: 'no-data' },
+    ])
+    const value = sanitizePou(pou, undefined).body.value as { rungs: { nodes: Record<string, unknown>[] }[] }
+    expect(value.rungs[0].nodes[0].draggable).toBe(true)
+    expect(value.rungs[0].nodes[1].draggable).toBe(false)
+    expect(value.rungs[0].nodes[2].draggable).toBe(false)
+    expect('data' in value.rungs[0].nodes[2]).toBe(false)
+  })
+
+  it('leaves non-array LD rung nodes untouched', () => {
+    const pou = makeLdPou([], {})
+    ;(pou.body.value as { rungs: Record<string, unknown>[] }).rungs[0].nodes = 'not-an-array'
+    const value = sanitizePou(pou, undefined).body.value as { rungs: { nodes: unknown }[] }
+    expect(value.rungs[0].nodes).toBe('not-an-array')
+  })
+
+  it('sanitizes FBD rung nodes the same way', () => {
+    const pou = {
+      name: 'MyFbd',
+      pouType: 'program',
+      interface: { variables: [] },
+      body: {
+        language: 'fbd',
+        value: {
+          name: 'MyFbd',
+          rung: {
+            nodes: [{ id: 'n1', selected: true, dragging: true, draggable: false, data: { draggable: true, hasDivergence: true } }],
+            edges: [],
+            selectedNodes: [{ id: 'ghost' }],
+          },
+        },
+      },
+      documentation: '',
+    } as unknown as PLCPou
+    const value = sanitizePou(pou, undefined).body.value as {
+      rung: { selectedNodes: unknown[]; nodes: { selected: boolean; dragging: boolean; draggable: boolean; data: Record<string, unknown> }[] }
+    }
+    expect(value.rung.selectedNodes).toEqual([])
+    expect(value.rung.nodes[0].selected).toBe(false)
+    expect(value.rung.nodes[0].dragging).toBe(false)
+    expect(value.rung.nodes[0].draggable).toBe(true)
+    expect('hasDivergence' in value.rung.nodes[0].data).toBe(false)
+  })
+
+  it('returns the POU unchanged when the graphical body value is missing', () => {
+    const pou = {
+      name: 'Empty',
+      pouType: 'program',
+      interface: { variables: [] },
+      body: { language: 'ld', value: undefined },
+      documentation: '',
+    } as unknown as PLCPou
+    expect(sanitizePou(pou, undefined)).toBe(pou)
+  })
+
+  it('preserves LD rung edge order (layout algorithms may be order-sensitive)', () => {
+    const edges = [
+      { id: 'e_charlie', source: 'c', target: 'd' },
+      { id: 'e_alpha', source: 'a', target: 'b' },
+      { id: 'e_bravo', source: 'b', target: 'c' },
+    ]
+    const pou = makeLdPou([], { edges })
+    const value = sanitizePou(pou, undefined).body.value as { rungs: { edges: { id: string }[] }[] }
+    expect(value.rungs[0].edges.map((e) => e.id)).toEqual(['e_charlie', 'e_alpha', 'e_bravo'])
+  })
+
+  it('canonicalizes reactFlowViewport from node content bounds', () => {
+    const pou = makeLdPou(
+      [{ id: 'n1', position: { x: 200, y: 10 }, width: 100, height: 60, draggable: true, data: { draggable: true } }],
+      { defaultBounds: [100, 50], reactFlowViewport: [999, 999] },
+    )
+    const value = sanitizePou(pou, undefined).body.value as { rungs: { reactFlowViewport: number[] }[] }
+    // bounds include the synthetic 150x40 origin node: maxX=300, maxY=70 -> [300, 70+20]
+    expect(value.rungs[0].reactFlowViewport).toEqual([300, 90])
+  })
+
+  it('floors the canonical viewport at defaultBounds', () => {
+    const pou = makeLdPou(
+      [{ id: 'n1', position: { x: 10, y: 10 }, width: 10, height: 10, draggable: true, data: { draggable: true } }],
+      { defaultBounds: [800, 200], reactFlowViewport: [123, 456] },
+    )
+    const value = sanitizePou(pou, undefined).body.value as { rungs: { reactFlowViewport: number[] }[] }
+    expect(value.rungs[0].reactFlowViewport).toEqual([800, 220])
+  })
+
+  it('prefers measured dimensions over declared width/height for the viewport', () => {
+    const pou = makeLdPou(
+      [
+        {
+          id: 'n1',
+          position: { x: 400, y: 0 },
+          width: 999,
+          height: 999,
+          measured: { width: 50, height: 30 },
+          draggable: true,
+          data: { draggable: true },
+        },
+      ],
+      { defaultBounds: [10, 10], reactFlowViewport: [1, 1] },
+    )
+    const value = sanitizePou(pou, undefined).body.value as { rungs: { reactFlowViewport: number[] }[] }
+    expect(value.rungs[0].reactFlowViewport).toEqual([450, 60])
+  })
+
+  it('passes the stored viewport through when the rung has no defaultBounds', () => {
+    const pou = makeLdPou([], { reactFlowViewport: [111, 222] })
+    const value = sanitizePou(pou, undefined).body.value as { rungs: { reactFlowViewport: number[] }[] }
+    expect(value.rungs[0].reactFlowViewport).toEqual([111, 222])
+  })
+
+  it('expands the viewport for negative positions and tolerates nodes without geometry', () => {
+    const pou = makeLdPou(
+      [
+        { id: 'neg', position: { x: -50, y: -30 }, width: 10, height: 10, draggable: true, data: { draggable: true } },
+        { id: 'bare', draggable: true, data: { draggable: true } },
+      ],
+      { defaultBounds: [10, 10], reactFlowViewport: [1, 1] },
+    )
+    const value = sanitizePou(pou, undefined).body.value as { rungs: { reactFlowViewport: number[] }[] }
+    // minX=-50, minY=-30; max bounds stay at the synthetic 150x40 -> [200, 70+20]
+    expect(value.rungs[0].reactFlowViewport).toEqual([200, 90])
+  })
+
+  it('treats non-numeric defaultBounds entries as zero for the viewport floor', () => {
+    const pou = makeLdPou(
+      [{ id: 'n1', position: { x: 0, y: 0 }, width: 10, height: 10, draggable: true, data: { draggable: true } }],
+      { defaultBounds: ['not-a-number', null], reactFlowViewport: [9, 9] },
+    )
+    const value = sanitizePou(pou, undefined).body.value as { rungs: { reactFlowViewport: number[] }[] }
+    // Floors collapse to 0 -> pure content bounds (synthetic origin node 150x40).
+    expect(value.rungs[0].reactFlowViewport).toEqual([150, 60])
+  })
+
+  it('leaves non-array FBD rung nodes untouched', () => {
+    const pou = {
+      name: 'MyFbd',
+      pouType: 'program',
+      interface: { variables: [] },
+      body: {
+        language: 'fbd',
+        value: { name: 'MyFbd', rung: { nodes: 'not-an-array', edges: [], selectedNodes: [] } },
+      },
+      documentation: '',
+    } as unknown as PLCPou
+    const value = sanitizePou(pou, undefined).body.value as { rung: { nodes: unknown } }
+    expect(value.rung.nodes).toBe('not-an-array')
+  })
+
+  it('returns the POU unchanged when an LD body has no rungs array', () => {
+    const pou = {
+      name: 'NoRungs',
+      pouType: 'program',
+      interface: { variables: [] },
+      body: { language: 'ld', value: { name: 'NoRungs' } },
+      documentation: '',
+    } as unknown as PLCPou
+    expect(sanitizePou(pou, undefined)).toBe(pou)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // collectDebugVariables
 // ---------------------------------------------------------------------------
 

--- a/src/frontend/utils/graphical/__tests__/sync-nodes-with-variables.test.ts
+++ b/src/frontend/utils/graphical/__tests__/sync-nodes-with-variables.test.ts
@@ -151,7 +151,7 @@ describe('syncNodesWithVariables', () => {
     expect(updateNode).toHaveBeenCalledWith(expect.objectContaining({ editorName: 'editor1' }))
   })
 
-  it('skips variable-pin nodes whose pin type cannot be resolved (never judges against \'\')', () => {
+  it("skips variable-pin nodes whose pin type cannot be resolved (never judges against '')", () => {
     const updateNode = vi.fn()
     const variable = makeVariable('myVar', 'BOOL')
     const node = makeNode('n1', 'variable', { name: 'myVar' } as Partial<PLCVariable>, { wrongVariable: true })
@@ -183,9 +183,9 @@ describe('syncNodesWithVariables', () => {
     const variable = makeVariable('reset_in', 'BOOL')
     const node = makeNode('n1', 'variable', { name: 'reset_in' } as Partial<PLCVariable>, pinExtra('BOOL'))
 
-    const ladderFlows = [
-      { name: 'editor1', rungs: [{ id: 'r1', nodes: [node], edges: [] }] },
-    ] as unknown as Parameters<typeof syncNodesWithVariables>[1]
+    const ladderFlows = [{ name: 'editor1', rungs: [{ id: 'r1', nodes: [node], edges: [] }] }] as unknown as Parameters<
+      typeof syncNodesWithVariables
+    >[1]
 
     syncNodesWithVariables([variable], ladderFlows, updateNode)
     expect(updateNode).not.toHaveBeenCalled()
@@ -196,9 +196,9 @@ describe('syncNodesWithVariables', () => {
     const variable = makeVariable('reset_in', 'INT')
     const node = makeNode('n1', 'variable', { name: 'reset_in' } as Partial<PLCVariable>, pinExtra('BOOL'))
 
-    const ladderFlows = [
-      { name: 'editor1', rungs: [{ id: 'r1', nodes: [node], edges: [] }] },
-    ] as unknown as Parameters<typeof syncNodesWithVariables>[1]
+    const ladderFlows = [{ name: 'editor1', rungs: [{ id: 'r1', nodes: [node], edges: [] }] }] as unknown as Parameters<
+      typeof syncNodesWithVariables
+    >[1]
 
     syncNodesWithVariables([variable], ladderFlows, updateNode)
     expect(updateNode).toHaveBeenCalledWith(
@@ -216,16 +216,14 @@ describe('syncNodesWithVariables', () => {
   it('clears a stale wrongVariable flag on a variable-pin node once the pin type matches', () => {
     const updateNode = vi.fn()
     const variable = makeVariable('reset_in', 'BOOL')
-    const node = makeNode(
-      'n1',
-      'variable',
-      { name: 'reset_in' } as Partial<PLCVariable>,
-      { ...pinExtra('BOOL'), wrongVariable: true },
-    )
+    const node = makeNode('n1', 'variable', { name: 'reset_in' } as Partial<PLCVariable>, {
+      ...pinExtra('BOOL'),
+      wrongVariable: true,
+    })
 
-    const ladderFlows = [
-      { name: 'editor1', rungs: [{ id: 'r1', nodes: [node], edges: [] }] },
-    ] as unknown as Parameters<typeof syncNodesWithVariables>[1]
+    const ladderFlows = [{ name: 'editor1', rungs: [{ id: 'r1', nodes: [node], edges: [] }] }] as unknown as Parameters<
+      typeof syncNodesWithVariables
+    >[1]
 
     syncNodesWithVariables([variable], ladderFlows, updateNode)
     expect(updateNode).toHaveBeenCalledWith(

--- a/src/frontend/utils/graphical/__tests__/sync-nodes-with-variables.test.ts
+++ b/src/frontend/utils/graphical/__tests__/sync-nodes-with-variables.test.ts
@@ -151,7 +151,7 @@ describe('syncNodesWithVariables', () => {
     expect(updateNode).toHaveBeenCalledWith(expect.objectContaining({ editorName: 'editor1' }))
   })
 
-  it('keeps a variable node marked as wrongVariable when type cannot be resolved', () => {
+  it('skips variable-pin nodes whose pin type cannot be resolved (never judges against \'\')', () => {
     const updateNode = vi.fn()
     const variable = makeVariable('myVar', 'BOOL')
     const node = makeNode('n1', 'variable', { name: 'myVar' } as Partial<PLCVariable>, { wrongVariable: true })
@@ -164,14 +164,76 @@ describe('syncNodesWithVariables', () => {
     ] as unknown as Parameters<typeof syncNodesWithVariables>[1]
 
     syncNodesWithVariables([variable], ladderFlows, updateNode)
-    // Node type 'variable' has no expected type (getBlockExpectedType returns ''),
-    // so the type comparison always fails and the node stays marked as wrong.
+    // No data.block.variableType -> expected type unknown -> don't judge.
+    // (The old behavior compared against '' and flagged every linked pin.)
+    expect(updateNode).not.toHaveBeenCalled()
+  })
+
+  const pinExtra = (pinType: string) => ({
+    variant: 'input',
+    block: {
+      id: 'B1',
+      handleId: 'CU',
+      variableType: { name: 'CU', class: 'input', type: { definition: 'base-type', value: pinType } },
+    },
+  })
+
+  it('accepts a variable-pin node whose variable matches the pin type', () => {
+    const updateNode = vi.fn()
+    const variable = makeVariable('reset_in', 'BOOL')
+    const node = makeNode('n1', 'variable', { name: 'reset_in' } as Partial<PLCVariable>, pinExtra('BOOL'))
+
+    const ladderFlows = [
+      { name: 'editor1', rungs: [{ id: 'r1', nodes: [node], edges: [] }] },
+    ] as unknown as Parameters<typeof syncNodesWithVariables>[1]
+
+    syncNodesWithVariables([variable], ladderFlows, updateNode)
+    expect(updateNode).not.toHaveBeenCalled()
+  })
+
+  it('flags a variable-pin node whose variable mismatches the pin type', () => {
+    const updateNode = vi.fn()
+    const variable = makeVariable('reset_in', 'INT')
+    const node = makeNode('n1', 'variable', { name: 'reset_in' } as Partial<PLCVariable>, pinExtra('BOOL'))
+
+    const ladderFlows = [
+      { name: 'editor1', rungs: [{ id: 'r1', nodes: [node], edges: [] }] },
+    ] as unknown as Parameters<typeof syncNodesWithVariables>[1]
+
+    syncNodesWithVariables([variable], ladderFlows, updateNode)
     expect(updateNode).toHaveBeenCalledWith(
       expect.objectContaining({
         node: expect.objectContaining({
           data: expect.objectContaining({
             variable: { ...variable, id: 'broken-n1' },
             wrongVariable: true,
+          }),
+        }),
+      }),
+    )
+  })
+
+  it('clears a stale wrongVariable flag on a variable-pin node once the pin type matches', () => {
+    const updateNode = vi.fn()
+    const variable = makeVariable('reset_in', 'BOOL')
+    const node = makeNode(
+      'n1',
+      'variable',
+      { name: 'reset_in' } as Partial<PLCVariable>,
+      { ...pinExtra('BOOL'), wrongVariable: true },
+    )
+
+    const ladderFlows = [
+      { name: 'editor1', rungs: [{ id: 'r1', nodes: [node], edges: [] }] },
+    ] as unknown as Parameters<typeof syncNodesWithVariables>[1]
+
+    syncNodesWithVariables([variable], ladderFlows, updateNode)
+    expect(updateNode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        node: expect.objectContaining({
+          data: expect.objectContaining({
+            variable,
+            wrongVariable: false,
           }),
         }),
       }),
@@ -198,7 +260,7 @@ describe('syncNodesWithVariables', () => {
     expect(updateNode).not.toHaveBeenCalled()
   })
 
-  it('marks a variable node as wrong when it has no expected type to compare', () => {
+  it('skips a variable node when it has no expected type to compare', () => {
     const updateNode = vi.fn()
     const variable = makeVariable('myVar', 'BOOL', 'base-type', '1')
     const node = makeNode('n1', 'variable', {
@@ -215,21 +277,12 @@ describe('syncNodesWithVariables', () => {
     ] as unknown as Parameters<typeof syncNodesWithVariables>[1]
 
     syncNodesWithVariables([variable], ladderFlows, updateNode)
-    // Node type 'variable' has no expected type (getBlockExpectedType returns ''),
-    // so the type comparison always fails and the node is flagged as wrong.
-    expect(updateNode).toHaveBeenCalledWith(
-      expect.objectContaining({
-        node: expect.objectContaining({
-          data: expect.objectContaining({
-            variable: { ...variable, id: 'broken-n1' },
-            wrongVariable: true,
-          }),
-        }),
-      }),
-    )
+    // Unresolvable expected type -> the node is not judged (the old behavior
+    // compared against '' and flagged every linked pin as broken).
+    expect(updateNode).not.toHaveBeenCalled()
   })
 
-  it('marks a block node as wrongVariable when variant has no name', () => {
+  it('skips a block node when its variant has no name (no expected type)', () => {
     const updateNode = vi.fn()
     const variable = makeVariable('myVar', 'INT')
     const node = makeNode('n1', 'block', {
@@ -246,13 +299,7 @@ describe('syncNodesWithVariables', () => {
     ] as unknown as Parameters<typeof syncNodesWithVariables>[1]
 
     syncNodesWithVariables([variable], ladderFlows, updateNode)
-    expect(updateNode).toHaveBeenCalledWith(
-      expect.objectContaining({
-        node: expect.objectContaining({
-          data: expect.objectContaining({ wrongVariable: true }),
-        }),
-      }),
-    )
+    expect(updateNode).not.toHaveBeenCalled()
   })
 
   it('clears wrongVariable when types now match (line 77)', () => {
@@ -328,7 +375,7 @@ describe('syncNodesWithVariables', () => {
 })
 
 describe('syncNodesWithVariablesFBD', () => {
-  it('marks a variable node as wrong when type cannot be resolved', () => {
+  it('skips a variable node when its type cannot be resolved', () => {
     const updateNode = vi.fn()
     const variable = makeVariable('myVar', 'INT', 'base-type', '2')
     const node = makeNode('n1', 'input-variable', {
@@ -345,20 +392,9 @@ describe('syncNodesWithVariablesFBD', () => {
     ] as unknown as Parameters<typeof syncNodesWithVariablesFBD>[1]
 
     syncNodesWithVariablesFBD([variable], fbdFlows, updateNode)
-    // Node type 'input-variable' has no expected type (getBlockExpectedType returns ''),
-    // so the type comparison always fails and the node is marked as wrong with a broken id.
-    expect(updateNode).toHaveBeenCalledWith(
-      expect.objectContaining({
-        editorName: 'fbd1',
-        nodeId: 'n1',
-        node: expect.objectContaining({
-          data: expect.objectContaining({
-            variable: { ...variable, id: 'broken-n1' },
-            wrongVariable: true,
-          }),
-        }),
-      }),
-    )
+    // Unresolvable expected type -> not judged (the old behavior compared
+    // against '' and falsely flagged linked FBD variable nodes as broken).
+    expect(updateNode).not.toHaveBeenCalled()
   })
 
   it('does not update when node has no variable', () => {
@@ -429,11 +465,17 @@ describe('syncNodesWithVariablesFBD', () => {
   it('filters flows by editorName', () => {
     const updateNode = vi.fn()
     const variable = makeVariable('myVar', 'INT', 'base-type', '2')
-    const node = makeNode('n1', 'input-variable', {
-      name: 'myVar',
-      id: '1',
-      type: { definition: 'base-type', value: 'BOOL' } as PLCVariable['type'],
-    })
+    // Block with a resolvable variant type that mismatches -> triggers an update.
+    const node = makeNode(
+      'n1',
+      'block',
+      {
+        name: 'myVar',
+        id: '1',
+        type: { definition: 'base-type', value: 'BOOL' } as PLCVariable['type'],
+      },
+      { variant: { name: 'BOOL' } },
+    )
 
     const fbdFlows = [
       { name: 'fbd1', rung: { nodes: [node], edges: [] } },
@@ -459,18 +501,8 @@ describe('syncNodesWithVariablesFBD', () => {
     >[1]
 
     syncNodesWithVariablesFBD([variable], fbdFlows, updateNode)
-    // Node type 'input-variable' has no expected type (getBlockExpectedType returns ''),
-    // so the type comparison always fails and the node is flagged as wrong.
-    expect(updateNode).toHaveBeenCalledWith(
-      expect.objectContaining({
-        node: expect.objectContaining({
-          data: expect.objectContaining({
-            variable: { ...variable, id: 'broken-n1' },
-            wrongVariable: true,
-          }),
-        }),
-      }),
-    )
+    // Unresolvable expected type -> not judged (no false "broken" flags).
+    expect(updateNode).not.toHaveBeenCalled()
   })
 
   it('clears wrongVariable on FBD node when types now match (line 136)', () => {

--- a/src/frontend/utils/graphical/sync-nodes-with-variables.ts
+++ b/src/frontend/utils/graphical/sync-nodes-with-variables.ts
@@ -23,6 +23,18 @@ const getBlockExpectedType = (node: Node): string => {
     return 'BOOL'
   }
 
+  // Variable-pin nodes (block-pin connectors): the expected type is the pin's
+  // declared type, carried in data.block.variableType. Their `variant` is the
+  // string 'input'/'output', so the generic variant branch below would yield
+  // '' and validateVariableType(x, '') is always false — which used to flag
+  // every LINKED pin as wrongVariable on each relink pass (project open,
+  // drag-stop), swapping its payload for a broken one and dirtying the POU.
+  if (node.type === 'variable') {
+    const pinType = (node.data as { block?: { variableType?: { type?: { value?: string } } } }).block?.variableType
+      ?.type?.value
+    return typeof pinType === 'string' ? pinType.trim().toUpperCase() : ''
+  }
+
   if (variant && typeof variant.name === 'string') {
     return variant.name.trim().toUpperCase()
   }
@@ -57,6 +69,10 @@ export const syncNodesWithVariables = (
         if (!target) return
 
         const expectedType = getBlockExpectedType(node)
+
+        // Unknown expectation — don't judge. sameType(x, '') is always false,
+        // so flagging here would mark perfectly valid links as broken.
+        if (!expectedType) return
 
         const isTheSameType = sameType(target.type.value, expectedType)
 
@@ -117,6 +133,10 @@ export const syncNodesWithVariablesFBD = (
       if (!target) return
 
       const expectedType = getBlockExpectedType(node)
+
+      // Unknown expectation — don't judge. sameType(x, '') is always false,
+      // so flagging here would mark perfectly valid links as broken.
+      if (!expectedType) return
 
       const isTheSameType = sameType(target.type.value, expectedType)
 

--- a/src/frontend/utils/save-project.ts
+++ b/src/frontend/utils/save-project.ts
@@ -57,6 +57,70 @@ export function sanitizePou(pou: PLCPou, editor: EditorLike | undefined): PLCPou
   return stripGraphicalSelections(next)
 }
 
+/**
+ * Canonicalize one graphical node for persistence. Beyond clearing selection
+ * state, this neutralizes runtime UI state that would otherwise byte-drift
+ * the serialized file against HEAD without any semantic change:
+ *
+ *   - `data.hasDivergence` is a render-time decoration (library-divergence
+ *     tooltip) that can leak into the store via rungLocal-derived writes.
+ *   - top-level `draggable` is toggled at runtime (drag-lock while a variable
+ *     input is focused); `data.draggable` is the design-time value set by the
+ *     node builders, so persist that instead.
+ */
+function sanitizeGraphicalNode(node: Record<string, unknown>): Record<string, unknown> {
+  const data = node.data as Record<string, unknown> | undefined
+  const { hasDivergence: _hasDivergence, ...cleanData } = data ?? {}
+  return {
+    ...node,
+    ...(data !== undefined ? { data: cleanData } : {}),
+    selected: false,
+    dragging: false,
+    draggable: Boolean(cleanData.draggable),
+  }
+}
+
+/**
+ * Deterministic `reactFlowViewport` from content, mirroring the formula in
+ * RungBody.updateReactFlowPanelExtent: bounds over all nodes plus the
+ * synthetic 150×40 origin node, floored at `defaultBounds`, +20px height
+ * padding. The runtime writes measured, timing-dependent values into
+ * `reactFlowViewport` (window size, drag history), so persisting the raw
+ * value makes byte stability depend on UI state. Serializing a pure function
+ * of content keeps unchanged rungs byte-identical. Returns the existing value
+ * when the rung lacks the inputs (e.g. FBD rungs have no defaultBounds).
+ */
+function canonicalRungViewport(rung: Record<string, unknown>): unknown {
+  const nodes = rung.nodes
+  const defaultBounds = rung.defaultBounds
+  if (!Array.isArray(nodes) || !Array.isArray(defaultBounds)) return rung.reactFlowViewport
+
+  let minX = 0
+  let minY = 0
+  let maxX = 150
+  let maxY = 40
+  for (const n of nodes as Array<Record<string, unknown>>) {
+    const pos = n.position as { x?: number; y?: number } | undefined
+    const measured = n.measured as { width?: number; height?: number } | undefined
+    const x = pos?.x ?? 0
+    const y = pos?.y ?? 0
+    const w = measured?.width ?? (n.width as number | undefined) ?? 0
+    const h = measured?.height ?? (n.height as number | undefined) ?? 0
+    if (x < minX) minX = x
+    if (y < minY) minY = y
+    if (x + w > maxX) maxX = x + w
+    if (y + h > maxY) maxY = y + h
+  }
+
+  let width = maxX - minX
+  let height = maxY - minY
+  const defaultWidth = Number(defaultBounds[0]) || 0
+  const defaultHeight = Number(defaultBounds[1]) || 0
+  if (width < defaultWidth) width = defaultWidth
+  if (height < defaultHeight) height = defaultHeight
+  return [width, height + 20]
+}
+
 function stripGraphicalSelections(pou: PLCPou): PLCPou {
   const lang = pou.body.language
   if (lang !== 'ld' && lang !== 'fbd') return pou
@@ -74,12 +138,9 @@ function stripGraphicalSelections(pou: PLCPou): PLCPou {
           rungs: (body.rungs as Array<Record<string, unknown>>).map((rung) => ({
             ...rung,
             selectedNodes: [],
+            reactFlowViewport: canonicalRungViewport(rung),
             nodes: Array.isArray(rung.nodes)
-              ? (rung.nodes as Array<Record<string, unknown>>).map((n) => ({
-                  ...n,
-                  selected: false,
-                  dragging: false,
-                }))
+              ? (rung.nodes as Array<Record<string, unknown>>).map(sanitizeGraphicalNode)
               : rung.nodes,
           })),
         },
@@ -99,11 +160,7 @@ function stripGraphicalSelections(pou: PLCPou): PLCPou {
             ...rung,
             selectedNodes: [],
             nodes: Array.isArray(rung.nodes)
-              ? (rung.nodes as Array<Record<string, unknown>>).map((n) => ({
-                  ...n,
-                  selected: false,
-                  dragging: false,
-                }))
+              ? (rung.nodes as Array<Record<string, unknown>>).map(sanitizeGraphicalNode)
               : rung.nodes,
           },
         },


### PR DESCRIPTION
Jira: DOPE-477

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/596

Shared-frontend mirror — the diff is byte-identical to the web PR except:
- `src/backend/web/utils/graphical-diff.ts` exists only in the web PR (the editor's `computeGraphicalDiff` is `unsupported`)
- lockfiles

See the web PR for the full problem/root-cause/fix breakdown and validation notes. Summary: raw-flow persistence (no Zod strip drift), transient drag-lock updates, canonical rung serialization, variable-pin identity reuse across layout rebuilds, variable-pin type validation fix (self-healing `wrongVariable`/`broken-*` corruption), and the stale diff-view HEAD cache fix.

Migration note: projects saved with the previous serialization show a one-time Modified diff per graphical POU on first save; committing it once migrates the file.

Validation on this repo: affected suites 159 tests green (jest), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYE8gdREZQNYQeLfFuuZ9T

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant node writes on blur when submitted variable/contact names match current values; focus/blur updates are now treated as UI-only (non-dirty).
  * Improved diff viewer reliability by using correct HEAD readiness, refreshing diffs after saved/deleted changes, and merging HEAD cache entries safely.
  * Preserved ladder/FBD diagram content fidelity by validating with schemas but persisting raw flow data (minus transient flags).
  * Kept ladder variable-node IDs stable across rebuilds and drag/drop, including identity reuse when variables are stripped.
  * Improved graphical diagram saving by removing UI selection/dragging state and normalizing viewport/layout deterministically.
* **Tests**
  * Added/updated coverage for diff caching/refresh, transient update behavior, variable identity reuse, and variable/type sync edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->