### PR TITLE
feat: runtime User Management screen with RBAC

### DIFF
--- a/src/backend/shared/firmware/__tests__/runtime-version-gate.test.ts
+++ b/src/backend/shared/firmware/__tests__/runtime-version-gate.test.ts
@@ -1,9 +1,41 @@
 import {
   describeIncompatibleRuntime,
   isStrucppCompatibleRuntime,
+  isUserManagementCapableRuntime,
   MIN_STRUCPP_RUNTIME_VERSION,
+  MIN_USER_MANAGEMENT_RUNTIME_VERSION,
   parseRuntimeVersion,
 } from '../runtime-version-gate'
+
+describe('isUserManagementCapableRuntime', () => {
+  it('is exposed with the documented minimum version', () => {
+    expect(MIN_USER_MANAGEMENT_RUNTIME_VERSION).toBe('4.1.9')
+  })
+
+  it('accepts v4.1.9 and newer', () => {
+    expect(isUserManagementCapableRuntime('v4.1.9')).toBe(true)
+    expect(isUserManagementCapableRuntime('4.1.10')).toBe(true)
+    expect(isUserManagementCapableRuntime('v4.2.0')).toBe(true)
+    expect(isUserManagementCapableRuntime('v5.0.0')).toBe(true)
+  })
+
+  it('accepts a pre-release on the target patch', () => {
+    expect(isUserManagementCapableRuntime('v4.1.9-rc.1')).toBe(true)
+  })
+
+  it('rejects versions older than 4.1.9', () => {
+    expect(isUserManagementCapableRuntime('v4.1.8')).toBe(false)
+    expect(isUserManagementCapableRuntime('v4.0.9')).toBe(false)
+    expect(isUserManagementCapableRuntime('v3.9.9')).toBe(false)
+  })
+
+  it('rejects unparseable / legacy version strings', () => {
+    expect(isUserManagementCapableRuntime('v4')).toBe(false)
+    expect(isUserManagementCapableRuntime('dev')).toBe(false)
+    expect(isUserManagementCapableRuntime(null)).toBe(false)
+    expect(isUserManagementCapableRuntime(undefined)).toBe(false)
+  })
+})
 
 describe('parseRuntimeVersion', () => {
   it('parses tagged release versions (with and without leading v)', () => {

--- a/src/backend/shared/firmware/runtime-version-gate.ts
+++ b/src/backend/shared/firmware/runtime-version-gate.ts
@@ -75,6 +75,26 @@ export function isStrucppCompatibleRuntime(raw: string | null | undefined): bool
   return v.minor >= 1
 }
 
+/** Minimum runtime version that ships the user-management API
+ *  (roles, whoami, unified update-user, delete/last-admin guards). */
+export const MIN_USER_MANAGEMENT_RUNTIME_VERSION = '4.1.9'
+
+/**
+ * Returns true iff the runtime version string represents a runtime
+ * that ships the user-management API (≥ 4.1.9). Older runtimes lack
+ * `whoami` / `update-user` and the RBAC guards, so the editor hides
+ * the User Management screen for them. Pre-release tags on the target
+ * patch (e.g. `v4.1.9-rc.1`) count as capable, matching the strucpp
+ * gate's treatment of the rc lineage.
+ */
+export function isUserManagementCapableRuntime(raw: string | null | undefined): boolean {
+  const v = parseRuntimeVersion(raw)
+  if (!v) return false
+  if (v.major !== 4) return v.major > 4
+  if (v.minor !== 1) return v.minor > 1
+  return v.patch >= 9
+}
+
 /**
  * Human-readable explanation suitable for surfacing as an error
  * when the gate rejects a runtime.  The reported version (or

--- a/src/frontend/assets/icons/project/Users.tsx
+++ b/src/frontend/assets/icons/project/Users.tsx
@@ -1,0 +1,38 @@
+import { ComponentProps } from 'react'
+
+import { cn } from '../../../utils/cn'
+
+type IUsersIconProps = ComponentProps<'svg'> & {
+  size?: 'sm' | 'md' | 'lg'
+}
+
+const sizeClasses = {
+  sm: 'w-5 h-5',
+  md: 'w-6 h-6',
+  lg: 'w-12 h-12',
+}
+
+export const UsersIcon = (props: IUsersIconProps) => {
+  const { className, size = 'sm', ...res } = props
+  return (
+    <svg
+      role='button'
+      viewBox='0 0 28 28'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      className={cn(`${sizeClasses[size]}`, className)}
+      {...res}
+    >
+      <circle cx='11' cy='9' r='4' fill='#023C97' />
+      <path
+        d='M4 22C4 18.134 7.13401 15 11 15C14.866 15 18 18.134 18 22V23C18 23.5523 17.5523 24 17 24H5C4.44772 24 4 23.5523 4 23V22Z'
+        fill='#023C97'
+      />
+      <circle cx='20' cy='10.5' r='3' fill='#B4D0FE' />
+      <path
+        d='M19 16C22.3137 16 25 18.6863 25 22V22.5C25 23.3284 24.3284 24 23.5 24H20.5C20.7761 24 21 23.7761 21 23.5V22C21 19.9954 20.2159 18.1738 18.9385 16.8262C19.0252 16.8154 19.1123 16.8079 19.2 16.8038C19.1327 16.5411 19.0693 16.2734 19 16Z'
+        fill='#B4D0FE'
+      />
+    </svg>
+  )
+}

--- a/src/frontend/components/_atoms/tab/index.tsx
+++ b/src/frontend/components/_atoms/tab/index.tsx
@@ -21,6 +21,7 @@ import { ServerIcon } from '../../../assets/icons/project/Server'
 import { SFCIcon } from '../../../assets/icons/project/SFC'
 import { STIcon } from '../../../assets/icons/project/ST'
 import { StructureIcon } from '../../../assets/icons/project/Structure'
+import { UsersIcon } from '../../../assets/icons/project/Users'
 import { useOpenPLCStore } from '../../../store'
 import type { TabsProps } from '../../../store/slices/tabs'
 import { cn } from '../../../utils/cn'
@@ -56,6 +57,7 @@ const TabIcons: Record<string, React.ReactNode> = {
   'ethercat-device': <DeviceTransferIcon className='h-4 w-4 flex-shrink-0' />,
   'library-manager': <LibraryIcon className='h-4 w-4 flex-shrink-0' />,
   'library-manifest': <LibraryManifestIcon className='h-4 w-4 flex-shrink-0' />,
+  'user-management': <UsersIcon className='h-4 w-4 flex-shrink-0' />,
   'diff-viewer': <GitCompare className='h-4 w-4 flex-shrink-0 text-[#0464FB]' />,
 }
 
@@ -87,6 +89,7 @@ const Tab = (props: ITabProps) => {
     | 'ethercat-device'
     | 'library-manager'
     | 'library-manifest'
+    | 'user-management'
     | 'diff-viewer' = 'il'
 
   if (fileDerivation?.type === 'data-type' || fileDerivation?.type === 'device') {
@@ -122,6 +125,9 @@ const Tab = (props: ITabProps) => {
   }
   if (fileDerivation?.type === 'library-manifest') {
     languageOrDerivation = 'library-manifest'
+  }
+  if (fileDerivation?.type === 'user-management') {
+    languageOrDerivation = 'user-management'
   }
   if (fileDerivation?.type === 'diff-viewer') {
     languageOrDerivation = 'diff-viewer'

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/board.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/board.tsx
@@ -60,6 +60,7 @@ const Board = memo(function () {
   const setRuntimeIpAddress = useOpenPLCStore((state) => state.deviceActions.setRuntimeIpAddress)
   const setRuntimeConnectionStatus = useOpenPLCStore((state) => state.deviceActions.setRuntimeConnectionStatus)
   const setRuntimeJwtToken = useOpenPLCStore((state) => state.deviceActions.setRuntimeJwtToken)
+  const setRuntimeVersion = useOpenPLCStore((state) => state.deviceActions.setRuntimeVersion)
   const openModal = useOpenPLCStore((state) => state.modalActions.openModal)
   const plcStatus = useOpenPLCStore((state): RuntimeConnection['plcStatus'] => state.runtimeConnection.plcStatus)
   const timingStats = useOpenPLCStore((state): TimingStats | null => state.runtimeConnection.timingStats)
@@ -364,6 +365,10 @@ const Board = memo(function () {
         setRuntimeConnectionStatus('error')
         return
       }
+
+      // Remember the runtime version so version-gated UI (e.g. User
+      // Management) can react to it for the lifetime of the connection.
+      setRuntimeVersion(result.runtimeVersion ?? null)
 
       // Validate runtime version matches the selected board target
       const versionValidation = validateRuntimeVersion(deviceBoard, result.runtimeVersion)

--- a/src/frontend/components/_features/[workspace]/editor/user-management/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/user-management/index.tsx
@@ -38,7 +38,10 @@ const UserManagementEditor = () => {
       setLoadError(listResult.error || 'Failed to load users')
       setUsers([])
     } else {
-      setUsers(listResult.users ?? [])
+      // Guard against a non-array payload (e.g. the runtime's existence-only
+      // {"msg":"Users found"} reply when the token is no longer valid), which
+      // would otherwise crash the table on `users.map`.
+      setUsers(Array.isArray(listResult.users) ? listResult.users : [])
     }
     if (meResult.success && meResult.user) {
       setCurrentUser(meResult.user)
@@ -111,6 +114,20 @@ const UserManagementEditor = () => {
   const canEditRow = (user: RuntimeUser) => isAdmin || user.id === currentUser?.id
   const canDeleteRow = (user: RuntimeUser) => isAdmin && user.id !== currentUser?.id
 
+  // When not connected (e.g. after changing your own password signs you out),
+  // show a neutral placeholder instead of the table + actions — those would
+  // hit the runtime unauthenticated and, worse, could render a non-array list.
+  if (connectionStatus !== 'connected') {
+    return (
+      <div className='flex h-full w-full select-none flex-col items-center justify-center gap-2 p-8 text-center'>
+        <h2 className='text-lg font-semibold text-neutral-1000 dark:text-white'>User Management</h2>
+        <p className='text-sm text-neutral-500 dark:text-neutral-400'>
+          You are not connected to a runtime. Connect to the runtime to manage its users.
+        </p>
+      </div>
+    )
+  }
+
   return (
     <div className='flex h-full w-full select-none flex-col overflow-auto p-8'>
       <div className='mb-6 flex items-start justify-between'>
@@ -133,10 +150,12 @@ const UserManagementEditor = () => {
             <button
               type='button'
               onClick={() => setCreateOpen(true)}
-              className='flex h-9 items-center justify-center gap-2 rounded-md bg-brand px-3 text-sm font-medium leading-none text-white hover:bg-brand-medium-dark'
+              className='flex h-9 items-center justify-center gap-2 rounded-md bg-brand px-3 text-sm font-medium text-white hover:bg-brand-medium-dark'
             >
-              <PlusIcon className='h-4 w-4' />
-              <span>New User</span>
+              {/* PlusIcon strokes `inherit`; without a stroke color it renders
+                  invisibly and its empty box pushed the label off-center. */}
+              <PlusIcon className='h-4 w-4 stroke-current' />
+              <span className='leading-none'>New User</span>
             </button>
           )}
         </div>

