### PR TITLE
fix(debug): expose HTTP fallback poll interval as a platform capability

### DIFF
--- a/src/frontend/hooks/useDebugPolling.ts
+++ b/src/frontend/hooks/useDebugPolling.ts
@@ -19,7 +19,8 @@
  *
  * Polling intervals:
  * - Modbus RTU / simulator: 50ms   (no network; keep the UI snappy)
- * - Web HTTP fallback:      1000ms  (WebRTC failed; each poll is a slow
+ * - Web HTTP fallback:      platform-capability-driven, 1000ms by default
+ *                                    (WebRTC failed; each poll is a slow
  *                                    orchestrator round-trip, so back off)
  * - Everything else:        200ms   (general purpose — TCP / WebSocket /
  *                                    web WebRTC data channel)
@@ -38,10 +39,6 @@ import { getTypeSizeByName, parseValueByTypeName } from '../utils/variable-sizes
 const RTU_POLL_INTERVAL_MS = 50
 /** Polling interval for higher-bandwidth transports (TCP / WebSocket). */
 const DEFAULT_POLL_INTERVAL_MS = 200
-/** Polling interval for the web HTTP fallback (WebRTC unavailable): each
- *  poll is a full orchestrator `run_command` round-trip, so we slow right
- *  down to avoid hammering the edge API / runtime. */
-const HTTP_FALLBACK_POLL_INTERVAL_MS = 1000
 
 // Batch size is transport-dependent. The wire request packs 3 bytes per
 // variable (arr:u8 + elem:u16); the response packs raw type-sized values
@@ -434,7 +431,7 @@ export function useDebugPolling({ debugTreesRef }: UseDebugPollingOptions): void
       const pollIntervalMs = usesRtuFraming
         ? RTU_POLL_INTERVAL_MS
         : usesHttpFallback
-          ? HTTP_FALLBACK_POLL_INTERVAL_MS
+          ? capabilities.debugHttpFallbackPollIntervalMs
           : DEFAULT_POLL_INTERVAL_MS
 
       // Fire first poll immediately, then schedule at fixed rate
@@ -492,6 +489,7 @@ export function useDebugPolling({ debugTreesRef }: UseDebugPollingOptions): void
     debugConnectionType,
     sessionDebugTransport,
     capabilities.isNativeApplication,
+    capabilities.debugHttpFallbackPollIntervalMs,
     workspaceActions,
   ])
 

--- a/src/middleware/shared/ports/platform-capabilities.ts
+++ b/src/middleware/shared/ports/platform-capabilities.ts
@@ -104,6 +104,17 @@ export interface PlatformCapabilities {
   /** True if the app supports EtherCAT device configuration and ESI repository. */
   hasEthercat: boolean
 
+  // --- Debugging ---
+
+  /**
+   * Polling interval (ms) for the debugger's HTTP fallback transport (used
+   * when WebRTC is unavailable). Each poll is a full proxied round-trip, so
+   * this is deployment-tunable rather than a fixed constant — e.g.
+   * autonomy-node runs no WebRTC signaling relay and wants this to match
+   * its general-purpose poll rate.
+   */
+  debugHttpFallbackPollIntervalMs: number
+
   // --- Environment ---
 
   /** True when running in a development build (Vite DEV / webpack development mode). */
@@ -139,6 +150,7 @@ export const EDITOR_CAPABILITIES: PlatformCapabilities = {
   hasDirectProgramUpload: false,
   hasPackageManager: true,
   hasEthercat: true,
+  debugHttpFallbackPollIntervalMs: 1000,
   isDevMode: false,
 }
 
@@ -182,5 +194,6 @@ export const WEB_CAPABILITIES: PlatformCapabilities = {
   hasDirectProgramUpload: true,
   hasPackageManager: false,
   hasEthercat: false,
+  debugHttpFallbackPollIntervalMs: 1000,
   isDevMode: false,
 }


### PR DESCRIPTION
## Summary
- Adds `debugHttpFallbackPollIntervalMs` to `PlatformCapabilities` (shared port), defaulting to `1000` for both editor and web profiles.
- `useDebugPolling.ts` now reads the HTTP-fallback cadence from `capabilities.debugHttpFallbackPollIntervalMs` instead of a hardcoded module constant.
- No behavior change for the editor: `EDITOR_CAPABILITIES.debugHttpFallbackPollIntervalMs` stays `1000`.

## Why
openplc-web#632 made this interval configurable via `VITE_DEBUG_HTTP_POLL_INTERVAL_MS`, read directly in the shared `useDebugPolling.ts` hook via `import.meta.env`. That broke this repo's shared-surface sync check — `import.meta.env` is Vite-only syntax that doesn't even compile under this repo's `commonjs` tsconfig target, and the editor has no equivalent env var.

This PR re-syncs the shared file by moving the override to the existing `PlatformCapabilities` seam (the same pattern already used for `hasVersionControl`/`isDevMode` in web's platform adapter): the shared hook stays platform-agnostic, and only web's `web-platform.ts` (not a shared-surface file) reads the env var.

Companion PR: Autonomy-Logic/openplc-web#632

## Test plan
- [x] `npx tsc --noEmit` — no new errors (4 pre-existing, unrelated react-flow type errors also present on `development`)
- [x] `npx eslint` / `npx prettier --check` on both touched files — clean
- [x] `npx jest src/__tests__/platform-context.test.tsx` — 13/13 pass
- [x] `npx tsx src/__architecture__/validate.ts` — passes
- [x] Confirmed `useDebugPolling.ts` and `platform-capabilities.ts` are now byte-identical with the openplc-web branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Debugger HTTP fallback polling now adapts to the platform’s configured capabilities.
  * Polling uses a 1000 ms default when WebRTC is unavailable and can update dynamically during a session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->