### PR TITLE
fix(graphical): dotted refs as constants + resolve globals/struct-members in LSP scope

### DIFF
--- a/src/frontend/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/fbd/autocomplete/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../../../services/graphical-scope'
 import { useOpenPLCStore } from '../../../../../store'
 import { cn } from '../../../../../utils/cn'
-import { getLiteralType } from '../../../../../utils/keywords'
+import { getLiteralType, isLegalIdentifier } from '../../../../../utils/keywords'
 import { toast } from '../../../../_features/[app]/toast/use-toast'
 import { useBoundPou } from '../../../../_features/[workspace]/editor/graphical/active-context'
 import { buildGenericNode } from '../../../../_molecules/graphical-editor/fbd/fbd-utils/nodes'
@@ -127,6 +127,16 @@ const FBDBlockAutoComplete = forwardRef<HTMLDivElement, FBDBlockAutoCompleteProp
           description: 'Variable name cannot be empty',
           variant: 'fail',
         })
+        return
+      }
+
+      // If the entry can't be a new variable NAME — a member/array reference
+      // (`some_struct.field`, `arr[3]`), a typed literal (`T#500ms`), a reserved
+      // word, etc. — don't try to create a variable. Bind it to the block
+      // verbatim as a constant/reference; strucpp validates the expression. New
+      // local-variable creation is only for plain, legal identifiers.
+      if (!isLegalIdentifier(variableName)[0]) {
+        submitVariableToBlock({ name: variableName } as PLCVariable)
         return
       }
 

--- a/src/frontend/components/_atoms/graphical-editor/fbd/block.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/fbd/block.tsx
@@ -6,6 +6,7 @@ import { RefreshIcon } from '../../../../assets/icons/interface/Refresh'
 import { useOpenPLCStore } from '../../../../store'
 import { checkVariableName } from '../../../../store/slices/project/validation/variables'
 import { cn } from '../../../../utils/cn'
+import { isLegalIdentifier } from '../../../../utils/keywords'
 import { toast } from '../../../_features/[app]/toast/use-toast'
 import { useBoundEditorModel, useBoundPou } from '../../../_features/[workspace]/editor/graphical/active-context'
 import { HighlightedTextArea } from '../../highlighted-textarea'