--- a/src/frontend/components/_features/[workspace]/editor/user-management/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/user-management/index.tsx
@@ -15,6 +15,8 @@ type EditTarget = { user: RuntimeUser; isSelf: boolean }
 const UserManagementEditor = () => {
   const runtime = useRuntime()
   const connectionStatus = useOpenPLCStore((s) => s.runtimeConnection.connectionStatus)
+  const setRuntimeConnectionStatus = useOpenPLCStore((s) => s.deviceActions.setRuntimeConnectionStatus)
+  const setRuntimeJwtToken = useOpenPLCStore((s) => s.deviceActions.setRuntimeJwtToken)
 
   const [users, setUsers] = useState<RuntimeUser[]>([])
   const [currentUser, setCurrentUser] = useState<RuntimeUser | null>(null)
@@ -69,8 +71,24 @@ const UserManagementEditor = () => {
       if (values.currentPassword) params.currentPassword = values.currentPassword
     }
     if (values.roleChanged) params.role = values.role
+    const changingOwnPassword = editTarget.isSelf && values.passwordChanged
     const result = await runtime.updateUser(editTarget.user.id, params)
     if (!result.success) return result.error || 'Failed to update user'
+
+    if (changingOwnPassword) {
+      // The runtime invalidates your token when you change your own password,
+      // so drop the local session and force a fresh login with the new one.
+      await runtime.clearCredentials()
+      setRuntimeJwtToken(null)
+      setRuntimeConnectionStatus('disconnected')
+      toast({
+        title: 'Password changed',
+        description: 'You have been signed out. Reconnect with your new password.',
+        variant: 'default',
+      })
+      return null
+    }
+
     toast({ title: 'User updated', description: `"${values.username}" was updated.`, variant: 'default' })
     void refresh()
     return null
@@ -115,10 +133,10 @@ const UserManagementEditor = () => {
             <button
               type='button'
               onClick={() => setCreateOpen(true)}
-              className='flex h-9 items-center gap-2 rounded-md bg-brand px-3 text-sm font-medium text-white hover:bg-brand-medium-dark'
+              className='flex h-9 items-center justify-center gap-2 rounded-md bg-brand px-3 text-sm font-medium leading-none text-white hover:bg-brand-medium-dark'
             >
               <PlusIcon className='h-4 w-4' />
-              New User
+              <span>New User</span>
             </button>
           )}
         </div>
