### PR TITLE
fix(naming): validate element names as IEC identifiers + robust basename on load

### DIFF
--- a/src/backend/shared/utils/__tests__/parse-project-files.test.ts
+++ b/src/backend/shared/utils/__tests__/parse-project-files.test.ts
@@ -212,6 +212,24 @@ describe('parseProjectFiles — fallback POU creation', () => {
     consoleSpy.mockRestore()
   })
 
+  it('derives the fallback name from the basename even for Windows backslash paths', () => {
+    // The desktop reader builds relativePaths with path.join → backslashes on
+    // Windows. A parse failure must still yield the bare basename, not the whole
+    // `pous\functions\...` path (the origin of the deleting-function corruption).
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const pouFiles: RawProjectFile[] = [
+      {
+        relativePath: 'pous\\functions\\Siren_FC.st',
+        // Missing END_FUNCTION / return type → parser throws → fallback.
+        content: 'FUNCTION Siren_FC\nVAR_INPUT\n  x : INT;\nEND_VAR\nbody',
+      },
+    ]
+    const result = parseProjectFiles('/p', makeProjectJson(), makeDeviceConfig(), makePinMapping(), pouFiles, [], [])
+    expect(result.projectData.pous).toHaveLength(1)
+    expect(result.projectData.pous[0].name).toBe('Siren_FC')
+    consoleSpy.mockRestore()
+  })
+
   it('warns and preserves declarations when a PROGRAM has a located interface-class variable (issue #904)', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const pouFiles: RawProjectFile[] = [

--- a/src/backend/shared/utils/parse-project-files.ts
+++ b/src/backend/shared/utils/parse-project-files.ts
@@ -111,11 +111,16 @@ function getLanguageFromExt(relativePath: string): string | null {
 
 /**
  * Extract the base filename without extension from a relative path.
+ *
+ * Splits on BOTH separators: the desktop reader builds relative paths with
+ * `path.join`, which emits backslashes on Windows, so a `/`-only split would
+ * return the whole `pous\functions\Name` path as the "basename" — the origin of
+ * the POU name→path corruption in the "deleting function" bug.
  */
 function getBaseNameFromPath(relativePath: string): string {
   return (
     relativePath
-      .split('/')
+      .split(/[\\/]/)
       .pop()
       ?.replace(/\.\w+$/, '') ?? 'unknown'
   )

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -119,6 +119,12 @@ describe('createSharedSlice', () => {
         expect(result.message).toBe('POU already exists')
       })
 
+      it('rejects a POU name that is not a valid IEC identifier', () => {
+        const result = store.getState().pouActions.create({ type: 'program', name: 'Siren FC', language: 'st' })
+        expect(result.ok).toBe(false)
+        expect(result.message).toContain("'Siren FC'")
+      })
+
       it('creates multiple POUs', () => {
         store.getState().pouActions.create({ type: 'program', name: 'Prog1', language: 'st' })
         store.getState().pouActions.create({ type: 'function', name: 'Func1', language: 'il' })
@@ -230,6 +236,11 @@ describe('createSharedSlice', () => {
         expect(result.message).toBe('POU name already exists')
       })
 
+      it('rejects renaming to a name with path separators (the deleting-function bug)', () => {
+        const result = store.getState().pouActions.rename('OldName', 'pous\\functions\\Siren FC')
+        expect(result.ok).toBe(false)
+      })
+
       it('updates editor name if current editor matches old name', () => {
         // OldName is the current editor
         expect(store.getState().editor.meta.name).toBe('OldName')
@@ -271,6 +282,11 @@ describe('createSharedSlice', () => {
         const result = store.getState().pouActions.duplicate('Source', 'Existing')
         expect(result.ok).toBe(false)
         expect(result.message).toBe('POU name already exists')
+      })
+
+      it('rejects duplicating to an invalid IEC identifier', () => {
+        const result = store.getState().pouActions.duplicate('Source', 'bad name')
+        expect(result.ok).toBe(false)
       })
 
       it('duplicates a function and preserves returnType', () => {
@@ -446,6 +462,11 @@ describe('createSharedSlice', () => {
         expect(result.ok).toBe(false)
         expect(result.message).toBe('Data type already exists')
       })
+
+      it('rejects a data type name that is not a valid IEC identifier', () => {
+        const result = store.getState().datatypeActions.create({ name: 'bad name', derivation: 'array' })
+        expect(result.ok).toBe(false)
+      })
     })
 
     // -----------------------------------------------------------------------
@@ -567,6 +588,11 @@ describe('createSharedSlice', () => {
         expect(result.ok).toBe(false)
         expect(result.message).toBe('Data type name already exists')
       })
+
+      it('rejects duplicating to an invalid IEC identifier', () => {
+        const result = store.getState().datatypeActions.duplicate('SourceDT', 'bad name')
+        expect(result.ok).toBe(false)
+      })
     })
   })
 
@@ -590,6 +616,13 @@ describe('createSharedSlice', () => {
     // -----------------------------------------------------------------------
     // deleteRequest
     // -----------------------------------------------------------------------
+    describe('create', () => {
+      it('rejects a server name that is not a valid IEC identifier', () => {
+        const result = store.getState().serverActions.create({ name: 'bad name', protocol: 'modbus-tcp' })
+        expect(result.ok).toBe(false)
+      })
+    })
+
     describe('deleteRequest', () => {
       it('opens the confirm-delete-element modal with server elementType', () => {
         store.getState().serverActions.deleteRequest('Server1')
@@ -694,6 +727,13 @@ describe('createSharedSlice', () => {
     // -----------------------------------------------------------------------
     // deleteRequest
     // -----------------------------------------------------------------------
+    describe('create', () => {
+      it('rejects a remote device name that is not a valid IEC identifier', () => {
+        const result = store.getState().remoteDeviceActions.create({ name: 'bad name', protocol: 'modbus-tcp' })
+        expect(result.ok).toBe(false)
+      })
+    })
+
     describe('deleteRequest', () => {
       it('opens the confirm-delete-element modal with remote-device elementType', () => {
         store.getState().remoteDeviceActions.deleteRequest('Device1')

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -6,6 +6,7 @@ import { isValidIecIdentifier } from '../../../../middleware/shared/utils/etherc
 import { parseIecStringToVariables } from '../../../utils/generate-iec-string-to-variables'
 import { generateIecVariablesToString } from '../../../utils/generate-iec-variables-to-string'
 import { syncNodesWithVariables, syncNodesWithVariablesFBD } from '../../../utils/graphical/sync-nodes-with-variables'
+import { isLegalIdentifier } from '../../../utils/keywords'
 import { restampFlowLibraryVariants } from '../../../utils/PLC/restamp-library-variants'
 import { collectAllSlaveNames } from '../../../utils/unique-slave-name'
 import type { FBDFlowType } from '../fbd'
@@ -43,6 +44,19 @@ function deleteElement(
   return { ok: true as const }
 }
 
+/**
+ * Reject element names that aren't valid IEC 61131-3 identifiers before they
+ * reach the file-path / parser layer. A name containing a space, slash, or
+ * backslash would otherwise be written straight into the on-disk POU path
+ * (`pous/<folder>/<name>.st`) and — on any parse failure — read back as the
+ * path itself, corrupting the name and orphaning files (the "deleting function"
+ * bug). Reuses the same primitive as variable-name validation for consistency.
+ */
+function validateElementName(name: string): { ok: true } | { ok: false; message: string } {
+  const [legal, reason] = isLegalIdentifier(name)
+  return legal ? { ok: true } : { ok: false, message: `'${name}' ${reason}` }
+}
+
 function renameElement(
   state: SharedRootState,
   oldName: string,
@@ -50,6 +64,9 @@ function renameElement(
   updateInProject: (oldName: string, newName: string) => { ok: boolean; message?: string } | void,
   afterRename?: (oldName: string, newName: string) => void,
 ) {
+  const nameCheck = validateElementName(newName)
+  if (!nameCheck.ok) return { ok: false as const, message: nameCheck.message }
+
   const result = updateInProject(oldName, newName)
   if (result && !result.ok) return { ok: false as const, message: result.message }
 
@@ -81,6 +98,9 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const state = getState()
       const existing = state.project.data.pous.find((p) => p.name === name)
       if (existing) return { ok: false, message: 'POU already exists' }
+
+      const nameCheck = validateElementName(name)
+      if (!nameCheck.ok) return nameCheck
 
       const pouDto = createPouObject({ type, name, language })
       const result = state.projectActions.createPou(pouDto)
@@ -155,6 +175,9 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const existing = state.project.data.pous.find((p) => p.name === newName)
       if (existing) return { ok: false, message: 'POU name already exists' }
 
+      const nameCheck = validateElementName(newName)
+      if (!nameCheck.ok) return nameCheck
+
       // Create a copy of the POU with the new name
       const language = sourcePou.body.language as 'il' | 'st' | 'ld' | 'sfc' | 'fbd' | 'python' | 'cpp'
       const pouDto = createPouObject({ type: sourcePou.pouType, name: newName, language })
@@ -202,6 +225,9 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const state = getState()
       const existing = state.project.data.dataTypes.find((d) => d.name === name)
       if (existing) return { ok: false, message: 'Data type already exists' }
+
+      const nameCheck = validateElementName(name)
+      if (!nameCheck.ok) return nameCheck
 
       const datatype = createDatatypeObject({ name, derivation })
       const result = state.projectActions.createDatatype({ data: datatype })
@@ -254,6 +280,9 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const existing = state.project.data.dataTypes.find((d) => d.name === newName)
       if (existing) return { ok: false, message: 'Data type name already exists' }
 
+      const nameCheck = validateElementName(newName)
+      if (!nameCheck.ok) return nameCheck
+
       const copy = { ...source, name: newName }
       const result = state.projectActions.createDatatype({ data: copy })
       /* istanbul ignore next -- defensive: shared slice already validates name uniqueness */
@@ -273,6 +302,9 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       /* istanbul ignore next -- defensive: servers is always initialized as [] */
       const servers = state.project.data.servers ?? []
       if (servers.some((s) => s.name === name)) return { ok: false, message: 'Server already exists' }
+
+      const nameCheck = validateElementName(name)
+      if (!nameCheck.ok) return nameCheck
 
       const result = state.projectActions.createServer({ data: { name, protocol } })
       /* istanbul ignore next -- defensive: shared slice already validates name uniqueness */
@@ -307,6 +339,9 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       /* istanbul ignore next -- defensive: remoteDevices is always initialized as [] */
       const devices = state.project.data.remoteDevices ?? []
       if (devices.some((d) => d.name === name)) return { ok: false, message: 'Remote device already exists' }
+
+      const nameCheck = validateElementName(name)
+      if (!nameCheck.ok) return nameCheck
 
       const result = state.projectActions.createRemoteDevice({ data: { name, protocol } })
       /* istanbul ignore next -- defensive: shared slice already validates name uniqueness */


### PR DESCRIPTION
Reject non-IEC-identifier names on create/rename/duplicate of POUs, data types, servers, and remote devices (reusing isLegalIdentifier), and make getBaseNameFromPath split on both path separators so a parse-failure fallback yields a clean basename on Windows.

Fixes the "deleting function" corruption (spaced/invalid POU name → parse failure → name rebuilt from the file path → path injected into the on-disk POU path → doubling + orphaned files).

Validated: web vitest (shared-slice 151) + editor jest (shared-slice & parse-project-files 205); tsc + eslint clean. Tested on web and desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project parsing for Windows-style paths so POU names are derived correctly.
  * Added validation to prevent invalid IEC identifiers when creating, renaming, or duplicating POUs, data types, servers, and remote devices.
  * Limited stored history to 50 entries to keep history management consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->