### PR TITLE
fix(explorer): stop rendering search-highlight markup as tree labels

### DIFF
--- a/src/frontend/components/_molecules/project-tree/__tests__/leaf-highlight.test.tsx
+++ b/src/frontend/components/_molecules/project-tree/__tests__/leaf-highlight.test.tsx
@@ -55,7 +55,12 @@ describe('ProjectTreeLeaf search highlight', () => {
 
   it('applies the same safe highlighting on expandable leaves', () => {
     const { container } = render(
-      <ProjectTreeExpandableLeaf leafLang='remoteDevice' leafType='remote-device' label='EtherBus' highlightQuery='Ether' />,
+      <ProjectTreeExpandableLeaf
+        leafLang='remoteDevice'
+        leafType='remote-device'
+        label='EtherBus'
+        highlightQuery='Ether'
+      />,
     )
 
     expect(container.textContent).toContain('EtherBus')

--- a/src/frontend/components/_molecules/project-tree/__tests__/leaf-highlight.test.tsx
+++ b/src/frontend/components/_molecules/project-tree/__tests__/leaf-highlight.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+
+import { ProjectTreeExpandableLeaf, ProjectTreeLeaf } from '../index'
+
+// https://github.com/Autonomy-Logic/openplc-editor/issues/640
+// The explorer used to pass a search-highlight HTML string as the leaf `label`,
+// which ProjectTreeLeaf renders as plain text — after any project search, the
+// matching POU's name appeared in the tree as literal markup
+// (`<span class="bg-brand-light...`). The label must stay the element's real
+// name; highlighting is applied safely inside the leaf via `highlightQuery`.
+describe('ProjectTreeLeaf search highlight', () => {
+  it('renders the plain name and applies a safe highlight when highlightQuery matches', () => {
+    const { container } = render(
+      <ProjectTreeLeaf leafLang='fbd' leafType='function-block' label='Taktgeber' highlightQuery='Takt' />,
+    )
+
+    expect(screen.getByText(/Takt/).textContent).not.toContain('<span')
+    expect(container.textContent).toBe('Taktgeber')
+
+    const highlight = container.querySelector('span.bg-brand-light')
+    expect(highlight).not.toBeNull()
+    expect(highlight?.textContent).toBe('Takt')
+  })
+
+  it('renders the plain name without highlight markup when there is no query', () => {
+    const { container } = render(<ProjectTreeLeaf leafLang='fbd' leafType='function-block' label='Taktgeber' />)
+
+    expect(container.textContent).toBe('Taktgeber')
+    expect(container.querySelector('span.bg-brand-light')).toBeNull()
+  })
+
+  it('never shows literal markup for a non-matching query', () => {
+    const { container } = render(
+      <ProjectTreeLeaf leafLang='fbd' leafType='function-block' label='Taktgeber' highlightQuery='zzz' />,
+    )
+
+    expect(container.textContent).toBe('Taktgeber')
+    expect(container.textContent).not.toContain('<span')
+  })
+
+  it('applies the same safe highlighting on expandable leaves', () => {
+    const { container } = render(
+      <ProjectTreeExpandableLeaf leafLang='remoteDevice' leafType='remote-device' label='EtherBus' highlightQuery='Ether' />,
+    )
+
+    expect(container.textContent).toContain('EtherBus')
+    expect(container.textContent).not.toContain('<span')
+    const highlight = container.querySelector('span.bg-brand-light')
+    expect(highlight?.textContent).toBe('Ether')
+  })
+})

--- a/src/frontend/components/_molecules/project-tree/__tests__/leaf-highlight.test.tsx
+++ b/src/frontend/components/_molecules/project-tree/__tests__/leaf-highlight.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 
+import { useOpenPLCStore } from '../../../../store'
 import { ProjectTreeExpandableLeaf, ProjectTreeLeaf } from '../index'
 
 // https://github.com/Autonomy-Logic/openplc-editor/issues/640
@@ -36,6 +37,20 @@ describe('ProjectTreeLeaf search highlight', () => {
 
     expect(container.textContent).toBe('Taktgeber')
     expect(container.textContent).not.toContain('<span')
+  })
+
+  it('keeps the plain name as the element identity while highlighted', () => {
+    const { container } = render(
+      <ProjectTreeLeaf leafLang='fbd' leafType='function-block' label='Taktgeber' highlightQuery='Takt' />,
+    )
+
+    const leaf = container.querySelector('li')
+    expect(leaf).not.toBeNull()
+    if (leaf) fireEvent.click(leaf)
+
+    // Selection must record the real POU name, never the decorated display string.
+    const { selectedProjectTreeLeaf } = useOpenPLCStore.getState().workspace
+    expect(selectedProjectTreeLeaf.label).toBe('Taktgeber')
   })
 
   it('applies the same safe highlighting on expandable leaves', () => {

--- a/src/frontend/components/_molecules/project-tree/index.tsx
+++ b/src/frontend/components/_molecules/project-tree/index.tsx
@@ -34,6 +34,7 @@ import { useOpenPLCStore } from '../../../store'
 import { WorkspaceProjectTreeLeafType } from '../../../store/slices/workspace/types'
 import { cn } from '../../../utils/cn'
 import { isUnsaved, unsavedLabel } from '../../../utils/unsaved-label'
+import { HighlightedText } from '../../_atoms/highlighted-text'
 import { toast } from '../../_features/[app]/toast/use-toast'
 
 const pousAllLanguages = ['il', 'st', 'python', 'cpp', 'ld', 'sfc', 'fbd'] as const
@@ -244,6 +245,12 @@ type IProjectTreeExpandableLeafProps = ComponentPropsWithoutRef<'li'> & {
   leafLang: IProjectTreeLeafProps['leafLang']
   leafType: WorkspaceProjectTreeLeafType
   label?: string
+  /**
+   * Search query used only to highlight matches in the displayed label.
+   * Kept separate from `label`, which must stay the element's real name:
+   * rename/duplicate/delete and selection all use `label` as identity.
+   */
+  highlightQuery?: string
   children?: ReactNode
 }
 
@@ -251,6 +258,7 @@ const ProjectTreeExpandableLeaf = ({
   leafLang,
   leafType,
   label,
+  highlightQuery,
   children,
   onClick: handleLeafClick,
   ...res
@@ -372,7 +380,7 @@ const ProjectTreeExpandableLeaf = ({
               )}
               onDoubleClick={() => !isDebuggerVisible && setIsEditing(true)}
             >
-              {handleLabel(label) || ''}
+              <HighlightedText text={handleLabel(label) || ''} searchQuery={highlightQuery} />
             </span>
           )}
         </div>
@@ -453,6 +461,12 @@ type IProjectTreeLeafProps = ComponentPropsWithoutRef<'li'> & {
     | 'libraryManifest'
   leafType: WorkspaceProjectTreeLeafType
   label?: string
+  /**
+   * Search query used only to highlight matches in the displayed label.
+   * Kept separate from `label`, which must stay the element's real name:
+   * rename/duplicate/delete and selection all use `label` as identity.
+   */
+  highlightQuery?: string
   busName?: string
   deviceId?: string
 }
@@ -489,6 +503,7 @@ const ProjectTreeLeaf = ({
   leafLang,
   leafType,
   label,
+  highlightQuery,
   busName,
   deviceId,
   onClick: handleLeafClick,
@@ -759,7 +774,7 @@ const ProjectTreeLeaf = ({
           )}
           onDoubleClick={() => !isDebuggerVisible && setIsEditing(true)}
         >
-          {handleLabel(label) || ''}
+          <HighlightedText text={handleLabel(label) || ''} searchQuery={highlightQuery} />
         </span>
       )}
 

--- a/src/frontend/components/_organisms/explorer/project.tsx
+++ b/src/frontend/components/_organisms/explorer/project.tsx
@@ -260,7 +260,7 @@ const Project = () => {
                     leafLang={pou.body.language as PouLeafLang}
                     leafType='program'
                     label={pou.name}
-                  highlightQuery={searchQuery}
+                    highlightQuery={searchQuery}
                     onClick={() =>
                       handleCreateTab({
                         name: pou.name,

--- a/src/frontend/components/_organisms/explorer/project.tsx
+++ b/src/frontend/components/_organisms/explorer/project.tsx
@@ -4,7 +4,6 @@ import { projectCapabilities } from '../../../../middleware/shared/ports/types'
 import { useCapabilities, useProject } from '../../../../middleware/shared/providers'
 import { FolderIcon } from '../../../assets/icons/interface/Folder'
 import { useOpenPLCStore } from '../../../store'
-import { extractSearchQuery } from '../../../store/slices/search/utils'
 import type { TabsProps } from '../../../store/slices/tabs'
 import { CreateEditorObjectFromTab, LIBRARY_MANIFEST_TAB_NAME } from '../../../store/slices/tabs/utils'
 import { useToast } from '../../_features/[app]/toast/use-toast'
@@ -204,7 +203,8 @@ const Project = () => {
                   key={pou.name}
                   leafLang={pou.body.language as PouLeafLang}
                   leafType='function'
-                  label={searchQuery ? extractSearchQuery(pou.name, searchQuery) : pou.name}
+                  label={pou.name}
+                  highlightQuery={searchQuery}
                   onClick={() =>
                     handleCreateTab({
                       name: pou.name,
@@ -226,7 +226,8 @@ const Project = () => {
                   key={pou.name}
                   leafLang={pou.body.language as PouLeafLang}
                   leafType='function-block'
-                  label={searchQuery ? extractSearchQuery(pou.name, searchQuery) : pou.name}
+                  label={pou.name}
+                  highlightQuery={searchQuery}
                   onClick={() =>
                     handleCreateTab({
                       name: pou.name,
@@ -250,7 +251,8 @@ const Project = () => {
                     key={pou.name}
                     leafLang={pou.body.language as PouLeafLang}
                     leafType='program'
-                    label={searchQuery ? extractSearchQuery(pou.name, searchQuery) : pou.name}
+                    label={pou.name}
+                  highlightQuery={searchQuery}
                     onClick={() =>
                       handleCreateTab({
                         name: pou.name,
@@ -273,7 +275,8 @@ const Project = () => {
                   key={name}
                   leafLang='arr'
                   leafType='data-type'
-                  label={searchQuery ? extractSearchQuery(name, searchQuery) : name}
+                  label={name}
+                  highlightQuery={searchQuery}
                   onClick={() =>
                     handleCreateTab({
                       name,
@@ -291,7 +294,8 @@ const Project = () => {
                   key={name}
                   leafLang='enum'
                   leafType='data-type'
-                  label={searchQuery ? extractSearchQuery(name, searchQuery) : name}
+                  label={name}
+                  highlightQuery={searchQuery}
                   /** Todo: Update the tab state */
                   onClick={() =>
                     handleCreateTab({
@@ -310,7 +314,8 @@ const Project = () => {
                   key={name}
                   leafLang='str'
                   leafType='data-type'
-                  label={searchQuery ? extractSearchQuery(name, searchQuery) : name}
+                  label={name}
+                  highlightQuery={searchQuery}
                   /** Todo: Update the tab state */
                   onClick={() =>
                     handleCreateTab({
@@ -409,7 +414,8 @@ const Project = () => {
                     key={server.name}
                     leafLang='server'
                     leafType='server'
-                    label={searchQuery ? extractSearchQuery(server.name, searchQuery) : server.name}
+                    label={server.name}
+                    highlightQuery={searchQuery}
                     onClick={() =>
                       handleCreateTab({
                         name: server.name,
@@ -433,7 +439,8 @@ const Project = () => {
                       key={device.name}
                       leafLang='remoteDevice'
                       leafType='remote-device'
-                      label={searchQuery ? extractSearchQuery(device.name, searchQuery) : device.name}
+                      label={device.name}
+                      highlightQuery={searchQuery}
                       onClick={() =>
                         handleCreateTab({
                           name: device.name,
@@ -449,7 +456,8 @@ const Project = () => {
                           leafType='ethercat-device'
                           busName={device.name}
                           deviceId={child.id}
-                          label={searchQuery ? extractSearchQuery(child.name, searchQuery) : child.name}
+                          label={child.name}
+                          highlightQuery={searchQuery}
                           onClick={() =>
                             handleCreateTab({
                               name: child.name,
@@ -465,7 +473,8 @@ const Project = () => {
                       key={device.name}
                       leafLang='remoteDevice'
                       leafType='remote-device'
-                      label={searchQuery ? extractSearchQuery(device.name, searchQuery) : device.name}
+                      label={device.name}
+                      highlightQuery={searchQuery}
                       onClick={() =>
                         handleCreateTab({
                           name: device.name,


### PR DESCRIPTION
# Pull request info

## References

This PR resolves #640.

### Link to Jira task

External contribution — no Jira access; branch follows the `bugfix/gh-<n>-<slug>` convention from CONTRIBUTING.md.

## Description of the changes proposed

**Root cause** (explains why the issue was unreproducible in the original thread): the corruption is not caused by editing a function block — it is triggered by the project search. `explorer/project.tsx` passed `extractSearchQuery(pou.name, searchQuery)` — a sanitized **HTML string** with `<span class='bg-brand-light...'>` around matches — as the `label` prop of `ProjectTreeLeaf`, which renders its label as plain text. Since `searchQuery` persists in the store after a search completes (it is only cleared when the search modal reopens or the project closes), the explorer permanently displayed the matching element's name as literal markup until restart. The reporter had searched for his function block at some point before editing it; editing was coincidental.

Deterministic reproduction on current `development` (verified in the running app): create a function block named `Taktgeber` → Search → type `Taktgeber` → Find → the tree leaf displays `<span class=\"bg-brand-light dark:bg-brand-medium-dark border-0 rounded-sm\">Taktgeber</span>` — byte-identical to the issue's screenshot.

**Secondary hazard fixed by the same change**: the decorated string was also used as the element's *identity* — `ProjectTreeLeaf` seeds its rename input from `label` and passes `label` to rename/duplicate/delete/selection. While a highlight matched, those actions targeted a POU name that does not exist.

**Fix**: `label` now always carries the plain element name (identity), and a new optional `highlightQuery` prop on `ProjectTreeLeaf`/`ProjectTreeExpandableLeaf` renders the visual highlight safely through the existing `HighlightedText` atom — the same approach the search results panel already uses. All 10 explorer call sites updated; `extractSearchQuery` remains in use by the search results panel where it is rendered correctly.

**After the fix** (running app, same repro steps — name renders with a proper highlight, matching the search panel):

![tree highlight after fix](https://raw.githubusercontent.com/emerson-d-lopes/openplc-editor/assets/gh-640-screenshots/640-fixed-highlight.png)

## DOD checklist

- [x] The code is complete and according to developers' standards.
- [x] I have performed a self-review of my code.
- [x] Meet the acceptance criteria.
- [x] Unit tests are written and green (4 new tests: safe highlight applied on both leaf variants, no literal markup, no-query and non-matching-query cases).
- [ ] Test coverage: components are outside the enforced coverage directories; full suite passes (5323 tests; the 4 pre-existing `board-info-resolver` failures on Windows fail identically on a clean checkout).
- [ ] Integration tests are written and green. (N/A — verified end-to-end in the running app: the reproduction that showed literal markup before the change now renders a highlighted name.)
- [ ] Changes were communicated and updated in the ticket description. (External contribution — GitHub issue referenced instead.)
- [ ] Reviewed and accepted by the Product Owner.
- [ ] End-to-end test are successful. (Repo's Playwright setup currently contains only the example spec.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5TQ1y3yBEDx73tYTHoUBj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The project explorer’s tree item labels now visually highlight matching search terms in-place.
  * Highlighting is consistent across expandable and non-expandable entries.

* **Bug Fixes**
  * Matching text is highlighted safely, keeping label content plain (no literal markup is introduced).
  * Labels are no longer rewritten for search—selection and identity still use the original label value.
  * No highlighting is shown when there’s no search query or no match.

* **Tests**
  * Added coverage for safe highlight rendering and correct selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->