@@ -162,7 +180,9 @@ const UserManagementEditor = () => {
                             onClick={() => setEditTarget({ user, isSelf })}
                             className='flex h-7 w-7 items-center justify-center rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-850'
                           >
-                            <PencilIcon className='h-4 w-4' />
+                            {/* pointer-events-none so the button's `title` tooltip wins
+                                over the icon SVG's own <title> ("Pencil Icon"). */}
+                            <PencilIcon className='pointer-events-none h-4 w-4' />
                           </button>
                         )}
                         {canDeleteRow(user) && (
@@ -172,7 +192,7 @@ const UserManagementEditor = () => {
                             onClick={() => setDeleteTarget(user)}
                             className='flex h-7 w-7 items-center justify-center rounded-md text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950'
                           >
-                            <TrashCanIcon className='h-4 w-4 stroke-current' />
+                            <TrashCanIcon className='pointer-events-none h-4 w-4 stroke-current' />
                           </button>
                         )}
                       </div>

--- a/src/frontend/components/_features/[workspace]/editor/user-management/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/user-management/index.tsx
@@ -1,0 +1,259 @@
+import { PencilIcon } from '@root/frontend/assets/icons/interface/Pencil'
+import { PlusIcon } from '@root/frontend/assets/icons/interface/Plus'
+import { RefreshIcon } from '@root/frontend/assets/icons/interface/Refresh'
+import { TrashCanIcon } from '@root/frontend/assets/icons/interface/TrashCan'
+import { toast } from '@root/frontend/components/_features/[app]/toast/use-toast'
+import { Modal, ModalContent, ModalTitle } from '@root/frontend/components/_molecules/modal'
+import { RuntimeUserModal, type RuntimeUserModalSubmit } from '@root/frontend/components/_organisms/modals/runtime-user-modal'
+import { useOpenPLCStore } from '@root/frontend/store'
+import type { RuntimeUser, UpdateUserParams } from '@root/middleware/shared/ports/runtime-port'
+import { useRuntime } from '@root/middleware/shared/providers'
+import { useCallback, useEffect, useState } from 'react'
+
+type EditTarget = { user: RuntimeUser; isSelf: boolean }
+
+const UserManagementEditor = () => {
+  const runtime = useRuntime()
+  const connectionStatus = useOpenPLCStore((s) => s.runtimeConnection.connectionStatus)
+
+  const [users, setUsers] = useState<RuntimeUser[]>([])
+  const [currentUser, setCurrentUser] = useState<RuntimeUser | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editTarget, setEditTarget] = useState<EditTarget | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<RuntimeUser | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  const isAdmin = currentUser?.role === 'admin'
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setLoadError(null)
+    const [listResult, meResult] = await Promise.all([runtime.listUsers(), runtime.whoAmI()])
+    if (!listResult.success) {
+      setLoadError(listResult.error || 'Failed to load users')
+      setUsers([])
+    } else {
+      setUsers(listResult.users ?? [])
+    }
+    if (meResult.success && meResult.user) {
+      setCurrentUser(meResult.user)
+    }
+    setLoading(false)
+  }, [runtime])
+
+  useEffect(() => {
+    // Reload whenever the screen mounts or the connection is (re)established.
+    if (connectionStatus === 'connected') {
+      void refresh()
+    }
+  }, [connectionStatus, refresh])
+
+  const handleCreate = async ({ username, password, role }: RuntimeUserModalSubmit): Promise<string | null> => {
+    if (!password) return 'Password is required'
+    const result = await runtime.createUser({ username, password, role })
+    if (!result.success) return result.error || 'Failed to create user'
+    toast({ title: 'User created', description: `"${username}" was created.`, variant: 'default' })
+    void refresh()
+    return null
+  }
+
+  const handleEdit = async (values: RuntimeUserModalSubmit): Promise<string | null> => {
+    if (!editTarget) return 'No user selected'
+    const params: UpdateUserParams = {}
+    if (values.usernameChanged) params.username = values.username
+    if (values.passwordChanged) {
+      params.password = values.password
+      if (values.currentPassword) params.currentPassword = values.currentPassword
+    }
+    if (values.roleChanged) params.role = values.role
+    const result = await runtime.updateUser(editTarget.user.id, params)
+    if (!result.success) return result.error || 'Failed to update user'
+    toast({ title: 'User updated', description: `"${values.username}" was updated.`, variant: 'default' })
+    void refresh()
+    return null
+  }
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return
+    setDeleting(true)
+    const result = await runtime.deleteUser(deleteTarget.id)
+    setDeleting(false)
+    if (!result.success) {
+      toast({ title: 'Delete failed', description: result.error || 'Failed to delete user', variant: 'fail' })
+      return
+    }
+    toast({ title: 'User deleted', description: `"${deleteTarget.username}" was deleted.`, variant: 'default' })
+    setDeleteTarget(null)
+    void refresh()
+  }
+
+  const canEditRow = (user: RuntimeUser) => isAdmin || user.id === currentUser?.id
+  const canDeleteRow = (user: RuntimeUser) => isAdmin && user.id !== currentUser?.id
+
+  return (
+    <div className='flex h-full w-full select-none flex-col overflow-auto p-8'>
+      <div className='mb-6 flex items-start justify-between'>
+        <div>
+          <h2 className='text-xl font-semibold text-neutral-1000 dark:text-white'>User Management</h2>
+          <p className='mt-1 text-sm text-neutral-600 dark:text-neutral-400'>
+            Manage the accounts that can log in to this runtime.
+          </p>
+        </div>
+        <div className='flex items-center gap-2'>
+          <button
+            type='button'
+            onClick={() => void refresh()}
+            title='Refresh'
+            className='flex h-9 w-9 items-center justify-center rounded-md border border-neutral-300 hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-850'
+          >
+            <RefreshIcon className='h-4 w-4' />
+          </button>
+          {isAdmin && (
+            <button
+              type='button'
+              onClick={() => setCreateOpen(true)}
+              className='flex h-9 items-center gap-2 rounded-md bg-brand px-3 text-sm font-medium text-white hover:bg-brand-medium-dark'
+            >
+              <PlusIcon className='h-4 w-4' />
+              New User
+            </button>
+          )}
+        </div>
+      </div>
+
+      {loading ? (
+        <p className='text-sm text-neutral-500'>Loading users…</p>
+      ) : loadError ? (
+        <p className='text-sm text-red-600 dark:text-red-400'>{loadError}</p>
+      ) : (
+        <div className='overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-800'>
+          <table className='w-full border-collapse text-sm'>
+            <thead>
+              <tr className='border-b border-neutral-200 bg-neutral-50 text-left dark:border-neutral-800 dark:bg-neutral-900'>
+                <th className='px-4 py-2 font-medium text-neutral-700 dark:text-neutral-300'>Username</th>
+                <th className='px-4 py-2 font-medium text-neutral-700 dark:text-neutral-300'>Role</th>
+                <th className='w-24 px-4 py-2 text-right font-medium text-neutral-700 dark:text-neutral-300'>
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((user) => {
+                const isSelf = user.id === currentUser?.id
+                return (
+                  <tr
+                    key={user.id}
+                    className='border-b border-neutral-100 last:border-b-0 dark:border-neutral-850'
+                  >
+                    <td className='px-4 py-2 text-neutral-850 dark:text-neutral-200'>
+                      {user.username}
+                      {isSelf && <span className='ml-2 text-xs text-neutral-400'>(you)</span>}
+                    </td>
+                    <td className='px-4 py-2 capitalize text-neutral-700 dark:text-neutral-300'>{user.role}</td>
+                    <td className='px-4 py-2'>
+                      <div className='flex items-center justify-end gap-2'>
+                        {canEditRow(user) && (
+                          <button
+                            type='button'
+                            title='Edit user'
+                            onClick={() => setEditTarget({ user, isSelf })}
+                            className='flex h-7 w-7 items-center justify-center rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-850'
+                          >
+                            <PencilIcon className='h-4 w-4' />
+                          </button>
+                        )}
+                        {canDeleteRow(user) && (
+                          <button
+                            type='button'
+                            title='Delete user'
+                            onClick={() => setDeleteTarget(user)}
+                            className='flex h-7 w-7 items-center justify-center rounded-md text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950'
+                          >
+                            <TrashCanIcon className='h-4 w-4 stroke-current' />
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+          {users.length === 0 && <p className='px-4 py-3 text-sm text-neutral-500'>No users found.</p>}
+        </div>
+      )}
+
+      {/* Create modal (admin only) */}
+      {isAdmin && (
+        <RuntimeUserModal
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+          mode='create'
+          title='New User'
+          submitLabel='Create user'
+          showRole
+          initialRole='user'
+          onSubmit={handleCreate}
+        />
+      )}
+
+      {/* Edit modal */}
+      {editTarget && (
+        <RuntimeUserModal
+          open={!!editTarget}
+          onOpenChange={(open) => {
+            if (!open) setEditTarget(null)
+          }}
+          mode='edit'
+          title={editTarget.isSelf ? 'Edit your account' : `Edit user — ${editTarget.user.username}`}
+          submitLabel='Save'
+          initialUsername={editTarget.user.username}
+          initialRole={editTarget.user.role}
+          // Only admins can change roles, and never their own (prevents self-lockout);
+          // the runtime enforces this too.
+          showRole={isAdmin && !editTarget.isSelf}
+          requireCurrentPassword={editTarget.isSelf}
+          onSubmit={handleEdit}
+        />
+      )}
+
+      {/* Delete confirmation */}
+      <Modal
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null)
+        }}
+      >
+        <ModalContent className='flex w-[360px] select-none flex-col rounded-lg p-6'>
+          <ModalTitle className='mb-2 text-lg font-semibold'>Delete user</ModalTitle>
+          <p className='mb-6 text-sm text-neutral-600 dark:text-neutral-400'>
+            "{deleteTarget?.username}" will no longer be able to log in to the runtime. This cannot be undone.
+          </p>
+          <div className='flex justify-end gap-3'>
+            <button
+              type='button'
+              onClick={() => setDeleteTarget(null)}
+              disabled={deleting}
+              className='rounded-md bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-1000 hover:bg-neutral-200 dark:bg-neutral-850 dark:text-neutral-100'
+            >
+              Cancel
+            </button>
+            <button
+              type='button'
+              onClick={() => void handleDelete()}
+              disabled={deleting}
+              className='rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50'
+            >
+              {deleting ? 'Deleting…' : 'Delete'}
+            </button>
+          </div>
+        </ModalContent>
+      </Modal>
+    </div>
+  )
+}
+
+export { UserManagementEditor }

--- a/src/frontend/components/_features/[workspace]/editor/user-management/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/user-management/index.tsx
@@ -4,7 +4,10 @@ import { RefreshIcon } from '@root/frontend/assets/icons/interface/Refresh'
 import { TrashCanIcon } from '@root/frontend/assets/icons/interface/TrashCan'
 import { toast } from '@root/frontend/components/_features/[app]/toast/use-toast'
 import { Modal, ModalContent, ModalTitle } from '@root/frontend/components/_molecules/modal'
-import { RuntimeUserModal, type RuntimeUserModalSubmit } from '@root/frontend/components/_organisms/modals/runtime-user-modal'
+import {
+  RuntimeUserModal,
+  type RuntimeUserModalSubmit,
+} from '@root/frontend/components/_organisms/modals/runtime-user-modal'
 import { useOpenPLCStore } from '@root/frontend/store'
 import type { RuntimeUser, UpdateUserParams } from '@root/middleware/shared/ports/runtime-port'
 import { useRuntime } from '@root/middleware/shared/providers'
@@ -181,10 +184,7 @@ const UserManagementEditor = () => {
               {users.map((user) => {
                 const isSelf = user.id === currentUser?.id
                 return (
-                  <tr
-                    key={user.id}
-                    className='border-b border-neutral-100 last:border-b-0 dark:border-neutral-850'
-                  >
+                  <tr key={user.id} className='border-b border-neutral-100 last:border-b-0 dark:border-neutral-850'>
                     <td className='px-4 py-2 text-neutral-850 dark:text-neutral-200'>
                       {user.username}
                       {isSelf && <span className='ml-2 text-xs text-neutral-400'>(you)</span>}

--- a/src/frontend/components/_molecules/project-tree/index.tsx
+++ b/src/frontend/components/_molecules/project-tree/index.tsx
@@ -30,6 +30,7 @@ import { ServerIcon } from '../../../assets/icons/project/Server'
 import { SFCIcon } from '../../../assets/icons/project/SFC'
 import { STIcon } from '../../../assets/icons/project/ST'
 import { StructureIcon } from '../../../assets/icons/project/Structure'
+import { UsersIcon } from '../../../assets/icons/project/Users'
 import { useOpenPLCStore } from '../../../store'
 import { WorkspaceProjectTreeLeafType } from '../../../store/slices/workspace/types'
 import { cn } from '../../../utils/cn'
@@ -451,6 +452,7 @@ type IProjectTreeLeafProps = ComponentPropsWithoutRef<'li'> & {
     | 'ethercatDevice'
     | 'softMotionDrive'
     | 'libraryManifest'
+    | 'userManagement'
   leafType: WorkspaceProjectTreeLeafType
   label?: string
   busName?: string
@@ -484,6 +486,7 @@ const LeafSources = {
   // render the same glyph — the manifest is the user's entry point
   // into a library project, so it earns a dedicated mark.
   libraryManifest: { LeafIcon: LibraryManifestIcon },
+  userManagement: { LeafIcon: UsersIcon },
 }
 const ProjectTreeLeaf = ({
   leafLang,
@@ -763,7 +766,7 @@ const ProjectTreeLeaf = ({
         </span>
       )}
 
-      {leafLang === 'devPin' || leafLang === 'devConfig' ? null : (
+      {leafLang === 'devPin' || leafLang === 'devConfig' || leafLang === 'userManagement' ? null : (
         <Popover.Root open={isPopoverOpen && !isDebuggerVisible} onOpenChange={setPopoverOpen}>
           <Popover.Trigger
             disabled={isDebuggerVisible}

--- a/src/frontend/components/_organisms/explorer/project.tsx
+++ b/src/frontend/components/_organisms/explorer/project.tsx
@@ -7,6 +7,7 @@ import { useOpenPLCStore } from '../../../store'
 import { extractSearchQuery } from '../../../store/slices/search/utils'
 import type { TabsProps } from '../../../store/slices/tabs'
 import { CreateEditorObjectFromTab, LIBRARY_MANIFEST_TAB_NAME } from '../../../store/slices/tabs/utils'
+import { isUserManagementCapableRuntime } from '../../../utils/device'
 import { useToast } from '../../_features/[app]/toast/use-toast'
 import { CreatePLCElement } from '../../_features/[workspace]/create-element'
 import {
@@ -57,8 +58,11 @@ const Project = () => {
   const canEdit = useOpenPLCStore((s) => s.workspace.canEdit)
 
   // Runtime User Management is only meaningful while connected to a runtime
-  // (it reads/writes the runtime's account list over the authenticated API).
+  // (it reads/writes the runtime's account list over the authenticated API)
+  // AND only exists on runtimes ≥ v4.1.9 — older runtimes lack the endpoints.
   const runtimeConnected = useOpenPLCStore((s) => s.runtimeConnection.connectionStatus === 'connected')
+  const runtimeVersion = useOpenPLCStore((s) => s.runtimeConnection.runtimeVersion)
+  const showUserManagement = runtimeConnected && isUserManagementCapableRuntime(runtimeVersion)
 
   // Per-project-type capability matrix — drives which branches
   // render.  Library projects only show Functions / Function Blocks /
@@ -378,7 +382,7 @@ const Project = () => {
                   }
                 />
               )}
-              {runtimeConnected && (
+              {showUserManagement && (
                 <ProjectTreeLeaf
                   key='User Management'
                   leafLang='userManagement'

--- a/src/frontend/components/_organisms/explorer/project.tsx
+++ b/src/frontend/components/_organisms/explorer/project.tsx
@@ -56,6 +56,10 @@ const Project = () => {
   // endpoint requires edit access, so gate the affordance here too.
   const canEdit = useOpenPLCStore((s) => s.workspace.canEdit)
 
+  // Runtime User Management is only meaningful while connected to a runtime
+  // (it reads/writes the runtime's account list over the authenticated API).
+  const runtimeConnected = useOpenPLCStore((s) => s.runtimeConnection.connectionStatus === 'connected')
+
   // Per-project-type capability matrix — drives which branches
   // render.  Library projects only show Functions / Function Blocks /
   // Data Types plus the manifest tab; Programs / Resource / Devices /
@@ -370,6 +374,21 @@ const Project = () => {
                       name: 'Orchestrators',
                       path: `/device/orchestrators`,
                       elementType: { type: 'device', derivation: 'orchestrators' },
+                    })
+                  }
+                />
+              )}
+              {runtimeConnected && (
+                <ProjectTreeLeaf
+                  key='User Management'
+                  leafLang='userManagement'
+                  leafType='user-management'
+                  label='User Management'
+                  onClick={() =>
+                    handleCreateTab({
+                      name: 'User Management',
+                      path: `/device/user-management`,
+                      elementType: { type: 'user-management' },
                     })
                   }
                 />

--- a/src/frontend/components/_organisms/modals/__tests__/runtime-user-modal.test.tsx
+++ b/src/frontend/components/_organisms/modals/__tests__/runtime-user-modal.test.tsx
@@ -1,0 +1,158 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { RuntimeUserModal, type RuntimeUserModalSubmit } from '../runtime-user-modal'
+
+// Plain typed closures (instead of vi.fn generics) so the same test file is
+// type-correct under both the editor's jest and the web's vitest runner.
+let submitCalls: RuntimeUserModalSubmit[]
+let submitReturn: string | null
+let openChanges: boolean[]
+
+const onSubmit = (values: RuntimeUserModalSubmit): Promise<string | null> => {
+  submitCalls.push(values)
+  return Promise.resolve(submitReturn)
+}
+const onOpenChange = (open: boolean) => {
+  openChanges.push(open)
+}
+
+beforeEach(() => {
+  submitCalls = []
+  submitReturn = null
+  openChanges = []
+})
+
+describe('RuntimeUserModal — password dirty tracking', () => {
+  it('does NOT report a password change when the password field is untouched (edit mode)', async () => {
+    render(
+      <RuntimeUserModal
+        open
+        onOpenChange={onOpenChange}
+        mode='edit'
+        title='Edit user'
+        submitLabel='Save'
+        initialUsername='bob'
+        onSubmit={onSubmit}
+      />,
+    )
+
+    // Change only the username; leave the pre-filled password placeholder alone.
+    fireEvent.change(screen.getByPlaceholderText('Enter username'), { target: { value: 'bobby' } })
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => expect(submitCalls).toHaveLength(1))
+    expect(submitCalls[0].usernameChanged).toBe(true)
+    expect(submitCalls[0].passwordChanged).toBe(false)
+    expect(submitCalls[0].password).toBeUndefined()
+  })
+
+  it('reports a password change once the field is edited (edit mode)', async () => {
+    render(
+      <RuntimeUserModal
+        open
+        onOpenChange={onOpenChange}
+        mode='edit'
+        title='Edit user'
+        submitLabel='Save'
+        initialUsername='bob'
+        onSubmit={onSubmit}
+      />,
+    )
+
+    const pass = screen.getByPlaceholderText('Enter password')
+    const confirm = screen.getByPlaceholderText('Confirm password')
+    // Focus clears the masked placeholder from both fields, then type a new one.
+    fireEvent.focus(pass)
+    fireEvent.change(pass, { target: { value: 'new-secret' } })
+    fireEvent.change(confirm, { target: { value: 'new-secret' } })
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => expect(submitCalls).toHaveLength(1))
+    expect(submitCalls[0].passwordChanged).toBe(true)
+    expect(submitCalls[0].password).toBe('new-secret')
+  })
+
+  it('blocks submit when nothing changed (edit mode)', async () => {
+    render(
+      <RuntimeUserModal
+        open
+        onOpenChange={onOpenChange}
+        mode='edit'
+        title='Edit user'
+        submitLabel='Save'
+        initialUsername='bob'
+        onSubmit={onSubmit}
+      />,
+    )
+    fireEvent.click(screen.getByText('Save'))
+    await screen.findByText('No changes to save')
+    expect(submitCalls).toHaveLength(0)
+  })
+
+  it('requires the current password to change your own password (self edit)', async () => {
+    render(
+      <RuntimeUserModal
+        open
+        onOpenChange={onOpenChange}
+        mode='edit'
+        title='Edit your account'
+        submitLabel='Save'
+        initialUsername='me'
+        requireCurrentPassword
+        onSubmit={onSubmit}
+      />,
+    )
+
+    const pass = screen.getByPlaceholderText('Enter password')
+    fireEvent.focus(pass)
+    fireEvent.change(pass, { target: { value: 'new-secret' } })
+    fireEvent.change(screen.getByPlaceholderText('Confirm password'), { target: { value: 'new-secret' } })
+    fireEvent.click(screen.getByText('Save'))
+
+    await screen.findByText('Your current password is required to change the password')
+    expect(submitCalls).toHaveLength(0)
+  })
+
+  it('rejects mismatched passwords', async () => {
+    render(
+      <RuntimeUserModal
+        open
+        onOpenChange={onOpenChange}
+        mode='create'
+        title='New user'
+        submitLabel='Create'
+        onSubmit={onSubmit}
+      />,
+    )
+    fireEvent.change(screen.getByPlaceholderText('Enter username'), { target: { value: 'bob' } })
+    fireEvent.change(screen.getByPlaceholderText('Enter password'), { target: { value: 'aaa' } })
+    fireEvent.change(screen.getByPlaceholderText('Confirm password'), { target: { value: 'bbb' } })
+    fireEvent.click(screen.getByText('Create'))
+
+    await screen.findByText('Passwords do not match')
+    expect(submitCalls).toHaveLength(0)
+  })
+
+  it('creates a user with the required fields and closes on success (create mode)', async () => {
+    render(
+      <RuntimeUserModal
+        open
+        onOpenChange={onOpenChange}
+        mode='create'
+        title='New user'
+        submitLabel='Create'
+        showRole
+        initialRole='user'
+        onSubmit={onSubmit}
+      />,
+    )
+    fireEvent.change(screen.getByPlaceholderText('Enter username'), { target: { value: 'bob' } })
+    fireEvent.change(screen.getByPlaceholderText('Enter password'), { target: { value: 'secret' } })
+    fireEvent.change(screen.getByPlaceholderText('Confirm password'), { target: { value: 'secret' } })
+    fireEvent.click(screen.getByText('Create'))
+
+    await waitFor(() => expect(submitCalls).toHaveLength(1))
+    expect(submitCalls[0]).toMatchObject({ username: 'bob', password: 'secret', role: 'user', passwordChanged: true })
+    await waitFor(() => expect(openChanges).toContain(false))
+  })
+})

--- a/src/frontend/components/_organisms/modals/runtime-create-user-modal.tsx
+++ b/src/frontend/components/_organisms/modals/runtime-create-user-modal.tsx
@@ -10,7 +10,7 @@ import { RuntimeUserModal, type RuntimeUserModalSubmit } from './runtime-user-mo
  * always makes this first account an admin).
  */
 const RuntimeCreateUserModal = () => {
-  const { modals, modalActions, deviceActions } = useOpenPLCStore()
+  const { modals, modalActions, deviceActions, runtimeConnection } = useOpenPLCStore()
   const runtime = useRuntime()
 
   const isOpen = modals['runtime-create-user']?.open || false
@@ -37,8 +37,12 @@ const RuntimeCreateUserModal = () => {
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {
-      // Cancelling the first-user setup abandons the connection attempt.
-      if (isOpen) deviceActions.setRuntimeConnectionStatus('disconnected')
+      // On success `handleSubmit` has already logged in and set the status to
+      // 'connected'; closing then must NOT tear that down. Only a genuine
+      // cancel (still connecting/disconnected) abandons the connection attempt.
+      if (isOpen && runtimeConnection.connectionStatus !== 'connected') {
+        deviceActions.setRuntimeConnectionStatus('disconnected')
+      }
       modalActions.closeModal()
     }
     modalActions.onOpenChange('runtime-create-user', open)

--- a/src/frontend/components/_organisms/modals/runtime-create-user-modal.tsx
+++ b/src/frontend/components/_organisms/modals/runtime-create-user-modal.tsx
@@ -1,174 +1,59 @@
-import { useState } from 'react'
-
 import { useRuntime } from '../../../../middleware/shared/providers'
 import { useOpenPLCStore } from '../../../store'
 import { getErrorMessage } from '../../../utils/get-error-message'
-import { Label } from '../../_atoms/label'
-import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'
+import { RuntimeUserModal, type RuntimeUserModalSubmit } from './runtime-user-modal'
 
+/**
+ * First-user bootstrap dialog: shown when connecting to a runtime that has no
+ * accounts yet. Reuses the shared RuntimeUserModal form and, on success, also
+ * logs in as the new user and marks the connection as established (the runtime
+ * always makes this first account an admin).
+ */
 const RuntimeCreateUserModal = () => {
-  const { modals, modalActions, deviceActions, runtimeConnection } = useOpenPLCStore()
+  const { modals, modalActions, deviceActions } = useOpenPLCStore()
   const runtime = useRuntime()
-  const [username, setUsername] = useState('')
-  const [password, setPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
-  const [error, setError] = useState('')
-  const [isLoading, setIsLoading] = useState(false)
 
   const isOpen = modals['runtime-create-user']?.open || false
 
-  // Build a stable unique suffix for input ids to prevent browser autofill
-  const deviceId = runtimeConnection.selectedDevice?.deviceId || 'default'
-
-  const handleCreateUser = async () => {
-    setError('')
-
-    if (!username || !password) {
-      setError('Username and password are required')
-      return
-    }
-
-    if (password !== confirmPassword) {
-      setError('Passwords do not match')
-      return
-    }
-
-    setIsLoading(true)
+  const handleSubmit = async ({ username, password }: RuntimeUserModalSubmit): Promise<string | null> => {
+    if (!password) return 'Password is required'
     try {
       const result = await runtime.createUser({ username, password })
-
-      if (result.success) {
-        const loginResult = await runtime.login({ username, password })
-        if (loginResult.success && loginResult.accessToken) {
-          deviceActions.setRuntimeJwtToken(loginResult.accessToken)
-          deviceActions.setRuntimeConnectionStatus('connected')
-          deviceActions.setStoredCredentials({ username, password })
-          modalActions.closeModal()
-          setUsername('')
-          setPassword('')
-          setConfirmPassword('')
-        } else {
-          setError('User created but login failed: ' + (loginResult.error || 'Unknown error'))
-        }
-      } else {
-        setError('Failed to create user: ' + (result.error || 'Unknown error'))
+      if (!result.success) {
+        return 'Failed to create user: ' + (result.error || 'Unknown error')
       }
+      const loginResult = await runtime.login({ username, password })
+      if (loginResult.success && loginResult.accessToken) {
+        deviceActions.setRuntimeJwtToken(loginResult.accessToken)
+        deviceActions.setRuntimeConnectionStatus('connected')
+        deviceActions.setStoredCredentials({ username, password })
+        return null
+      }
+      return 'User created but login failed: ' + (loginResult.error || 'Unknown error')
     } catch (err) {
-      setError('Error: ' + getErrorMessage(err))
-    } finally {
-      setIsLoading(false)
+      return 'Error: ' + getErrorMessage(err)
     }
   }
 
-  const handleCancel = () => {
-    modalActions.closeModal()
-    deviceActions.setRuntimeConnectionStatus('disconnected')
-    setUsername('')
-    setPassword('')
-    setConfirmPassword('')
-    setError('')
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      // Cancelling the first-user setup abandons the connection attempt.
+      if (isOpen) deviceActions.setRuntimeConnectionStatus('disconnected')
+      modalActions.closeModal()
+    }
+    modalActions.onOpenChange('runtime-create-user', open)
   }
 
   return (
-    <Modal
+    <RuntimeUserModal
       open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          handleCancel()
-        }
-        modalActions.onOpenChange('runtime-create-user', open)
-      }}
-    >
-      <ModalContent className='flex min-h-[480px] w-[400px] select-none flex-col items-center justify-start rounded-lg p-6'>
-        <ModalTitle className='mb-4 text-xl font-semibold'>Create First User</ModalTitle>
-
-        <p className='mb-6 text-center text-sm text-neutral-600 dark:text-neutral-400'>
-          This OpenPLC Runtime has no users registered. Please create the first user account.
-        </p>
-
-        <form
-          autoComplete='off'
-          onSubmit={(e) => {
-            e.preventDefault()
-            void handleCreateUser()
-          }}
-          className='flex w-full flex-col gap-4'
-        >
-          <div>
-            <Label htmlFor={`create-user-${deviceId}`} className='mb-2 block text-sm'>
-              Username
-            </Label>
-            <input
-              id={`create-user-${deviceId}`}
-              name={`create-user-${deviceId}`}
-              type='text'
-              autoComplete='off'
-              autoCapitalize='none'
-              spellCheck={false}
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              placeholder='Enter username'
-              className='w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-850 outline-none focus:border-brand dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300'
-              disabled={isLoading}
-            />
-          </div>
-
-          <div>
-            <Label htmlFor={`create-pass-${deviceId}`} className='mb-2 block text-sm'>
-              Password
-            </Label>
-            <input
-              id={`create-pass-${deviceId}`}
-              name={`create-pass-${deviceId}`}
-              type='password'
-              autoComplete='off'
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder='Enter password'
-              className='w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-850 outline-none focus:border-brand dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300'
-              disabled={isLoading}
-            />
-          </div>
-
-          <div>
-            <Label htmlFor={`create-pass-confirm-${deviceId}`} className='mb-2 block text-sm'>
-              Confirm Password
-            </Label>
-            <input
-              id={`create-pass-confirm-${deviceId}`}
-              name={`create-pass-confirm-${deviceId}`}
-              type='password'
-              autoComplete='off'
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              placeholder='Confirm password'
-              className='w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-850 outline-none focus:border-brand dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300'
-              disabled={isLoading}
-            />
-          </div>
-
-          {error && <p className='text-sm text-red-600 dark:text-red-400'>{error}</p>}
-
-          <div className='mt-4 flex gap-3'>
-            <button
-              type='submit'
-              disabled={isLoading}
-              className='flex-1 rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-medium-dark disabled:opacity-50'
-            >
-              {isLoading ? 'Creating...' : 'Create User'}
-            </button>
-            <button
-              type='button'
-              onClick={handleCancel}
-              disabled={isLoading}
-              className='flex-1 rounded-md bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-1000 hover:bg-neutral-200 dark:bg-neutral-850 dark:text-neutral-100'
-            >
-              Cancel
-            </button>
-          </div>
-        </form>
-      </ModalContent>
-    </Modal>
+      onOpenChange={handleOpenChange}
+      mode='bootstrap'
+      title='Create First User'
+      description='This OpenPLC Runtime has no users registered. Please create the first user account.'
+      submitLabel='Create User'
+      onSubmit={handleSubmit}
+    />
   )
 }
 

--- a/src/frontend/components/_organisms/modals/runtime-create-user-modal.tsx
+++ b/src/frontend/components/_organisms/modals/runtime-create-user-modal.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react'
+
 import { useRuntime } from '../../../../middleware/shared/providers'
 import { useOpenPLCStore } from '../../../store'
 import { getErrorMessage } from '../../../utils/get-error-message'
@@ -10,10 +12,21 @@ import { RuntimeUserModal, type RuntimeUserModalSubmit } from './runtime-user-mo
  * always makes this first account an admin).
  */
 const RuntimeCreateUserModal = () => {
-  const { modals, modalActions, deviceActions, runtimeConnection } = useOpenPLCStore()
+  const { modals, modalActions, deviceActions } = useOpenPLCStore()
   const runtime = useRuntime()
 
   const isOpen = modals['runtime-create-user']?.open || false
+
+  // Tracks whether this run successfully created + logged in. A ref (not the
+  // store's connectionStatus) because handleSubmit sets the status and the
+  // modal then calls onOpenChange(false) synchronously — before a re-render —
+  // so reading connectionStatus from the render closure would be stale and the
+  // close handler would wrongly tear down the just-established connection.
+  const succeededRef = useRef(false)
+
+  useEffect(() => {
+    if (isOpen) succeededRef.current = false
+  }, [isOpen])
 
   const handleSubmit = async ({ username, password }: RuntimeUserModalSubmit): Promise<string | null> => {
     if (!password) return 'Password is required'
@@ -27,6 +40,7 @@ const RuntimeCreateUserModal = () => {
         deviceActions.setRuntimeJwtToken(loginResult.accessToken)
         deviceActions.setRuntimeConnectionStatus('connected')
         deviceActions.setStoredCredentials({ username, password })
+        succeededRef.current = true
         return null
       }
       return 'User created but login failed: ' + (loginResult.error || 'Unknown error')
@@ -37,10 +51,9 @@ const RuntimeCreateUserModal = () => {
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {
-      // On success `handleSubmit` has already logged in and set the status to
-      // 'connected'; closing then must NOT tear that down. Only a genuine
-      // cancel (still connecting/disconnected) abandons the connection attempt.
-      if (isOpen && runtimeConnection.connectionStatus !== 'connected') {
+      // Only a genuine cancel (no successful login this run) abandons the
+      // connection attempt; a success close must keep the 'connected' status.
+      if (isOpen && !succeededRef.current) {
         deviceActions.setRuntimeConnectionStatus('disconnected')
       }
       modalActions.closeModal()

--- a/src/frontend/components/_organisms/modals/runtime-user-modal.tsx
+++ b/src/frontend/components/_organisms/modals/runtime-user-modal.tsx
@@ -209,25 +209,6 @@ const RuntimeUserModal = (props: RuntimeUserModalProps) => {
             </div>
           )}
 
-          {isEdit && requireCurrentPassword && passwordTouched && (
-            <div>
-              <Label htmlFor='runtime-user-current-pass' className='mb-2 block text-sm'>
-                Current password
-              </Label>
-              <input
-                id='runtime-user-current-pass'
-                name='runtime-user-current-pass'
-                type='password'
-                autoComplete='off'
-                value={currentPassword}
-                onChange={(e) => setCurrentPassword(e.target.value)}
-                placeholder='Enter your current password'
-                className={inputClass}
-                disabled={isLoading}
-              />
-            </div>
-          )}
-
           <div>
             <Label htmlFor='runtime-user-pass' className='mb-2 block text-sm'>
               {isEdit ? 'New password' : 'Password'}
@@ -263,6 +244,28 @@ const RuntimeUserModal = (props: RuntimeUserModalProps) => {
               disabled={isLoading}
             />
           </div>
+
+          {/* Rendered last, and only once the password is actually being
+              changed, so adding it doesn't shove the field the user just
+              clicked (the new-password field) down the form. */}
+          {isEdit && requireCurrentPassword && passwordTouched && (
+            <div>
+              <Label htmlFor='runtime-user-current-pass' className='mb-2 block text-sm'>
+                Current password
+              </Label>
+              <input
+                id='runtime-user-current-pass'
+                name='runtime-user-current-pass'
+                type='password'
+                autoComplete='off'
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                placeholder='Enter your current password'
+                className={inputClass}
+                disabled={isLoading}
+              />
+            </div>
+          )}
 
           {error && <p className='text-sm text-red-600 dark:text-red-400'>{error}</p>}
 

--- a/src/frontend/components/_organisms/modals/runtime-user-modal.tsx
+++ b/src/frontend/components/_organisms/modals/runtime-user-modal.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useState } from 'react'
+
+import type { RuntimeUserRole } from '../../../../middleware/shared/ports/runtime-port'
+import { Label } from '../../_atoms/label'
+import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'
+
+/**
+ * Normalized result of the form. `*Changed` flags let the caller send only the
+ * fields the user actually touched — critically, `password` is present ONLY
+ * when the password field was genuinely edited, so an untouched form never
+ * resets a password.
+ */
+export interface RuntimeUserModalSubmit {
+  username: string
+  role?: RuntimeUserRole
+  password?: string
+  currentPassword?: string
+  usernameChanged: boolean
+  passwordChanged: boolean
+  roleChanged: boolean
+}
+
+interface RuntimeUserModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** bootstrap = first-user setup, create = admin adding a user, edit = modify existing. */
+  mode: 'bootstrap' | 'create' | 'edit'
+  title: string
+  description?: string
+  submitLabel: string
+  /** Prefill (edit mode). */
+  initialUsername?: string
+  initialRole?: RuntimeUserRole
+  /** Show the Role selector (admin managing accounts). */
+  showRole?: boolean
+  /** Editing your OWN account: a password change must be confirmed with the
+   *  current password (blocks a stolen session from silently resetting it). */
+  requireCurrentPassword?: boolean
+  /** Returns an error message to display, or null on success (which closes the modal). */
+  onSubmit: (values: RuntimeUserModalSubmit) => Promise<string | null>
+}
+
+// Eight bullets shown in a password field in edit mode so it *looks* populated
+// without ever holding (or submitting) a real password. Cleared on first edit.
+const PASSWORD_PLACEHOLDER = '••••••••'
+
+const inputClass =
+  'w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-850 outline-none focus:border-brand dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300'
+
+const RuntimeUserModal = (props: RuntimeUserModalProps) => {
+  const {
+    open,
+    onOpenChange,
+    mode,
+    title,
+    description,
+    submitLabel,
+    initialUsername = '',
+    initialRole = 'user',
+    showRole = false,
+    requireCurrentPassword = false,
+    onSubmit,
+  } = props
+
+  const isEdit = mode === 'edit'
+
+  const [username, setUsername] = useState(initialUsername)
+  const [role, setRole] = useState<RuntimeUserRole>(initialRole)
+  // In edit mode the password fields start as a masked placeholder; a real
+  // change is only registered once the user focuses and types (passwordTouched).
+  const [password, setPassword] = useState(isEdit ? PASSWORD_PLACEHOLDER : '')
+  const [confirmPassword, setConfirmPassword] = useState(isEdit ? PASSWORD_PLACEHOLDER : '')
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [passwordTouched, setPasswordTouched] = useState(false)
+  const [error, setError] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Reset every field when the modal (re)opens, so a reused instance never
+  // leaks state between the account it was last opened for and the next.
+  useEffect(() => {
+    if (open) {
+      setUsername(initialUsername)
+      setRole(initialRole)
+      setPassword(isEdit ? PASSWORD_PLACEHOLDER : '')
+      setConfirmPassword(isEdit ? PASSWORD_PLACEHOLDER : '')
+      setCurrentPassword('')
+      setPasswordTouched(false)
+      setError('')
+      setIsLoading(false)
+    }
+  }, [open, initialUsername, initialRole, isEdit])
+
+  // First interaction with the password fields (edit mode) clears the masked
+  // placeholder from BOTH inputs so the placeholder can never be submitted.
+  const beginPasswordEdit = () => {
+    if (isEdit && !passwordTouched) {
+      setPassword('')
+      setConfirmPassword('')
+      setPasswordTouched(true)
+    }
+  }
+
+  const handleSubmit = async () => {
+    setError('')
+
+    // A password counts as changed only when actually edited to a non-empty value.
+    const passwordChanged = isEdit ? passwordTouched && password.length > 0 : true
+    const usernameTrimmed = username.trim()
+    const usernameChanged = isEdit ? usernameTrimmed !== initialUsername : true
+    const roleChanged = showRole ? role !== initialRole : false
+
+    if (!usernameTrimmed) {
+      setError('Username is required')
+      return
+    }
+
+    if (passwordChanged) {
+      if (!password) {
+        setError('Password is required')
+        return
+      }
+      if (password !== confirmPassword) {
+        setError('Passwords do not match')
+        return
+      }
+      if (requireCurrentPassword && !currentPassword) {
+        setError('Your current password is required to change the password')
+        return
+      }
+    }
+
+    if (isEdit && !usernameChanged && !passwordChanged && !roleChanged) {
+      setError('No changes to save')
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      const result = await onSubmit({
+        username: usernameTrimmed,
+        role: showRole ? role : undefined,
+        password: passwordChanged ? password : undefined,
+        currentPassword: passwordChanged && requireCurrentPassword ? currentPassword : undefined,
+        usernameChanged,
+        passwordChanged,
+        roleChanged,
+      })
+      if (result) {
+        setError(result)
+      } else {
+        onOpenChange(false)
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <ModalContent className='flex w-[400px] select-none flex-col items-center justify-start rounded-lg p-6'>
+        <ModalTitle className='mb-4 text-xl font-semibold'>{title}</ModalTitle>
+
+        {description && (
+          <p className='mb-6 text-center text-sm text-neutral-600 dark:text-neutral-400'>{description}</p>
+        )}
+
+        <form
+          autoComplete='off'
+          onSubmit={(e) => {
+            e.preventDefault()
+            void handleSubmit()
+          }}
+          className='flex w-full flex-col gap-4'
+        >
+          <div>
+            <Label htmlFor='runtime-user-name' className='mb-2 block text-sm'>
+              Username
+            </Label>
+            <input
+              id='runtime-user-name'
+              name='runtime-user-name'
+              type='text'
+              autoComplete='off'
+              autoCapitalize='none'
+              spellCheck={false}
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder='Enter username'
+              className={inputClass}
+              disabled={isLoading}
+            />
+          </div>
+
+          {showRole && (
+            <div>
+              <Label htmlFor='runtime-user-role' className='mb-2 block text-sm'>
+                Role
+              </Label>
+              <select
+                id='runtime-user-role'
+                value={role}
+                onChange={(e) => setRole(e.target.value as RuntimeUserRole)}
+                className={inputClass}
+                disabled={isLoading}
+              >
+                <option value='admin'>Admin</option>
+                <option value='user'>User</option>
+              </select>
+            </div>
+          )}
+
+          {isEdit && requireCurrentPassword && passwordTouched && (
+            <div>
+              <Label htmlFor='runtime-user-current-pass' className='mb-2 block text-sm'>
+                Current password
+              </Label>
+              <input
+                id='runtime-user-current-pass'
+                name='runtime-user-current-pass'
+                type='password'
+                autoComplete='off'
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                placeholder='Enter your current password'
+                className={inputClass}
+                disabled={isLoading}
+              />
+            </div>
+          )}
+
+          <div>
+            <Label htmlFor='runtime-user-pass' className='mb-2 block text-sm'>
+              {isEdit ? 'New password' : 'Password'}
+            </Label>
+            <input
+              id='runtime-user-pass'
+              name='runtime-user-pass'
+              type='password'
+              autoComplete='new-password'
+              value={password}
+              onFocus={beginPasswordEdit}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder='Enter password'
+              className={inputClass}
+              disabled={isLoading}
+            />
+          </div>
+
+          <div>
+            <Label htmlFor='runtime-user-pass-confirm' className='mb-2 block text-sm'>
+              Confirm password
+            </Label>
+            <input
+              id='runtime-user-pass-confirm'
+              name='runtime-user-pass-confirm'
+              type='password'
+              autoComplete='new-password'
+              value={confirmPassword}
+              onFocus={beginPasswordEdit}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder='Confirm password'
+              className={inputClass}
+              disabled={isLoading}
+            />
+          </div>
+
+          {error && <p className='text-sm text-red-600 dark:text-red-400'>{error}</p>}
+
+          <div className='mt-2 flex gap-3'>
+            <button
+              type='submit'
+              disabled={isLoading}
+              className='flex-1 rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-medium-dark disabled:opacity-50'
+            >
+              {isLoading ? 'Saving...' : submitLabel}
+            </button>
+            <button
+              type='button'
+              onClick={() => onOpenChange(false)}
+              disabled={isLoading}
+              className='flex-1 rounded-md bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-1000 hover:bg-neutral-200 dark:bg-neutral-850 dark:text-neutral-100'
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export { RuntimeUserModal }

--- a/src/frontend/screens/workspace-screen.tsx
+++ b/src/frontend/screens/workspace-screen.tsx
@@ -29,6 +29,7 @@ import { ResourcesEditor } from '../components/_features/[workspace]/editor/reso
 import { ModbusServerEditor } from '../components/_features/[workspace]/editor/server/modbus-server'
 import { OpcUaServerEditor } from '../components/_features/[workspace]/editor/server/opcua-server'
 import { S7CommServerEditor } from '../components/_features/[workspace]/editor/server/s7comm-server'
+import { UserManagementEditor } from '../components/_features/[workspace]/editor/user-management'
 import { VendorScreenEditor } from '../components/_features/[workspace]/editor/vendor-screen'
 import { Search } from '../components/_features/[workspace]/search'
 import { SourceControlPanel } from '../components/_features/[workspace]/source-control'
@@ -580,6 +581,7 @@ const WorkspaceScreen = () => {
                         {editor['type'] === 'plc-vendor-screen' && <VendorScreenEditor />}
                         {editor['type'] === 'plc-package-manager' && <PackageManagerEditor />}
                         {editor['type'] === 'plc-library-manager' && <LibraryManagerEditor />}
+                        {editor['type'] === 'plc-user-management' && <UserManagementEditor />}
                         {editor['type'] === 'plc-library-manifest' && <LibraryManifestEditor />}
                         {editor['type'] === 'diff-viewer' && <DiffViewerEditor />}
 

--- a/src/frontend/store/__tests__/device-slice.test.ts
+++ b/src/frontend/store/__tests__/device-slice.test.ts
@@ -1220,6 +1220,24 @@ describe('createDeviceSlice', () => {
   })
 
   // -----------------------------------------------------------------------
+  // setRuntimeVersion
+  // -----------------------------------------------------------------------
+  describe('setRuntimeVersion', () => {
+    it('stores the runtime version', () => {
+      const store = makeStore()
+      store.getState().deviceActions.setRuntimeVersion('v4.1.9')
+      expect(store.getState().runtimeConnection.runtimeVersion).toBe('v4.1.9')
+    })
+
+    it('clears the runtime version with null', () => {
+      const store = makeStore()
+      store.getState().deviceActions.setRuntimeVersion('v4.1.9')
+      store.getState().deviceActions.setRuntimeVersion(null)
+      expect(store.getState().runtimeConnection.runtimeVersion).toBeNull()
+    })
+  })
+
+  // -----------------------------------------------------------------------
   // setPlcRuntimeStatus
   // -----------------------------------------------------------------------
   describe('setPlcRuntimeStatus', () => {
@@ -1401,6 +1419,7 @@ describe('createDeviceSlice', () => {
       store.getState().deviceActions.setIncludeTimingStatsInPolling(true)
       store.getState().deviceActions.setEthercatStatus(makeEthercatStatus())
       store.getState().deviceActions.setIncludeEthercatStatsInPolling(true)
+      store.getState().deviceActions.setRuntimeVersion('v4.1.9')
 
       store.getState().deviceActions.clearRuntimeConnection()
       const rc = store.getState().runtimeConnection
@@ -1408,6 +1427,7 @@ describe('createDeviceSlice', () => {
       expect(rc.connectionStatus).toBe('disconnected')
       expect(rc.plcStatus).toBeNull()
       expect(rc.ipAddress).toBeNull()
+      expect(rc.runtimeVersion).toBeNull()
       expect(rc.selectedDevice).toBeNull()
       expect(rc.storedCredentials).toBeNull()
       expect(rc.timingStats).toBeNull()

--- a/src/frontend/store/__tests__/device-types.test.ts
+++ b/src/frontend/store/__tests__/device-types.test.ts
@@ -96,6 +96,7 @@ describe('Device slice types', () => {
         connectionStatus: 'disconnected',
         plcStatus: null,
         ipAddress: null,
+        runtimeVersion: null,
         selectedDevice: null,
         storedCredentials: null,
         timingStats: null,
@@ -137,6 +138,7 @@ describe('Device slice types', () => {
         connectionStatus: 'connected',
         plcStatus: 'RUNNING',
         ipAddress: '192.168.1.1',
+        runtimeVersion: 'v4.1.9',
         selectedDevice: {
           orchestratorId: 'o',
           orchestratorAgentId: 'a',
@@ -177,6 +179,7 @@ describe('Device slice types', () => {
           connectionStatus: 'disconnected',
           plcStatus: null,
           ipAddress: null,
+          runtimeVersion: null,
           selectedDevice: null,
           storedCredentials: null,
           timingStats: null,

--- a/src/frontend/store/__tests__/tabs-utils.test.ts
+++ b/src/frontend/store/__tests__/tabs-utils.test.ts
@@ -291,6 +291,13 @@ describe('tabs/utils', () => {
       expect(result.type).toBe('plc-server')
     })
 
+    it('creates editor from user-management tab', () => {
+      const tab: TabsProps = { name: 'User Management', elementType: { type: 'user-management' } }
+      const result = CreateEditorObjectFromTab(tab)
+      expect(result.type).toBe('plc-user-management')
+      expect(result.meta.name).toBe('User Management')
+    })
+
     it('creates editor from diff-viewer tab', () => {
       const tab: TabsProps = {
         name: 'Diff: devices/configuration.json',

--- a/src/frontend/store/slices/device/slice.ts
+++ b/src/frontend/store/slices/device/slice.ts
@@ -51,6 +51,7 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
     connectionStatus: 'disconnected',
     plcStatus: null,
     ipAddress: null,
+    runtimeVersion: null,
     selectedDevice: null,
     storedCredentials: null,
     timingStats: null,
@@ -118,6 +119,7 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
           runtimeConnection.connectionStatus = 'disconnected'
           runtimeConnection.plcStatus = null
           runtimeConnection.ipAddress = null
+          runtimeConnection.runtimeVersion = null
           runtimeConnection.selectedDevice = null
           runtimeConnection.storedCredentials = null
           runtimeConnection.timingStats = null
@@ -445,6 +447,13 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
         }),
       )
     },
+    setRuntimeVersion: (version): void => {
+      setState(
+        produce(({ runtimeConnection }: DeviceSlice) => {
+          runtimeConnection.runtimeVersion = version
+        }),
+      )
+    },
     setPlcRuntimeStatus: (status): void => {
       setState(
         produce(({ runtimeConnection }: DeviceSlice) => {
@@ -508,6 +517,7 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
           runtimeConnection.connectionStatus = 'disconnected'
           runtimeConnection.plcStatus = null
           runtimeConnection.ipAddress = null
+          runtimeConnection.runtimeVersion = null
           runtimeConnection.selectedDevice = null
           runtimeConnection.storedCredentials = null
           runtimeConnection.timingStats = null

--- a/src/frontend/store/slices/device/types.ts
+++ b/src/frontend/store/slices/device/types.ts
@@ -64,6 +64,10 @@ export type RuntimeConnection = {
   connectionStatus: ConnectionStatus
   plcStatus: PlcStatus | null
   ipAddress: string | null
+  /** Version string reported by the connected runtime (from
+   *  get-users-info / the X-OpenPLC-Runtime-Version header), or null
+   *  when unknown. Gates version-dependent UI like User Management. */
+  runtimeVersion: string | null
   selectedDevice: SelectedDevice | null
   storedCredentials: StoredCredentials | null
   timingStats: TimingStats | null
@@ -144,6 +148,7 @@ export type DeviceActions = {
   setRuntimeIpAddress: (ipAddress: string) => void
   setRuntimeJwtToken: (token: string | null) => void
   setRuntimeConnectionStatus: (status: ConnectionStatus) => void
+  setRuntimeVersion: (version: string | null) => void
   setPlcRuntimeStatus: (status: PlcStatus | null) => void
   setSelectedDevice: (device: SelectedDevice | null) => void
   setStoredCredentials: (credentials: StoredCredentials | null) => void

--- a/src/frontend/store/slices/editor/types.ts
+++ b/src/frontend/store/slices/editor/types.ts
@@ -181,6 +181,14 @@ export type EditorModel = EditorModelBase &
         }
       }
     | {
+        /** Runtime User Management screen. A device-scoped singleton shown
+         *  under the Device tree branch while connected to a runtime. */
+        type: 'plc-user-management'
+        meta: {
+          name: string
+        }
+      }
+    | {
         /** The Library Project's manifest tab — Monaco-wrapped
          *  `library.json` at the project root.  Only ever opened
          *  when `meta.type === 'plc-library'`.  Always present

--- a/src/frontend/store/slices/tabs/types.ts
+++ b/src/frontend/store/slices/tabs/types.ts
@@ -18,6 +18,7 @@ export type TabsProps = {
     | { type: 'package-manager' }
     | { type: 'library-manager' }
     | { type: 'library-manifest' }
+    | { type: 'user-management' }
     | { type: 'ethercat-device'; busName: string; deviceId: string }
     | { type: 'diff-viewer'; filePath: string }
   configuration?: Record<string, unknown>

--- a/src/frontend/store/slices/tabs/utils.ts
+++ b/src/frontend/store/slices/tabs/utils.ts
@@ -127,6 +127,11 @@ const CreateLibraryManagerEditor = (name = 'Library Manager'): EditorModel => ({
   meta: { name },
 })
 
+const CreateUserManagementEditor = (name = 'User Management'): EditorModel => ({
+  type: 'plc-user-management',
+  meta: { name },
+})
+
 /** Canonical tab name + factory for the Library Project's manifest
  *  editor.  Display label (also the file-slice key the dirty
  *  tracker + save flow look up under); intentionally NOT the on-
@@ -177,6 +182,8 @@ const CreateEditorObjectFromTab = (tab: TabsProps): EditorModel => {
       return CreateLibraryManagerEditor(name)
     case 'library-manifest':
       return CreateLibraryManifestEditor(name)
+    case 'user-management':
+      return CreateUserManagementEditor(name)
     case 'diff-viewer':
       return CreateDiffViewerEditor(name, elementType.filePath)
   }
@@ -196,6 +203,7 @@ export {
   CreateRemoteDeviceEditor,
   CreateResourceEditor,
   CreateServerEditor,
+  CreateUserManagementEditor,
   CreateVendorScreenEditor,
   LIBRARY_MANIFEST_TAB_NAME,
 }

--- a/src/frontend/store/slices/workspace/types.ts
+++ b/src/frontend/store/slices/workspace/types.ts
@@ -39,6 +39,7 @@ export type WorkspaceProjectTreeLeafType =
   | 'package-manager'
   | 'library-manager'
   | 'library-manifest'
+  | 'user-management'
   | 'ethercat-device'
   | null
 

--- a/src/frontend/utils/device.ts
+++ b/src/frontend/utils/device.ts
@@ -11,8 +11,12 @@
  * cleaner "does this target support <feature>?".
  */
 
-import { parseRuntimeVersion } from '@root/backend/shared/firmware/runtime-version-gate'
+import { isUserManagementCapableRuntime, parseRuntimeVersion } from '@root/backend/shared/firmware/runtime-version-gate'
 import { type BoardInfoLike, resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
+
+// Re-exported so component/store layers (which may not import backend-shared
+// directly) can gate UI on runtime capability through the utils layer.
+export { isUserManagementCapableRuntime }
 
 /**
  * Minimal board info shape used by device utility functions.

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -247,11 +247,13 @@ class MainProcessBridge implements MainIpcModule {
   }
 
   handleRuntimeListUsers = async (_event: IpcMainInvokeEvent, ipAddress: string) => {
-    const res = await this.makeRuntimeApiRequest<RuntimeUser[]>(
-      ipAddress,
-      '/api/get-users-info',
-      (data) => JSON.parse(data) as RuntimeUser[],
-    )
+    const res = await this.makeRuntimeApiRequest<RuntimeUser[]>(ipAddress, '/api/get-users-info', (data) => {
+      // With a valid admin token this is a user array; without one the runtime
+      // answers the existence-only {"msg":"Users found"} object — coerce that
+      // (or any non-array) to an empty list so the caller never gets a non-array.
+      const parsed: unknown = JSON.parse(data)
+      return Array.isArray(parsed) ? (parsed as RuntimeUser[]) : []
+    })
     return res.success ? { success: true, users: res.data } : { success: false, error: res.error }
   }
 

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -21,6 +21,7 @@ import type {
   ListPublicLibrariesArgs,
   ListPublicLibrariesResponse,
 } from '@root/middleware/shared/ports/public-catalog-types'
+import type { RuntimeUser, RuntimeUserRole, UpdateUserParams } from '@root/middleware/shared/ports/runtime-port'
 import { createRuntimeTokenManager } from '@root/middleware/shared/runtime-auth/runtime-token-manager'
 import { CreatePouFileProps } from '@root/types/IPC/pou-service'
 import { CreateProjectFileProps } from '@root/types/IPC/project-service'
@@ -214,20 +215,78 @@ class MainProcessBridge implements MainIpcModule {
     ipAddress: string,
     username: string,
     password: string,
+    role?: RuntimeUserRole,
   ) => {
     try {
+      // `role` is only honoured by the runtime for authenticated (admin) creation;
+      // the unauthenticated first-user bootstrap always becomes an admin regardless.
+      const body: { username: string; password: string; role?: RuntimeUserRole } = { username, password }
+      if (role) body.role = role
+      const payload = JSON.stringify(body)
+
+      // First-user bootstrap runs before any login (no token yet) and the
+      // runtime allows it unauthenticated. Once a session exists this is an
+      // admin adding an account, which the runtime requires to be authenticated
+      // — route it through the token authority so an expired token is refreshed.
+      if (this.tokens.hasToken()) {
+        const res = await this.makeRuntimeApiPostRequest(ipAddress, '/api/create-user', payload, () => undefined)
+        return res.success ? { success: true } : { success: false, error: res.error }
+      }
+
       const res = await this.httpRequest({
         method: 'POST',
         url: this.runtimeUrl(ipAddress, '/api/create-user'),
-        body: JSON.stringify({ username, password, role: 'user' }),
+        body: payload,
       })
-      if (res.statusCode === 201) {
-        return { success: true }
-      }
+      if (res.statusCode === 201) return { success: true }
       return { success: false, error: res.data }
     } catch (error) {
       return { success: false, error: getErrorMessage(error) }
     }
+  }
+
+  handleRuntimeListUsers = async (_event: IpcMainInvokeEvent, ipAddress: string) => {
+    const res = await this.makeRuntimeApiRequest<RuntimeUser[]>(
+      ipAddress,
+      '/api/get-users-info',
+      (data) => JSON.parse(data) as RuntimeUser[],
+    )
+    return res.success ? { success: true, users: res.data } : { success: false, error: res.error }
+  }
+
+  handleRuntimeWhoAmI = async (_event: IpcMainInvokeEvent, ipAddress: string) => {
+    const res = await this.makeRuntimeApiRequest<RuntimeUser>(
+      ipAddress,
+      '/api/whoami',
+      (data) => JSON.parse(data) as RuntimeUser,
+    )
+    return res.success ? { success: true, user: res.data } : { success: false, error: res.error }
+  }
+
+  handleRuntimeUpdateUser = async (
+    _event: IpcMainInvokeEvent,
+    ipAddress: string,
+    userId: number,
+    params: UpdateUserParams,
+  ) => {
+    // The runtime expects snake_case `current_password`; only send provided fields.
+    const body: Record<string, string> = {}
+    if (params.username !== undefined) body.username = params.username
+    if (params.password !== undefined) body.password = params.password
+    if (params.currentPassword !== undefined) body.current_password = params.currentPassword
+    if (params.role !== undefined) body.role = params.role
+    const res = await this.makeRuntimeApiMutation(
+      'PUT',
+      ipAddress,
+      `/api/update-user/${userId}`,
+      JSON.stringify(body),
+    )
+    return res.success ? { success: true } : { success: false, error: res.error }
+  }
+
+  handleRuntimeDeleteUser = async (_event: IpcMainInvokeEvent, ipAddress: string, userId: number) => {
+    const res = await this.makeRuntimeApiMutation('DELETE', ipAddress, `/api/delete-user/${userId}`)
+    return res.success ? { success: true } : { success: false, error: res.error }
   }
 
   private async performAuthentication(
@@ -400,6 +459,72 @@ class MainProcessBridge implements MainIpcModule {
         (r) => !r.success && this.isTokenExpiredError(r.statusCode, r.error),
       )
       .then(stripStatus)
+  }
+
+  /**
+   * Authenticated PUT/DELETE against the runtime API, going through the token
+   * authority. Unlike the GET/POST helpers this retries only on 401 (a genuine
+   * expired token): the user-management endpoints use 403 as a legitimate
+   * business response (e.g. "current password incorrect", "admin required"),
+   * so retrying on 403 would trigger a pointless re-authentication. Any 2xx is
+   * success; the raw body is returned so callers can surface error messages.
+   */
+  private makeRuntimeApiMutation(
+    method: 'PUT' | 'DELETE',
+    ipAddress: string,
+    endpoint: string,
+    body?: string,
+  ): Promise<{ success: true; data: string } | { success: false; error: string }> {
+    type R = { success: true; data: string } | { success: false; error: string; statusCode?: number }
+
+    const doRequest = (token: string): Promise<R> =>
+      new Promise((resolve) => {
+        const headers: Record<string, string | number> = { Authorization: `Bearer ${token}` }
+        if (body !== undefined) {
+          headers['Content-Type'] = 'application/json'
+          headers['Content-Length'] = Buffer.byteLength(body)
+        }
+        const req = https.request(
+          {
+            hostname: ipAddress,
+            port: this.RUNTIME_API_PORT,
+            path: endpoint,
+            method,
+            headers,
+            ...getRuntimeHttpsOptions(),
+          },
+          (res: IncomingMessage) => {
+            let data = ''
+            res.on('data', (chunk: Buffer) => {
+              data += chunk.toString()
+            })
+            res.on('end', () => {
+              const statusCode = res.statusCode ?? 0
+              if (statusCode >= 200 && statusCode < 300) {
+                resolve({ success: true, data })
+              } else {
+                resolve({ success: false, error: data || `Unexpected status: ${statusCode}`, statusCode })
+              }
+            })
+          },
+        )
+        req.setTimeout(this.RUNTIME_CONNECTION_TIMEOUT_MS, () => {
+          req.destroy()
+          resolve({ success: false, error: 'Connection timeout' })
+        })
+        req.on('error', (error: Error) => {
+          resolve({ success: false, error: error.message })
+        })
+        if (body !== undefined) req.write(body)
+        req.end()
+      })
+
+    return this.tokens
+      .withAuth<R>(
+        (token) => doRequest(token),
+        (r) => !r.success && r.statusCode === 401,
+      )
+      .then((r) => (r.success ? { success: true, data: r.data } : { success: false, error: r.error }))
   }
 
   /**
@@ -903,6 +1028,10 @@ class MainProcessBridge implements MainIpcModule {
     // ===================== RUNTIME API =====================
     this.registerHandle('runtime:get-users-info', this.handleRuntimeGetUsersInfo)
     this.registerHandle('runtime:create-user', this.handleRuntimeCreateUser)
+    this.registerHandle('runtime:list-users', this.handleRuntimeListUsers)
+    this.registerHandle('runtime:whoami', this.handleRuntimeWhoAmI)
+    this.registerHandle('runtime:update-user', this.handleRuntimeUpdateUser)
+    this.registerHandle('runtime:delete-user', this.handleRuntimeDeleteUser)
     this.registerHandle('runtime:login', this.handleRuntimeLogin)
     this.registerHandle('runtime:get-status', this.handleRuntimeGetStatus)
     this.registerHandle('runtime:start-plc', this.handleRuntimeStartPlc)

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -278,12 +278,7 @@ class MainProcessBridge implements MainIpcModule {
     if (params.password !== undefined) body.password = params.password
     if (params.currentPassword !== undefined) body.current_password = params.currentPassword
     if (params.role !== undefined) body.role = params.role
-    const res = await this.makeRuntimeApiMutation(
-      'PUT',
-      ipAddress,
-      `/api/update-user/${userId}`,
-      JSON.stringify(body),
-    )
+    const res = await this.makeRuntimeApiMutation('PUT', ipAddress, `/api/update-user/${userId}`, JSON.stringify(body))
     return res.success ? { success: true } : { success: false, error: res.error }
   }
 

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -227,9 +227,10 @@ class MainProcessBridge implements MainIpcModule {
       // First-user bootstrap runs before any login (no token yet) and the
       // runtime allows it unauthenticated. Once a session exists this is an
       // admin adding an account, which the runtime requires to be authenticated
-      // — route it through the token authority so an expired token is refreshed.
+      // — route it through the token authority (mutation helper accepts the
+      // runtime's 201 Created and refreshes an expired token).
       if (this.tokens.hasToken()) {
-        const res = await this.makeRuntimeApiPostRequest(ipAddress, '/api/create-user', payload, () => undefined)
+        const res = await this.makeRuntimeApiMutation('POST', ipAddress, '/api/create-user', payload)
         return res.success ? { success: true } : { success: false, error: res.error }
       }
 
@@ -470,7 +471,7 @@ class MainProcessBridge implements MainIpcModule {
    * success; the raw body is returned so callers can surface error messages.
    */
   private makeRuntimeApiMutation(
-    method: 'PUT' | 'DELETE',
+    method: 'POST' | 'PUT' | 'DELETE',
     ipAddress: string,
     endpoint: string,
     body?: string,

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -15,6 +15,12 @@ import type {
   ListPublicLibrariesArgs,
   ListPublicLibrariesResponse,
 } from '@root/middleware/shared/ports/public-catalog-types'
+import type {
+  ListUsersResult,
+  RuntimeUserRole,
+  UpdateUserParams,
+  WhoAmIResult,
+} from '@root/middleware/shared/ports/runtime-port'
 import type { PLCProjectData } from '@root/middleware/shared/ports/types'
 import { CreatePouFileProps, PouServiceResponse } from '@root/types/IPC/pou-service'
 import { CreateProjectFileProps, IProjectServiceResponse } from '@root/types/IPC/project-service'
@@ -455,8 +461,20 @@ const rendererProcessBridge = {
     ipAddress: string,
     username: string,
     password: string,
+    role?: RuntimeUserRole,
   ): Promise<{ success: boolean; error?: string }> =>
-    ipcRenderer.invoke('runtime:create-user', ipAddress, username, password),
+    ipcRenderer.invoke('runtime:create-user', ipAddress, username, password, role),
+  runtimeListUsers: (ipAddress: string): Promise<ListUsersResult> =>
+    ipcRenderer.invoke('runtime:list-users', ipAddress),
+  runtimeWhoAmI: (ipAddress: string): Promise<WhoAmIResult> => ipcRenderer.invoke('runtime:whoami', ipAddress),
+  runtimeUpdateUser: (
+    ipAddress: string,
+    userId: number,
+    params: UpdateUserParams,
+  ): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('runtime:update-user', ipAddress, userId, params),
+  runtimeDeleteUser: (ipAddress: string, userId: number): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('runtime:delete-user', ipAddress, userId),
   runtimeLogin: (
     ipAddress: string,
     username: string,

--- a/src/middleware/adapters/editor/__tests__/runtime-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/runtime-adapter.test.ts
@@ -11,6 +11,13 @@ beforeEach(() => {
     runtimeLogin: jest.fn().mockResolvedValue({ success: true, accessToken: 'jwt-token-123' }),
     runtimeCreateUser: jest.fn().mockResolvedValue({ success: true }),
     runtimeGetUsersInfo: jest.fn().mockResolvedValue({ hasUsers: true, runtimeVersion: '4.0.0' }),
+    runtimeListUsers: jest.fn().mockResolvedValue({
+      success: true,
+      users: [{ id: 1, username: 'admin', role: 'admin' }],
+    }),
+    runtimeWhoAmI: jest.fn().mockResolvedValue({ success: true, user: { id: 1, username: 'admin', role: 'admin' } }),
+    runtimeUpdateUser: jest.fn().mockResolvedValue({ success: true }),
+    runtimeDeleteUser: jest.fn().mockResolvedValue({ success: true }),
     runtimeGetStatus: jest.fn().mockResolvedValue({ success: true, status: 'RUNNING' }),
     runtimeStartPlc: jest.fn().mockResolvedValue({ success: true }),
     runtimeStopPlc: jest.fn().mockResolvedValue({ success: true }),
@@ -83,11 +90,17 @@ describe('login', () => {
 // ---------------------------------------------------------------------------
 
 describe('createUser', () => {
-  it('delegates to bridge with IP and credentials', async () => {
+  it('delegates to bridge with IP and credentials (no role forwards undefined)', async () => {
     const result = await adapter.createUser({ username: 'newuser', password: 'pass123' })
 
-    expect(window.bridge.runtimeCreateUser).toHaveBeenCalledWith('192.168.1.100', 'newuser', 'pass123')
+    expect(window.bridge.runtimeCreateUser).toHaveBeenCalledWith('192.168.1.100', 'newuser', 'pass123', undefined)
     expect(result).toEqual({ success: true })
+  })
+
+  it('forwards the role when provided', async () => {
+    await adapter.createUser({ username: 'newuser', password: 'pass123', role: 'admin' })
+
+    expect(window.bridge.runtimeCreateUser).toHaveBeenCalledWith('192.168.1.100', 'newuser', 'pass123', 'admin')
   })
 
   it('returns error when no IP configured', async () => {
@@ -102,6 +115,91 @@ describe('createUser', () => {
     const result = await adapter.createUser({ username: 'newuser', password: 'pass123' })
 
     expect(result).toEqual({ success: false, error: 'Connection refused' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// listUsers / whoAmI / updateUser / deleteUser
+// ---------------------------------------------------------------------------
+
+describe('listUsers', () => {
+  it('delegates to bridge with IP', async () => {
+    const result = await adapter.listUsers()
+    expect(window.bridge.runtimeListUsers).toHaveBeenCalledWith('192.168.1.100')
+    expect(result).toEqual({ success: true, users: [{ id: 1, username: 'admin', role: 'admin' }] })
+  })
+
+  it('returns error when no IP configured', async () => {
+    mockIpAddress = ''
+    const result = await adapter.listUsers()
+    expect(result).toEqual({ success: false, error: 'No runtime IP address configured' })
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeListUsers as jest.Mock).mockRejectedValue(new Error('list failed'))
+    const result = await adapter.listUsers()
+    expect(result).toEqual({ success: false, error: 'list failed' })
+  })
+})
+
+describe('whoAmI', () => {
+  it('delegates to bridge with IP', async () => {
+    const result = await adapter.whoAmI()
+    expect(window.bridge.runtimeWhoAmI).toHaveBeenCalledWith('192.168.1.100')
+    expect(result).toEqual({ success: true, user: { id: 1, username: 'admin', role: 'admin' } })
+  })
+
+  it('returns error when no IP configured', async () => {
+    mockIpAddress = ''
+    const result = await adapter.whoAmI()
+    expect(result).toEqual({ success: false, error: 'No runtime IP address configured' })
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeWhoAmI as jest.Mock).mockRejectedValue(new Error('whoami failed'))
+    const result = await adapter.whoAmI()
+    expect(result).toEqual({ success: false, error: 'whoami failed' })
+  })
+})
+
+describe('updateUser', () => {
+  it('delegates to bridge with IP, id and params', async () => {
+    const params = { username: 'bobby', password: 'np', currentPassword: 'op', role: 'user' as const }
+    const result = await adapter.updateUser(7, params)
+    expect(window.bridge.runtimeUpdateUser).toHaveBeenCalledWith('192.168.1.100', 7, params)
+    expect(result).toEqual({ success: true })
+  })
+
+  it('returns error when no IP configured', async () => {
+    mockIpAddress = ''
+    const result = await adapter.updateUser(7, { username: 'x' })
+    expect(result).toEqual({ success: false, error: 'No runtime IP address configured' })
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeUpdateUser as jest.Mock).mockRejectedValue(new Error('update failed'))
+    const result = await adapter.updateUser(7, { username: 'x' })
+    expect(result).toEqual({ success: false, error: 'update failed' })
+  })
+})
+
+describe('deleteUser', () => {
+  it('delegates to bridge with IP and id', async () => {
+    const result = await adapter.deleteUser(9)
+    expect(window.bridge.runtimeDeleteUser).toHaveBeenCalledWith('192.168.1.100', 9)
+    expect(result).toEqual({ success: true })
+  })
+
+  it('returns error when no IP configured', async () => {
+    mockIpAddress = ''
+    const result = await adapter.deleteUser(9)
+    expect(result).toEqual({ success: false, error: 'No runtime IP address configured' })
+  })
+
+  it('catches bridge errors', async () => {
+    ;(window.bridge.runtimeDeleteUser as jest.Mock).mockRejectedValue(new Error('delete failed'))
+    const result = await adapter.deleteUser(9)
+    expect(result).toEqual({ success: false, error: 'delete failed' })
   })
 })
 

--- a/src/middleware/adapters/editor/runtime-adapter.ts
+++ b/src/middleware/adapters/editor/runtime-adapter.ts
@@ -21,12 +21,15 @@ import type {
   DiscoverDevicesOptions,
   DiscoverDevicesResult,
   DiscoveredRuntimeDevice,
+  ListUsersResult,
   LoginParams,
   LoginResult,
   RuntimeLogsResult,
   RuntimePort,
   RuntimeStatusResult,
+  UpdateUserParams,
   UsersInfoResult,
+  WhoAmIResult,
 } from '../../shared/ports/runtime-port'
 import type { SerialPort, Unsubscribe } from '../../shared/ports/types'
 
@@ -62,7 +65,7 @@ export function createEditorRuntimeAdapter(getIpAddress: () => string): RuntimeP
     async createUser(params) {
       try {
         const ip = requireIp()
-        return await window.bridge.runtimeCreateUser(ip, params.username, params.password)
+        return await window.bridge.runtimeCreateUser(ip, params.username, params.password, params.role)
       } catch (err) {
         return { success: false, error: getErrorMessage(err) }
       }
@@ -74,6 +77,42 @@ export function createEditorRuntimeAdapter(getIpAddress: () => string): RuntimeP
         return await window.bridge.runtimeGetUsersInfo(ip)
       } catch (err) {
         return { hasUsers: false, error: getErrorMessage(err) }
+      }
+    },
+
+    async listUsers(): Promise<ListUsersResult> {
+      try {
+        const ip = requireIp()
+        return await window.bridge.runtimeListUsers(ip)
+      } catch (err) {
+        return { success: false, error: getErrorMessage(err) }
+      }
+    },
+
+    async whoAmI(): Promise<WhoAmIResult> {
+      try {
+        const ip = requireIp()
+        return await window.bridge.runtimeWhoAmI(ip)
+      } catch (err) {
+        return { success: false, error: getErrorMessage(err) }
+      }
+    },
+
+    async updateUser(userId: number, params: UpdateUserParams) {
+      try {
+        const ip = requireIp()
+        return await window.bridge.runtimeUpdateUser(ip, userId, params)
+      } catch (err) {
+        return { success: false, error: getErrorMessage(err) }
+      }
+    },
+
+    async deleteUser(userId: number) {
+      try {
+        const ip = requireIp()
+        return await window.bridge.runtimeDeleteUser(ip, userId)
+      } catch (err) {
+        return { success: false, error: getErrorMessage(err) }
       }
     },
 

--- a/src/middleware/shared/ports/runtime-port.ts
+++ b/src/middleware/shared/ports/runtime-port.ts
@@ -61,15 +61,55 @@ export interface LoginResult {
   error?: string
 }
 
+/**
+ * RBAC role for a runtime account. `admin` may manage every account;
+ * `user` may edit only its own account and cannot create/delete users.
+ */
+export type RuntimeUserRole = 'admin' | 'user'
+
 export interface CreateUserParams {
   username: string
   password: string
+  /** Role for the new account. Ignored for the unauthenticated first-user
+   *  bootstrap (the runtime always makes the first user an admin). */
+  role?: RuntimeUserRole
 }
 
 export interface UsersInfoResult {
   hasUsers: boolean
   runtimeVersion?: string
   error?: string
+}
+
+/** A user account as reported by the runtime. */
+export interface RuntimeUser {
+  id: number
+  username: string
+  role: RuntimeUserRole
+}
+
+export interface ListUsersResult {
+  success: boolean
+  users?: RuntimeUser[]
+  error?: string
+}
+
+export interface WhoAmIResult {
+  success: boolean
+  user?: RuntimeUser
+  error?: string
+}
+
+/**
+ * Fields to change on an existing account. Only the provided fields are
+ * applied. `currentPassword` is required by the runtime when changing your
+ * OWN password (not when an admin resets another user's password).
+ */
+export interface UpdateUserParams {
+  username?: string
+  password?: string
+  currentPassword?: string
+  role?: RuntimeUserRole
 }
 
 export interface RuntimeStatusResult {
@@ -132,6 +172,18 @@ export interface RuntimePort {
 
   /** Check if the runtime has users and get its version. */
   getUsersInfo(): Promise<UsersInfoResult>
+
+  /** List all user accounts on the runtime (requires authentication). */
+  listUsers(): Promise<ListUsersResult>
+
+  /** Return the currently authenticated account (id, username, role). */
+  whoAmI(): Promise<WhoAmIResult>
+
+  /** Update an account's username, password and/or role. */
+  updateUser(userId: number, params: UpdateUserParams): Promise<{ success: boolean; error?: string }>
+
+  /** Delete an account by id (admin only; cannot delete your own account). */
+  deleteUser(userId: number): Promise<{ success: boolean; error?: string }>
 
   /** Get current PLC runtime status with optional timing statistics. */
   getStatus(includeStats?: boolean): Promise<RuntimeStatusResult>


### PR DESCRIPTION
## Summary
Adds a **User Management** screen under the project tree's **Device** folder, shown only while connected to a runtime. An admin can list, create, edit, and delete runtime accounts; a normal user can edit only their own account. Pairs with the runtime API PR (Autonomy-Logic/openplc-runtime#155) and the web parity PR.

## Changes
- **Screen**: single users table (OPC-UA style) with per-row edit/delete icons, a Role column, `(you)` marker, and a `+ New User` button — actions role-gated in the UI (the runtime is the real authorization boundary).
- **Reusable `RuntimeUserModal`** (create | edit | bootstrap). The existing first-user dialog is refactored to use it. In edit mode the password field shows a masked placeholder and a password is only sent when actually edited (dirty-tracked) — **an untouched form never resets a password**; editing your own password requires the current password.
- **Ports/adapter/IPC**: `RuntimePort` gains `listUsers` / `whoAmI` / `updateUser` / `deleteUser` and a `role` on `createUser`; editor adapter + new `runtime:*` IPC channels implement them. `create-user` goes unauthenticated for first-user bootstrap, authenticated (admin) afterwards.
- New `plc-user-management` editor variant + gated Device-tree leaf + Users icon.

## Cross-repo / parity
- All shared files (`frontend/**`, `middleware/shared/**`) are byte-identical with openplc-web (compare-surfaces gate passes, 0 diffs).

## Testing
- Editor adapter methods (100%), tabs factory, and `RuntimeUserModal` dirty-password / current-password / validation rules. Typecheck, ESLint, and `validate:arch` clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a version-gated **User Management** device-tree section, editor tab, and icon (with suppressed leaf actions where applicable).
  * Introduced runtime user management: list users, view current user, and create/edit/delete users with role-aware UI, permission-aware actions, and password-change handling.
* **Bug Fixes**
  * Improved runtime user flows to reliably detect edited fields, validate changes, and handle sign-out/authorization outcomes cleanly.
* **Tests**
  * Expanded coverage for runtime capability gating, IPC/adapter delegation, and user modal validation (create/edit password-change scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->