### PR TITLE
fix(lsp): resolve connection and message types from one vscode-jsonrpc copy (DOPE-505)

### DIFF
--- a/src/frontend/services/lsp-shared/transport.ts
+++ b/src/frontend/services/lsp-shared/transport.ts
@@ -26,7 +26,11 @@ import {
   BrowserMessageWriter,
   createMessageConnection,
   type MessageConnection,
-} from 'vscode-jsonrpc/browser'
+  // Import via the protocol package so the connection and the message types
+  // (InitializeRequest, DidOpen…, ParameterStructures) share ONE vscode-jsonrpc
+  // copy — a second copy fails ParameterStructures identity checks at runtime
+  // ("Unknown parameter structure byName"). See DOPE-505.
+} from 'vscode-languageserver-protocol/browser'
 
 export interface LspTransport {
   /** JSON-RPC connection.  Caller is responsible for `listen()`. */

--- a/src/frontend/services/python-lsp/index.ts
+++ b/src/frontend/services/python-lsp/index.ts
@@ -62,7 +62,7 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
   // workspace members get `publishDiagnostics` — without these
   // notifications the document buffer is populated but never
   // enters the analysis queue.
-  let pyrightConnection: import('vscode-jsonrpc/browser').MessageConnection | null = null
+  let pyrightConnection: import('vscode-languageserver-protocol/browser').MessageConnection | null = null
 
   // Per-URI registry, keyed by Monaco model URI.  Holds the
   // preamble Pyright sees concatenated with the user body, the LSP


### PR DESCRIPTION
## Problem

In openplc-web the dual `vscode-jsonrpc` copies (8.2.1 direct + 8.2.0 nested under `vscode-languageserver-protocol`) crash project load at the ST-LSP `initialize` handshake with **"Unknown parameter structure byName"** (`ParameterStructures` identity check across copies).

The editor's npm layout dedupes 8.x to one copy, so runtime is unaffected here — this is the byte-identical mirror of the shared `src/frontend` fix per the mirror-PR policy.

## Fix

`lsp-shared/transport.ts` imports the transport through `'vscode-languageserver-protocol/browser'` (re-exports `vscode-jsonrpc/browser` resolved against its own nested copy) so connection and message types share one copy in every layout. Same-source type for `pyrightConnection` in `python-lsp`.

## Validation

- `tsc --noEmit`: 0 errors
- jest services tests: pass

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/616

Jira: [DOPE-505](https://autonomylogic.atlassian.net/browse/DOPE-505)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Zbz8hMi93XvA1RenC9bXN

[DOPE-505]: https://autonomylogic.atlassian.net/browse/DOPE-505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language server communication reliability by aligning browser-based protocol components and connection types.
  * Prevented potential runtime mismatches when processing language server messages and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->