### PR TITLE
chore(deps): upgrade @xyflow/react 12.0.1 → 12.11.2 (DOPE-492)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-plc-editor",
-  "version": "4.2.6",
+  "version": "4.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-plc-editor",
-      "version": "4.2.6",
+      "version": "4.2.8",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
@@ -33,7 +33,7 @@
         "@tailwindcss/forms": "^0.5.10",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-table": "^8.21.2",
-        "@xyflow/react": "^12.0.1",
+        "@xyflow/react": "^12.11.2",
         "auto-zustand-selectors-hook": "^2.0.0",
         "avr8js": "0.20.0",
         "axios": "^1.13.6",
@@ -9816,15 +9816,15 @@
       }
     },
     "node_modules/@types/d3-selection": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.10.tgz",
-      "integrity": "sha512-cuHoUgS/V3hLdjJOLTT691+G2QoqAjCVLmr4kJXR4ha56w1Zdu8UUQ5TxLRqudgNjwXeQxKMq4j+lyf9sWuslg==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
       "license": "MIT"
     },
     "node_modules/@types/d3-transition": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.8.tgz",
-      "integrity": "sha512-ew63aJfQ/ms7QQ4X7pk5NxQ9fZH/z+i24ZfJ6tJSfqxJMrYLiK01EAs2/Rtw/JreGUsS3pLPNV644qXFGnoZNQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-selection": "*"
@@ -11049,17 +11049,28 @@
       "license": "Apache-2.0"
     },
     "node_modules/@xyflow/react": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.0.1.tgz",
-      "integrity": "sha512-iGh/nO7key0sVH0c8TW2qvLNU0akJ20Mi3LPUF2pymhRqerrBk0EJhPLXRThbYWy4pNWUnkhpBLB0/gr884qnw==",
+      "version": "12.11.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
+      "integrity": "sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==",
+      "license": "MIT",
       "dependencies": {
-        "@xyflow/system": "0.0.35",
+        "@xyflow/system": "0.0.79",
         "classcat": "^5.0.3",
         "zustand": "^4.4.0"
       },
       "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
         "react": ">=17",
         "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@xyflow/react/node_modules/zustand": {
@@ -11091,15 +11102,18 @@
       }
     },
     "node_modules/@xyflow/system": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.35.tgz",
