### PR TITLE
fix: File -> Open did nothing when open project had unsaved changes (DOPE-447)

### DIFF
--- a/src/frontend/components/_organisms/modals/save-changes-modal.tsx
+++ b/src/frontend/components/_organisms/modals/save-changes-modal.tsx
@@ -43,7 +43,7 @@ const SaveChangesModal = ({ isOpen, validationContext, onAfterAction, ...rest }:
   const capabilities = useCapabilities()
 
   const {
-    sharedWorkspaceActions: { clearStatesOnCloseProject },
+    sharedWorkspaceActions: { clearStatesOnCloseProject, handleOpenProjectResponse },
   } = useOpenPLCStore()
 
   const clearAndClose = () => {
@@ -64,9 +64,13 @@ const SaveChangesModal = ({ isOpen, validationContext, onAfterAction, ...rest }:
         clearAndClose()
         openModal('create-project', null)
         return
-      case 'open-project':
-        await projectPort.openProject()
+      case 'open-project': {
+        const result = await projectPort.openProject()
+        if (result.success && result.data) {
+          handleOpenProjectResponse(result.data)
+        }
         return
+      }
       case 'open-recent-project':
       case 'open-project-by-path':
         // Execute the deferred action (e.g., re-open the recent project)


### PR DESCRIPTION
## Summary

Fixes [DOPE-447](https://autonomylogic.atlassian.net/browse/DOPE-447): with a project open and unsaved changes present, File -> Open showed the save-changes prompt, then the file picker — but the selected project never loaded.

## Root cause

The save-changes modal's `'open-project'` case called `projectPort.openProject()` and discarded the result, so `handleOpenProjectResponse` was never dispatched and the picked project data was thrown away. This is the same defect pattern fixed for the saved/initial-state path in 595670203 — this path was missed.

## Fix

`save-changes-modal.tsx`: await the picker result and dispatch `handleOpenProjectResponse(result.data)`, mirroring the accelerator-handler and start-screen flows. `handleOpenProjectResponse` already runs `clearStatesOnCloseProject()` first, so tabs/editors/flow state are reset before the new project loads.

## Verification

- ESLint and `tsc --noEmit` pass
- File remains byte-identical with the openplc-web mirror

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQFVaMMwCZ77YYJKHSaWRM

[DOPE-447]: https://autonomylogic.atlassian.net/browse/DOPE-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the save-changes flow when opening a project so the app now handles successful results more reliably.
  * After a successful open-project action, the app now continues with the returned data instead of stopping early, helping ensure the next screen or state updates correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->