### PR TITLE
fix(project): persist structural changes only on save (unify web + desktop)

### DIFF
--- a/src/frontend/components/_molecules/project-tree/index.tsx
+++ b/src/frontend/components/_molecules/project-tree/index.tsx
@@ -1,7 +1,6 @@
 import * as Popover from '@radix-ui/react-popover'
 import { ComponentPropsWithoutRef, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { useCapabilities, useProject } from '../../../../middleware/shared/providers'
 import { ArrowIcon } from '../../../assets/icons/interface/Arrow'
 import { CloseIcon } from '../../../assets/icons/interface/Close'
 import { ConfigIcon } from '../../../assets/icons/interface/Config'
@@ -31,7 +30,6 @@ import { ServerIcon } from '../../../assets/icons/project/Server'
 import { SFCIcon } from '../../../assets/icons/project/SFC'
 import { STIcon } from '../../../assets/icons/project/ST'
 import { StructureIcon } from '../../../assets/icons/project/Structure'
-import { executeSaveProject } from '../../../services/save-actions'
 import { useOpenPLCStore } from '../../../store'
 import { WorkspaceProjectTreeLeafType } from '../../../store/slices/workspace/types'
 import { cn } from '../../../utils/cn'
@@ -266,9 +264,6 @@ const ProjectTreeExpandableLeaf = ({
     remoteDeviceActions: { deleteRequest: deleteRemoteDeviceRequest, rename: renameRemoteDevice },
     fileActions: { getFile },
   } = useOpenPLCStore()
-  const projectPort = useProject()
-  const capabilities = useCapabilities()
-  const { hasVersionControl } = capabilities
 
   const [isExpanded, setIsExpanded] = useState(true)
   const [isEditing, setIsEditing] = useState(false)
@@ -287,7 +282,7 @@ const ProjectTreeExpandableLeaf = ({
     setSelectedProjectTreeLeaf({ label, type: leafType })
   }
 
-  const handleRenameFile = async (renamed: string) => {
+  const handleRenameFile = (renamed: string) => {
     setIsEditing(false)
     if (!renamed || !label) return
     if (renamed === label) return
@@ -296,15 +291,8 @@ const ProjectTreeExpandableLeaf = ({
       setNewLabel(label || '')
       return
     }
-    // Only auto-persist on platforms that track per-file changes — otherwise
-    // the user's first action on a fresh project triggers a full save with
-    // no version-control benefit. Local editor users keep the existing
-    // "save on Ctrl+S" mental model.
-    if (hasVersionControl) {
-      // Persist immediately so refresh doesn't show the old name (rename
-      // queues the old path's deletion in `pendingDeletions`, save propagates).
-      await executeSaveProject(projectPort, capabilities)
-    }
+    // Soft, unsaved change: renameElement flags the workspace dirty; the rename
+    // persists on the next save, consistently on web and desktop.
   }
 
   const handleDeleteFile = () => {
@@ -519,9 +507,6 @@ const ProjectTreeLeaf = ({
     ethercatDeviceActions: { delete: deleteEthercatDevice, rename: renameEthercatDevice },
     fileActions: { getFile },
   } = useOpenPLCStore()
-  const projectPort = useProject()
-  const capabilities = useCapabilities()
-  const { hasVersionControl } = capabilities
 
   const [isEditing, setIsEditing] = useState(false)
   const [newLabel, setNewLabel] = useState(label || '')
@@ -557,7 +542,7 @@ const ProjectTreeLeaf = ({
     setSelectedProjectTreeLeaf({ label, type: leafType })
   }
 
-  const handleRenameFile = async (newLabel: string) => {
+  const handleRenameFile = (newLabel: string) => {
     setIsEditing(false)
 
     if (!isAPou && !isDatatype && !isServer && !isRemoteDevice && !isEthercatDevice) {
@@ -578,60 +563,33 @@ const ProjectTreeLeaf = ({
       return
     }
 
-    // No-op: user blurred or hit Enter without changing anything. Skip the
-    // auto-save below so we don't persist a phantom rename event.
+    // No-op: user blurred or hit Enter without changing anything.
     if (newLabel === label) return
 
-    // Auto-save on rename only matters on platforms that track per-file
-    // changes (web). Local editor users would otherwise eat a full project
-    // save on every rename with no version-control payoff — so gate the
-    // persist behind the capability and let the editor follow the regular
-    // Ctrl+S flow.
-    const persist = async () => {
-      if (hasVersionControl) await executeSaveProject(projectPort, capabilities)
-    }
-
+    // Renames are soft, unsaved changes: renameElement flags the workspace
+    // dirty and queues the old path in `pendingDeletions`. Nothing is written
+    // to disk until the user saves — identical on web and desktop.
     if (isAPou) {
       const res = renamePou(label, newLabel)
-      if (!res.ok) {
-        setNewLabel(label || '')
-        return
-      }
-      // Persist immediately: rename creates a new file in S3 and removes
-      // the old, plus updates the badge correctly via pendingDeletions.
-      await persist()
+      if (!res.ok) setNewLabel(label || '')
       return
     }
 
     if (isDatatype) {
       const res = renameDatatype(label, newLabel)
-      if (!res.ok) {
-        setNewLabel(label || '')
-        return
-      }
-      // Datatype lives inside project.json — saving rewrites it with the
-      // renamed entry. No separate file deletion needed.
-      await persist()
+      if (!res.ok) setNewLabel(label || '')
       return
     }
 
     if (isServer) {
       const res = renameServer(label, newLabel)
-      if (!res.ok) {
-        setNewLabel(label || '')
-        return
-      }
-      await persist()
+      if (!res.ok) setNewLabel(label || '')
       return
     }
 
     if (isRemoteDevice) {
       const res = renameRemoteDevice(label, newLabel)
-      if (!res.ok) {
-        setNewLabel(label || '')
-        return
-      }
-      await persist()
+      if (!res.ok) setNewLabel(label || '')
       return
     }
 
@@ -648,7 +606,7 @@ const ProjectTreeLeaf = ({
     }
   }
 
-  const handleDuplicateFile = async () => {
+  const handleDuplicateFile = () => {
     if (!isAPou && !isDatatype) {
       toast({
         title: 'Error',
@@ -667,20 +625,15 @@ const ProjectTreeLeaf = ({
       return
     }
 
+    // Duplicating is a soft, unsaved change: the shared duplicate actions flag
+    // the new element dirty; it persists on the next save, like create.
     if (isAPou) {
       duplicatePou(label, `${label}_copy`)
-      // Persist the new POU file to S3 immediately. Without this, the duplicate
-      // exists only in editor memory and disappears on refresh — same class of
-      // bug as the delete flow we fixed in delete-confirmation-modal.
-      await executeSaveProject(projectPort, capabilities)
       return
     }
 
     if (isDatatype) {
       duplicateDatatype(label, `${label}_copy`)
-      // Datatypes live inside project.json; saving the project rewrites it
-      // with the new datatype included.
-      await executeSaveProject(projectPort, capabilities)
       return
     }
 

--- a/src/frontend/components/_organisms/modals/delete-confirmation-modal.tsx
+++ b/src/frontend/components/_organisms/modals/delete-confirmation-modal.tsx
@@ -1,7 +1,5 @@
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
-import { useCapabilities, useProject } from '../../../../middleware/shared/providers'
 import { WarningIcon } from '../../../assets/icons/interface/Warning'
-import { executeSaveProject } from '../../../services/save-actions'
 import { useOpenPLCStore } from '../../../store'
 import type { RungLadderState } from '../../../store/slices/ladder'
 import { BasicNodeData } from '../../_atoms/graphical-editor/ladder/utils/types'
@@ -67,8 +65,6 @@ function resolveDeleteTarget(
 
 const ConfirmDeleteElementModal = ({ rung, isOpen, ...rest }: ConfirmDeleteElementProps) => {
   const store = useOpenPLCStore()
-  const projectPort = useProject()
-  const capabilities = useCapabilities()
   const {
     editor,
     project: {
@@ -147,8 +143,7 @@ const ConfirmDeleteElementModal = ({ rung, isOpen, ...rest }: ConfirmDeleteEleme
     })
   }
 
-  const handleDeleteElement = async (): Promise<void> => {
-    let needsPersist = false
+  const handleDeleteElement = (): void => {
     try {
       // Ladder rung deletion: takes precedence when a rung is provided.
       // Rung deletes are an in-editor edit, not a file-level deletion — they
@@ -175,7 +170,6 @@ const ConfirmDeleteElementModal = ({ rung, isOpen, ...rest }: ConfirmDeleteEleme
             description: `POU "${name}" was successfully deleted.`,
             variant: 'default',
           })
-          needsPersist = true
           break
         case 'datatype':
           deleteDatatypeAction(name)
@@ -194,7 +188,6 @@ const ConfirmDeleteElementModal = ({ rung, isOpen, ...rest }: ConfirmDeleteEleme
             description: `Server "${name}" was successfully deleted.`,
             variant: 'default',
           })
-          needsPersist = true
           break
         case 'remote-device':
           deleteRemoteDeviceAction(name)
@@ -203,7 +196,6 @@ const ConfirmDeleteElementModal = ({ rung, isOpen, ...rest }: ConfirmDeleteEleme
             description: `Remote device "${name}" was successfully deleted.`,
             variant: 'default',
           })
-          needsPersist = true
           break
         default:
           throw new Error('Unknown element type')
@@ -216,16 +208,11 @@ const ConfirmDeleteElementModal = ({ rung, isOpen, ...rest }: ConfirmDeleteEleme
       })
     }
 
+    // Deletions are soft and consistent across web and desktop: the element is
+    // removed from the in-memory project, its file removal is queued in
+    // `pendingDeletions`, and the workspace is flagged dirty (see deleteElement).
+    // Nothing is written to disk until the user saves.
     closeModal()
-
-    // For element types that map to a file in S3 (POU, server, remote device),
-    // trigger a full project save so the deletion is actually persisted.
-    // Otherwise the file stays in S3 and reappears on refresh — only the
-    // local UI state had been updated. executeSaveProject surfaces its own
-    // success/failure toasts.
-    if (needsPersist) {
-      await executeSaveProject(projectPort, capabilities)
-    }
   }
 
   const handleCloseModal = () => {

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -180,6 +180,12 @@ describe('createSharedSlice', () => {
         expect(state.libraries.user).toHaveLength(0)
       })
 
+      it('flags the workspace dirty after delete (persist only on save)', () => {
+        store.getState().workspaceActions.setEditingState('saved')
+        store.getState().pouActions.delete('Main')
+        expect(store.getState().workspace.editingState).toBe('unsaved')
+      })
+
       it('clears editor if current editor matches deleted POU', () => {
         // Main should be the current editor after create
         expect(store.getState().editor.meta.name).toBe('Main')
@@ -223,6 +229,12 @@ describe('createSharedSlice', () => {
         expect(state.libraries.user[0].name).toBe('NewName')
       })
 
+      it('flags the workspace dirty after rename (persist only on save)', () => {
+        store.getState().workspaceActions.setEditingState('saved')
+        store.getState().pouActions.rename('OldName', 'NewName')
+        expect(store.getState().workspace.editingState).toBe('unsaved')
+      })
+
       it('returns error when new name already exists', () => {
         store.getState().pouActions.create({ type: 'function', name: 'Existing', language: 'st' })
         const result = store.getState().pouActions.rename('OldName', 'Existing')
@@ -258,6 +270,12 @@ describe('createSharedSlice', () => {
         // Editor model added but not set as current (no tab opened)
         expect(state.files['Copy']).toBeDefined()
         expect(state.files['Copy'].isNew).toBe(true)
+      })
+
+      it('flags the workspace dirty after duplicate (persist only on save)', () => {
+        store.getState().workspaceActions.setEditingState('saved')
+        store.getState().pouActions.duplicate('Source', 'Copy')
+        expect(store.getState().workspace.editingState).toBe('unsaved')
       })
 
       it('returns error when source POU does not exist', () => {
@@ -553,6 +571,12 @@ describe('createSharedSlice', () => {
         expect(state.project.data.dataTypes[1].name).toBe('CopyDT')
         expect(state.project.data.dataTypes[1].derivation).toBe('array')
         expect(state.files['CopyDT']).toBeDefined()
+      })
+
+      it('flags the workspace dirty after duplicate (persist only on save)', () => {
+        store.getState().workspaceActions.setEditingState('saved')
+        store.getState().datatypeActions.duplicate('SourceDT', 'CopyDT')
+        expect(store.getState().workspace.editingState).toBe('unsaved')
       })
 
       it('returns error when source data type does not exist', () => {

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -40,6 +40,13 @@ function deleteElement(
   if (currentEditor.type !== 'available' && currentEditor.meta.name === name) {
     state.editorActions.clearEditor()
   }
+
+  // A delete is an unsaved structural change (the file removal is queued in
+  // `pendingDeletions`). Flag the workspace dirty so it persists ONLY on the
+  // next save — identical on web and desktop. The file entry is already gone,
+  // so mark the workspace directly rather than via a file-scoped helper.
+  state.workspaceActions.setEditingState('unsaved')
+
   return { ok: true as const }
 }
 
@@ -69,6 +76,11 @@ function renameElement(
   state.fbdFlowActions.renameFBDFlow(oldName, newName)
 
   afterRename?.(oldName, newName)
+
+  // A rename is an unsaved structural change — flag it dirty (the renamed file
+  // now lives under `newName`) so it persists ONLY on the next save, identical
+  // on web and desktop.
+  state.sharedWorkspaceActions.handleFileAndWorkspaceSavedState(newName)
 
   return { ok: true as const }
 }
@@ -193,6 +205,9 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       state.editorActions.addModel(editorModel)
       state.fileActions.addFile({ name: newName, type: sourcePou.pouType, filePath: newName, isNew: true })
 
+      // Persist only on save: flag the new POU dirty instead of auto-saving.
+      state.sharedWorkspaceActions.handleFileAndWorkspaceSavedState(newName)
+
       return { ok: true }
     },
   },
@@ -262,6 +277,9 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const editorModel = createEditorObjectForDatatype(newName, source.derivation)
       state.editorActions.addModel(editorModel)
       state.fileActions.addFile({ name: newName, type: 'data-type', filePath: newName, isNew: true })
+
+      // Persist only on save: flag the new datatype dirty instead of auto-saving.
+      state.sharedWorkspaceActions.handleFileAndWorkspaceSavedState(newName)
 
       return { ok: true }
     },


### PR DESCRIPTION
Structural changes (delete / rename / duplicate of POUs, data types, servers, remote devices) now persist ONLY on save and flag the workspace dirty — identical on web and desktop. Removes the inconsistent auto-save (delete + duplicate always, rename web-only) that defeated the desktop soft-delete/undo model.

Validated: web vitest + editor jest shared-slice (155 each); tsc + eslint clean. Tested on web and desktop.

Follow-up (separate PR): web exit-interception — back button -> save dialog + native tab-close warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project tree renames and duplications are now retained as unsaved changes until the next regular save.
  * Deleting project elements no longer triggers an immediate save.
  * Workspace status now correctly switches to “unsaved” after renaming, duplicating, or deleting items.
  * Added coverage to verify unsaved-state behavior for these actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->