### PR TITLE
perf(graphical-editor): migrate to narrow zustand selectors (DOPE-487)

### DIFF
--- a/src/frontend/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
@@ -31,14 +31,10 @@ type FBDBlockAutoCompleteProps = ComponentPropsWithRef<'div'> & {
 const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProps>(
   ({ block: unknownBlock, isOpen, setIsOpen, keyPressed, valueToSearch }: FBDBlockAutoCompleteProps, ref) => {
     const pouName = useBoundPou()
-    const {
-      project: {
-        data: { pous },
-      },
-      projectActions: { createVariable },
-      fbdFlows,
-      fbdFlowActions: { updateNode, addNode },
-    } = useOpenPLCStore()
+    const pous = useOpenPLCStore((state) => state.project.data.pous)
+    const createVariable = useOpenPLCStore((state) => state.projectActions.createVariable)
+    const fbdFlows = useOpenPLCStore((state) => state.fbdFlows)
+    const { updateNode, addNode } = useOpenPLCStore((state) => state.fbdFlowActions)
 
     const block = unknownBlock as Node<BasicNodeData> & { positionAbsoluteX?: number; positionAbsoluteY?: number }
     const { edges, rung } = useMemo(() => {

--- a/src/frontend/components/_atoms/graphical-editor/fbd/block.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/fbd/block.tsx
@@ -49,18 +49,10 @@ export const BlockNodeElement = <T extends object>({
 }) => {
   const pouName = useBoundPou()
   const editor = useBoundEditorModel()
-  const {
-    editorActions: { updateModelVariables, updateModelFBD },
-    libraries,
-    fbdFlows,
-    fbdFlowActions: { setNodes, setEdges },
-    project,
-    project: {
-      data: { pous },
-    },
-    projectActions: { updateVariable, deleteVariable },
-    snapshotActions: { pushToHistory },
-  } = useOpenPLCStore()
+  const { updateModelVariables, updateModelFBD } = useOpenPLCStore((state) => state.editorActions)
+  const { setNodes, setEdges } = useOpenPLCStore((state) => state.fbdFlowActions)
+  const { updateVariable, deleteVariable } = useOpenPLCStore((state) => state.projectActions)
+  const pushToHistory = useOpenPLCStore((state) => state.snapshotActions.pushToHistory)
 
   const {
     name: blockName,
@@ -82,9 +74,6 @@ export const BlockNodeElement = <T extends object>({
   const inputNameRef = useRef<HTMLInputElement>(null)
   const [inputNameFocus, setInputNameFocus] = useState<boolean>(true)
 
-  const { pou, rung, node, variables, edges } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
-    nodeId: nodeId ?? '',
-  })
   /**
    * useEffect to focus the name input when the correct block type is selected
    */
@@ -118,6 +107,16 @@ export const BlockNodeElement = <T extends object>({
     if (blockNameValue === blockName) {
       return
     }
+
+    const { project, libraries, fbdFlows } = useOpenPLCStore.getState()
+    const { pou, rung, node, variables, edges } = getFBDPouVariablesRungNodeAndEdges(
+      pouName,
+      project.data.pous,
+      fbdFlows,
+      {
+        nodeId: nodeId ?? '',
+      },
+    )
 
     const libraryBlock = libraries.system.flatMap((block) => block.pous).find((pou) => pou.name === blockNameValue)
 
@@ -331,17 +330,13 @@ export const BlockNodeElement = <T extends object>({
 export const Block = <T extends object>(block: BlockProps<T>) => {
   const { data, dragging, height, width, selected, id } = block
   const pouName = useBoundPou()
-  const {
-    project,
-    project: {
-      data: { pous },
-    },
-    projectActions: { createVariable },
-    snapshotActions: { pushToHistory },
-    libraries: { user: userLibraries },
-    fbdFlows,
-    fbdFlowActions: { updateNode, setNodes, setEdges },
-  } = useOpenPLCStore()
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
+  const createVariable = useOpenPLCStore((state) => state.projectActions.createVariable)
+  const pushToHistory = useOpenPLCStore((state) => state.snapshotActions.pushToHistory)
+  const { updateNode, setNodes, setEdges } = useOpenPLCStore((state) => state.fbdFlowActions)
+  // Pou-scoped subscription: immer's structural sharing keeps this flow's
+  // identity stable when other POUs' flows (or unrelated slices) change.
+  const flow = useOpenPLCStore((state) => state.fbdFlows.find((f) => f.name === pouName))
   const { type: blockType } = (data.variant as BlockVariant) ?? DEFAULT_BLOCK_TYPE
   const documentation = getBlockDocumentation(data.variant as BlockVariant)
 
@@ -349,7 +344,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
   const [wrongVariable, setWrongVariable] = useState<boolean>(false)
   const [hoveringBlock, setHoveringBlock] = useState(false)
 
-  const { rung, node, variables } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
+  const { rung, node, variables } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, flow ? [flow] : [], {
     nodeId: id ?? '',
   })
 
@@ -456,6 +451,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
       return
     }
 
+    const { fbdFlows } = useOpenPLCStore.getState()
     const { rung, node, variables } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
       nodeId: id,
     })
@@ -508,7 +504,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
       if (matchingVariable) {
         variableToLink = matchingVariable
       } else if (createIfNotFound) {
-        const pouData = project.data.pous.find((p) => p.name === pouName)
+        const pouData = pous.find((p) => p.name === pouName)
         pushToHistory(pouName, {
           variables: pouData?.interface?.variables ?? [],
           body: pouData?.body.value,
@@ -550,6 +546,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
   }
 
   const handleUpdateDivergence = () => {
+    const { fbdFlows, libraries } = useOpenPLCStore.getState()
     const { rung, node, pou } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
       nodeId: id,
     })
@@ -558,7 +555,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
     const variant = (node.data as BlockNodeData<BlockVariant>)?.variant
     if (!variant) return
 
-    const libMatch = userLibraries.find((lib) => lib.name === variant.name && lib.type === variant.type)
+    const libMatch = libraries.user.find((lib) => lib.name === variant.name && lib.type === variant.type)
     if (!libMatch) return
 
     const libPou = pous.find((pou) => pou.name === libMatch.name)

--- a/src/frontend/components/_atoms/graphical-editor/fbd/comment.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/fbd/comment.tsx
@@ -12,14 +12,8 @@ import { CommentNode, CommentProps } from './utils/types'
 const CommentElement = (block: CommentProps) => {
   const { id, selected, data, width, height } = block
   const pouName = useBoundPou()
-  const {
-    editorActions: { updateModelFBD },
-    fbdFlows,
-    fbdFlowActions: { updateNode },
-    project: {
-      data: { pous },
-    },
-  } = useOpenPLCStore()
+  const updateModelFBD = useOpenPLCStore((state) => state.editorActions.updateModelFBD)
+  const updateNode = useOpenPLCStore((state) => state.fbdFlowActions.updateNode)
 
   const blockRef = useRef<HTMLDivElement>(null)
   const inputVariableRef = useRef<
@@ -48,7 +42,8 @@ const CommentElement = (block: CommentProps) => {
       return
     }
 
-    const { node: commentaryBlock } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
+    const { project, fbdFlows } = useOpenPLCStore.getState()
+    const { node: commentaryBlock } = getFBDPouVariablesRungNodeAndEdges(pouName, project.data.pous, fbdFlows, {
       nodeId: id,
     })
     if (!commentaryBlock) return
@@ -98,7 +93,8 @@ const CommentElement = (block: CommentProps) => {
   }, [commentFocused])
 
   const handleSubmitCommentaryValueOnTextareaBlur = () => {
-    const { node: commentaryBlock } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
+    const { project, fbdFlows } = useOpenPLCStore.getState()
+    const { node: commentaryBlock } = getFBDPouVariablesRungNodeAndEdges(pouName, project.data.pous, fbdFlows, {
       nodeId: id,
     })
     if (!commentaryBlock) return

--- a/src/frontend/components/_atoms/graphical-editor/fbd/connection.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/fbd/connection.tsx
@@ -19,14 +19,9 @@ import { getFBDPouVariablesRungNodeAndEdges } from './utils/utils'
 const ConnectionElement = (block: ConnectionProps) => {
   const { id, data, selected, type } = block
   const pouName = useBoundPou()
-  const {
-    editorActions: { updateModelFBD },
-    fbdFlows,
-    fbdFlowActions: { updateNode },
-    project: {
-      data: { pous },
-    },
-  } = useOpenPLCStore()
+  const updateModelFBD = useOpenPLCStore((state) => state.editorActions.updateModelFBD)
+  const updateNode = useOpenPLCStore((state) => state.fbdFlowActions.updateNode)
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
 
   const inputConnectionRef = useRef<
     HTMLTextAreaElement & {
@@ -66,6 +61,7 @@ const ConnectionElement = (block: ConnectionProps) => {
    * Update inputError state when the variable is updated
    */
   useEffect(() => {
+    const { fbdFlows } = useOpenPLCStore.getState()
     const { rung, node: connectionNode } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
       nodeId: id,
     })
@@ -95,6 +91,7 @@ const ConnectionElement = (block: ConnectionProps) => {
   const handleSubmitConnectionValueOnTextareaBlur = (connectionName?: string) => {
     const connectionNameToSubmit = connectionName || connectionValue
 
+    const { fbdFlows } = useOpenPLCStore.getState()
     const {
       pou,
       rung,

--- a/src/frontend/components/_atoms/graphical-editor/fbd/variable.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/fbd/variable.tsx
@@ -41,14 +41,9 @@ import { getFBDPouVariablesRungNodeAndEdges } from './utils/utils'
 const VariableElement = (block: VariableProps) => {
   const { id, data, selected } = block
   const pouName = useBoundPou()
-  const {
-    editorActions: { updateModelFBD },
-    fbdFlows,
-    fbdFlowActions: { updateNode },
-    project: {
-      data: { pous },
-    },
-  } = useOpenPLCStore()
+  const updateModelFBD = useOpenPLCStore((state) => state.editorActions.updateModelFBD)
+  const updateNode = useOpenPLCStore((state) => state.fbdFlowActions.updateNode)
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
 
   const debugger_ = useDebugger()
   const isDebuggerVisible = useIsDebuggerVisible()
@@ -87,7 +82,7 @@ const VariableElement = (block: VariableProps) => {
   /**
    * Get the connection type
    */
-  const flow = useMemo(() => fbdFlows.find((flow) => flow.name === pouName), [fbdFlows, pouName])
+  const flow = useOpenPLCStore((state) => state.fbdFlows.find((flow) => flow.name === pouName))
 
   const connections = useMemo(() => {
     const rung = flow?.rung
@@ -277,7 +272,7 @@ const VariableElement = (block: VariableProps) => {
 
   const getVariableType = (): string | undefined => {
     if (!data.variable || !data.variable.name) return undefined
-    const { pou } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, { nodeId: id })
+    const pou = pous.find((pou) => pou.name === pouName)
     if (!pou) return undefined
     const variable = (pou.interface?.variables ?? []).find(
       (v: PLCVariable) => v.name.toLowerCase() === data.variable.name.toLowerCase(),
@@ -421,7 +416,8 @@ const VariableElement = (block: VariableProps) => {
   const handleSubmitVariableValueOnTextareaBlur = (variableName?: string) => {
     const variableNameToSubmit = variableName || variableValue
 
-    const { pou, rung, node } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
+    const { project, fbdFlows } = useOpenPLCStore.getState()
+    const { pou, rung, node } = getFBDPouVariablesRungNodeAndEdges(pouName, project.data.pous, fbdFlows, {
       nodeId: id,
     })
     if (!pou || !rung || !node) return

--- a/src/frontend/components/_atoms/graphical-editor/ladder/autocomplete/index.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/autocomplete/index.tsx
@@ -54,14 +54,9 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
     ref,
   ) => {
     const pouName = useBoundPou()
-    const {
-      project: {
-        data: { pous },
-      },
-      projectActions: { createVariable },
-      ladderFlows,
-      ladderFlowActions: { updateNode },
-    } = useOpenPLCStore()
+    const pous = useOpenPLCStore((state) => state.project.data.pous)
+    const createVariable = useOpenPLCStore((state) => state.projectActions.createVariable)
+    const updateNode = useOpenPLCStore((state) => state.ladderFlowActions.updateNode)
 
     const expectedType = expectedTypeForBlock(block, blockType)
 
@@ -84,9 +79,15 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
     }, [pouName, valueToSearch, expectedType, blockType, pous])
 
     const submitVariableToBlock = (variable: PLCVariable) => {
-      const { rung, node: variableNode } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
-        nodeId: (block as Node<BasicNodeData>).id,
-      })
+      const { project, ladderFlows } = useOpenPLCStore.getState()
+      const { rung, node: variableNode } = getLadderPouVariablesRungNodeAndEdges(
+        pouName,
+        project.data.pous,
+        ladderFlows,
+        {
+          nodeId: (block as Node<BasicNodeData>).id,
+        },
+      )
       if (!rung || !variableNode) return
 
       updateNode({
@@ -143,13 +144,19 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
     }
 
     const submitAddVariable = ({ variableName }: { variableName: string }) => {
+      const { project, ladderFlows } = useOpenPLCStore.getState()
       if (!variableName.trim()) {
         // For variable nodes on block handles, clearing the name resets the variable
         // so that a branch (contacts/coils) can be placed on the handle instead.
         if (blockType === 'variable') {
-          const { rung, node: variableNode } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
-            nodeId: (block as Node<BasicNodeData>).id,
-          })
+          const { rung, node: variableNode } = getLadderPouVariablesRungNodeAndEdges(
+            pouName,
+            project.data.pous,
+            ladderFlows,
+            {
+              nodeId: (block as Node<BasicNodeData>).id,
+            },
+          )
           if (rung && variableNode) {
             updateNode({
               editorName: pouName,
@@ -175,7 +182,7 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
         return
       }
 
-      const { rung, node } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+      const { rung, node } = getLadderPouVariablesRungNodeAndEdges(pouName, project.data.pous, ladderFlows, {
         nodeId: (block as Node<BasicNodeData>).id,
       })
       if (!rung || !node) return

--- a/src/frontend/components/_atoms/graphical-editor/ladder/block.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/block.tsx
@@ -59,17 +59,10 @@ export const BlockNodeElement = <T extends object>({
 }) => {
   const pouName = useBoundPou()
   const editor = useBoundEditorModel()
-  const {
-    editorActions: { updateModelVariables },
-    libraries,
-    ladderFlows,
-    ladderFlowActions: { setNodes, setEdges, setHandleBranches },
-    project: {
-      data: { pous },
-    },
-    projectActions: { updateVariable, deleteVariable },
-    snapshotActions: { pushToHistory },
-  } = useOpenPLCStore()
+  const updateModelVariables = useOpenPLCStore((state) => state.editorActions.updateModelVariables)
+  const { setNodes, setEdges, setHandleBranches } = useOpenPLCStore((state) => state.ladderFlowActions)
+  const { updateVariable, deleteVariable } = useOpenPLCStore((state) => state.projectActions)
+  const pushToHistory = useOpenPLCStore((state) => state.snapshotActions.pushToHistory)
 
   const {
     name: blockName,
@@ -166,6 +159,8 @@ export const BlockNodeElement = <T extends object>({
       return
     }
 
+    const { project, libraries, ladderFlows } = useOpenPLCStore.getState()
+    const pous = project.data.pous
     const libraryBlock = resolveLibraryBlock(blockNameValue, libraries, pous)
 
     if (!libraryBlock) {
@@ -405,26 +400,21 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
   const { data, dragging, height, width, selected, id } = block
 
   const pouName = useBoundPou()
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
+  const createVariable = useOpenPLCStore((state) => state.projectActions.createVariable)
+  const pushToHistory = useOpenPLCStore((state) => state.snapshotActions.pushToHistory)
   const {
-    project: {
-      data: { pous },
-    },
-    projectActions: { createVariable },
-    snapshotActions: { pushToHistory },
-    libraries: { user: userLibraries },
-    ladderFlows,
-    ladderFlowActions: { updateNode, setNodes, setEdges, setHandleBranches: setHandleBranchesBlock },
-  } = useOpenPLCStore()
+    updateNode,
+    setNodes,
+    setEdges,
+    setHandleBranches: setHandleBranchesBlock,
+  } = useOpenPLCStore((state) => state.ladderFlowActions)
   const { type: blockType } = (data.variant as BlockVariant) ?? DEFAULT_BLOCK_TYPE
   const documentation = getBlockDocumentation(data.variant as newBlockVariant)
 
   const [blockVariableValue, setBlockVariableValue] = useState<string>('')
   const [wrongVariable, setWrongVariable] = useState<boolean>(false)
   const [hoveringBlock, setHoveringBlock] = useState(false)
-
-  const { variables, rung, node } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
-    nodeId: id,
-  })
 
   const connectedOutputNames = useMemo(() => {
     const names = new Set<string>()
@@ -461,6 +451,10 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
       switch (blockType) {
         case 'function-block': {
           if (!data.variable || data.variable.name === '') {
+            const { project, ladderFlows } = useOpenPLCStore.getState()
+            const { variables } = getLadderPouVariablesRungNodeAndEdges(pouName, project.data.pous, ladderFlows, {
+              nodeId: id,
+            })
             const { name, number } = checkVariableName(variables.all, (data.variant as BlockVariant).name.toUpperCase())
 
             handleSubmitBlockVariableOnTextareaBlur(`${name}${number}`, true)
@@ -485,6 +479,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
       return
     }
 
+    const { ladderFlows } = useOpenPLCStore.getState()
     const {
       variables: freshVariables,
       rung: freshRung,
@@ -550,6 +545,11 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
       setWrongVariable(true)
       return
     }
+
+    const { ladderFlows } = useOpenPLCStore.getState()
+    const { variables, rung, node } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+      nodeId: id,
+    })
 
     if (!rung || !node) {
       toast({ title: 'Error', description: 'Could not find the related rung or node', variant: 'fail' })
@@ -641,6 +641,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
   }
 
   const handleUpdateDivergence = () => {
+    const { ladderFlows, libraries } = useOpenPLCStore.getState()
     const { variables, rung, node, edges } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
       nodeId: id,
     })
@@ -650,7 +651,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
     const variant = (node.data as BlockNodeData<BlockVariant>)?.variant
     if (!variant) return
 
-    const libMatch = userLibraries.find((lib) => lib.name === variant.name && lib.type === variant.type)
+    const libMatch = libraries.user.find((lib) => lib.name === variant.name && lib.type === variant.type)
     if (!libMatch) return
 
     const libPou = pous.find((pou) => pou.name === libMatch.name)
@@ -879,6 +880,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
             handleSubmit={() => handleSubmitBlockVariableOnTextareaBlur(blockVariableValue, false)}
             onFocus={(e) => {
               e.target.select()
+              const { ladderFlows } = useOpenPLCStore.getState()
               const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
                 nodeId: id,
               })
@@ -898,6 +900,7 @@ export const Block = <T extends object>(block: BlockProps<T>) => {
               return
             }}
             onBlur={() => {
+              const { ladderFlows } = useOpenPLCStore.getState()
               const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
                 nodeId: id,
               })

--- a/src/frontend/components/_atoms/graphical-editor/ladder/coil.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/coil.tsx
@@ -21,13 +21,8 @@ export type { CoilNode } from './utils/types'
 export const Coil = (block: CoilProps) => {
   const { selected, data, id } = block
   const pouName = useBoundPou()
-  const {
-    project: {
-      data: { pous },
-    },
-    ladderFlows,
-    ladderFlowActions: { updateNode },
-  } = useOpenPLCStore()
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
+  const updateNode = useOpenPLCStore((state) => state.ladderFlowActions.updateNode)
 
   const debugger_ = useDebugger()
   const isDebuggerVisible = useIsDebuggerVisible()
@@ -149,7 +144,8 @@ export const Coil = (block: CoilProps) => {
    */
   const handleSubmitCoilVariableOnTextareaBlur = (variableName?: string) => {
     const variableNameToSubmit = variableName || coilVariableValue
-    const { rung, node } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+    const { project, ladderFlows } = useOpenPLCStore.getState()
+    const { rung, node } = getLadderPouVariablesRungNodeAndEdges(pouName, project.data.pous, ladderFlows, {
       nodeId: id,
       variableName: variableNameToSubmit,
     })
@@ -215,7 +211,8 @@ export const Coil = (block: CoilProps) => {
             readOnly={isDebuggerVisible}
             onFocus={(e) => {
               e.target.select()
-              const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+              const { project, ladderFlows } = useOpenPLCStore.getState()
+              const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, project.data.pous, ladderFlows, {
                 nodeId: id ?? '',
               })
               if (!node || !rung) return
@@ -234,7 +231,8 @@ export const Coil = (block: CoilProps) => {
               return
             }}
             onBlur={() => {
-              const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+              const { project, ladderFlows } = useOpenPLCStore.getState()
+              const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, project.data.pous, ladderFlows, {
                 nodeId: id ?? '',
               })
               if (!node || !rung) return

--- a/src/frontend/components/_atoms/graphical-editor/ladder/contact.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/contact.tsx
@@ -21,13 +21,8 @@ export type { ContactNode } from './utils/types'
 export const Contact = (block: ContactProps) => {
   const { selected, data, id } = block
   const pouName = useBoundPou()
-  const {
-    project: {
-      data: { pous },
-    },
-    ladderFlows,
-    ladderFlowActions: { updateNode },
-  } = useOpenPLCStore()
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
+  const updateNode = useOpenPLCStore((state) => state.ladderFlowActions.updateNode)
 
   const debugger_ = useDebugger()
   const isDebuggerVisible = useIsDebuggerVisible()
@@ -150,7 +145,8 @@ export const Contact = (block: ContactProps) => {
    */
   const handleSubmitContactVariableOnTextareaBlur = (variableName?: string) => {
     const variableNameToSubmit = variableName || contactVariableValue
-    const { rung, node } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+    const { project, ladderFlows } = useOpenPLCStore.getState()
+    const { rung, node } = getLadderPouVariablesRungNodeAndEdges(pouName, project.data.pous, ladderFlows, {
       nodeId: id,
       variableName: variableNameToSubmit,
     })
@@ -216,7 +212,8 @@ export const Contact = (block: ContactProps) => {
             readOnly={isDebuggerVisible}
             onFocus={(e) => {
               e.target.select()
-              const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+              const { project, ladderFlows } = useOpenPLCStore.getState()
+              const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, project.data.pous, ladderFlows, {
                 nodeId: id ?? '',
               })
               if (!node || !rung) return
@@ -235,7 +232,8 @@ export const Contact = (block: ContactProps) => {
               return
             }}
             onBlur={() => {
-              const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+              const { project, ladderFlows } = useOpenPLCStore.getState()
+              const { node, rung } = getLadderPouVariablesRungNodeAndEdges(pouName, project.data.pous, ladderFlows, {
                 nodeId: id ?? '',
               })
               if (!node || !rung) return

--- a/src/frontend/components/_atoms/graphical-editor/ladder/variable.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/variable.tsx
@@ -34,13 +34,8 @@ import { BlockNodeData, BlockVariant, LadderBlockConnectedVariables, VariableNod
 const VariableElement = (block: VariableProps) => {
   const { id, data } = block
   const pouName = useBoundPou()
-  const {
-    project: {
-      data: { pous },
-    },
-    ladderFlows,
-    ladderFlowActions: { updateNode },
-  } = useOpenPLCStore()
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
+  const updateNode = useOpenPLCStore((state) => state.ladderFlowActions.updateNode)
   const debugger_ = useDebugger()
   const isDebuggerVisible = useIsDebuggerVisible()
   const getCompositeKey = useDebugCompositeKey()
@@ -165,7 +160,8 @@ const VariableElement = (block: VariableProps) => {
   const handleSubmitVariableValueOnTextareaBlur = (currentValue?: string) => {
     const variableNameToSubmit = currentValue ?? variableValue
 
-    const { pou, rung, node } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+    const { project, ladderFlows } = useOpenPLCStore.getState()
+    const { pou, rung, node } = getLadderPouVariablesRungNodeAndEdges(pouName, project.data.pous, ladderFlows, {
       nodeId: id,
     })
     if (!pou || !rung || !node) return
@@ -238,7 +234,7 @@ const VariableElement = (block: VariableProps) => {
 
   const getVariableType = (): string | undefined => {
     if (!data.variable || !data.variable.name) return undefined
-    const { pou } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, { nodeId: id })
+    const pou = pous.find((pou) => pou.name === pouName)
     if (!pou) return undefined
     const variable = (pou.interface?.variables ?? []).find(
       (v) => v.name.toLowerCase() === data.variable.name.toLowerCase(),

--- a/src/frontend/components/_features/[workspace]/editor/graphical/elements/fbd/block/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/elements/fbd/block/index.tsx
@@ -64,17 +64,12 @@ const searchLibraryByPouName = (
 const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: BlockElementProps<T>) => {
   const pouName = useBoundPou()
   const editor = useBoundEditorModel()
-  const {
-    editorActions: { updateModelVariables },
-    fbdFlows,
-    fbdFlowActions: { setNodes, setEdges },
-    project: {
-      data: { pous },
-    },
-    projectActions: { updateVariable, deleteVariable },
-    libraries,
-    modalActions: { onOpenChange },
-  } = useOpenPLCStore()
+  const updateModelVariables = useOpenPLCStore((state) => state.editorActions.updateModelVariables)
+  const { setNodes, setEdges } = useOpenPLCStore((state) => state.fbdFlowActions)
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
+  const { updateVariable, deleteVariable } = useOpenPLCStore((state) => state.projectActions)
+  const libraries = useOpenPLCStore((state) => state.libraries)
+  const onOpenChange = useOpenPLCStore((state) => state.modalActions.onOpenChange)
 
   const maxInputs = 20
 
@@ -362,6 +357,7 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
       executionOrder: Number(formState.executionOrder),
     }
 
+    const { fbdFlows } = useOpenPLCStore.getState()
     const { rung, edges, variables } = getFBDPouVariablesRungNodeAndEdges(pouName, pous, fbdFlows, {
       nodeId: selectedNode.id,
     })

--- a/src/frontend/components/_features/[workspace]/editor/graphical/elements/fbd/block/library.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/elements/fbd/block/library.tsx
@@ -16,12 +16,9 @@ export const ModalBlockLibrary = ({
   setSelectedFileKey: (string: string) => void
 }) => {
   const pouName = useBoundPou()
-  const {
-    project: {
-      data: { pous },
-    },
-    libraries: { system, user },
-  } = useOpenPLCStore()
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
+  const system = useOpenPLCStore((state) => state.libraries.system)
+  const user = useOpenPLCStore((state) => state.libraries.user)
   // Scope the visible system pool to bundled (canonical) +
   // project-enabled libraries — same gate the explorer's library
   // tree uses, so the picker shows exactly what the project can

--- a/src/frontend/components/_features/[workspace]/editor/graphical/elements/ladder/block/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/elements/ladder/block/index.tsx
@@ -63,17 +63,12 @@ const searchLibraryByPouName = (libraries: LibraryState['libraries'], pous: PLCP
 const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: BlockElementProps<T>) => {
   const pouName = useBoundPou()
   const editor = useBoundEditorModel()
-  const {
-    editorActions: { updateModelVariables },
-    ladderFlows,
-    ladderFlowActions: { setNodes, setEdges, setHandleBranches },
-    project: {
-      data: { pous },
-    },
-    projectActions: { updateVariable, deleteVariable },
-    libraries,
-    modalActions: { onOpenChange },
-  } = useOpenPLCStore()
+  const updateModelVariables = useOpenPLCStore((state) => state.editorActions.updateModelVariables)
+  const { setNodes, setEdges, setHandleBranches } = useOpenPLCStore((state) => state.ladderFlowActions)
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
+  const { updateVariable, deleteVariable } = useOpenPLCStore((state) => state.projectActions)
+  const libraries = useOpenPLCStore((state) => state.libraries)
+  const onOpenChange = useOpenPLCStore((state) => state.modalActions.onOpenChange)
 
   const maxInputs = 20
 
@@ -372,6 +367,7 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
       executionOrder: Number(formState.executionOrder),
     }
 
+    const { ladderFlows } = useOpenPLCStore.getState()
     const { rung, edges, variables } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
       nodeId: selectedNode.id,
     })

--- a/src/frontend/components/_features/[workspace]/editor/graphical/elements/ladder/block/library.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/elements/ladder/block/library.tsx
@@ -16,12 +16,9 @@ export const ModalBlockLibrary = ({
   setSelectedFileKey: (string: string) => void
 }) => {
   const pouName = useBoundPou()
-  const {
-    project: {
-      data: { pous },
-    },
-    libraries: { system, user },
-  } = useOpenPLCStore()
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
+  const system = useOpenPLCStore((state) => state.libraries.system)
+  const user = useOpenPLCStore((state) => state.libraries.user)
   // Scope the visible system pool to bundled (canonical) +
   // project-enabled libraries — same gate the FBD picker and the
   // explorer's library tree use.

--- a/src/frontend/components/_features/[workspace]/editor/graphical/elements/ladder/coil/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/elements/ladder/coil/index.tsx
@@ -15,14 +15,8 @@ type CoilElementProps = {
 
 const CoilElement = ({ isOpen, onClose, node }: CoilElementProps) => {
   const pouName = useBoundPou()
-  const {
-    ladderFlows,
-    project: {
-      data: { pous },
-    },
-    ladderFlowActions: { updateNode },
-    modalActions: { onOpenChange },
-  } = useOpenPLCStore()
+  const updateNode = useOpenPLCStore((state) => state.ladderFlowActions.updateNode)
+  const onOpenChange = useOpenPLCStore((state) => state.modalActions.onOpenChange)
 
   const [selectedModifier, setSelectedModifier] = useState<string | null>(node?.data.variant as string)
   const coilModifiers = Object.entries(DEFAULT_COIL_TYPES).map(([label, coil]) => ({
@@ -42,7 +36,8 @@ const CoilElement = ({ isOpen, onClose, node }: CoilElementProps) => {
   }
 
   const handleConfirmAlteration = () => {
-    const { rung } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+    const { project, ladderFlows } = useOpenPLCStore.getState()
+    const { rung } = getLadderPouVariablesRungNodeAndEdges(pouName, project.data.pous, ladderFlows, {
       nodeId: node.id,
     })
     if (!rung) return

--- a/src/frontend/components/_features/[workspace]/editor/graphical/elements/ladder/contact/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/elements/ladder/contact/index.tsx
@@ -15,14 +15,8 @@ type ContactElementProps = {
 
 const ContactElement = ({ isOpen, onClose, node }: ContactElementProps) => {
   const pouName = useBoundPou()
-  const {
-    ladderFlows,
-    project: {
-      data: { pous },
-    },
-    ladderFlowActions: { updateNode },
-    modalActions: { onOpenChange },
-  } = useOpenPLCStore()
+  const updateNode = useOpenPLCStore((state) => state.ladderFlowActions.updateNode)
+  const onOpenChange = useOpenPLCStore((state) => state.modalActions.onOpenChange)
 
   const [selectedModifier, setSelectedModifier] = useState<string | null>(node?.data.variant as string)
   const contactModifiers = Object.entries(DEFAULT_CONTACT_TYPES).map(([label, contact]) => ({
@@ -42,7 +36,8 @@ const ContactElement = ({ isOpen, onClose, node }: ContactElementProps) => {
   }
 
   const handleConfirmAlteration = () => {
-    const { rung } = getLadderPouVariablesRungNodeAndEdges(pouName, pous, ladderFlows, {
+    const { project, ladderFlows } = useOpenPLCStore.getState()
+    const { rung } = getLadderPouVariablesRungNodeAndEdges(pouName, project.data.pous, ladderFlows, {
       nodeId: node.id,
     })
     if (!rung) return

--- a/src/frontend/components/_features/[workspace]/editor/graphical/ladder/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/ladder/index.tsx
@@ -40,21 +40,23 @@ export default function LadderEditor() {
   // in the wrapper one level up.  Mirrors `FbdEditor` — see that
   // file for the multi-mount rationale.
   const pouName = useBoundPou()
-  const {
-    ladderFlows,
-    ladderFlowActions,
-    searchNodePosition,
-    modals,
-    project: {
-      data: { pous },
-    },
-    projectActions: { updatePou },
-    modalActions: { closeModal },
-    sharedWorkspaceActions: { handleFileAndWorkspaceSavedState },
-    snapshotActions: { pushToHistory },
-    libraries: { user: userLibraries },
-    workspace: { isDebuggerVisible },
-  } = useOpenPLCStore()
+  // Pou-scoped subscription: immer's structural sharing keeps this flow's
+  // identity stable when other POUs' flows (or unrelated slices) change.
+  const flow = useOpenPLCStore((state) => state.ladderFlows.find((f) => f.name === pouName))
+  const ladderFlowActions = useOpenPLCStore((state) => state.ladderFlowActions)
+  const searchNodePosition = useOpenPLCStore((state) => state.searchNodePosition)
+  const blockElementModal = useOpenPLCStore((state) => state.modals['block-ladder-element'])
+  const contactElementModal = useOpenPLCStore((state) => state.modals['contact-ladder-element'])
+  const coilElementModal = useOpenPLCStore((state) => state.modals['coil-ladder-element'])
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
+  const updatePou = useOpenPLCStore((state) => state.projectActions.updatePou)
+  const closeModal = useOpenPLCStore((state) => state.modalActions.closeModal)
+  const handleFileAndWorkspaceSavedState = useOpenPLCStore(
+    (state) => state.sharedWorkspaceActions.handleFileAndWorkspaceSavedState,
+  )
+  const pushToHistory = useOpenPLCStore((state) => state.snapshotActions.pushToHistory)
+  const userLibraries = useOpenPLCStore((state) => state.libraries.user)
+  const isDebuggerVisible = useOpenPLCStore((state) => state.workspace.isDebuggerVisible)
 
   const captureSnapshot = useCallback(
     (pouName: string): PouHistorySnapshot | null => {
@@ -71,7 +73,6 @@ export default function LadderEditor() {
 
   const updateModelLadder = ladderSelectors.useUpdateModelLadder()
 
-  const flow = ladderFlows.find((flow) => flow.name === pouName)
   const rungs = flow?.rungs || []
   const flowUpdated = flow?.updated || false
 
@@ -308,25 +309,25 @@ export default function LadderEditor() {
         </DndContext>
         <CreateRung onClick={handleAddNewRung} />
         <Portal.Root>
-          {modals['block-ladder-element']?.open && (
+          {blockElementModal?.open && (
             <BlockElement
               onClose={handleModalClose}
-              selectedNode={modals['block-ladder-element'].data as BlockNode<BlockVariant>}
-              isOpen={modals['block-ladder-element'].open}
+              selectedNode={blockElementModal.data as BlockNode<BlockVariant>}
+              isOpen={blockElementModal.open}
             />
           )}
-          {modals['contact-ladder-element']?.open && (
+          {contactElementModal?.open && (
             <ContactElement
               onClose={handleModalClose}
-              node={modals['contact-ladder-element'].data as ContactNode}
-              isOpen={modals['contact-ladder-element'].open}
+              node={contactElementModal.data as ContactNode}
+              isOpen={contactElementModal.open}
             />
           )}
-          {modals['coil-ladder-element']?.open && (
+          {coilElementModal?.open && (
             <CoilElement
               onClose={handleModalClose}
-              node={modals['coil-ladder-element'].data as CoilNode}
-              isOpen={modals['coil-ladder-element'].open}
+              node={coilElementModal.data as CoilNode}
+              isOpen={coilElementModal.open}
             />
           )}
         </Portal.Root>

--- a/src/frontend/components/_molecules/graphical-editor/fbd/fbd-utils/useCopyPaste.ts
+++ b/src/frontend/components/_molecules/graphical-editor/fbd/fbd-utils/useCopyPaste.ts
@@ -39,7 +39,7 @@ export const useFBDClipboard = ({
 }) => {
   const pouName = useBoundPou()
   const isActive = useIsGraphicalEditorActive()
-  const { fbdFlowActions } = useOpenPLCStore()
+  const fbdFlowActions = useOpenPLCStore((state) => state.fbdFlowActions)
 
   // True when the clipboard event originated from a DOM node inside
   // this FBD instance's viewport.  Used to scope **copy** and **cut**

--- a/src/frontend/components/_molecules/graphical-editor/fbd/index.tsx
+++ b/src/frontend/components/_molecules/graphical-editor/fbd/index.tsx
@@ -51,21 +51,18 @@ export const FBDBody = ({ rung, nodeDivergences = [], isDebuggerActive = false }
   // tab store mutations don't fire effects against the wrong flow.
   const pouName = useBoundPou()
   const editor = useBoundEditorModel()
-  const {
-    editorActions: { updateModelVariables },
-    fbdFlowActions,
-    libraries,
-    project,
-    projectActions: { deleteVariable },
-    modals,
-    modalActions: { closeModal, openModal },
-  } = useOpenPLCStore()
+  const updateModelVariables = useOpenPLCStore((state) => state.editorActions.updateModelVariables)
+  const fbdFlowActions = useOpenPLCStore((state) => state.fbdFlowActions)
+  const deleteVariable = useOpenPLCStore((state) => state.projectActions.deleteVariable)
+  const { closeModal, openModal } = useOpenPLCStore((state) => state.modalActions)
+  const blockElementModal = useOpenPLCStore((state) => state.modals['block-fbd-element'])
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
+  const resourceInstances = useOpenPLCStore((state) => state.project.data.configurations.resource.instances)
   const isDebuggerVisible = useIsDebuggerVisible()
   const debugVariableValues = useDebugBoolValuesMap()
   const debugForcedVariables = useDebugForcedVariablesMap()
   const { captureAndPush } = usePouSnapshot()
 
-  const { pous } = project.data
   const pouRef = pous.find((pou) => pou.name === pouName)
   const getCompositeKey = useDebugCompositeKey()
   const [rungLocal, setRungLocal] = useState<FBDRungState>(rung)
@@ -141,8 +138,7 @@ export const FBDBody = ({ rung, nodeDivergences = [], isDebuggerActive = false }
       if (!sourceHandle) return undefined
 
       if (pouRef?.pouType !== 'function-block') {
-        const instances = project.data.configurations.resource.instances
-        const programInstance = instances.find((inst: { program: string }) => inst.program === pouName)
+        const programInstance = resourceInstances.find((inst: { program: string }) => inst.program === pouName)
         if (!programInstance) return undefined
       }
 
@@ -251,7 +247,7 @@ export const FBDBody = ({ rung, nodeDivergences = [], isDebuggerActive = false }
     debugForcedVariables,
     pouName,
     pouRef?.interface?.variables,
-    project.data.configurations.resource.instances,
+    resourceInstances,
   ])
 
   const styledNodes = useMemo(() => {
@@ -371,6 +367,7 @@ export const FBDBody = ({ rung, nodeDivergences = [], isDebuggerActive = false }
   ) => {
     captureAndPush(pouName)
 
+    const { libraries } = useOpenPLCStore.getState()
     let pouLibrary = undefined
     if (library) {
       const [blockLibraryType, blockLibrary, pouName] = library.split('/')
@@ -678,16 +675,11 @@ export const FBDBody = ({ rung, nodeDivergences = [], isDebuggerActive = false }
 
       handleAddElementByDropping(position, blockType as CustomFbdNodeTypes, library)
     },
-    // `libraries.system`, `libraries.user`, and `pous` aren't read
-    // directly in onDrop's body — `handleAddElementByDropping` closes
-    // over all three.  Omitting any one means the memoized callback
-    // keeps a reference to the pre-update handler, so a freshly
-    // installed system library / freshly created user FB / freshly
-    // saved POU stays invisible until something else forces a re-bind
-    // (full project save resets `rung`, which is why "Save Project"
-    // used to mask this — and why catalog-installed libs threw
-    // "block type ... does not exist" on first drop).
-    [rung, reactFlowInstance, libraries.system, libraries.user, pous],
+    // `handleAddElementByDropping` reads `libraries` via getState() at call
+    // time (never stale) and `pous` via subscription, so unlike the previous
+    // whole-store version this callback no longer needs library deps to
+    // re-bind for freshly installed libraries.
+    [rung, reactFlowInstance, pous],
   )
 
   /**
@@ -790,11 +782,11 @@ export const FBDBody = ({ rung, nodeDivergences = [], isDebuggerActive = false }
           },
         }}
       />
-      {modals['block-fbd-element']?.open && (
+      {blockElementModal?.open && (
         <BlockElement
           onClose={handleModalClose}
-          selectedNode={modals['block-fbd-element'].data as BlockNode<object>}
-          isOpen={modals['block-fbd-element'].open}
+          selectedNode={blockElementModal.data as BlockNode<object>}
+          isOpen={blockElementModal.open}
         />
       )}
     </div>

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/body.tsx
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/body.tsx
@@ -73,22 +73,18 @@ const EDGE_COLOR_TRUE = '#00FF00'
 export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActive = false }: RungBodyProps) => {
   const pouName = useBoundPou()
   const editor = useBoundEditorModel()
-  const {
-    ladderFlowActions,
-    ladderFlows,
-    libraries,
-    editorActions: { updateModelVariables },
-    project,
-    projectActions: { deleteVariable },
-    modalActions: { openModal },
-    searchQuery,
-    searchActions: { setSearchNodePosition },
-  } = useOpenPLCStore()
+  const ladderFlowActions = useOpenPLCStore((state) => state.ladderFlowActions)
+  const updateModelVariables = useOpenPLCStore((state) => state.editorActions.updateModelVariables)
+  const deleteVariable = useOpenPLCStore((state) => state.projectActions.deleteVariable)
+  const openModal = useOpenPLCStore((state) => state.modalActions.openModal)
+  const searchQuery = useOpenPLCStore((state) => state.searchQuery)
+  const setSearchNodePosition = useOpenPLCStore((state) => state.searchActions.setSearchNodePosition)
+  const pous = useOpenPLCStore((state) => state.project.data.pous)
+  const resourceInstances = useOpenPLCStore((state) => state.project.data.configurations.resource.instances)
   const isDebuggerVisible = useIsDebuggerVisible()
   const debugVariableValues = useDebugBoolValuesMap()
 
   const { captureAndPush } = usePouSnapshot()
-  const { pous } = project.data
   const pouRef = pous.find((pou) => pou.name === pouName)
   const getCompositeKey = useDebugCompositeKey()
   const nodeTypes = useMemo(() => customNodeTypes, [])
@@ -188,8 +184,7 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
       if (!sourceHandle) return undefined
 
       if (pouRef?.pouType !== 'function-block') {
-        const instances = project.data.configurations.resource.instances
-        const programInstance = instances.find((inst) => inst.program === pouName)
+        const programInstance = resourceInstances.find((inst) => inst.program === pouName)
         if (!programInstance) return undefined
       }
 
@@ -274,7 +269,16 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
 
       return edge
     })
-  }, [rungLocal.edges, rungLocal.nodes, isDebuggerVisible, debugVariableValues, pouName, project, getCompositeKey])
+  }, [
+    rungLocal.edges,
+    rungLocal.nodes,
+    isDebuggerVisible,
+    debugVariableValues,
+    pouName,
+    pouRef,
+    resourceInstances,
+    getCompositeKey,
+  ])
 
   const styledNodes = useMemo(() => {
     const baseNodes = !isDebuggerVisible
@@ -352,7 +356,8 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
     isDebuggerActive,
     debugVariableValues,
     pouName,
-    project,
+    pouRef,
+    resourceInstances,
     getCompositeKey,
   ])
 
@@ -451,6 +456,7 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
    * Add a new node to the rung
    */
   const handleAddNode = (newNodeType: string = 'mockNode', blockType: string | undefined) => {
+    const { libraries, ladderFlows } = useOpenPLCStore.getState()
     let pouLibrary = undefined
     if (blockType) {
       const [blockLibraryType, blockLibrary, pouName] = blockType.split('/')
@@ -533,6 +539,7 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
    * Remove some nodes from the rung
    */
   const handleRemoveNode = (nodes: FlowNode[]) => {
+    const { ladderFlows } = useOpenPLCStore.getState()
     const { nodes: newNodes, edges: newEdges, handleBranches } = removeElements({ ...rungLocal }, nodes)
 
     captureAndPush(pouName)
@@ -642,6 +649,7 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
    * Handle the stop of a node drag
    */
   const handleNodeDragStop = (node: FlowNode) => {
+    const { ladderFlows } = useOpenPLCStore.getState()
     const result = onElementDrop(rungLocal, rung, node)
 
     captureAndPush(pouName)
@@ -859,24 +867,11 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
       // Then add the node to the rung
       handleAddNode(blockType, library)
     },
-    // `libraries.system`, `libraries.user`, and `pous` aren't read
-    // directly here — `handleAddNode` closes over all three.  Omitting
-    // any of them means the memoized callback keeps a reference to the
-    // pre-update handler, so a freshly installed system library /
-    // freshly created user FB / freshly saved POU stays invisible
-    // until something else forces a re-bind (matches the FBD onDrop
-    // dep set; same failure mode: catalog-installed libs threw
-    // "block type ... does not exist" on first drop).
-    [
-      rung,
-      rungLocal,
-      setReactFlowPanelExtent,
-      reactFlowPanelExtent,
-      isDebuggerActive,
-      libraries.system,
-      libraries.user,
-      pous,
-    ],
+    // `handleAddNode` reads `libraries`/`ladderFlows` via getState() at call
+    // time (never stale) and `pous` via subscription, so unlike the previous
+    // whole-store version this callback no longer needs library/pou deps to
+    // re-bind for freshly installed libraries.
+    [rung, rungLocal, setReactFlowPanelExtent, reactFlowPanelExtent, isDebuggerActive, pous],
   )
 
   return (

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/header.tsx
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/header.tsx
@@ -26,10 +26,8 @@ type RungHeaderProps = {
 
 export const RungHeader = ({ rung, isOpen, draggableHandleProps, className, onClick }: RungHeaderProps) => {
   const editorName = useBoundPou()
-  const {
-    ladderFlowActions: { addComment, duplicateRung },
-    modalActions: { openModal },
-  } = useOpenPLCStore()
+  const { addComment, duplicateRung } = useOpenPLCStore((state) => state.ladderFlowActions)
+  const openModal = useOpenPLCStore((state) => state.modalActions.openModal)
 
   const containerRef = useRef<HTMLDivElement>(null)
   const textAreaRef = useRef<HTMLTextAreaElement>(null)

--- a/src/frontend/components/_organisms/graphical-editor/ladder/rung/index.tsx
+++ b/src/frontend/components/_organisms/graphical-editor/ladder/rung/index.tsx
@@ -22,15 +22,16 @@ type RungProps = {
 }
 
 export const Rung = ({ className, index, id, rung, nodeDivergences, isDebuggerActive }: RungProps) => {
-  const {
-    ladderFlows,
-    editorActions: { updateModelLadder, getIsRungOpen },
-  } = useOpenPLCStore()
+  // Primitive selector: this per-rung component only needs the rung count of
+  // its own flow (for the rounded-corner styling), so subscribe to just that.
+  const rungsCount = useOpenPLCStore(
+    (state) => state.ladderFlows.find((flow) => flow.rungs.some((r) => r.id === rung.id))?.rungs.length ?? 0,
+  )
+  const { updateModelLadder, getIsRungOpen } = useOpenPLCStore((state) => state.editorActions)
 
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id })
 
   const [isOpen, setIsOpen] = useState<boolean>(true)
-  const flow = ladderFlows.find((flow) => flow.rungs.some((r) => r.id === rung.id)) || { rungs: [] }
 
   const handleOpenSection = () => {
     setIsOpen(!isOpen)
@@ -69,14 +70,14 @@ export const Rung = ({ className, index, id, rung, nodeDivergences, isDebuggerAc
         draggableHandleProps={isDebuggerActive ? undefined : listeners}
         className={cn('border border-transparent', {
           'rounded-t-lg': index === 0,
-          'rounded-b-lg': index === flow.rungs.length - 1 && !isOpen,
+          'rounded-b-lg': index === rungsCount - 1 && !isOpen,
         })}
       />
       {getIsRungOpen({ rungId: rung.id }) && (
         <RungBody
           rung={rung}
           className={cn('border border-transparent', {
-            'rounded-b-lg': index === flow.rungs.length - 1,
+            'rounded-b-lg': index === rungsCount - 1,
           })}
           nodeDivergences={nodeDivergences}
           isDebuggerActive={isDebuggerActive}

--- a/src/frontend/hooks/use-pou-snapshot.ts
+++ b/src/frontend/hooks/use-pou-snapshot.ts
@@ -6,17 +6,16 @@ import { useOpenPLCStore } from '../store'
  * Convenience hook wrapping snapshotActions.pushToHistory().
  * Captures the current POU state (variables, body, globalVariables, and
  * graphical flow state for LD/FBD) and pushes it to the undo history.
+ *
+ * State is read via getState() at capture time (not subscribed): the hook
+ * never re-renders its consumers and `captureAndPush` keeps a stable identity.
  */
 export function usePouSnapshot() {
-  const {
-    project,
-    ladderFlows,
-    fbdFlows,
-    snapshotActions: { pushToHistory, undo, redo },
-  } = useOpenPLCStore()
+  const { pushToHistory, undo, redo } = useOpenPLCStore((state) => state.snapshotActions)
 
   const captureAndPush = useCallback(
     (pouName: string) => {
+      const { project, ladderFlows, fbdFlows } = useOpenPLCStore.getState()
       const pou = project.data.pous.find((p) => p.name === pouName)
       if (!pou) return
 
@@ -31,7 +30,7 @@ export function usePouSnapshot() {
         globalVariables: JSON.parse(JSON.stringify(project.data.configurations.resource.globalVariables)),
       })
     },
-    [project.data.pous, project.data.configurations.resource.globalVariables, ladderFlows, fbdFlows, pushToHistory],
+    [pushToHistory],
   )
 
   return { captureAndPush, undo, redo }


### PR DESCRIPTION
# Pull request info

## References

### Link to Jira task

[DOPE-487](https://autonomylogic.atlassian.net/browse/DOPE-487) — Perf 1/5 of [DOPE-446](https://autonomylogic.atlassian.net/browse/DOPE-446)

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/600 (`src/frontend` byte-identical)

## Description of the changes proposed

Root cause **C1** of DOPE-446: 25 graphical-editor call sites subscribed to the whole Zustand store via bare `useOpenPLCStore()`, so any store write (keystroke, poll tick, modal open, tab switch) re-rendered every node of every rung of every open POU.

- **Render-path reads** → narrowest-path selectors: `s.project.data.pous`, `s.libraries.user`, pou-scoped `s.ladderFlows.find(f => f.name === pouName)` (immer structural sharing keeps sibling identities stable), specific modal keys (`modals['block-fbd-element']`…), and primitives where possible (`Rung` now subscribes to just its flow's rung count).
- **Handler-only reads** → `useOpenPLCStore.getState()` at event time: no subscription, no stale closures. The load-bearing `onDrop` dep-array workarounds ("freshly installed library invisible until re-bind") became unnecessary and were removed with updated comments.
- **Actions** → stable action/action-group selects.
- `usePouSnapshot` no longer subscribes at all — reads at capture time, stable `captureAndPush` identity.
- Debug-styling memos in `RungBody`/`FBDBody` now depend on `pouRef`/`resourceInstances` (the values actually read) instead of the whole `project` object.

**Compilation safety:** store writes, flow persistence (raw-object policy from DOPE-477), and the compile pipeline input are untouched — save-without-edit produces a zero source-control diff (manually verified in both apps).

## Validation

Full instrumented A/B in the web mirror (see the mirror PR's table: typing 26–42 whole-editor commits/s → ~2/keystroke local; idle spikes → flat 0; modal open/close worst task 61 ms vs 470 ms full-canvas pass, at 73 mounted rung instances). Electron app manually validated: LD/FBD editing, modals, undo, and save-without-edit → zero source-control diff. Jest suite green.

Known residuals (by design, later subtasks): first-focus full pass until memo barriers land (DOPE-488), rung-duplication scaling (DOPE-489), FBD `onMouseMove` commits (DOPE-491).

## DOD checklist

- [x] The code is complete and according to developers' standards.
- [x] I have performed a self-review of my code.
- [x] Meet the acceptance criteria.
- [x] Unit tests are written and green (jest suite passed).
- [ ] Test coverage: unchanged (no covered-directory code touched).
- [x] Integration tests are written and green.
- [x] Changes were communicated and updated in the ticket description.
- [ ] Reviewed and accepted by the Product Owner.
- [x] End-to-end test are successful (live validation in both apps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3FiQAY3P1gJDnGhuHbAab

[DOPE-487]: https://autonomylogic.atlassian.net/browse/DOPE-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOPE-446]: https://autonomylogic.atlassian.net/browse/DOPE-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graphical editor reliability by ensuring edits, variable updates, drag-and-drop actions, and undo snapshots use the latest project state.
  * Improved ladder and function block rendering consistency, including rung styling and debugger output updates.
* **Performance**
  * Reduced unnecessary editor updates by subscribing only to the data required by each component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->