### PR TITLE
fix: Modbus/TCP: incorrect behavior when the connection is lost (issue #691)

### DIFF
--- a/src/backend/shared/utils/modbus/__tests__/generate-modbus-master-config.test.ts
+++ b/src/backend/shared/utils/modbus/__tests__/generate-modbus-master-config.test.ts
@@ -112,6 +112,48 @@ describe('generateModbusMasterConfig', () => {
     expect(ioPoints[0].iec_location).toBe('%MW0')
     expect(ioPoints[0].len).toBe(10)
     expect(ioPoints[0].cycle_time_ms).toBe(100)
+    expect(ioPoints[0].error_handling).toBe('keep-last-value')
+  })
+
+  // Regression, openplc-editor#691: the per-group "Keep last value / Set to
+  // zero" choice existed only in the UI. It was stored in the project and
+  // dropped here, so the runtime never learned about it and always kept the
+  // last value when a device went unreachable.
+  it('emits the error handling each IO group is configured with', () => {
+    const device = makeTcpDevice()
+    device.modbusTcpConfig!.ioGroups[0].errorHandling = 'set-to-zero'
+
+    const parsed = JSON.parse(generateModbusMasterConfig([device])!)
+
+    expect(parsed[0].config.io_points[0].error_handling).toBe('set-to-zero')
+  })
+
+  it('emits error handling per point, not per device', () => {
+    const device = makeTcpDevice()
+    const [firstGroup] = device.modbusTcpConfig!.ioGroups
+    device.modbusTcpConfig!.ioGroups = [
+      { ...firstGroup, id: 'g1', errorHandling: 'set-to-zero' },
+      { ...firstGroup, id: 'g2', errorHandling: 'keep-last-value' },
+    ]
+
+    const parsed = JSON.parse(generateModbusMasterConfig([device])!)
+
+    expect(parsed[0].config.io_points.map((p: { error_handling: string }) => p.error_handling)).toEqual([
+      'set-to-zero',
+      'keep-last-value',
+    ])
+  })
+
+  it('defaults to keeping the last value when a group predates the field', () => {
+    // Projects saved before the option shipped have no value stored; the
+    // runtime's historical behaviour is to keep the last value.
+    const device = makeTcpDevice()
+    const group = device.modbusTcpConfig!.ioGroups[0]
+    delete (group as { errorHandling?: unknown }).errorHandling
+
+    const parsed = JSON.parse(generateModbusMasterConfig([device])!)
+
+    expect(parsed[0].config.io_points[0].error_handling).toBe('keep-last-value')
   })
 
   it('generates RTU config with serial port parameters', () => {

--- a/src/backend/shared/utils/modbus/generate-modbus-master-config.ts
+++ b/src/backend/shared/utils/modbus/generate-modbus-master-config.ts
@@ -6,6 +6,12 @@ interface ModbusMasterIOPoint {
   iec_location: string
   len: number
   cycle_time_ms: number
+  /** What the runtime does with this point's IEC buffer while the device is
+   *  unreachable. The UI has offered the choice per I/O group for a while, but
+   *  it never reached the config — so the runtime always kept the last value
+   *  (openplc-editor#691). Emitted for every point so a config never leaves
+   *  the behaviour implicit. */
+  error_handling: ModbusIOGroup['errorHandling']
 }
 
 // Base device config with common fields
@@ -83,6 +89,9 @@ const convertIOGroupToIOPoint = (ioGroup: ModbusIOGroup): ModbusMasterIOPoint =>
     iec_location: iecLocation,
     len: ioGroup.length,
     cycle_time_ms: ioGroup.cycleTime,
+    // Groups saved before the field existed have no value; the runtime's
+    // historical behaviour is to keep the last value, so default to it.
+    error_handling: ioGroup.errorHandling ?? 'keep-last-value',
   }
 }
 


### PR DESCRIPTION
## Problem

A Modbus TCP remote device offers a per-I/O-group choice of what happens to the values when
the device becomes unreachable — "Keep last value" or "Set to zero" (#691). Picking "Set to
zero" changed nothing: the values stayed frozen at the last successful read for as long as the
device was down.

The option existed only in the UI. It was stored in the project and dropped here, so the
runtime never learned about it and always kept the last value.

## Fix

`generate-modbus-master-config.ts` now emits `error_handling` on every I/O point:

- `ModbusMasterIOPoint` carries the field.
- `convertIOGroupToIOPoint` copies it from the group, defaulting to `keep-last-value` for
  groups saved before the field existed — which is also the behaviour the runtime had until
  now, so old projects keep working exactly as they do today.

It is emitted **per point**, not per device, because the UI configures it per I/O group and
each group becomes one point: a device can legitimately have one group zeroing and another
holding its last value.

## Testing

25 tests passing in `src/backend/shared/utils/modbus` (3 new):

- the field is emitted with the value the group is configured with;
- two groups on the same device emit their own values independently;
- a group with no stored value defaults to `keep-last-value`.

eslint clean, prettier clean, `tsc --noEmit` reports nothing new.

## Notes for reviewers

- **This PR alone changes no behaviour.** It only puts the setting in the config file; the
  runtime side that acts on it is a separate PR in openplc-runtime. Until both ship, "Set to
  zero" still behaves as "Keep last value".
- `src/backend/shared/` is part of the shared surface, so this needs a matching PR in
  **openplc-web** with the byte-identical change; the sync check looks for an open editor PR.
- No new field in the project model: `errorHandling` was already persisted per I/O group. This
  only stops discarding it.

Refs #691

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Modbus I/O points now include their configured error-handling behavior.
  * Existing projects without an error-handling setting default to **keep last value**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->