### PR TITLE
fix(compiler): pass -mlongcalls to Xtensa precompile so libOpenPLCUserLib links on ESP32

### DIFF
--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -1444,7 +1444,24 @@ class CompilerModule {
       `-I${srcDir}`,
       `-I${baremetalDir}`,
     ]
-    const trailingFlags = ['-std=gnu++17', '-fno-rtti', ...extraNonIncludeFlags]
+    // ESP32/S2/S3 are Xtensa: a direct `call8` only reaches +/-512 KB. Without
+    // `-mlongcalls` the linker cannot relax an out-of-range `call8` into
+    // `l32r`+`callx8`, so once the firmware `.text` grows past that range
+    // (always, on ESP32, with WiFi + Modbus linked in) the precompiled
+    // `libOpenPLCUserLib.a` fails to link with
+    // "dangerous relocation: call8: call target out of range" against
+    // `memcpy` / `__udivdi3` / `<pou>_setup` / `<pou>_loop`. The normal
+    // sketch compile already gets `-mlongcalls` via the core cpp_flags;
+    // the precompile TUs must match. Gated on the Xtensa compiler so the
+    // RISC-V parts (esp32c3/c6/h2 -> riscv32-esp-elf-g++) and AVR/ARM
+    // toolchains -- which reject `-mlongcalls` -- stay untouched.
+    const isXtensaToolchain = String(tcProps.properties['compiler.cpp.cmd'] || '').includes('xtensa')
+    const trailingFlags = [
+      '-std=gnu++17',
+      '-fno-rtti',
+      ...(isXtensaToolchain ? ['-mlongcalls'] : []),
+      ...extraNonIncludeFlags,
+    ]
 
     const execMaxBuffer = 16 * 1024 * 1024
 


### PR DESCRIPTION
## Problem

Any program targeting an ESP32 (Xtensa) board fails at the **final link step** with a batch of:

```
libOpenPLCUserLib.a(arduino_runtime_glue.o): dangerous relocation: call8: call target out of range: __udivdi3
libOpenPLCUserLib.a(arduino_runtime_glue.o): ... memcpy / memset / updateInputBuffers / updateOutputBuffers
libOpenPLCUserLib.a(pou_<NAME>.o): dangerous relocation: call8: call target out of range: <name>_setup / <name>_loop
collect2.exe: error: ld returned 1 exit status
```

Reproduced on **ESP32 Generic** and **ESP32 WROOM** (Editor 4.2.10, esp32:esp32@3.3.11, arduino-cli 1.4.1, STruC++ 0.6.1, Windows).

## Root cause

The translation units archived into the precompiled `libOpenPLCUserLib.a` are compiled **without `-mlongcalls`**.

On Xtensa a direct `call8` only reaches ±512 KB. Without `-mlongcalls`, the linker cannot relax an out-of-range `call8` into an indirect `l32r`+`callx8`. Once the firmware `.text` grows past that range — which always happens on ESP32 because WiFi + Network + Modbus are linked in — the link aborts.

The normal Arduino sketch compilation for the same board **does** get `-mlongcalls` (it lives in the core's `flags/cpp_flags`). Only the precompile step in `compiler-module.ts` (`[precompile] Compiling N TU(s) ...`) omits it, because the per-TU `trailingFlags` don't include it.

### Evidence (objdump of a precompiled object, before the fix)

`pou_<NAME>.o`, `operator()`:

```
a5:  000025    call8   <a8_output_setup>
     a5: R_XTENSA_SLOT0_OP  a8_output_setup      <-- bare call8, no longcall literal
b4:  000025    call8   <a8_output_loop>
     b4: R_XTENSA_SLOT0_OP  a8_output_loop
```

With `-mlongcalls` gcc emits `l32r a8,<lit>; callx8 a8`, which the linker can always relax.

## Fix

In `src/backend/editor/compiler/compiler-module.ts`, add `-mlongcalls` to the per-TU `trailingFlags` **only for Xtensa toolchains** (gated on `compiler.cpp.cmd` containing `xtensa`, so RISC-V `esp32c3/c6/h2` → `riscv32-esp-elf-g++` and AVR/ARM toolchains — which reject the flag — are untouched).

## Verification

After the change, a **Build only** for ESP32 Generic completes with `Compilation complete` and no `dangerous relocation` errors; the ELF links with PCF8574 + WiFi + Network + Wire + `libOpenPLCUserLib`.

## Note

Worth checking whether the shared/centralized compiler path (the composer referenced by both the editor `compileArduino` flow and the web `compiler-adapter` branch) needs the same Xtensa guard for cloud builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compilation compatibility for Xtensa toolchains by automatically applying the required long-call option during library precompilation.
  * Preserved existing compiler behavior for other toolchains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->