### PR TITLE
fix: Login timeout too short for runtime v4 on original Raspberry Pi (Issue #526 )

### DIFF
--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -133,6 +133,7 @@ class MainProcessBridge implements MainIpcModule {
   // ===================== RUNTIME API HANDLERS =====================
   private readonly RUNTIME_API_PORT = 8443
   private readonly RUNTIME_CONNECTION_TIMEOUT_MS = 5000 // 5 seconds (important-comment)
+  private readonly RUNTIME_LOGIN_TIMEOUT_MS = 15000 // 15 seconds
 
   /**
    * Low-level HTTP helper that handles data accumulation, timeout, and error handling.
@@ -143,6 +144,7 @@ class MainProcessBridge implements MainIpcModule {
     url: string
     body?: string
     headers?: Record<string, string>
+    timeoutMs?: number
   }): Promise<{ statusCode: number; data: string; headers: IncomingHttpHeaders }> {
     return new Promise((resolve, reject) => {
       const parsedUrl = new URL(options.url)
@@ -172,7 +174,7 @@ class MainProcessBridge implements MainIpcModule {
           resolve({ statusCode: res.statusCode ?? 0, data, headers: res.headers })
         })
       })
-      req.setTimeout(this.RUNTIME_CONNECTION_TIMEOUT_MS, () => {
+      req.setTimeout(options.timeoutMs ?? this.RUNTIME_CONNECTION_TIMEOUT_MS, () => {
         req.destroy()
         reject(new Error('Connection timeout'))
       })
@@ -297,6 +299,7 @@ class MainProcessBridge implements MainIpcModule {
         method: 'POST',
         url: this.runtimeUrl(ipAddress, '/api/login'),
         body: JSON.stringify({ username, password }),
+        timeoutMs: this.RUNTIME_LOGIN_TIMEOUT_MS,
       })
       if (res.statusCode === 200) {
         try {


### PR DESCRIPTION
## Problem

Connecting to runtime v4 on weak hardware fails with **"Login Failed: Connection
timeout"** (#526). Reported on a first-generation Raspberry Pi, and confirmed by a
second user running the runtime in Docker on a WirenBoard 7 controller — so it is
not specific to one board.

The runtime answers `/api/login` successfully, just slowly: 7-10s measured by the
reporter, against the editor's 5s budget.

## Root cause

`/api/login` verifies the password through `check_password`, and the runtime derives
it with **PBKDF2-SHA256 at 600,000 iterations**
(`webserver/restapi.py`: `derivation_method = "pbkdf2:sha256:600000"`). That costs
~115ms on a desktop x86 and several seconds on an ARMv6 CPU with no crypto
acceleration, which matches the reported 7-10s once the rest of the request is
added.

Note for whoever revisits this: the issue hypothesises low entropy slowing
`create_access_token`. That does not hold up — the runtime signs with HS256 (no
RSA), and `uuid4`/`getrandom` do not block after boot; the reporter also tried
`haveged` with no effect. The cost is the KDF, which is deliberate (600k is the
current OWASP figure for PBKDF2-SHA256), not a bug.

So the editor side is legitimately accommodating a slow device, not papering over a
defect.

## Fix

A dedicated `RUNTIME_LOGIN_TIMEOUT_MS = 15000`, applied **per request** through a new
optional `timeoutMs` on the low-level `httpRequest` helper. The general
`RUNTIME_CONNECTION_TIMEOUT_MS = 5000` is untouched, so an unreachable device is
still reported in 5s for every other runtime call — raising the global default would
have made every failure four times slower to surface.

The reporter validated 10s in his environment; 15s is chosen for margin, and costs
nothing on hardware that answers quickly.

**This also covers the automatic re-authentication.** The token manager calls
`performAuthentication` when the 15-minute JWT expires, so on such hardware the old
timeout broke the session *mid-session*, not just at connect time — a symptom the
issue does not mention but that follows from the same cause.

## Testing

`tsc --noEmit` and prettier clean. The 7 eslint warnings the file reports are
pre-existing (`require-await` on library/package handlers) — verified by running
eslint against the same file at `HEAD`.

No unit test added: `src/main/` is outside the coverage-enforced directories, and
asserting `req.setTimeout` would mean mocking `https.request` for a one-line
behaviour — more mock than value. The behaviour was validated in the field by the
reporter, who compiled the editor with a raised login timeout and connected
successfully.

## Notes for reviewers

- **No openplc-web mirror needed.** `src/main/` is not part of the shared surface
  (`compare-surfaces.py` reports `match: True, 0 diffs` with this change applied),
  and the web app has no Electron main process. Its own runtime calls go through an
  axios instance with a 30s timeout, so it never hit this.
- **Suggested follow-up on the runtime side:** the JWT expiry is the
  flask-jwt-extended default of 15 minutes, which means one full PBKDF2 derivation
  every 15 minutes per session — on a single-core Pi that competes with the PLC task.
  Raising the expiry would cut those re-authentications ~4x. Lowering the iteration
  count would fix the latency outright but weakens password hashing, so that is a
  product call rather than a patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the login request timeout to 15 seconds to better accommodate slower authentication responses.
  * Kept the standard 5-second timeout for other requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->