### PR TITLE
fix: located Output-class variable in main PROGRAM wipes all POU variables on reopen (DOPE-445)

### DIFF
--- a/src/backend/shared/utils/__tests__/parse-project-files.test.ts
+++ b/src/backend/shared/utils/__tests__/parse-project-files.test.ts
@@ -212,6 +212,42 @@ describe('parseProjectFiles — fallback POU creation', () => {
     consoleSpy.mockRestore()
   })
 
+  it('warns and preserves declarations when a PROGRAM has a located interface-class variable (issue #904)', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const pouFiles: RawProjectFile[] = [
+      {
+        relativePath: 'pous/programs/main.st',
+        content:
+          'PROGRAM main\nVAR_OUTPUT\n  Q1 : BOOL AT %QX0.0;\nEND_VAR\nVAR\n  latch : RS;\nEND_VAR\n\n\nEND_PROGRAM',
+      },
+    ]
+    const result = parseProjectFiles('/p', makeProjectJson(), makeDeviceConfig(), makePinMapping(), pouFiles, [], [])
+    // Falls back: the structured variable list is empty, but the raw
+    // declarations survive in variablesText for in-app repair.
+    expect(result.projectData.pous).toHaveLength(1)
+    expect(result.projectData.pous[0].interface?.variables).toEqual([])
+    expect(result.projectData.pous[0].variablesText).toContain('AT %QX0.0')
+    // The failure is surfaced: names the POU and file, states the offending
+    // rule, and points at the repair path.
+    expect(result.warnings).toBeDefined()
+    const warning = result.warnings!.find((w) => w.includes('pous/programs/main.st'))
+    expect(warning).toContain('POU "main"')
+    expect(warning).toMatch(/Location \("AT"\) is not allowed for variables of class "OUTPUT"/)
+    expect(warning).toContain('code view')
+    consoleSpy.mockRestore()
+  })
+
+  it('warns with a partial-data message when a graphical POU fails to parse', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const pouFiles: RawProjectFile[] = [
+      { relativePath: 'pous/programs/FbdPou.fbd', content: 'PROGRAM FbdPou\nnot valid json\nEND_PROGRAM' },
+    ]
+    const result = parseProjectFiles('/p', makeProjectJson(), makeDeviceConfig(), makePinMapping(), pouFiles, [], [])
+    expect(result.warnings).toBeDefined()
+    expect(result.warnings!.some((w) => w.includes('FbdPou') && w.includes('partial data'))).toBe(true)
+    consoleSpy.mockRestore()
+  })
+
   it('fallback extracts documentation from (* ... *) comments', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const pouFiles: RawProjectFile[] = [

--- a/src/backend/shared/utils/parse-project-files.ts
+++ b/src/backend/shared/utils/parse-project-files.ts
@@ -257,7 +257,7 @@ function foldLegacyVariableAliases(value: unknown): unknown {
   return value
 }
 
-function parsePouFile(file: RawProjectFile): (PLCPou & { variablesText?: string }) | null {
+function parsePouFile(file: RawProjectFile, warnings: string[]): (PLCPou & { variablesText?: string }) | null {
   const ext = file.relativePath.split('.').pop()?.toLowerCase()
   /* istanbul ignore if -- defensive: parseProjectFiles upstream only forwards files whose
      extension matched the POU file glob; an extension-less file path can never reach here */
@@ -303,9 +303,20 @@ function parsePouFile(file: RawProjectFile): (PLCPou & { variablesText?: string 
     }
   } catch (err) {
     console.error(`[parseProjectFiles] Failed to parse POU: ${file.relativePath}`, err)
+    const pouName = getBaseNameFromPath(file.relativePath)
+    const reason =
+      err instanceof Error ? err.message : /* istanbul ignore next -- every parser throw site uses Error */ String(err)
+    // Surface the failure on project open (the console panel shows these
+    // warnings) instead of silently loading the POU with no variables —
+    // GitHub issue #904. For textual POUs the raw declarations survive in
+    // `variablesText`, so point the user at the in-app repair path.
+    warnings.push(
+      language === 'st' || language === 'il'
+        ? `POU "${pouName}" (${file.relativePath}) could not be fully parsed: ${reason} Its variable declarations were preserved as raw text — open the POU's variables editor in code view, fix the declaration, and save.`
+        : `POU "${pouName}" (${file.relativePath}) could not be fully parsed and was loaded with partial data: ${reason}`,
+    )
     // Fallback: preserve as much data as possible
     try {
-      const pouName = getBaseNameFromPath(file.relativePath)
       return createFallbackPou(file.content, language, pouType, pouName)
     } catch (fallbackErr) {
       /* istanbul ignore next -- defensive: createFallbackPou itself is non-throwing for any
@@ -465,7 +476,7 @@ export function parseProjectFiles(
   // Parse POU files
   const pous: (PLCPou & { variablesText?: string })[] = []
   for (const file of filteredPouFiles) {
-    const pou = parsePouFile(file)
+    const pou = parsePouFile(file, warnings)
     if (pou) {
       // Ensure all POUs have a name (derive from filename if missing)
       if (!pou.name) {

--- a/src/frontend/components/_molecules/variables-table/editable-cell.tsx
+++ b/src/frontend/components/_molecules/variables-table/editable-cell.tsx
@@ -568,7 +568,12 @@ const EditableLocationCell = ({
       />
     ) : null
 
-  return selected ? (
+  // The read-only rule must gate the selected branch too: without the
+  // `isEditable()` check the combobox rendered fully interactive on any
+  // selected row, letting the user attach a location to an interface-class
+  // (input/output/inOut/external/temp) variable — an invalid declaration
+  // that broke the project on reopen (GitHub issue #904).
+  return selected && isEditable() ? (
     <div className='flex w-full flex-1 items-center gap-1'>
       {warningGlyph}
       <GenericComboboxCell

--- a/src/frontend/components/_organisms/variables-editor/index.tsx
+++ b/src/frontend/components/_organisms/variables-editor/index.tsx
@@ -961,7 +961,7 @@ const VariablesEditor = ({ name: propName, isActive: _isActive = true }: Variabl
       setParseError(null)
       handleFileAndWorkspaceSavedState(editor.meta.name)
 
-      if (freshPou && freshPou.interface && 'variablesText' in freshPou.interface) {
+      if (freshPou && 'variablesText' in freshPou) {
         clearPouVariablesText(editor.meta.name)
       }
 

--- a/src/frontend/store/__tests__/project-validation-variables.test.ts
+++ b/src/frontend/store/__tests__/project-validation-variables.test.ts
@@ -180,6 +180,11 @@ describe('checkVariableName', () => {
 // ===========================================================================
 
 describe('createVariableValidation', () => {
+  it('strips the location when creating an interface-class variable (issue #904)', () => {
+    const result = createVariableValidation([], makeVariable('Q1', 'BOOL', '%QX0.0', 'output'))
+    expect(result).toEqual({ name: 'Q1', location: '' })
+  })
+
   it('returns unchanged name and location when no conflicts', () => {
     const variable = makeVariable('NewVar', 'INT', '')
     const result = createVariableValidation([], variable)
@@ -410,10 +415,19 @@ describe('createVariableValidation', () => {
 describe('updateVariableValidation', () => {
   const existingVars = [makeVariable('Var1', 'INT', '%QW0'), makeVariable('Var2', 'BOOL', '%QX0.0')]
 
-  it('returns ok: true when updating class only', () => {
+  it('clears an existing location when class changes to an interface class (issue #904)', () => {
+    // Var1 holds location '%QW0'; a located VAR_OUTPUT entry is invalid IEC
+    // and would fail to parse on project reopen, so the class change must
+    // clear the location in the same update.
     const result = updateVariableValidation(existingVars, { class: 'output' }, existingVars[0])
     expect(result.ok).toBe(true)
-    expect(result.data).toEqual({ class: 'output' })
+    expect(result.data).toEqual({ class: 'output', location: '' })
+  })
+
+  it('keeps the location when class changes to local', () => {
+    const result = updateVariableValidation(existingVars, { class: 'local' }, existingVars[0])
+    expect(result.ok).toBe(true)
+    expect(result.data).toEqual({ class: 'local' })
   })
 
   // -- Name validation --
@@ -441,6 +455,27 @@ describe('updateVariableValidation', () => {
   })
 
   // -- Location validation --
+  it('rejects a location on an interface-class variable (issue #904)', () => {
+    const outputVar = makeVariable('OutVar', 'BOOL', '', 'output')
+    const result = updateVariableValidation([outputVar], { location: '%QX0.1' }, outputVar)
+    expect(result.ok).toBe(false)
+    expect(result.title).toContain('Location is not allowed')
+    expect(result.message).toContain('OUTPUT')
+  })
+
+  it('rejects a combined update setting an interface class and a location together', () => {
+    const localVar = makeVariable('LVar', 'BOOL', '')
+    const result = updateVariableValidation([localVar], { class: 'input', location: '%IX0.0' }, localVar)
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('INPUT')
+  })
+
+  it('accepts a location in a combined update that sets class local', () => {
+    const inputVar = makeVariable('IVar', 'BOOL', '', 'input')
+    const result = updateVariableValidation([], { class: 'local', location: '%QX0.0' }, inputVar)
+    expect(result.ok).toBe(true)
+  })
+
   it('returns error when location already exists', () => {
     const result = updateVariableValidation(existingVars, { location: '%QW0' }, existingVars[1])
     expect(result.ok).toBe(false)

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -1902,6 +1902,38 @@ describe('createSharedSlice', () => {
         }
       })
 
+      it('delivers the raw variable text to the auto-opened main POU (issue #904)', () => {
+        // The reporter's exact scenario: "main" itself carries the
+        // unparseable variables. The auto-open block adds and activates a
+        // default table-mode model for it BEFORE the code-mode pass runs —
+        // addModel no-ops on the duplicate and setEditor early-returns on
+        // the active editor, so the raw text must flow through
+        // updateModelVariablesForName to reach the active editor.
+        const rawText = 'VAR_OUTPUT\n  Q1 : BOOL AT %QX0.0;\nEND_VAR'
+        const data = makeMinimalProjectResponse()
+        const unparseableMain = {
+          name: 'main',
+          pouType: 'program' as const,
+          interface: { variables: [] as PLCVariable[] },
+          body: { language: 'st' as const, value: '' },
+          documentation: '',
+          variablesText: rawText,
+        }
+        data.projectData.pous.length = 0
+        data.projectData.pous.push(unparseableMain)
+
+        store.getState().sharedWorkspaceActions.handleOpenProjectResponse(data)
+
+        // main was auto-opened and is the active editor
+        const state = store.getState()
+        expect(state.editor.meta.name).toBe('main')
+        // The active editor must show the preserved declarations in code view
+        expect('variable' in state.editor && state.editor.variable).toEqual({
+          display: 'code',
+          code: rawText,
+        })
+      })
+
       it('does not create code-mode model for POU with variables (non-empty)', () => {
         const data = makeMinimalProjectResponse()
         // main has variables, so no variablesText processing should occur

--- a/src/frontend/store/slices/project/validation/variables.ts
+++ b/src/frontend/store/slices/project/validation/variables.ts
@@ -1,4 +1,5 @@
 import type { PLCVariable } from '../../../../../middleware/shared/ports/types'
+import { DISALLOWED_LOCATION_CLASSES } from '../../../../utils/generate-iec-string-to-variables'
 import {
   BOOL_LOCATION_REGEX,
   DWORD_LOCATION_REGEX,
@@ -308,7 +309,12 @@ const createVariableValidation = (
   variables: PLCVariable[],
   variable: PLCVariable,
 ): { name: string; location: string } => {
-  const { name: variableName, location: variableLocation } = variable
+  const { name: variableName } = variable
+  // Interface-class variables cannot carry a physical location — the ST
+  // parser rejects such declarations when the project is reopened
+  // (GitHub issue #904). Strip the location instead of rejecting so
+  // creation flows that clone an existing row as a template still succeed.
+  const variableLocation = DISALLOWED_LOCATION_CLASSES.includes(variable.class) ? '' : variable.location
   const response = { name: variableName, location: variableLocation }
 
   if (checkIfVariableExists(variables, variableName)) {
@@ -351,7 +357,16 @@ const updateVariableValidation = (
 ) => {
   let response: ProjectResponse = { ok: true }
 
-  if (dataToBeUpdated.class) response.data = { class: dataToBeUpdated.class }
+  if (dataToBeUpdated.class) {
+    // Switching to an interface class makes an existing physical location
+    // invalid IEC — the saved declaration would fail to parse on reopen
+    // (GitHub issue #904) — so clear the location in the same update.
+    // Enforced here (not only in the table UI) so every caller keeps the
+    // invariant.
+    response.data = DISALLOWED_LOCATION_CLASSES.includes(dataToBeUpdated.class)
+      ? { class: dataToBeUpdated.class, location: '' }
+      : { class: dataToBeUpdated.class }
+  }
 
   if (dataToBeUpdated.name || dataToBeUpdated.name === '') {
     const { name } = dataToBeUpdated
@@ -385,6 +400,21 @@ const updateVariableValidation = (
 
   if (dataToBeUpdated.location) {
     const { location } = dataToBeUpdated
+
+    // A physical location is only valid on `local` (VAR) and `global`
+    // (VAR_GLOBAL) declarations — mirrors the parser rule that makes a
+    // located interface-class variable un-parseable on project reopen
+    // (GitHub issue #904).
+    const effectiveClass = dataToBeUpdated.class ?? variableToUpdate.class
+    if (effectiveClass && DISALLOWED_LOCATION_CLASSES.includes(effectiveClass)) {
+      response = {
+        ok: false,
+        title: 'Location is not allowed.',
+        message: `Variables of class "${effectiveClass.toUpperCase()}" cannot have a physical location ("AT"). Use class LOCAL for located variables.`,
+      }
+      return response
+    }
+
     // Exclude the variable being updated so re-setting its own
     // location (e.g. re-picking the same address to refresh a
     // renamed alias) doesn't trip the uniqueness check on itself.

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -843,11 +843,19 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
             model.variable = { display: 'code', code: pouWithText.variablesText }
           }
           getState().editorActions.addModel(model)
-          // If this is the active editor (main POU), update it too
-          /* istanbul ignore next -- setEditor early-returns when name matches current editor */
-          if (getState().editor.meta.name === pou.name) {
-            getState().editorActions.setEditor(model)
-          }
+          // The auto-open block above may already have added and activated a
+          // default table-mode model for this POU (it prefers "main" — exactly
+          // the POU most likely to carry the unparseable variables). `addModel`
+          // no-ops on duplicates and `setEditor` early-returns when the name
+          // matches the active editor, so neither can deliver the raw text to
+          // an existing model — the code view would show an empty skeleton
+          // instead of the preserved declarations. `updateModelVariablesForName`
+          // updates whichever object holds the POU: the active editor or the
+          // stored model.
+          getState().editorActions.updateModelVariablesForName(pou.name, {
+            display: 'code',
+            code: pouWithText.variablesText,
+          })
         }
       })
 

--- a/src/frontend/utils/__tests__/generate-iec-string-to-variables.test.ts
+++ b/src/frontend/utils/__tests__/generate-iec-string-to-variables.test.ts
@@ -191,6 +191,13 @@ describe('parseIecStringToVariables', () => {
     expect(() => parseIecStringToVariables(input)).toThrow(/Location.*not allowed.*OUTPUT/)
   })
 
+  it('includes the offending line and a repair hint in the located-class error (issue #904)', () => {
+    const input = 'VAR_OUTPUT\n  actuator AT %QX0.0 : BOOL;\nEND_VAR'
+    expect(() => parseIecStringToVariables(input)).toThrow(
+      'Syntax error on line 2: "actuator AT %QX0.0 : BOOL;". Location ("AT") is not allowed for variables of class "OUTPUT". Move "actuator" to a VAR block (class LOCAL) or remove the "AT %QX0.0" clause.',
+    )
+  })
+
   it('throws when location is used with inOut class', () => {
     const input = 'VAR_IN_OUT\n  x AT %MW0 : INT;\nEND_VAR'
     expect(() => parseIecStringToVariables(input)).toThrow(/Location.*not allowed.*INOUT/)

--- a/src/frontend/utils/generate-iec-string-to-variables.ts
+++ b/src/frontend/utils/generate-iec-string-to-variables.ts
@@ -12,6 +12,21 @@ const varBlockToClass: Record<string, PLCVariable['class']> = {
   VAR_GLOBAL: 'global',
 }
 
+/**
+ * Classes whose declarations cannot carry a physical location ("AT").
+ * IEC 61131-3 only allows located declarations in VAR and VAR_GLOBAL
+ * blocks — interface sections describe the call contract, not hardware.
+ * Shared with the store-level variable validation so edit time and load
+ * time enforce the same rule (GitHub issue #904).
+ */
+export const DISALLOWED_LOCATION_CLASSES: ReadonlyArray<PLCVariable['class']> = [
+  'input',
+  'output',
+  'inOut',
+  'external',
+  'temp',
+]
+
 // Primary format: name : type AT location := initialValue ; (* documentation *)
 const lineRegex =
   // eslint-disable-next-line no-useless-escape
@@ -120,11 +135,9 @@ export const parseIecStringToVariables = (
 
     const { name, location, type, initialValue, documentation } = match.groups
 
-    const disallowedLocationClasses: Array<PLCVariable['class']> = ['input', 'output', 'inOut', 'external', 'temp']
-
-    if (location && disallowedLocationClasses.includes(currentClass)) {
+    if (location && DISALLOWED_LOCATION_CLASSES.includes(currentClass)) {
       throw new Error(
-        `Syntax error on line ${lineNumber}: Location ("AT") is not allowed for variables of class "${currentClass.toUpperCase()}".`,
+        `Syntax error on line ${lineNumber}: "${line}". Location ("AT") is not allowed for variables of class "${currentClass.toUpperCase()}". Move "${name}" to a VAR block (class LOCAL) or remove the "AT ${location}" clause.`,
       )
     }
 


### PR DESCRIPTION
Fixes #904 · Jira: DOPE-445

## Problem

A variable with an interface class (`input`/`output`/`inOut`/`external`/`temp`) **and** a physical location (`AT %QX...`) is invalid IEC 61131-3. The editor let users create one anyway, saved it, and on reopen the ST parser rejected the declaration — **silently discarding every variable of the POU** (including FB instance variables), so the program no longer ran.

## Root causes & fixes

1. **UI hole** (`variables-table/editable-cell.tsx`): the location cell's *selected-row* branch rendered a fully interactive combobox, ignoring the existing `isEditable()` read-only rule — this is how the location got attached to an `Output`-class variable. The selected branch now honors the guard.
2. **No store-level enforcement** (`validation/variables.ts`): `updateVariable` now rejects setting a location on an interface-class variable, clears the location when the class changes to one, and `createVariable` strips it — using a `DISALLOWED_LOCATION_CLASSES` constant shared with the ST parser so edit time and load time enforce the same rule.
3. **Silent load failure** (`parse-project-files.ts`): a POU that fails to parse now pushes a warning (surfaced in the console panel on project open) naming the POU, file, and offending declaration, instead of only `console.error`.
4. **Repair path**:
   - the parser error now includes the offending line and a fix hint (*Move "Q1" to a VAR block (class LOCAL) or remove the "AT %QX0.0" clause*);
   - the preserved raw declarations now actually reach the auto-opened POU's code view (`shared/slice.ts` routed them through `addModel`/`setEditor`, which both no-op when the model already exists/is active — the raw text was dropped for exactly the auto-opened `main` POU);
   - committing repaired code to table view now clears the stale fallback `variablesText` (`variables-editor/index.tsx` checked the field on `pou.interface`, but it lives on the POU top level), so a later table-mode save no longer resurrects the broken declaration.

## Recovery for already-corrupted projects

Opening an affected project now shows a console warning with the exact line and fix, the variables editor opens in code view with the preserved declarations, and saving after the repair persists correctly from either code or table view.

## Tests

- New regression tests: parser repair-hint message, class↔location cross-validation (update/create), fallback warning + `variablesText` preservation on load, raw-text delivery to the auto-opened POU.
- Full suite green; `tsc`, ESLint, Prettier clean. Touched covered files at 100% functions/lines/statements.
- Manually validated in the app: corrupted-project open → console warning → code-view repair → save → reopen (both save paths).

Mirror of: https://github.com/Autonomy-Logic/openplc-web/pull/598

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsPXB6bqvFU4RLBQ6snwDp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for variables with physical locations, preventing invalid declarations from being saved or reopened.
  * Added clearer error messages and repair guidance when a variable uses an unsupported location.
  * Fixed project loading so files with partial parsing still open with usable content and visible warnings.
  * Preserved raw variable declarations in code view when structured parsing fails, helping recover affected items more easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
