### PR TITLE
fix(variables): accept %MX memory-bit locations for BOOL (v4.2.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-plc-editor",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
-  "version": "4.2.9",
+  "version": "4.2.10",
   "license": "GPL-3.0",
   "author": {
     "name": "Autonomy Logic"

--- a/src/frontend/data/constants/app-version.ts
+++ b/src/frontend/data/constants/app-version.ts
@@ -18,4 +18,4 @@
  * compares a per-deploy `BUILD_ID` (git commit SHA), not this version, so a
  * stale tab is detected on every deploy even without a version bump.
  */
-export const APP_VERSION = '4.2.9'
+export const APP_VERSION = '4.2.10'

--- a/src/frontend/store/__tests__/project-validation-variables.test.ts
+++ b/src/frontend/store/__tests__/project-validation-variables.test.ts
@@ -507,6 +507,15 @@ describe('updateVariableValidation', () => {
     expect(result.ok).toBe(true)
   })
 
+  it.each(['%QX0.0', '%IX0.0', '%MX0.0', '%MX3.7'])(
+    'accepts every valid IEC area prefix for BOOL locations (%s)',
+    (location) => {
+      const boolVar = makeVariable('Test', 'BOOL', '')
+      const result = updateVariableValidation([], { location }, boolVar)
+      expect(result.ok).toBe(true)
+    },
+  )
+
   it('returns ok: true when location is valid for WORD type', () => {
     const wordVar = makeVariable('Test', 'WORD', '')
     const result = updateVariableValidation([], { location: '%QW0' }, wordVar)

--- a/src/frontend/store/slices/project/validation/variables.ts
+++ b/src/frontend/store/slices/project/validation/variables.ts
@@ -153,7 +153,7 @@ const variableLocationValidation = (variableLocation: string, variableType: stri
 const variableLocationValidationErrorMessage = (variableType: string) => {
   switch (variableType.toUpperCase()) {
     case 'BOOL':
-      return 'Valid locations: %QX0.0..7, %IX0.0..7 (change the number to the desired location)'
+      return 'Valid locations: %QX0.0..7, %IX0.0..7, %MX0.0..7 (change the number to the desired location)'
     case 'INT':
     case 'UINT':
     case 'WORD':

--- a/src/frontend/utils/PLC/address-constants/types.ts
+++ b/src/frontend/utils/PLC/address-constants/types.ts
@@ -1,6 +1,7 @@
 export const PLC_ADDRESS_PREFIX = {
   BOOL_OUTPUT: '%QX',
   BOOL_INPUT: '%IX',
+  BOOL_MEMORY: '%MX',
   WORD_OUTPUT: '%QW',
   WORD_INPUT: '%IW',
   WORD_MEMORY: '%MW',
@@ -12,7 +13,10 @@ export const PLC_ADDRESS_PREFIX = {
   LWORD_MEMORY: '%ML',
 } as const
 
-export const BOOL_LOCATION_REGEX = /^%[QI]X\d+\.\d$/
+// Accept every valid IEC area prefix — input (I), output (Q) and memory (M).
+// `%MX` memory bits are legitimate (e.g. Modbus coils) and were previously
+// rejected here, unlike the word-width regexes below which already allow M.
+export const BOOL_LOCATION_REGEX = /^%[QIM]X\d+\.\d$/
 export const WORD_LOCATION_REGEX = /^%[QIM]W\d+$/
 export const DWORD_LOCATION_REGEX = /^%[QIM]D\d+$/
 export const LWORD_LOCATION_REGEX = /^%[QIM]L\d+$/


### PR DESCRIPTION
## Problem
Forum report ["%MX locations now invalid - Runtime v4"](https://edge.autonomylogic.com/forum/thread/mx-locations-now-invalid-runtime-v4): `BOOL` variables mapped to `%MX` memory bits (e.g. Modbus coils) are rejected as **"Location is invalid. Valid locations: %QX0.0..7, %IX0.0..7"** — `%MX` is a legitimate IEC 61131-3 memory bit and is explicitly exposed by the Modbus TCP server as coils.

## Root cause
`BOOL_LOCATION_REGEX = /^%[QI]X\d+\.\d$/` omitted the memory area (`M`), while `WORD/DWORD/LWORD` regexes already accept `%[QIM]`. So `%MX` was the only valid IEC area silently rejected (for BOOL).

## Fix
- `BOOL_LOCATION_REGEX` → `/^%[QIM]X\d+\.\d$/` — accepts every valid IEC area prefix (I/Q/M), consistent with the word-width regexes.
- BOOL hint message now lists `%MX0.0..7`.
- Added validation tests for `%QX/%IX/%MX`.
- Bumped `APP_VERSION` + `package.json` to **4.2.10** (patch release).

## Verification
- Unit tests pass (incl. new `%MX` cases).
- **Browser-tested in openplc-web** (`dev:local`): `%MX0.0` now accepted on a BOOL; an invalid `%MZ0.0` is still rejected — validation intact.

Shared surfaces are byte-identical with the openplc-web PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boolean variable locations now support `%MX` memory addresses alongside input and output addresses.
  * Validation accepts valid `%MX` bit locations, including addresses such as `%MX0.0` and `%MX3.7`.

* **Bug Fixes**
  * Updated validation guidance to accurately list supported Boolean address ranges.

* **Chores**
  * Updated the application and package version to 4.2.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->