-      "integrity": "sha512-QaUkahvmMs2gY2ykxUfjs5CbkXzU5fQNtmoQQ6HmHoAr8n2D7UyLO/UEXlke2jxuCDuiwpXhrzn4DmffVJd2qA==",
+      "version": "0.0.79",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.79.tgz",
+      "integrity": "sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==",
+      "license": "MIT",
       "dependencies": {
         "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
         "@types/d3-selection": "^3.0.10",
         "@types/d3-transition": "^3.0.8",
         "@types/d3-zoom": "^3.0.8",
         "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@tailwindcss/forms": "^0.5.10",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-table": "^8.21.2",
-    "@xyflow/react": "^12.0.1",
+    "@xyflow/react": "^12.11.2",
     "auto-zustand-selectors-hook": "^2.0.0",
     "avr8js": "0.20.0",
     "axios": "^1.13.6",

--- a/src/frontend/components/_atoms/graphical-editor/fbd/handle.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/fbd/handle.tsx
@@ -3,6 +3,8 @@ import { Handle, HandleProps } from '@xyflow/react'
 import { cn } from '../../../../utils/cn'
 
 export type CustomHandleProps = HandleProps & {
+  /** FBD handles always carry an explicit id — strip the `null` xyflow ≥12.11 allows */
+  id?: string
   glbPosition: {
     x: number
     y: number
@@ -39,7 +41,7 @@ export const CustomHandle = ({
   )
 }
 
-type BuildHandleProps = HandleProps & {
+type BuildHandleProps = Omit<CustomHandleProps, 'glbPosition' | 'relPosition'> & {
   glbX: number
   glbY: number
   relX: number
@@ -53,7 +55,7 @@ type BuildHandleProps = HandleProps & {
  * @param relY: number - The y coordinate of the handle based on the relative position (inside the node)
  * @returns CustomHandleProps
  */
-export const buildHandle = ({ glbX, glbY, relX, relY, ...rest }: BuildHandleProps) => {
+export const buildHandle = ({ glbX, glbY, relX, relY, ...rest }: BuildHandleProps): CustomHandleProps => {
   return {
     glbPosition: {
       x: glbX,

--- a/src/frontend/components/_atoms/graphical-editor/ladder/handle.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/ladder/handle.tsx
@@ -3,6 +3,8 @@ import { Handle, HandleProps } from '@xyflow/react'
 import { cn } from '../../../../utils/cn'
 
 export type CustomHandleProps = HandleProps & {
+  /** ladder handles always carry an explicit id — strip the `null` xyflow ≥12.11 allows */
+  id?: string
   glbPosition: {
     x: number
     y: number
@@ -37,7 +39,7 @@ export const CustomHandle = ({
   )
 }
 
-type BuildHandleProps = HandleProps & {
+type BuildHandleProps = Omit<CustomHandleProps, 'glbPosition' | 'relPosition'> & {
   glbX: number
   glbY: number
   relX: number
@@ -51,7 +53,7 @@ type BuildHandleProps = HandleProps & {
  * @param relY: number - The y coordinate of the handle based on the relative position (inside the node)
  * @returns CustomHandleProps
  */
-export const buildHandle = ({ glbX, glbY, relX, relY, ...rest }: BuildHandleProps) => {
+export const buildHandle = ({ glbX, glbY, relX, relY, ...rest }: BuildHandleProps): CustomHandleProps => {
   return {
     glbPosition: {
       x: glbX,

--- a/src/frontend/components/_molecules/graphical-editor/fbd/index.tsx
+++ b/src/frontend/components/_molecules/graphical-editor/fbd/index.tsx
@@ -634,17 +634,19 @@ export const FBDBody = ({ rung, nodeDivergences = [], isDebuggerActive = false }
   /**
    * When the node drag stops, update the fbd rung state
    */
-  const onNodeDragStop = useStableCallback((_e: globalThis.MouseEvent | globalThis.TouchEvent, _node: FlowNode, nodes: FlowNode[]) => {
-    setDragging(false)
-    fbdFlowActions.setRung({
-      editorName: pouName,
-      rung: {
-        ...rungLocal,
-        nodes: rungLocal.nodes.map((node) => nodes.find((n) => n.id === node.id) ?? node),
-        edges: rungLocal.edges,
-      },
-    })
-  })
+  const onNodeDragStop = useStableCallback(
+    (_e: globalThis.MouseEvent | globalThis.TouchEvent, _node: FlowNode, nodes: FlowNode[]) => {
+      setDragging(false)
+      fbdFlowActions.setRung({
+        editorName: pouName,
+        rung: {
+          ...rungLocal,
+          nodes: rungLocal.nodes.map((node) => nodes.find((n) => n.id === node.id) ?? node),
+          edges: rungLocal.edges,
+        },
+      })
+    },
+  )
 
   /**
    * Handle the drag enter of the viewport

--- a/src/frontend/components/_molecules/graphical-editor/fbd/index.tsx
+++ b/src/frontend/components/_molecules/graphical-editor/fbd/index.tsx
@@ -634,7 +634,7 @@ export const FBDBody = ({ rung, nodeDivergences = [], isDebuggerActive = false }
   /**
    * When the node drag stops, update the fbd rung state
    */
-  const onNodeDragStop = useStableCallback((_e: MouseEvent, _node: FlowNode, nodes: FlowNode[]) => {
+  const onNodeDragStop = useStableCallback((_e: globalThis.MouseEvent | globalThis.TouchEvent, _node: FlowNode, nodes: FlowNode[]) => {
     setDragging(false)
     fbdFlowActions.setRung({
       editorName: pouName,

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/body.tsx
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/body.tsx
@@ -680,8 +680,8 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
   /**
    * Handle the drag of a node
    */
-  const handleNodeDrag = (event: MouseEvent) => {
-    if (!reactFlowInstance) return
+  const handleNodeDrag = (event: globalThis.MouseEvent | globalThis.TouchEvent) => {
+    if (!reactFlowInstance || !('clientX' in event)) return
     const closestPlaceholder = onElementDragOver(rungLocal, reactFlowInstance, { x: event.clientX, y: event.clientY })
     if (!closestPlaceholder) return
 
@@ -753,13 +753,13 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
   const onNodesDelete = useStableCallback((nodes: FlowNode[]) => {
     handleRemoveNode(nodes)
   })
-  const onNodeDragStart = useStableCallback((_event: MouseEvent, node: FlowNode) => {
+  const onNodeDragStart = useStableCallback((_event: globalThis.MouseEvent | globalThis.TouchEvent, node: FlowNode) => {
     handleNodeStartDrag(node)
   })
-  const onNodeDrag = useStableCallback((event: MouseEvent) => {
+  const onNodeDrag = useStableCallback((event: globalThis.MouseEvent | globalThis.TouchEvent) => {
     handleNodeDrag(event)
   })
-  const onNodeDragStop = useStableCallback((_event: MouseEvent, node: FlowNode) => {
+  const onNodeDragStop = useStableCallback((_event: globalThis.MouseEvent | globalThis.TouchEvent, node: FlowNode) => {
     handleNodeDragStop(node)
   })
   const onNodeDoubleClick = useStableCallback((_event: MouseEvent, node: FlowNode) => {
@@ -978,7 +978,9 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
               onDragOver: onDragOver,
               onDrop: onDrop,
 
-              nodeExtent: reactFlowPanelExtent,
+              // No nodeExtent here: node positions belong to the ladder layout engine. xyflow ≥12.9
+              // stopped recomputing drag-clamped positionAbsolute when the extent later grows, so a
+              // mid-drag clamp against the stale extent would freeze nodes at wrong positions (DOPE-492).
               translateExtent: reactFlowPanelExtent,
               panActivationKeyCode: null,
               panOnDrag: false,


### PR DESCRIPTION
## What

Bump `@xyflow/react` 12.0.1 → 12.11.2 (`@xyflow/system` 0.0.35 → 0.0.79 rides along). Same major, 11 minor releases. Prerequisite for the ladder single-instance-per-POU refactor (DOPE-446 series); brings free perf wins on measured ladder/FBD hot paths (skip-measurement rendering 12.8.5, faster insertion 12.9, FlowRenderer re-render eliminations 12.10, draggable-only XYDrag + imperative viewport 12.11.2).

Byte-identical mirror of the shared `src/frontend` changes per the mirror-PR policy.

## Code changes

**Type-level breaks fixed:** `HandleProps.id` (now `string | null`) pinned back to `id?: string` in `CustomHandleProps` + typed `buildHandle` returns (ladder + fbd `handle.tsx`); `OnNodeDrag` native-event signatures in `ladder/rung/body.tsx` + `fbd/index.tsx`.

**Behavior fix:** removed `nodeExtent` from the ladder `ReactFlowPanel` — xyflow ≥12.9 no longer recomputes drag-clamped `positionAbsolute` when the extent later grows, so a mid-drag clamp against the stale extent froze ladder nodes at wrong positions (corruption + "Maximum update depth" crash on drag-out-of-parallel). Layout engine owns positions; `translateExtent` stays.

## Validation

- DOPE-492 regression checklist validated manually (drag scenarios incl. parallel round-trip)
- `tsc --noEmit`: 0 errors; jest: all green; prod build (main+renderer): pass

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/617

Jira: [DOPE-492](https://autonomylogic.atlassian.net/browse/DOPE-492)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Zbz8hMi93XvA1RenC9bXN

[DOPE-492]: https://autonomylogic.atlassian.net/browse/DOPE-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved graphical editor support for touch-based dragging.
  * Added more reliable handle identification in ladder and function-block diagrams.

* **Bug Fixes**
  * Prevented nodes from being incorrectly constrained during ladder diagram dragging.
  * Improved drag event handling across mouse and touch interactions.

* **Improvements**
  * Updated the graphical editor framework for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->