### PR TITLE
fix(debugger): trend sample-and-hold rendering and sliding window (DOPE-330)

### DIFF
--- a/src/frontend/components/_molecules/charts/line-chart.tsx
+++ b/src/frontend/components/_molecules/charts/line-chart.tsx
@@ -46,9 +46,7 @@ const LineChart = ({ data, isBool = false, range, now, startTime, label }: LineC
     return {
       chart: {
         id: chartId,
-        // ctx.update() clears and rebuilds the whole SVG on every update. Tweening that rebuild replays partial
-        // states through rAF, which is what reads as flicker — so redraw atomically and let the sample rate
-        // (RENDER_INTERVAL_MS in the debugger) carry the motion instead.
+        // Tweening ApexCharts' full-SVG rebuild replays partial states and reads as flicker.
         animations: { enabled: false },
         toolbar: { show: false },
         zoom: { enabled: false },
@@ -84,7 +82,6 @@ const LineChart = ({ data, isBool = false, range, now, startTime, label }: LineC
         xaxis: { lines: { show: false } },
         yaxis: { lines: { show: true } },
       },
-      // Debug values are sampled per scan, so hold each value until the next sample and jump vertically.
       stroke: { curve: 'stepline' as const, width: 2 },
       tooltip: { enabled: false },
       states: {

--- a/src/frontend/components/_molecules/charts/line-chart.tsx
+++ b/src/frontend/components/_molecules/charts/line-chart.tsx
@@ -46,7 +46,10 @@ const LineChart = ({ data, isBool = false, range, now, startTime, label }: LineC
     return {
       chart: {
         id: chartId,
-        animations: { enabled: true, easing: 'linear' as const, dynamicAnimation: { speed: 500 } },
+        // ctx.update() clears and rebuilds the whole SVG on every update. Tweening that rebuild replays partial
+        // states through rAF, which is what reads as flicker — so redraw atomically and let the sample rate
+        // (RENDER_INTERVAL_MS in the debugger) carry the motion instead.
+        animations: { enabled: false },
         toolbar: { show: false },
         zoom: { enabled: false },
         background: 'transparent',
@@ -81,7 +84,8 @@ const LineChart = ({ data, isBool = false, range, now, startTime, label }: LineC
         xaxis: { lines: { show: false } },
         yaxis: { lines: { show: true } },
       },
-      stroke: { curve: isBool ? ('stepline' as const) : ('smooth' as const), width: 2 },
+      // Debug values are sampled per scan, so hold each value until the next sample and jump vertically.
+      stroke: { curve: 'stepline' as const, width: 2 },
       tooltip: { enabled: false },
       states: {
         hover: { filter: { type: 'none' } },

--- a/src/frontend/components/_organisms/debugger/index.tsx
+++ b/src/frontend/components/_organisms/debugger/index.tsx
@@ -17,10 +17,8 @@ type Point = { t: number; y: number }
 type SeriesEntry = { points: Point[]; isBool: boolean; compositeKey: string }
 
 const MAX_BUFFER_SECONDS = 600 // Keep 10 minutes of data regardless of displayed range
-const SAMPLE_INTERVAL_MS = 100 // Trend sampling clock, independent of the poll rate
-// ApexCharts clears and rebuilds the entire SVG on every update, so repaint less often than we sample. The chart
-// redraws without animation, so this interval alone sets how fluid the window slide looks — raise it if the
-// rebuilds become visible, lower it if the motion looks stepped.
+const SAMPLE_INTERVAL_MS = 100
+// ApexCharts rebuilds the entire SVG per update, so repaint slower than we sample.
 const RENDER_INTERVAL_MS = 200
 
 const Debugger = ({ graphList }: DebuggerData) => {
@@ -37,7 +35,6 @@ const Debugger = ({ graphList }: DebuggerData) => {
   const debugBoolValues = useDebugBoolValuesMap()
   const debugNonBoolValues = useDebugNonBoolValuesMap()
 
-  // Latest polled values, so the sampling clock can read them without re-arming on every change.
   const valuesRef = useRef({ bool: debugBoolValues, nonBool: debugNonBoolValues })
   valuesRef.current = { bool: debugBoolValues, nonBool: debugNonBoolValues }
 
@@ -71,8 +68,7 @@ const Debugger = ({ graphList }: DebuggerData) => {
     }
   }, [graphList])
 
-  // Sample on a fixed clock rather than on value change: the poller only commits to the store when a
-  // value differs, so a variable holding steady stops emitting samples and the trend freezes mid-window.
+  // The poller only writes to the store when a value changes, so sample on a clock or steady values freeze the trend.
   useEffect(() => {
     if (isPaused || graphList.length === 0) return
     const sample = () => {

--- a/src/frontend/components/_organisms/debugger/index.tsx
+++ b/src/frontend/components/_organisms/debugger/index.tsx
@@ -17,6 +17,11 @@ type Point = { t: number; y: number }
 type SeriesEntry = { points: Point[]; isBool: boolean; compositeKey: string }
 
 const MAX_BUFFER_SECONDS = 600 // Keep 10 minutes of data regardless of displayed range
+const SAMPLE_INTERVAL_MS = 100 // Trend sampling clock, independent of the poll rate
+// ApexCharts clears and rebuilds the entire SVG on every update, so repaint less often than we sample. The chart
+// redraws without animation, so this interval alone sets how fluid the window slide looks — raise it if the
+// rebuilds become visible, lower it if the motion looks stepped.
+const RENDER_INTERVAL_MS = 200
 
 const Debugger = ({ graphList }: DebuggerData) => {
   const [isPaused, setIsPaused] = useState(false)
@@ -31,6 +36,10 @@ const Debugger = ({ graphList }: DebuggerData) => {
   const debugDataStale = useOpenPLCStore(useCallback((s) => s.workspace.debugDataStale, []))
   const debugBoolValues = useDebugBoolValuesMap()
   const debugNonBoolValues = useDebugNonBoolValuesMap()
+
+  // Latest polled values, so the sampling clock can read them without re-arming on every change.
+  const valuesRef = useRef({ bool: debugBoolValues, nonBool: debugNonBoolValues })
+  valuesRef.current = { bool: debugBoolValues, nonBool: debugNonBoolValues }
 
   // Track elapsed time with a 1-second interval
   useEffect(() => {
@@ -62,45 +71,56 @@ const Debugger = ({ graphList }: DebuggerData) => {
     }
   }, [graphList])
 
+  // Sample on a fixed clock rather than on value change: the poller only commits to the store when a
+  // value differs, so a variable holding steady stops emitting samples and the trend freezes mid-window.
   useEffect(() => {
     if (isPaused || graphList.length === 0) return
-    const now = Date.now()
-    // Set start time on first data
-    if (startTimeRef.current === null) {
-      startTimeRef.current = now
-    }
-    const set = historiesRef.current
-    for (const [, entry] of set) {
-      const raw = entry.compositeKey
-        ? (debugBoolValues.get(entry.compositeKey) ?? debugNonBoolValues.get(entry.compositeKey))
-        : undefined
-      if (raw === undefined) continue
-      let y: number | null = null
-      const rawStr = String(raw).toUpperCase()
-      if (rawStr === 'TRUE') {
-        y = 1
-        entry.isBool = true
-      } else if (rawStr === 'FALSE') {
-        y = 0
-        entry.isBool = true
-      } else {
-        const n = Number(raw)
-        y = Number.isNaN(n) ? null : n
+    const sample = () => {
+      const now = Date.now()
+      // Set start time on first data
+      if (startTimeRef.current === null) {
+        startTimeRef.current = now
       }
-      if (y !== null) {
-        entry.points.push({ t: now, y })
-        // Trim based on max buffer, not displayed range
-        const bufferCutoff = now - MAX_BUFFER_SECONDS * 1000
-        const validStartIndex = entry.points.findIndex((p) => p.t >= bufferCutoff)
-        if (validStartIndex === -1) {
-          entry.points.length = 0
-        } else if (validStartIndex > 0) {
-          entry.points.splice(0, validStartIndex)
+      const set = historiesRef.current
+      for (const [, entry] of set) {
+        const raw = entry.compositeKey
+          ? (valuesRef.current.bool.get(entry.compositeKey) ?? valuesRef.current.nonBool.get(entry.compositeKey))
+          : undefined
+        if (raw === undefined) continue
+        let y: number | null = null
+        const rawStr = String(raw).toUpperCase()
+        if (rawStr === 'TRUE') {
+          y = 1
+          entry.isBool = true
+        } else if (rawStr === 'FALSE') {
+          y = 0
+          entry.isBool = true
+        } else {
+          const n = Number(raw)
+          y = Number.isNaN(n) ? null : n
+        }
+        if (y !== null) {
+          entry.points.push({ t: now, y })
+          // Trim based on max buffer, not displayed range
+          const bufferCutoff = now - MAX_BUFFER_SECONDS * 1000
+          const validStartIndex = entry.points.findIndex((p) => p.t >= bufferCutoff)
+          if (validStartIndex === -1) {
+            entry.points.length = 0
+          } else if (validStartIndex > 0) {
+            entry.points.splice(0, validStartIndex)
+          }
         }
       }
     }
+    sample()
     setRenderTrigger((prev) => prev + 1)
-  }, [debugBoolValues, debugNonBoolValues, isPaused, graphList])
+    const sampler = setInterval(sample, SAMPLE_INTERVAL_MS)
+    const painter = setInterval(() => setRenderTrigger((prev) => prev + 1), RENDER_INTERVAL_MS)
+    return () => {
+      clearInterval(sampler)
+      clearInterval(painter)
+    }
+  }, [isPaused, graphList])
 
   const renderSeries = useMemo(() => {
     const now = Date.now()


### PR DESCRIPTION
Fixes the trend rendering reported in #590, plus two bugs that surfaced while validating it.

Jira: [DOPE-330](https://autonomylogic.atlassian.net/browse/DOPE-330)

## The reported bug

A variable ramping 0.0 → 3.0 s and resetting instantaneously to 0.0 drew a **descending ramp** at the reset, implying a gradual decrease that never happens. Cause: `stroke.curve` was `isBool ? 'stepline' : 'smooth'`, so every non-BOOL series got spline interpolation through values the PLC never held.

Debug values are sampled once per scan, so sample-and-hold is the correct rendering for **every** type, not just BOOL — `curve: 'stepline'` unconditionally. The BOOL path is unchanged.

## Two bugs found while validating

**1. The trend froze whenever a value held steady.** `useDebugPolling` only commits to the store when a value differs, and the sampling effect was keyed on the two value `Map` references. Steady value → no store write → effect never re-ran → no samples, no `renderTrigger`, and `renderSeries`' `now` froze with it, so the x-window stopped sliding too. The trend only advanced as a side effect of values changing.

Fixed by sampling on a fixed 100 ms clock, reading the latest maps through a ref so the interval never re-arms on value change. Point-push, BOOL coercion and buffer trim logic are unchanged — only what drives them. This also makes the stepline fix visible at all: a horizontal hold segment needs samples *during* the hold to draw from.

**2. Flicker on every repaint.** ApexCharts' `ctx.update()` does `clear({isUpdating:true})` → `create()` → `mount()` — it rebuilds the entire SVG on every update, series or options alike. Tweening that rebuild replays partial states through rAF, which is what reads as flicker. Measured with a `MutationObserver`: ~1980 axis + 924 grid node insertions over 3 s, i.e. ~20 full rebuilds/s.

Fixed by disabling the tween so each rebuild is one atomic paint, and decoupling repaint cadence (`RENDER_INTERVAL_MS = 200`) from sample cadence (`SAMPLE_INTERVAL_MS = 100`).

On `development` rebuilds were value-change-driven: 0 Hz while steady, ~5 Hz on a ramp at the 200 ms TCP poll. `RENDER_INTERVAL_MS = 200` caps it at that same ceiling, so this is no worse than today on a changing value — it just no longer freezes when steady.

## Verification

Validated interactively against a live debug session (REAL ramp + scaled value, 1-minute range): reset renders as a vertical edge, the window slides continuously while values hold steady, and no flicker. Earlier iterations were rejected by testing — tween-speed alignment and swapping `xaxis.min/max` for `xaxis.range` both failed, because `ctx.update()` rebuilds regardless of which update path is taken; only the rebuild *rate* matters.

`tsc -p tsconfig.app.json`, eslint and prettier clean. One pre-existing eslint warning remains at `debugger/index.tsx:138` (`useMemo` unnecessary dep `renderTrigger`) — present on `development` too, left alone.

## Follow-ups (not in this PR)

- `debugTick` is dead state: `setDebugTick` has no caller outside tests, yet the debugger panel renders it, so it always shows `0`.
- ApexCharts rebuilding the whole SVG per update is why the repaint rate has to be throttled at all. A canvas-based strip chart would remove the constraint.

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/631

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwVC4DQxNTKewgeDvmwWY3


[DOPE-330]: https://autonomylogic.atlassian.net/browse/DOPE-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced line chart flickering by disabling transition/animation rendering during redraws.
  * Standardized line chart trend lines to always use step-style curves for clearer discrete value changes.
  * Improved debugger chart accuracy by switching to fixed-interval time sampling of trend points.
  * Smoothed debugger chart updates by throttling repaint frequency while retaining recent data history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->