### PR TITLE
fix(resources): cascade-delete global variable used as VAR_EXTERNAL

### DIFF
--- a/src/frontend/components/_organisms/global-variables-editor/index.tsx
+++ b/src/frontend/components/_organisms/global-variables-editor/index.tsx
@@ -1,7 +1,7 @@
 // import * as PrimitiveSwitch from '@radix-ui/react-switch'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import type { PLCGlobalVariable } from '../../../../middleware/shared/ports/types'
+import type { PLCGlobalVariable, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { CodeIcon } from '../../../assets/icons/interface/CodeIcon'
 import { MinusIcon } from '../../../assets/icons/interface/Minus'
 import { PlusIcon } from '../../../assets/icons/interface/Plus'
@@ -15,6 +15,7 @@ import { generateIecVariablesToString } from '../../../utils/generate-iec-variab
 import TableActions from '../../_atoms/table-actions'
 import { toast } from '../../_features/[app]/toast/use-toast'
 import { GlobalVariablesTable } from '../../_molecules/global-variables-table'
+import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'
 import { VariablesCodeEditor } from '../variables-code-editor'
 
 const GlobalVariablesEditor = () => {
@@ -62,6 +63,14 @@ const GlobalVariablesEditor = () => {
   const [tableData, setTableData] = useState<PLCGlobalVariable[]>([])
   const [editorCode, setEditorCode] = useState(() => generateIecVariablesToString(tableData))
   const [parseError, setParseError] = useState<string | null>(null)
+
+  // Pending confirmation when the global being deleted is used as `VAR_EXTERNAL`
+  // in one or more POUs — deleting it will also remove those external declarations.
+  const [pendingGlobalDelete, setPendingGlobalDelete] = useState<{
+    variable: PLCVariable
+    selectedRow: number
+    pous: string[]
+  } | null>(null)
 
   const [editorVariables, setEditorVariables] = useState<GlobalVariablesTableType>({
     display: 'table',
@@ -267,26 +276,51 @@ const GlobalVariablesEditor = () => {
     handleFileAndWorkspaceSavedState('Resource')
   }
 
-  const handleRemoveVariable = () => {
-    if (editorVariables.display === 'code') return
-
+  const performGlobalDelete = (variableToDelete: PLCVariable, selectedRow: number, force: boolean) => {
     pushToHistory(editor.meta.name)
+    removeDebugVariable(`resource:${variableToDelete.name}`)
 
-    const selectedRow = parseInt(editorVariables.selectedRow)
-    const variableToDelete = globalVariables.filter((v) => v.name)[selectedRow]
-    if (variableToDelete) {
-      removeDebugVariable(`resource:${variableToDelete.name}`)
+    const result = deleteVariable({ scope: 'global', variableName: variableToDelete.name, force })
+    if (!result.ok) {
+      toast({ title: result.title ?? 'Error', description: result.message, variant: 'fail' })
+      return
     }
-    deleteVariable({ scope: 'global', rowId: selectedRow })
 
     const variables = globalVariables.filter((variable) => variable.name)
     if (selectedRow === variables.length - 1) {
-      updateModelVariables({
-        display: 'table',
-        selectedRow: selectedRow - 1,
-      })
+      updateModelVariables({ display: 'table', selectedRow: selectedRow - 1 })
     }
     handleFileAndWorkspaceSavedState('Resource')
+  }
+
+  const handleRemoveVariable = () => {
+    if (editorVariables.display === 'code') return
+
+    const selectedRow = parseInt(editorVariables.selectedRow)
+    const variableToDelete = globalVariables.filter((v) => v.name)[selectedRow]
+    if (!variableToDelete) return
+
+    // If any POU declares this global as VAR_EXTERNAL, confirm the cascade first.
+    const referencingPous = snapshotPous
+      .filter((pou) =>
+        pou.interface?.variables?.some(
+          (v) => v.class === 'external' && v.name.toLowerCase() === variableToDelete.name.toLowerCase(),
+        ),
+      )
+      .map((pou) => pou.name)
+
+    if (referencingPous.length > 0) {
+      setPendingGlobalDelete({ variable: variableToDelete, selectedRow, pous: referencingPous })
+      return
+    }
+
+    performGlobalDelete(variableToDelete, selectedRow, false)
+  }
+
+  const confirmGlobalDelete = () => {
+    if (!pendingGlobalDelete) return
+    performGlobalDelete(pendingGlobalDelete.variable, pendingGlobalDelete.selectedRow, true)
+    setPendingGlobalDelete(null)
   }
 
   const handleRowClick = (row: HTMLTableRowElement) => {
@@ -427,6 +461,39 @@ const GlobalVariablesEditor = () => {
           {parseError && <p className='mt-2 text-xs text-red-500'>Erro: {parseError}</p>}
         </div>
       )}
+
+      <Modal
+        open={pendingGlobalDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingGlobalDelete(null)
+        }}
+      >
+        <ModalContent className='flex h-fit min-h-0 w-[440px] select-none flex-col items-center justify-start rounded-lg p-6'>
+          <ModalTitle className='mb-4 text-lg font-semibold'>Delete global variable?</ModalTitle>
+          <p className='mb-6 text-center text-sm text-neutral-600 dark:text-neutral-400'>
+            <span className='font-medium'>{pendingGlobalDelete?.variable.name}</span> is used as an external variable in{' '}
+            {pendingGlobalDelete?.pous.join(', ')}. Deleting it will also remove{' '}
+            {pendingGlobalDelete && pendingGlobalDelete.pous.length > 1
+              ? 'those external references'
+              : 'that external reference'}
+            . Continue?
+          </p>
+          <div className='flex w-full gap-3'>
+            <button
+              onClick={confirmGlobalDelete}
+              className='flex-1 rounded-md bg-red-500 px-4 py-2 text-sm font-medium text-white hover:bg-red-600'
+            >
+              Delete
+            </button>
+            <button
+              onClick={() => setPendingGlobalDelete(null)}
+              className='flex-1 rounded-md bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-1000 hover:bg-neutral-200 dark:bg-neutral-850 dark:text-neutral-100'
+            >
+              Cancel
+            </button>
+          </div>
+        </ModalContent>
+      </Modal>
     </div>
   )
 }

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -3260,6 +3260,56 @@ describe('createProjectSlice', () => {
       expect(result.ok).toBe(false)
       expect(result.title).toBe('Cannot Delete Global Variable')
       expect(result.message).toContain('Consumer')
+      expect((result.data as { referencingPous: string[] }).referencingPous).toEqual(['Consumer'])
+      // Not forced → nothing was deleted.
+      expect(
+        store.getState().project.data.configurations.resource.globalVariables.some((v) => v.name === 'SharedVar'),
+      ).toBe(true)
+    })
+
+    it('deleteVariable global with force cascades: removes the global + external refs from every POU', () => {
+      store.getState().projectActions.createVariable({ scope: 'global', data: makeVariable('SharedVar', 'global') })
+      for (const name of ['Consumer', 'Consumer2']) {
+        seedPou(store, {
+          ...makePou(name, 'program'),
+          interface: {
+            variables: [
+              {
+                name: 'SharedVar',
+                class: 'external',
+                type: { definition: 'base-type', value: 'INT' },
+                location: '',
+                documentation: '',
+              },
+              {
+                name: 'keep_me',
+                class: 'local',
+                type: { definition: 'base-type', value: 'BOOL' },
+                location: '',
+                documentation: '',
+              },
+            ],
+          },
+        })
+      }
+
+      const result = store.getState().projectActions.deleteVariable({
+        scope: 'global',
+        variableName: 'SharedVar',
+        force: true,
+      })
+
+      expect(result.ok).toBe(true)
+      // The global itself is gone.
+      expect(
+        store.getState().project.data.configurations.resource.globalVariables.some((v) => v.name === 'SharedVar'),
+      ).toBe(false)
+      // The external declaration is removed from every referencing POU; unrelated locals stay.
+      for (const name of ['Consumer', 'Consumer2']) {
+        const vars = store.getState().project.data.pous.find((p) => p.name === name)?.interface?.variables ?? []
+        expect(vars.some((v) => v.name === 'SharedVar')).toBe(false)
+        expect(vars.some((v) => v.name === 'keep_me')).toBe(true)
+      }
     })
 
     it('updateOpcUaServerConfig with top-level updates (cycleTimeMs)', () => {

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -822,36 +822,43 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       const found = getVariableBasedOnRowIdOrVariableId(variables, rowId, variableId)
       return found?.variable
     },
-    deleteVariable: ({ scope, associatedPou, rowId, variableId, variableName }) => {
+    deleteVariable: ({ scope, associatedPou, rowId, variableId, variableName, force }) => {
       if (scope === 'local') {
         const reconcile = reconcileVariablesText(associatedPou, getState, setState)
         if (!reconcile.ok) return reconcile
       }
 
+      // Deleting a global that POUs declare as `VAR_EXTERNAL` must handle those
+      // references too. Without `force`, refuse and report the referencing POUs
+      // (the editor surfaces a confirmation). With `force`, cascade-delete: drop
+      // the global AND the matching external declaration from every such POU.
+      let cascade: { globalName: string; pous: string[] } | null = null
       if (scope === 'global') {
         const state = getState()
         const globalVars = state.project.data.configurations.resource.globalVariables
-
-        let variableToDelete: PLCVariable | undefined
-        if (variableName) {
-          variableToDelete = globalVars.find((v) => v.name.toLowerCase() === variableName.toLowerCase())
-        } else {
-          variableToDelete = getVariableBasedOnRowIdOrVariableId(globalVars, rowId, variableId)?.variable
-        }
+        const variableToDelete = variableName
+          ? globalVars.find((v) => v.name.toLowerCase() === variableName.toLowerCase())
+          : getVariableBasedOnRowIdOrVariableId(globalVars, rowId, variableId)?.variable
 
         if (variableToDelete) {
-          const externalReferences = state.project.data.pous.filter((pou) =>
-            pou.interface?.variables?.some(
-              (v) => v.class === 'external' && v.name.toLowerCase() === variableToDelete.name.toLowerCase(),
-            ),
-          )
-
-          if (externalReferences.length > 0) {
-            const pouNames = externalReferences.map((pou) => pou.name).join(', ')
-            return fail(
-              `The global variable "${variableToDelete.name}" is referenced by external variables in the following POUs: ${pouNames}. Please remove these references before deleting the global variable.`,
-              'Cannot Delete Global Variable',
+          const referencingPous = state.project.data.pous
+            .filter((pou) =>
+              pou.interface?.variables?.some(
+                (v) => v.class === 'external' && v.name.toLowerCase() === variableToDelete.name.toLowerCase(),
+              ),
             )
+            .map((pou) => pou.name)
+
+          if (referencingPous.length > 0) {
+            if (!force) {
+              return {
+                ok: false,
+                title: 'Cannot Delete Global Variable',
+                message: `The global variable "${variableToDelete.name}" is used as an external variable in the following POUs: ${referencingPous.join(', ')}.`,
+                data: { referencingPous },
+              }
+            }
+            cascade = { globalName: variableToDelete.name, pous: referencingPous }
           }
         }
       }
@@ -875,17 +882,34 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
               return
             }
             variables.splice(idx, 1)
-            return
+          } else {
+            const found = getVariableBasedOnRowIdOrVariableId(variables, rowId, variableId)
+            if (!found) {
+              response = fail('Variable not found')
+              return
+            }
+            variables.splice(found.index, 1)
           }
-          const found = getVariableBasedOnRowIdOrVariableId(variables, rowId, variableId)
-          if (!found) {
-            response = fail('Variable not found')
-            return
+
+          // Cascade: remove the matching VAR_EXTERNAL from every referencing POU.
+          if (cascade) {
+            const { globalName, pous } = cascade
+            for (const pouName of pous) {
+              const pouVars = slice.project.data.pous.find((p) => p.name === pouName)?.interface?.variables
+              const extIdx =
+                pouVars?.findIndex(
+                  (v) => v.class === 'external' && v.name.toLowerCase() === globalName.toLowerCase(),
+                ) ?? -1
+              if (pouVars && extIdx !== -1) pouVars.splice(extIdx, 1)
+            }
           }
-          variables.splice(found.index, 1)
         }),
       )
       if (scope === 'local' && response.ok) regenerateVariablesText(associatedPou, getState)
+      // Refresh the vars-text of every POU whose external declaration we removed.
+      if (response.ok && cascade) {
+        for (const pouName of cascade.pous) regenerateVariablesText(pouName, getState)
+      }
       return response
     },
     rearrangeVariables: ({ scope, associatedPou, rowId, variableId, newIndex }) => {

--- a/src/frontend/store/slices/project/types.ts
+++ b/src/frontend/store/slices/project/types.ts
@@ -137,6 +137,14 @@ export type ProjectActions = {
     rowId?: number
     variableId?: string
     variableName?: string
+    /**
+     * Global scope only. When a global is referenced as `VAR_EXTERNAL` by any
+     * POU, deletion is refused by default and the response carries the
+     * referencing POU names in `data.referencingPous`. Pass `force: true` to
+     * cascade-delete: remove the global AND the matching external declaration
+     * from every referencing POU.
+     */
+    force?: boolean
   }) => ProjectResponse
   rearrangeVariables: (args: {
     scope: 'global' | 'local'


### PR DESCRIPTION
## Problem

When a global variable (on **Resources**) is used as a `VAR_EXTERNAL` in any POU, deleting it did nothing — no warning, no message, no delete. The store's `deleteVariable` guard *did* refuse the deletion, but the global-variables editor swallowed the failure response, so the Remove button was a silent no-op. Odd, confusing UX.

## Fix

The editor now detects up front which POUs reference the global as external and shows a **confirmation modal** naming them:

> `test_global` is used as an external variable in `main`. Deleting it will also remove that external reference. Continue?

On **Delete**, `deleteVariable` is called with `force: true`, which:

- removes the global variable, **and**
- removes the matching `VAR_EXTERNAL` declaration from every referencing POU.

Per the agreed approach (option A), we remove only the external **declarations**. Any graphical nodes that still reference the deleted global go unresolved (the user resolves them) — we don't deep-clean diagram nodes.

## Changes

- **`project` slice** — `deleteVariable` gains a `force?` flag. Without it, a global deletion blocked by external refs returns `ok: false` plus the referencing POU names in `data.referencingPous`. With it, the external-declaration removal cascades to every referencing POU (and their var-text is regenerated).
- **global-variables editor** — surfaces the block as a confirmation modal instead of a silent no-op.
- **tests** — assert `referencingPous` is reported when unforced, and that `force: true` cascades removal across every referencing POU while retaining unrelated locals.

## Testing

- `tsc`, ESLint (0 errors), Prettier clean.
- Full Jest suite green; slice coverage thresholds met.
- Verified in-browser (Chrome, web dev:local): deleting a global referenced as external in `main` shows the modal; confirming deletes the global and removes the `VAR_EXTERNAL test_global` from `main`, retaining all other locals; no console errors.

Shared surface is byte-identical with the matching PR on the other repo (`compare-surfaces.py` → `match: true`, 0 diffs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
