### PR TITLE
Release 4.2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-plc-editor",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
-  "version": "4.2.9",
+  "version": "4.2.10",
   "license": "GPL-3.0",
   "author": {
     "name": "Autonomy Logic"

--- a/src/frontend/components/_molecules/project-tree/__tests__/leaf-highlight.test.tsx
+++ b/src/frontend/components/_molecules/project-tree/__tests__/leaf-highlight.test.tsx
@@ -55,7 +55,12 @@ describe('ProjectTreeLeaf search highlight', () => {
 
   it('applies the same safe highlighting on expandable leaves', () => {
     const { container } = render(
-      <ProjectTreeExpandableLeaf leafLang='remoteDevice' leafType='remote-device' label='EtherBus' highlightQuery='Ether' />,
+      <ProjectTreeExpandableLeaf
+        leafLang='remoteDevice'
+        leafType='remote-device'
+        label='EtherBus'
+        highlightQuery='Ether'
+      />,
     )
 
     expect(container.textContent).toContain('EtherBus')

--- a/src/frontend/components/_molecules/project-tree/__tests__/leaf-highlight.test.tsx
+++ b/src/frontend/components/_molecules/project-tree/__tests__/leaf-highlight.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+
+import { ProjectTreeExpandableLeaf, ProjectTreeLeaf } from '../index'
+
+// https://github.com/Autonomy-Logic/openplc-editor/issues/640
+// The explorer used to pass a search-highlight HTML string as the leaf `label`,
+// which ProjectTreeLeaf renders as plain text — after any project search, the
+// matching POU's name appeared in the tree as literal markup
+// (`<span class="bg-brand-light...`). The label must stay the element's real
+// name; highlighting is applied safely inside the leaf via `highlightQuery`.
+describe('ProjectTreeLeaf search highlight', () => {
+  it('renders the plain name and applies a safe highlight when highlightQuery matches', () => {
+    const { container } = render(
+      <ProjectTreeLeaf leafLang='fbd' leafType='function-block' label='Taktgeber' highlightQuery='Takt' />,
+    )
+
+    expect(screen.getByText(/Takt/).textContent).not.toContain('<span')
+    expect(container.textContent).toBe('Taktgeber')
+
+    const highlight = container.querySelector('span.bg-brand-light')
+    expect(highlight).not.toBeNull()
+    expect(highlight?.textContent).toBe('Takt')
+  })
+
+  it('renders the plain name without highlight markup when there is no query', () => {
+    const { container } = render(<ProjectTreeLeaf leafLang='fbd' leafType='function-block' label='Taktgeber' />)
+
+    expect(container.textContent).toBe('Taktgeber')
+    expect(container.querySelector('span.bg-brand-light')).toBeNull()
+  })
+
+  it('never shows literal markup for a non-matching query', () => {
+    const { container } = render(
+      <ProjectTreeLeaf leafLang='fbd' leafType='function-block' label='Taktgeber' highlightQuery='zzz' />,
+    )
+
+    expect(container.textContent).toBe('Taktgeber')
+    expect(container.textContent).not.toContain('<span')
+  })
+
+  it('applies the same safe highlighting on expandable leaves', () => {
+    const { container } = render(
+      <ProjectTreeExpandableLeaf leafLang='remoteDevice' leafType='remote-device' label='EtherBus' highlightQuery='Ether' />,
+    )
+
+    expect(container.textContent).toContain('EtherBus')
+    expect(container.textContent).not.toContain('<span')
+    const highlight = container.querySelector('span.bg-brand-light')
+    expect(highlight?.textContent).toBe('Ether')
+  })
+})

--- a/src/frontend/components/_molecules/project-tree/__tests__/leaf-highlight.test.tsx
+++ b/src/frontend/components/_molecules/project-tree/__tests__/leaf-highlight.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 
+import { useOpenPLCStore } from '../../../../store'
 import { ProjectTreeExpandableLeaf, ProjectTreeLeaf } from '../index'
 
 // https://github.com/Autonomy-Logic/openplc-editor/issues/640
@@ -36,6 +37,20 @@ describe('ProjectTreeLeaf search highlight', () => {
 
     expect(container.textContent).toBe('Taktgeber')
     expect(container.textContent).not.toContain('<span')
+  })
+
+  it('keeps the plain name as the element identity while highlighted', () => {
+    const { container } = render(
+      <ProjectTreeLeaf leafLang='fbd' leafType='function-block' label='Taktgeber' highlightQuery='Takt' />,
+    )
+
+    const leaf = container.querySelector('li')
+    expect(leaf).not.toBeNull()
+    if (leaf) fireEvent.click(leaf)
+
+    // Selection must record the real POU name, never the decorated display string.
+    const { selectedProjectTreeLeaf } = useOpenPLCStore.getState().workspace
+    expect(selectedProjectTreeLeaf.label).toBe('Taktgeber')
   })
 
   it('applies the same safe highlighting on expandable leaves', () => {

--- a/src/frontend/components/_molecules/project-tree/index.tsx
+++ b/src/frontend/components/_molecules/project-tree/index.tsx
@@ -34,6 +34,7 @@ import { useOpenPLCStore } from '../../../store'
 import { WorkspaceProjectTreeLeafType } from '../../../store/slices/workspace/types'
 import { cn } from '../../../utils/cn'
 import { isUnsaved, unsavedLabel } from '../../../utils/unsaved-label'
+import { HighlightedText } from '../../_atoms/highlighted-text'
 import { toast } from '../../_features/[app]/toast/use-toast'
 
 const pousAllLanguages = ['il', 'st', 'python', 'cpp', 'ld', 'sfc', 'fbd'] as const
@@ -244,6 +245,12 @@ type IProjectTreeExpandableLeafProps = ComponentPropsWithoutRef<'li'> & {
   leafLang: IProjectTreeLeafProps['leafLang']
   leafType: WorkspaceProjectTreeLeafType
   label?: string
+  /**
+   * Search query used only to highlight matches in the displayed label.
+   * Kept separate from `label`, which must stay the element's real name:
+   * rename/duplicate/delete and selection all use `label` as identity.
+   */
+  highlightQuery?: string
   children?: ReactNode
 }
 
@@ -251,6 +258,7 @@ const ProjectTreeExpandableLeaf = ({
   leafLang,
   leafType,
   label,
+  highlightQuery,
   children,
   onClick: handleLeafClick,
   ...res
@@ -372,7 +380,7 @@ const ProjectTreeExpandableLeaf = ({
               )}
               onDoubleClick={() => !isDebuggerVisible && setIsEditing(true)}
             >
-              {handleLabel(label) || ''}
+              <HighlightedText text={handleLabel(label) || ''} searchQuery={highlightQuery} />
             </span>
           )}
         </div>
@@ -453,6 +461,12 @@ type IProjectTreeLeafProps = ComponentPropsWithoutRef<'li'> & {
     | 'libraryManifest'
   leafType: WorkspaceProjectTreeLeafType
   label?: string
+  /**
+   * Search query used only to highlight matches in the displayed label.
+   * Kept separate from `label`, which must stay the element's real name:
+   * rename/duplicate/delete and selection all use `label` as identity.
+   */
+  highlightQuery?: string
   busName?: string
   deviceId?: string
 }
@@ -489,6 +503,7 @@ const ProjectTreeLeaf = ({
   leafLang,
   leafType,
   label,
+  highlightQuery,
   busName,
   deviceId,
   onClick: handleLeafClick,
@@ -759,7 +774,7 @@ const ProjectTreeLeaf = ({
           )}
           onDoubleClick={() => !isDebuggerVisible && setIsEditing(true)}
         >
-          {handleLabel(label) || ''}
+          <HighlightedText text={handleLabel(label) || ''} searchQuery={highlightQuery} />
         </span>
       )}
 

--- a/src/frontend/components/_organisms/explorer/project.tsx
+++ b/src/frontend/components/_organisms/explorer/project.tsx
@@ -260,7 +260,7 @@ const Project = () => {
                     leafLang={pou.body.language as PouLeafLang}
                     leafType='program'
                     label={pou.name}
-                  highlightQuery={searchQuery}
+                    highlightQuery={searchQuery}
                     onClick={() =>
                       handleCreateTab({
                         name: pou.name,

--- a/src/frontend/components/_organisms/explorer/project.tsx
+++ b/src/frontend/components/_organisms/explorer/project.tsx
@@ -4,7 +4,6 @@ import { projectCapabilities } from '../../../../middleware/shared/ports/types'
 import { useCapabilities, useProject } from '../../../../middleware/shared/providers'
 import { FolderIcon } from '../../../assets/icons/interface/Folder'
 import { useOpenPLCStore } from '../../../store'
-import { extractSearchQuery } from '../../../store/slices/search/utils'
 import type { TabsProps } from '../../../store/slices/tabs'
 import { CreateEditorObjectFromTab, LIBRARY_MANIFEST_TAB_NAME } from '../../../store/slices/tabs/utils'
 import { useToast } from '../../_features/[app]/toast/use-toast'
@@ -204,7 +203,8 @@ const Project = () => {
                   key={pou.name}
                   leafLang={pou.body.language as PouLeafLang}
                   leafType='function'
-                  label={searchQuery ? extractSearchQuery(pou.name, searchQuery) : pou.name}
+                  label={pou.name}
+                  highlightQuery={searchQuery}
                   onClick={() =>
                     handleCreateTab({
                       name: pou.name,
@@ -226,7 +226,8 @@ const Project = () => {
                   key={pou.name}
                   leafLang={pou.body.language as PouLeafLang}
                   leafType='function-block'
-                  label={searchQuery ? extractSearchQuery(pou.name, searchQuery) : pou.name}
+                  label={pou.name}
+                  highlightQuery={searchQuery}
                   onClick={() =>
                     handleCreateTab({
                       name: pou.name,
@@ -250,7 +251,8 @@ const Project = () => {
                     key={pou.name}
                     leafLang={pou.body.language as PouLeafLang}
                     leafType='program'
-                    label={searchQuery ? extractSearchQuery(pou.name, searchQuery) : pou.name}
+                    label={pou.name}
+                  highlightQuery={searchQuery}
                     onClick={() =>
                       handleCreateTab({
                         name: pou.name,
@@ -273,7 +275,8 @@ const Project = () => {
                   key={name}
                   leafLang='arr'
                   leafType='data-type'
-                  label={searchQuery ? extractSearchQuery(name, searchQuery) : name}
+                  label={name}
+                  highlightQuery={searchQuery}
                   onClick={() =>
                     handleCreateTab({
                       name,
@@ -291,7 +294,8 @@ const Project = () => {
                   key={name}
                   leafLang='enum'
                   leafType='data-type'
-                  label={searchQuery ? extractSearchQuery(name, searchQuery) : name}
+                  label={name}
+                  highlightQuery={searchQuery}
                   /** Todo: Update the tab state */
                   onClick={() =>
                     handleCreateTab({
@@ -310,7 +314,8 @@ const Project = () => {
                   key={name}
                   leafLang='str'
                   leafType='data-type'
-                  label={searchQuery ? extractSearchQuery(name, searchQuery) : name}
+                  label={name}
+                  highlightQuery={searchQuery}
                   /** Todo: Update the tab state */
                   onClick={() =>
                     handleCreateTab({
@@ -409,7 +414,8 @@ const Project = () => {
                     key={server.name}
                     leafLang='server'
                     leafType='server'
-                    label={searchQuery ? extractSearchQuery(server.name, searchQuery) : server.name}
+                    label={server.name}
+                    highlightQuery={searchQuery}
                     onClick={() =>
                       handleCreateTab({
                         name: server.name,
@@ -433,7 +439,8 @@ const Project = () => {
                       key={device.name}
                       leafLang='remoteDevice'
                       leafType='remote-device'
-                      label={searchQuery ? extractSearchQuery(device.name, searchQuery) : device.name}
+                      label={device.name}
+                      highlightQuery={searchQuery}
                       onClick={() =>
                         handleCreateTab({
                           name: device.name,
@@ -449,7 +456,8 @@ const Project = () => {
                           leafType='ethercat-device'
                           busName={device.name}
                           deviceId={child.id}
-                          label={searchQuery ? extractSearchQuery(child.name, searchQuery) : child.name}
+                          label={child.name}
+                          highlightQuery={searchQuery}
                           onClick={() =>
                             handleCreateTab({
                               name: child.name,
@@ -465,7 +473,8 @@ const Project = () => {
                       key={device.name}
                       leafLang='remoteDevice'
                       leafType='remote-device'
-                      label={searchQuery ? extractSearchQuery(device.name, searchQuery) : device.name}
+                      label={device.name}
+                      highlightQuery={searchQuery}
                       onClick={() =>
                         handleCreateTab({
                           name: device.name,

--- a/src/frontend/data/constants/app-version.ts
+++ b/src/frontend/data/constants/app-version.ts
@@ -18,4 +18,4 @@
  * compares a per-deploy `BUILD_ID` (git commit SHA), not this version, so a
  * stale tab is detected on every deploy even without a version bump.
  */
-export const APP_VERSION = '4.2.9'
+export const APP_VERSION = '4.2.10'

--- a/src/frontend/store/__tests__/project-validation-variables.test.ts
+++ b/src/frontend/store/__tests__/project-validation-variables.test.ts
@@ -507,6 +507,15 @@ describe('updateVariableValidation', () => {
     expect(result.ok).toBe(true)
   })
 
+  it.each(['%QX0.0', '%IX0.0', '%MX0.0', '%MX3.7'])(
+    'accepts every valid IEC area prefix for BOOL locations (%s)',
+    (location) => {
+      const boolVar = makeVariable('Test', 'BOOL', '')
+      const result = updateVariableValidation([], { location }, boolVar)
+      expect(result.ok).toBe(true)
+    },
+  )
+
   it('returns ok: true when location is valid for WORD type', () => {
     const wordVar = makeVariable('Test', 'WORD', '')
     const result = updateVariableValidation([], { location: '%QW0' }, wordVar)

--- a/src/frontend/store/slices/project/validation/variables.ts
+++ b/src/frontend/store/slices/project/validation/variables.ts
@@ -153,7 +153,7 @@ const variableLocationValidation = (variableLocation: string, variableType: stri
 const variableLocationValidationErrorMessage = (variableType: string) => {
   switch (variableType.toUpperCase()) {
     case 'BOOL':
-      return 'Valid locations: %QX0.0..7, %IX0.0..7 (change the number to the desired location)'
+      return 'Valid locations: %QX0.0..7, %IX0.0..7, %MX0.0..7 (change the number to the desired location)'
     case 'INT':
     case 'UINT':
     case 'WORD':

--- a/src/frontend/utils/PLC/address-constants/types.ts
+++ b/src/frontend/utils/PLC/address-constants/types.ts
@@ -1,6 +1,7 @@
 export const PLC_ADDRESS_PREFIX = {
   BOOL_OUTPUT: '%QX',
   BOOL_INPUT: '%IX',
+  BOOL_MEMORY: '%MX',
   WORD_OUTPUT: '%QW',
   WORD_INPUT: '%IW',
   WORD_MEMORY: '%MW',
@@ -12,7 +13,10 @@ export const PLC_ADDRESS_PREFIX = {
   LWORD_MEMORY: '%ML',
 } as const
 
-export const BOOL_LOCATION_REGEX = /^%[QI]X\d+\.\d$/
+// Accept every valid IEC area prefix — input (I), output (Q) and memory (M).
+// `%MX` memory bits are legitimate (e.g. Modbus coils) and were previously
+// rejected here, unlike the word-width regexes below which already allow M.
+export const BOOL_LOCATION_REGEX = /^%[QIM]X\d+\.\d$/
 export const WORD_LOCATION_REGEX = /^%[QIM]W\d+$/
 export const DWORD_LOCATION_REGEX = /^%[QIM]D\d+$/
 export const LWORD_LOCATION_REGEX = /^%[QIM]L\d+$/


### PR DESCRIPTION
Promote `development` → `main` for the **4.2.10** patch release.

- fix(variables): accept `%MX` memory-bit locations for BOOL (forum regression "%MX locations now invalid - Runtime v4"). Browser-verified in openplc-web.
- Version bumped to 4.2.10 (`APP_VERSION` + `package.json`, in sync).

After merge, tag `v4.2.10` on `main` to trigger the Build and Release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)