### PR TITLE
chore(strucpp): pin v0.6.2 for located-global sync

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -1,6 +1,6 @@
 {
   "strucpp": {
-    "version": "v0.6.1",
+    "version": "v0.6.2",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }


### PR DESCRIPTION
## What

Pin STruC++ to **v0.6.2** in `binary-versions.json`. One line; no code changes.

## Why

v0.6.2 emits `locatedGlobals[]` — the storage pointers of every located `CONFIGURATION VAR_GLOBAL` — plus C-linkage accessors, so the runtime can identify which entries of `locatedVars[]` are configuration-scope by **pointer identity** instead of inferring it from their position in the array.

The runtime's inference was backwards (STruC++ emits config globals first, not last), so a single located variable declared in a POU made the runtime conclude the project had zero located globals and silently stop syncing all of them. Reported on the forum as *"%MX locations now invalid - Runtime v4"*: Modbus coil writes reached the image but never the program. Located `%IX`/`%QX`/`%MW` globals were equally affected.

The generated code is what carries `locatedGlobals[]`, so a project must be **re-exported** from an editor shipping v0.6.2 for the runtime fix to activate. That is why this pin is needed even though no editor code changes are.

## Behaviour change worth flagging

v0.6.2 also tightens located-address validation and **rejects projects that previously compiled**:

- a location declared on anything other than `VAR` / `VAR_GLOBAL`,
- a located variable in a `PROGRAM` instantiated more than once,
- a POU-local location colliding with a located `CONFIGURATION VAR_GLOBAL`.

Editor-authored projects should be unaffected — the editor already blocks located interface classes at edit and load time (`DISALLOWED_LOCATION_CLASSES`, GH issue #904) — but hand-written or imported ST may not be. Each of those previously produced a program that looked fine and did not work, so the errors surface pre-existing breakage rather than new restrictions. Worth a release-note line.

## Notes

- `APP_VERSION` deliberately **untouched**, so this can batch with whatever else lands before the next release.
- Shared-surface parity verified against the sibling repo: **982 files, 0 diffs** (`compare-surfaces.py`). `binary-versions.json` is not a gated surface, but the pin must match functionally in both repos, hence the identical change on each side.
- v0.6.2 is not released yet; the STruC++ PR is open and the release must be cut as `v0.6.2` to match this pin.

## Verified

Patched a local editor's bundled STruC++ to this build and tested end-to-end against a Raspberry Pi running the runtime fix: a Modbus coil write to a located `%MX0.0` global now reaches program logic, and the runtime reports `2 config-scope shared globals` where it previously reported `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

### Related PRs — merge together

This fix spans four repos. All target `development`.

| Repo | PR | Contents |
|---|---|---|
| STruCpp | Autonomy-Logic/STruCpp#202 | emits `locatedGlobals[]` + accessors; tightens located-address validation |
| openplc-runtime | Autonomy-Logic/openplc-runtime#161 | consumes it via pointer-identity join |
| openplc-editor | Autonomy-Logic/openplc-editor#983 | pins STruC++ v0.6.2 |
| openplc-web | Autonomy-Logic/openplc-web#643 | pins STruC++ v0.6.2 (shared parity) |

**Ordering:** the runtime degrades gracefully against an older STruC++ (warns, skips located globals, program still runs), and an older runtime ignores the new symbols entirely — so merge order does not matter. But the fix only becomes active for a project **re-exported** from an editor shipping v0.6.2, so all four need to land before it reaches users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `strucpp` binary to version `v0.6.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->