@@ -504,6 +505,13 @@ const Block = <T extends object>(block: BlockProps<T>) => {
       if (matchingVariable) {
         variableToLink = matchingVariable
       } else if (createIfNotFound) {
+        // An entry that can't be a new variable NAME — a member/array reference,
+        // a typed literal (`T#500ms`), a reserved word — is bound to the block
+        // verbatim as a constant/reference instead of erroring.
+        if (!isLegalIdentifier(variableNameToSubmit)[0]) {
+          updateNodeVariable({ name: variableNameToSubmit })
+          return
+        }
         const pouData = pous.find((p) => p.name === pouName)
         pushToHistory(pouName, {
           variables: pouData?.interface?.variables ?? [],

--- a/src/frontend/components/_atoms/graphical-editor/ladder/autocomplete/index.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/autocomplete/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../../../../services/graphical-scope'
 import { useOpenPLCStore } from '../../../../../store'
 import { cn } from '../../../../../utils/cn'
-import { getLiteralType } from '../../../../../utils/keywords'
+import { getLiteralType, isLegalIdentifier } from '../../../../../utils/keywords'
 import { toast } from '../../../../_features/[app]/toast/use-toast'
 import { useBoundPou } from '../../../../_features/[workspace]/editor/graphical/active-context'
 import { GraphicalEditorAutocomplete } from '../../autocomplete'
@@ -186,6 +186,21 @@ const VariablesBlockAutoComplete = forwardRef<HTMLDivElement, VariablesBlockAuto
         nodeId: (block as Node<BasicNodeData>).id,
       })
       if (!rung || !node) return
+
+      // If the entry can't be a new variable NAME — a member/array reference
+      // (`some_struct.field`, `arr[3]`), a typed literal (`T#500ms`), a reserved
+      // word, etc. — don't try to create a variable. Bind it to the node
+      // verbatim as a constant/reference; strucpp validates the expression. New
+      // local-variable creation is only for plain, legal identifiers.
+      if (!isLegalIdentifier(variableName)[0]) {
+        updateNode({
+          editorName: pouName,
+          rungId: rung.id,
+          nodeId: node.id,
+          node: { ...node, data: { ...node.data, variable: { name: variableName } } },
+        })
+        return
+      }
 
       const variableType = newVariableTypeForExpected(expectedType)
 

--- a/src/frontend/components/_atoms/graphical-editor/ladder/block.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/block.tsx
@@ -8,6 +8,7 @@ import { useOpenPLCStore } from '../../../../store'
 import { LibraryState } from '../../../../store/slices/library'
 import { checkVariableName } from '../../../../store/slices/project/validation/variables'
 import { cn } from '../../../../utils/cn'
+import { isLegalIdentifier } from '../../../../utils/keywords'
 import { toast } from '../../../_features/[app]/toast/use-toast'
 import { useBoundEditorModel, useBoundPou } from '../../../_features/[workspace]/editor/graphical/active-context'
 import { updateDiagramElementsPosition } from '../../../_molecules/graphical-editor/ladder/rung/ladder-utils/elements/diagram'
@@ -602,6 +603,13 @@ const Block = <T extends object>(block: BlockProps<T>) => {
       if (matchingVariable) {
         variableToLink = matchingVariable
       } else if (createIfNotFound) {
+        // An entry that can't be a new variable NAME — a member/array reference,
+        // a typed literal (`T#500ms`), a reserved word — is bound to the block
+        // verbatim as a constant/reference instead of erroring.
+        if (!isLegalIdentifier(variableNameToSubmit)[0]) {
+          updateNodeVariable({ name: variableNameToSubmit })
+          return
+        }
         const project = useOpenPLCStore.getState().project
         const currentPou = project.data.pous.find((p) => p.name === pouName)
         pushToHistory(pouName, {

--- a/src/frontend/services/graphical-scope.ts
+++ b/src/frontend/services/graphical-scope.ts
@@ -23,8 +23,17 @@ import type { PLCVariable } from '../../middleware/shared/ports/types'
 import { getVariableRestrictionType, validateVariableType } from '../utils/PLC/validate-variable-type'
 import { getScopedQueryApi } from './st-lsp'
 
-/** LSP `CompletionItemKind.Variable` — strucpp's kind for in-scope variables and instance/struct members. */
+/**
+ * LSP `CompletionItemKind`s that denote a value symbol bindable to a box.
+ * strucpp emits `Variable` (6) for in-scope variables and FUNCTION_BLOCK
+ * instance members (`TON0.Q`), but `Field` (5) for STRUCT members
+ * (`my_struct.field`). Both must be accepted, or struct-member access never
+ * autocompletes or validates.
+ */
 const LSP_KIND_VARIABLE = 6
+const LSP_KIND_FIELD = 5
+const isValueCompletionKind = (kind: number | undefined): boolean =>
+  kind === LSP_KIND_VARIABLE || kind === LSP_KIND_FIELD
 
 /** Max instance/struct variables to drill into when a type-filtered search has no direct hits. */
 const SCOPE_EXPAND_LIMIT = 8
@@ -92,7 +101,7 @@ export async function getScopeCompletions(
   const { anchor, segment } = splitExpression(value)
   const items = await api.completeInScope(pouName, anchor)
   const needle = segment.toLowerCase()
-  const matching = items.filter((item) => item.kind === LSP_KIND_VARIABLE && item.label.toLowerCase().includes(needle))
+  const matching = items.filter((item) => isValueCompletionKind(item.kind) && item.label.toLowerCase().includes(needle))
 
   const direct = matching
     .filter((item) => {
@@ -120,7 +129,7 @@ export async function getScopeCompletions(
       const memberAnchor = `${anchor}${instance.label}.`
       const members = await api.completeInScope(pouName, memberAnchor)
       return members
-        .filter((m) => m.kind === LSP_KIND_VARIABLE && m.type && validateVariableType(m.type, expectedType).isValid)
+        .filter((m) => isValueCompletionKind(m.kind) && m.type && validateVariableType(m.type, expectedType).isValid)
         .map((m) => ({ label: `${instance.label}.${m.label}`, insertText: memberAnchor + m.label, type: m.type }))
     }),
   )
@@ -146,7 +155,9 @@ export async function resolveScopeExpressionType(pouName: string, expression: st
   if (items.length === 0) return { status: 'unavailable' }
 
   const { name, indexed } = stripSubscript(segment)
-  const match = items.find((item) => item.kind === LSP_KIND_VARIABLE && item.label.toLowerCase() === name.toLowerCase())
+  const match = items.find(
+    (item) => isValueCompletionKind(item.kind) && item.label.toLowerCase() === name.toLowerCase(),
+  )
   if (!match || !match.type) return { status: 'unknown' }
 
   if (indexed) {

--- a/src/frontend/utils/PLC/__tests__/pou-signature-serializer.test.ts
+++ b/src/frontend/utils/PLC/__tests__/pou-signature-serializer.test.ts
@@ -185,6 +185,34 @@ describe('serializePouSignatureToST', () => {
       expect(text.split('\n')[position.line]).toBe('in1.')
     })
 
+    it('re-emits external variables as plain VAR so globals resolve in the throwaway doc', () => {
+      const pou = makePou({
+        name: 'Main',
+        pouType: 'program',
+        interface: {
+          variables: [
+            {
+              id: 'g1',
+              name: 'some_global_complex',
+              class: 'external',
+              type: { definition: 'derived', value: 'testing_arr' },
+              documentation: '',
+              debug: false,
+              location: '',
+            },
+          ],
+        },
+        body: { language: 'fbd', value: {} as never },
+      })
+      const { text } = serializePouScopeForQuery(pou, 'some_global_complex.')
+      // The external is rewritten to a self-contained local VAR (type inline)
+      // so strucpp resolves the global + its struct/array members without a
+      // matching VAR_GLOBAL in this throwaway document.
+      expect(text).toContain('some_global_complex : testing_arr;')
+      expect(text).not.toContain('VAR_EXTERNAL')
+      expect(text).toContain('some_global_complex.')
+    })
+
     it('keeps the function return type while swapping only the name', () => {
       const pou = makePou({
         name: 'AbsInt',

--- a/src/frontend/utils/PLC/pou-signature-serializer.ts
+++ b/src/frontend/utils/PLC/pou-signature-serializer.ts
@@ -139,7 +139,17 @@ export function serializePouScopeForQuery(
     pou.pouType === 'function' && pou.interface?.returnType
       ? `${startKeyword} ${name} : ${pou.interface.returnType}`
       : `${startKeyword} ${name}`
-  const variables = generateIecVariablesToString(pou.interface?.variables ?? [])
+  // External variables (`VAR_EXTERNAL`) reference resource globals declared in a
+  // separate CONFIGURATION document. This throwaway query doc isn't part of that
+  // configuration, so strucpp can't resolve a bare `VAR_EXTERNAL` here — the
+  // global and its struct/array members would come back unknown (the box shows
+  // yellow, no autocomplete). Re-emit externals as plain `VAR`: they carry their
+  // real type inline, so the symbol and its members resolve self-containedly.
+  // Scope-query-only — the POU's real stub keeps `VAR_EXTERNAL`.
+  const scopeVariables = (pou.interface?.variables ?? []).map((variable) =>
+    variable.class === 'external' ? { ...variable, class: 'local' as const } : variable,
+  )
+  const variables = generateIecVariablesToString(scopeVariables)
   const prefix = `${declaration}\n${variables}\n`
   // `prefix` ends with '\n', so split length - 1 is the 0-indexed line
   // the body expression sits on.


### PR DESCRIPTION
Byte-identical companion PRs (shared `frontend/` surface — verified `compare-surfaces.py` match: true, 0 diffs). Fixes graphical (LD/FBD) variable-box editing so complex/global references compile and resolve.

## Fixes

1. **Dotted box entries bind as constants (not rejected).** A member/array reference (`some_global_complex.structureVar`), typed literal (`T#500ms`), or reserved word entered in a variable box was routed to `createVariable`, whose `isLegalIdentifier` check rejected the dot with an "Illegal Variable Name" toast and discarded the entry (while the box still displayed it → the compiler saw the old value). Now, when the entry can't be a legal new variable *name*, it's bound to the block verbatim (constant/reference); `createVariable` and `isLegalIdentifier` are untouched, so new variable *names* still reject those characters. Applied to all four box-commit sites (fbd/ladder × autocomplete/block).

2. **Global (`VAR_EXTERNAL`) variables resolve in the LSP scope query.** `serializePouScopeForQuery` re-emits the POU's external variables as plain `VAR` in the throwaway query doc, so strucpp resolves the global (and its type's members) without a matching `VAR_GLOBAL`.

3. **Struct members autocomplete/validate.** strucpp returns STRUCT members as `CompletionItemKind.Field` (5); the scope filter only accepted `Variable` (6), so struct fields were dropped for both completion and validation. Now `Field` is accepted alongside `Variable`.

## Verification
- `tsc` 0 errors, ESLint clean, Prettier clean.
- Editor jest + web vitest suites for the touched pure logic pass (the 3 pre-existing `boot.test.ts` "Worker is not defined" failures on web are unrelated).
- Manually verified live in the browser (openplc-web `dev:local`): dotted refs bind with no toast; `test_global` resolves; `test_complex.` lists all struct fields in an ANY box and narrows to `structureBool` in a BOOL box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Graphical FBD and Ladder editors now correctly accept expressions such as structure members, array elements, typed literals, and reserved words without incorrectly creating variables.
  * Improved autocomplete and type resolution for structure fields and other value references.
  * External variables are now handled correctly when resolving types and members in scope queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->