### PR TITLE
chore(release): bump version to 4.2.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-plc-editor",
-  "version": "4.2.8",
+  "version": "4.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-plc-editor",
-      "version": "4.2.8",
+      "version": "4.2.10",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-plc-editor",
   "description": "OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime",
-  "version": "4.2.9",
+  "version": "4.2.10",
   "license": "GPL-3.0",
   "author": {
     "name": "Autonomy Logic"

--- a/src/frontend/data/constants/app-version.ts
+++ b/src/frontend/data/constants/app-version.ts
@@ -18,4 +18,4 @@
  * compares a per-deploy `BUILD_ID` (git commit SHA), not this version, so a
  * stale tab is detected on every deploy even without a version bump.
  */
-export const APP_VERSION = '4.2.9'
+export const APP_VERSION = '4.2.10'


### PR DESCRIPTION
Ships the LSP alias-location and array-resolution fixes (#966, strucpp v0.6.1).

`APP_VERSION` is the single source of truth for the human-facing version and stays byte-identical across both repos; `package.json` is kept equal so electron-builder stamps the desktop binary with the same value and the release tag `v4.2.10` matches.

`release/app/package.json` is left alone — `release.yml` stamps it from the tag at build time.

Paired with [openplc-web#630](https://github.com/Autonomy-Logic/openplc-web/pull/630).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **4.2.10**.
  * Version information displayed in the application and editor now reflects the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->