### PR TITLE
chore(release): bump version to 4.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-plc-editor",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "license": "GPL-3.0",
   "author": {
     "name": "Autonomy Logic"

--- a/src/frontend/data/constants/app-version.ts
+++ b/src/frontend/data/constants/app-version.ts
@@ -18,4 +18,4 @@
  * compares a per-deploy `BUILD_ID` (git commit SHA), not this version, so a
  * stale tab is detected on every deploy even without a version bump.
  */
-export const APP_VERSION = '4.2.8'
+export const APP_VERSION = '4.2.9'


### PR DESCRIPTION
Bumps the app version to **4.2.9** ahead of the release.

- `APP_VERSION` in `src/frontend/data/constants/app-version.ts` (the single source of truth the About dialog renders, shared byte-for-byte with openplc-web).
- `package.json.version` set to the same value so electron-builder stamps the binary and the release tag `v4.2.9` match.

Both are bumped together to avoid the About-dialog/binary drift. Web mirror PR accompanies this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 4.2.9.
  * Updated the displayed version information to remain consistent across the app and packaged builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->