### PR TITLE
fix(pou): show return type selector for graphical function POUs

### DIFF
--- a/src/frontend/components/_organisms/variables-editor/__tests__/return-type-visibility.test.tsx
+++ b/src/frontend/components/_organisms/variables-editor/__tests__/return-type-visibility.test.tsx
@@ -8,7 +8,11 @@ vi.mock('@root/frontend/components/_organisms/variables-code-editor', () => ({
 import { useOpenPLCStore } from '../../../../store'
 import { VariablesEditor } from '../index'
 
-const createPou = (name: string, type: 'program' | 'function' | 'function-block', language: 'st' | 'fbd' | 'ld') => {
+const createPou = (
+  name: string,
+  type: 'program' | 'function' | 'function-block',
+  language: 'st' | 'fbd' | 'ld' | 'sfc',
+) => {
   const result = useOpenPLCStore.getState().pouActions.create({ type, name, language })
   expect(result.ok).toBe(true)
 }
@@ -25,6 +29,19 @@ describe('VariablesEditor return type selector', () => {
     createPou('LdFunction', 'function', 'ld')
     render(<VariablesEditor name='LdFunction' />)
     expect(screen.getByText('Return type :')).toBeTruthy()
+  })
+
+  it('shows the return type selector for a function written in SFC', () => {
+    createPou('SfcFunction', 'function', 'sfc')
+    render(<VariablesEditor name='SfcFunction' />)
+    expect(screen.getByText('Return type :')).toBeTruthy()
+  })
+
+  it('associates the return type label with its select trigger', () => {
+    createPou('LabeledFunction', 'function', 'fbd')
+    render(<VariablesEditor name='LabeledFunction' />)
+    const trigger = screen.getByLabelText('Return type :')
+    expect(trigger.id).toBe('return-type')
   })
 
   it('shows the return type selector for a function written in ST', () => {

--- a/src/frontend/components/_organisms/variables-editor/__tests__/return-type-visibility.test.tsx
+++ b/src/frontend/components/_organisms/variables-editor/__tests__/return-type-visibility.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+
+// The variables code editor pulls in Monaco, which cannot run in jsdom.
+vi.mock('@root/frontend/components/_organisms/variables-code-editor', () => ({
+  VariablesCodeEditor: () => <div data-testid='variables-code-editor' />,
+}))
+
+import { useOpenPLCStore } from '../../../../store'
+import { VariablesEditor } from '../index'
+
+const createPou = (name: string, type: 'program' | 'function' | 'function-block', language: 'st' | 'fbd' | 'ld') => {
+  const result = useOpenPLCStore.getState().pouActions.create({ type, name, language })
+  expect(result.ok).toBe(true)
+}
+
+// https://github.com/Autonomy-Logic/openplc-editor/issues/696
+describe('VariablesEditor return type selector', () => {
+  it('shows the return type selector for a function written in FBD', () => {
+    createPou('FbdFunction', 'function', 'fbd')
+    render(<VariablesEditor name='FbdFunction' />)
+    expect(screen.getByText('Return type :')).toBeTruthy()
+  })
+
+  it('shows the return type selector for a function written in LD', () => {
+    createPou('LdFunction', 'function', 'ld')
+    render(<VariablesEditor name='LdFunction' />)
+    expect(screen.getByText('Return type :')).toBeTruthy()
+  })
+
+  it('shows the return type selector for a function written in ST', () => {
+    createPou('StFunction', 'function', 'st')
+    render(<VariablesEditor name='StFunction' />)
+    expect(screen.getByText('Return type :')).toBeTruthy()
+  })
+
+  it('does not show the return type selector for an FBD program', () => {
+    createPou('FbdProgram', 'program', 'fbd')
+    render(<VariablesEditor name='FbdProgram' />)
+    expect(screen.queryByText('Return type :')).toBeNull()
+  })
+
+  it('does not show the return type selector for an FBD function block', () => {
+    createPou('FbdBlock', 'function-block', 'fbd')
+    render(<VariablesEditor name='FbdBlock' />)
+    expect(screen.queryByText('Return type :')).toBeNull()
+  })
+})

--- a/src/frontend/components/_organisms/variables-editor/index.tsx
+++ b/src/frontend/components/_organisms/variables-editor/index.tsx
@@ -1052,7 +1052,7 @@ const VariablesEditor = ({ name: propName, isActive: _isActive = true }: Variabl
         <div aria-label='Variables editor actions' className='relative flex h-8 w-full gap-4'>
           {editorVariables.display === 'table' && (
             <div aria-label='Variables editor table actions container' className='flex h-full w-full select-none gap-4'>
-              {editor.type === 'plc-textual' && editor.meta.pouType === 'function' && (
+              {(editor.type === 'plc-textual' || editor.type === 'plc-graphical') && editor.meta.pouType === 'function' && (
                 <div className='flex h-full max-w-lg flex-1 items-center gap-2'>
                   <label
                     htmlFor='return type'

--- a/src/frontend/components/_organisms/variables-editor/index.tsx
+++ b/src/frontend/components/_organisms/variables-editor/index.tsx
@@ -1052,42 +1052,43 @@ const VariablesEditor = ({ name: propName, isActive: _isActive = true }: Variabl
         <div aria-label='Variables editor actions' className='relative flex h-8 w-full gap-4'>
           {editorVariables.display === 'table' && (
             <div aria-label='Variables editor table actions container' className='flex h-full w-full select-none gap-4'>
-              {(editor.type === 'plc-textual' || editor.type === 'plc-graphical') && editor.meta.pouType === 'function' && (
-                <div className='flex h-full max-w-lg flex-1 items-center gap-2'>
-                  <label
-                    htmlFor='return-type'
-                    className='w-fit text-nowrap text-xs font-medium text-neutral-1000 dark:text-neutral-300'
-                  >
-                    Return type :
-                  </label>
-                  <Select value={returnType} onValueChange={handleReturnTypeChange}>
-                    <SelectTrigger
-                      id='return-type'
-                      placeholder={returnType}
-                      withIndicator
-                      className='group flex h-full w-full items-center justify-between rounded-lg border border-neutral-500 px-2 font-caption text-cp-sm font-medium text-neutral-850 outline-none dark:border-neutral-850 dark:text-neutral-300'
-                    />
-                    <SelectContent
-                      position='popper'
-                      sideOffset={3}
-                      align='center'
-                      className='box h-fit min-w-44 overflow-hidden rounded-lg bg-white outline-none dark:bg-neutral-950'
+              {(editor.type === 'plc-textual' || editor.type === 'plc-graphical') &&
+                editor.meta.pouType === 'function' && (
+                  <div className='flex h-full max-w-lg flex-1 items-center gap-2'>
+                    <label
+                      htmlFor='return-type'
+                      className='w-fit text-nowrap text-xs font-medium text-neutral-1000 dark:text-neutral-300'
                     >
-                      {returnTypeOptions.map((filter) => (
-                        <SelectItem
-                          key={filter}
-                          value={filter}
-                          className='flex w-full cursor-pointer items-center justify-center py-1 outline-none hover:bg-neutral-100 dark:hover:bg-neutral-900'
-                        >
-                          <span className='text-center font-caption text-xs font-normal text-neutral-700 dark:text-neutral-500'>
-                            {filter}
-                          </span>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              )}
+                      Return type :
+                    </label>
+                    <Select value={returnType} onValueChange={handleReturnTypeChange}>
+                      <SelectTrigger
+                        id='return-type'
+                        placeholder={returnType}
+                        withIndicator
+                        className='group flex h-full w-full items-center justify-between rounded-lg border border-neutral-500 px-2 font-caption text-cp-sm font-medium text-neutral-850 outline-none dark:border-neutral-850 dark:text-neutral-300'
+                      />
+                      <SelectContent
+                        position='popper'
+                        sideOffset={3}
+                        align='center'
+                        className='box h-fit min-w-44 overflow-hidden rounded-lg bg-white outline-none dark:bg-neutral-950'
+                      >
+                        {returnTypeOptions.map((filter) => (
+                          <SelectItem
+                            key={filter}
+                            value={filter}
+                            className='flex w-full cursor-pointer items-center justify-center py-1 outline-none hover:bg-neutral-100 dark:hover:bg-neutral-900'
+                          >
+                            <span className='text-center font-caption text-xs font-normal text-neutral-700 dark:text-neutral-500'>
+                              {filter}
+                            </span>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
 
               <div
                 id='Pou documentation'

--- a/src/frontend/components/_organisms/variables-editor/index.tsx
+++ b/src/frontend/components/_organisms/variables-editor/index.tsx
@@ -1055,14 +1055,14 @@ const VariablesEditor = ({ name: propName, isActive: _isActive = true }: Variabl
               {(editor.type === 'plc-textual' || editor.type === 'plc-graphical') && editor.meta.pouType === 'function' && (
                 <div className='flex h-full max-w-lg flex-1 items-center gap-2'>
                   <label
-                    htmlFor='return type'
+                    htmlFor='return-type'
                     className='w-fit text-nowrap text-xs font-medium text-neutral-1000 dark:text-neutral-300'
                   >
                     Return type :
                   </label>
                   <Select value={returnType} onValueChange={handleReturnTypeChange}>
                     <SelectTrigger
-                      id='class-filter'
+                      id='return-type'
                       placeholder={returnType}
                       withIndicator
                       className='group flex h-full w-full items-center justify-between rounded-lg border border-neutral-500 px-2 font-caption text-cp-sm font-medium text-neutral-850 outline-none dark:border-neutral-850 dark:text-neutral-300'


### PR DESCRIPTION
# Pull request info

## References

This PR resolves #696.

### Link to Jira task

External contribution — no Jira access; branch follows the `bugfix/gh-<n>-<slug>` convention from CONTRIBUTING.md.

## Description of the changes proposed

- The return type selector in the variables editor was rendered only when `editor.type === 'plc-textual'`, so functions written in FBD, LD, or SFC had no way to select their return type (the field simply never appeared, as reported in #696).
- Everything below the UI already supports graphical function return types: `projectActions.updatePouReturnType` is language-agnostic, `createPouObject` defaults new functions to `BOOL`, and the ST transpiler emits `FUNCTION <name> : <returnType>` for graphical POUs (`emit/pou-graphical.ts`). The selector's render condition was the only gap.
- Extended the condition to `(editor.type === 'plc-textual' || editor.type === 'plc-graphical') && editor.meta.pouType === 'function'`. Both editor model variants carry the same `meta.pouType` shape, so TypeScript narrowing is unaffected.
- Added a component test (`return-type-visibility.test.tsx`, 5 cases): selector visible for FBD, LD, and ST functions; absent for an FBD program and an FBD function block. The FBD and LD cases fail without the fix and pass with it.

## DOD checklist

- [x] The code is complete and according to developers' standards.
- [x] I have performed a self-review of my code.
- [x] Meet the acceptance criteria.
- [x] Unit tests are written and green.
- [ ] Test coverage: components are outside the enforced coverage directories; full suite passes (5324 tests, the 4 pre-existing `board-info-resolver` failures on Windows are unrelated and fail on a clean checkout too).
- [ ] Integration tests are written and green. (N/A — UI-only change; no integration surface.)
- [ ] Changes were communicated and updated in the ticket description. (External contribution — GitHub issue referenced instead.)
- [ ] Reviewed and accepted by the Product Owner.
- [ ] End-to-end test are successful. (Repo's Playwright setup currently contains only the example spec.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5TQ1y3yBEDx73tYTHoUBj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed **Return type** selector visibility logic so it only appears for applicable function POUs, including correct behavior across graphical and textual editors.

* **New Features**
  * The Variables Editor now reliably shows the **Return type** selector for function POUs in both FBD/LDM/ST/SFC contexts.

* **Tests**
  * Added automated tests covering language-mode and POU-type visibility, plus accessibility behavior to ensure the label correctly targets the **Return type** control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->