### PR TITLE
fix(runtime-v4): report a switch in STOP as a warning, not a failed upload

### DIFF
--- a/src/backend/editor/compiler/editor-compiler-platform-port.ts
+++ b/src/backend/editor/compiler/editor-compiler-platform-port.ts
@@ -24,7 +24,7 @@
  * `middleware/adapters/web/`.
  */
 
-import { deployRuntimeProgram } from '@root/backend/shared/library/deploy-runtime-program'
+import { deployReachedDevice, deployRuntimeProgram } from '@root/backend/shared/library/deploy-runtime-program'
 import { probeRuntimeVersion } from '@root/backend/shared/library/probe-runtime-version'
 import {
   fromSchemaShape,
@@ -387,7 +387,11 @@ export function createEditorCompilerPlatformPort(
           startIntervalMs: context.startIntervalMs,
         })
 
-        return { ok: deployOutcome === 'STARTED' }
+        // 'STARTED' is not the only success: a runtime that refused to start
+        // because its hardware mode switch reads STOP has still taken the
+        // program. deployReachedDevice keeps that judgement in one place, shared
+        // with the web adapter.
+        return { ok: deployReachedDevice(deployOutcome) }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         log(`Runtime v4 upload failed: ${message}`, 'error')
@@ -486,7 +490,11 @@ export function createEditorCompilerPlatformPort(
           startTimeoutMs: context.startTimeoutMs,
           startIntervalMs: context.startIntervalMs,
         })
-        return { ok: deployOutcome === 'STARTED' }
+        // 'STARTED' is not the only success: a runtime that refused to start
+        // because its hardware mode switch reads STOP has still taken the
+        // program. deployReachedDevice keeps that judgement in one place, shared
+        // with the web adapter.
+        return { ok: deployReachedDevice(deployOutcome) }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         log(`Runtime v3 upload failed: ${message}`, 'error')

--- a/src/backend/shared/library/__tests__/start-plc-after-build.test.ts
+++ b/src/backend/shared/library/__tests__/start-plc-after-build.test.ts
@@ -54,6 +54,25 @@ describe('startPlcAfterBuild', () => {
     expect(calls()).toBe(3)
   })
 
+  it('treats a mode switch in STOP as a warning, not a failure', async () => {
+    // The runtime refuses to start while a hardware switch reads STOP. The
+    // program is on the device, so this must NOT read as a failed upload -- that
+    // sent users hunting for a problem that did not exist.
+    const { fetch, calls } = scriptedFetch(['START:ERROR_SWITCH_STOP'])
+    const logs: Array<{ level: string; message: string }> = []
+    const outcome = await startPlcAfterBuild({
+      fetchStart: fetch,
+      onLog: (level, message) => logs.push({ level, message }),
+      pollIntervalMs: 1,
+    })
+    expect(outcome).toBe('SWITCH_IN_STOP')
+    // Not retried: nothing changes until a human moves the switch.
+    expect(calls()).toBe(1)
+    expect(logs[logs.length - 1].level).toBe('warning')
+    expect(logs[logs.length - 1].message).toMatch(/uploaded/i)
+    expect(logs[logs.length - 1].message).toMatch(/switch is in STOP/i)
+  })
+
   it('bails with FAILED on a non-BUSY error reply', async () => {
     const { fetch, calls } = scriptedFetch(['ERROR:INVALID_PROGRAM'])
     const logs: Array<{ level: string; message: string }> = []

--- a/src/backend/shared/library/deploy-runtime-program.ts
+++ b/src/backend/shared/library/deploy-runtime-program.ts
@@ -23,12 +23,30 @@ import { startPlcAfterBuild, type StartPlcAfterBuildOptions } from './start-plc-
 
 export type DeployRuntimeProgramOutcome =
   | 'STARTED'
+  | 'UPLOADED_NOT_STARTED'
   | 'UPLOAD_FAILED'
   | 'BUILD_FAILED'
   | 'BUILD_TIMEOUT'
   | 'BUILD_ERROR'
   | 'START_FAILED'
   | 'START_TIMEOUT'
+
+/**
+ * Did the program reach the device?
+ *
+ * Distinct from "did it start", because those are different questions and the
+ * upload step must only fail for the first one. A runtime that refuses to start
+ * while its hardware mode switch reads STOP has still taken the program, and
+ * reporting that as a failed upload sends the user looking for a problem that
+ * does not exist.
+ *
+ * Shared rather than re-derived per platform: the editor and web adapters both
+ * turn this outcome into `UploadResult.ok`, and they must not drift on which
+ * outcomes count.
+ */
+export function deployReachedDevice(outcome: DeployRuntimeProgramOutcome): boolean {
+  return outcome === 'STARTED' || outcome === 'UPLOADED_NOT_STARTED'
+}
 
 export type DeployRuntimeProgramLogLevel = 'info' | 'error' | 'warning' | 'debug'
 
@@ -109,6 +127,9 @@ export async function deployRuntimeProgram(opts: DeployRuntimeProgramOptions): P
     pollIntervalMs: opts.startIntervalMs,
   })
   if (startOutcome === 'STARTED') return 'STARTED'
+  // Refused by the hardware mode switch: uploaded, deliberately not running.
+  // startPlcAfterBuild has already explained it as a warning.
+  if (startOutcome === 'SWITCH_IN_STOP') return 'UPLOADED_NOT_STARTED'
   if (startOutcome === 'TIMEOUT') return 'START_TIMEOUT'
   return 'START_FAILED'
 }

--- a/src/backend/shared/library/start-plc-after-build.ts
+++ b/src/backend/shared/library/start-plc-after-build.ts
@@ -21,12 +21,17 @@
  *   - 150-ms interval between attempts.
  *   - `START:OK` or `ALREADY_RUNNING` in the runtime's reply → SUCCESS.
  *   - `BUSY` in the reply → keep retrying.
+ *   - `ERROR_SWITCH_STOP` → SWITCH_IN_STOP: not an error.  The runtime
+ *     refuses to start while a hardware mode switch reads STOP, and
+ *     leaving the switch there is a normal thing for someone to do
+ *     while uploading.  The upload succeeded; only the start was
+ *     declined, and the user decides when to allow it.
  *   - Any other reply → terminal failure (e.g. invalid program).
  *   - Network error on the fetch → terminal failure.
  *   - Deadline elapsed → TIMEOUT (a warning, not a fatal error).
  */
 
-export type StartPlcAfterBuildOutcome = 'STARTED' | 'FAILED' | 'TIMEOUT'
+export type StartPlcAfterBuildOutcome = 'STARTED' | 'FAILED' | 'TIMEOUT' | 'SWITCH_IN_STOP'
 
 export type StartPlcAfterBuildLogLevel = 'info' | 'error' | 'warning'
 
@@ -72,6 +77,18 @@ export async function startPlcAfterBuild(opts: StartPlcAfterBuildOptions): Promi
     if (status.includes('START:OK') || status.includes('ALREADY_RUNNING')) {
       opts.onLog('info', 'PLC started.')
       return 'STARTED'
+    }
+
+    // A hardware mode switch in STOP is a refusal, not a failure: the
+    // program is on the device, and the runtime is doing exactly what it
+    // should by declining to run it until the switch says so. Retrying
+    // would be wrong too — nothing changes until someone moves it.
+    if (status.includes('ERROR_SWITCH_STOP')) {
+      opts.onLog(
+        'warning',
+        'Program uploaded. The PLC was not started because the mode switch is in STOP — move it to RUN to start.',
+      )
+      return 'SWITCH_IN_STOP'
     }
 
     // Only BUSY is retryable — everything else is a real error

--- a/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
@@ -452,6 +452,33 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
           })
           return
         }
+
+        // A refusal arrives as a successful request carrying a refusal status —
+        // the HTTP call worked, the runtime just declined. Checking only
+        // `success` therefore swallowed it: pressing Start with the mode switch
+        // in STOP did nothing at all, with no dialog and not even a log line.
+        //
+        // The switch case gets a dialog rather than a console entry because the
+        // user just asked for this explicitly and is watching the button; only
+        // they can resolve it, by moving the switch.
+        const status = result.status ?? ''
+        if (status.includes('ERROR_SWITCH_STOP')) {
+          void showDebuggerMessage(
+            'warning',
+            'PLC Not Started',
+            'The mode switch on the device is in STOP, so the runtime refused to start the PLC. Move the switch to RUN and try again.',
+            ['OK'],
+          )
+          return
+        }
+        if (!status.includes('START:OK') && !status.includes('ALREADY_RUNNING')) {
+          addLog({
+            id: crypto.randomUUID(),
+            level: 'error',
+            message: `Failed to start PLC: ${status || 'unknown response'}`,
+          })
+          return
+        }
       }
 
       const statusResult = await runtime.getStatus()

--- a/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
@@ -452,33 +452,6 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
           })
           return
         }
-
-        // A refusal arrives as a successful request carrying a refusal status —
-        // the HTTP call worked, the runtime just declined. Checking only
-        // `success` therefore swallowed it: pressing Start with the mode switch
-        // in STOP did nothing at all, with no dialog and not even a log line.
-        //
-        // The switch case gets a dialog rather than a console entry because the
-        // user just asked for this explicitly and is watching the button; only
-        // they can resolve it, by moving the switch.
-        const status = result.status ?? ''
-        if (status.includes('ERROR_SWITCH_STOP')) {
-          void showDebuggerMessage(
-            'warning',
-            'PLC Not Started',
-            'The mode switch on the device is in STOP, so the runtime refused to start the PLC. Move the switch to RUN and try again.',
-            ['OK'],
-          )
-          return
-        }
-        if (!status.includes('START:OK') && !status.includes('ALREADY_RUNNING')) {
-          addLog({
-            id: crypto.randomUUID(),
-            level: 'error',
-            message: `Failed to start PLC: ${status || 'unknown response'}`,
-          })
-          return
-        }
       }
 
       const statusResult = await runtime.getStatus()

--- a/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
@@ -425,6 +425,11 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
 
   const handlePlcControl = useCallback(async (): Promise<void> => {
     if (!jwtToken || connectionStatus !== 'connected') return
+    // Mid-transition the runtime refuses everything but PING and STATUS with
+    // COMMAND:BUSY, so a start or stop here can only produce a confusing error.
+    // The button is disabled for this too; guarding the handler as well covers
+    // any other caller and the gap between a stale render and the next poll.
+    if (plcStatus === 'TRANSITIONING') return
 
     try {
       if (plcStatus === 'RUNNING') {
@@ -459,6 +464,18 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
       addLog({ id: crypto.randomUUID(), level: 'error', message: `PLC control error: ${getErrorMessage(error)}` })
     }
   }, [runtime, jwtToken, connectionStatus, plcStatus, addLog])
+
+  /**
+   * Run/stop is blocked while the runtime is mid-transition.
+   *
+   * TRANSITIONING means a start or stop is in flight: the runtime answers
+   * COMMAND:BUSY to everything except PING and STATUS, and the state it will
+   * settle on is not decided yet. Clicking then cannot do what the icon says --
+   * the icon itself is ambiguous, since it is drawn from a state that is about to
+   * change -- so the button goes inert until the runtime lands.
+   */
+  const isPlcTransitioning = plcStatus === 'TRANSITIONING'
+  const isPlcControlBlocked = connectionStatus !== 'connected' || isPlcTransitioning
 
   // ---------------------------------------------------------------------------
   // Simulator control (Start/Stop simulator + auto-debug)
@@ -904,20 +921,22 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
                   : 'Start Simulator'
                 : connectionStatus !== 'connected'
                   ? 'Connect to runtime first'
-                  : plcStatus === 'RUNNING'
-                    ? 'Stop PLC'
-                    : 'Start PLC'
+                  : isPlcTransitioning
+                    ? 'PLC is changing state...'
+                    : plcStatus === 'RUNNING'
+                      ? 'Stop PLC'
+                      : 'Start PLC'
             }
           >
             <PlayButton
               onClick={isSimulatorBoard ? () => void handleSimulatorControl() : () => void handlePlcControl()}
-              disabled={isSimulatorBoard ? isCompiling || isDebuggerProcessing : connectionStatus !== 'connected'}
+              disabled={isSimulatorBoard ? isCompiling || isDebuggerProcessing : isPlcControlBlocked}
               className={cn(
                 isSimulatorBoard
                   ? isCompiling || isDebuggerProcessing
                     ? disabledButtonClass
                     : ''
-                  : connectionStatus !== 'connected'
+                  : isPlcControlBlocked
                     ? disabledButtonClass
                     : '',
               )}


### PR DESCRIPTION
## Problem

Uploading a program with the hardware mode switch in STOP ends like this:

```
Compilation completed successfully (exit code: 0).
Failed to start PLC: START:ERROR_SWITCH_STOP
Failed to upload to runtime.
Stopping compilation process.
```

Every line after the first is wrong. The program reached the device and compiled there. The runtime declined to *start* it, which is exactly what a mode switch in STOP is for — and leaving the switch there while uploading is normal, intentional behaviour, not a fault.

## Fix

- `startPlcAfterBuild` recognises `ERROR_SWITCH_STOP` as its own outcome (`SWITCH_IN_STOP`) and explains it as a **warning**: *"Program uploaded. The PLC was not started because the mode switch is in STOP — move it to RUN to start."*
- It is no longer retried. Nothing changes until someone moves the switch, so the 5 s BUSY loop had no business spinning on it.
- `deployRuntimeProgram` maps it to `UPLOADED_NOT_STARTED`, and both platform adapters treat that as a successful upload, so the pipeline no longer bails.
- "Did the program reach the device?" now lives in one shared predicate, `deployReachedDevice()`, instead of being re-derived as `outcome === 'STARTED'` per adapter — the editor had that in two places and web in a third, which is how the two would drift.

## Paired PR

The changed logic is in shared surface code, so this ships as a matching pair:
- openplc-editor: `fix/upload-warning-when-switch-in-stop`
- openplc-web: `fix/upload-warning-when-switch-in-stop`

`start-plc-after-build.ts` and `deploy-runtime-program.ts` are byte-identical across both repos before and after.

## Testing

- New unit test in both repos: `ERROR_SWITCH_STOP` yields `SWITCH_IN_STOP`, logs at `warning`, and is fetched exactly once (not retried). Editor 8/8 jest, web 15/15 vitest.
- `tsc --noEmit` clean on web; on editor the only errors are 4 pre-existing ReactFlow typing errors in the graphical editor, none in files touched here.
- The runtime-side behaviour this responds to was verified on an SLM-RP4: `START:ERROR_SWITCH_STOP` is returned by the START handler while the switch reads STOP.

## Noticed, not fixed here

`START_TIMEOUT` still maps to a failed upload, so a runtime that stays BUSY past the deadline logs a warning saying it may still start and then reports "Failed to upload to runtime." Same shape of bug, different trigger — left out to keep this change to the reported one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment handling when the device switch is in STOP after a successful upload.
  * Uploads are now recognized as successful even when the program does not start automatically.
  * Prevented unnecessary retries and clarified warnings for programs uploaded while the device remains stopped.
  * Disabled PLC start/stop controls while the runtime is transitioning, with updated status messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
---

## Follow-up commit: run/stop blocked while transitioning

The sidebar run/stop button is now inert while `plcStatus === 'TRANSITIONING'`, with the tooltip reading "PLC is changing state..." rather than offering Start or Stop. Rationale: mid-transition the runtime refuses everything but PING and STATUS, and the icon is drawn from a state that is about to change, so a click cannot do what it appears to.

`handlePlcControl` carries the same guard. Status is polled every 2 s, so a render can be that stale; the guard closes the window where the button still looks live, and covers callers that are not the click. The condition is one derived flag, not repeated across the `disabled` prop, the `className` and the tooltip.

No test added: there is no existing suite for `workspace-activity-bar` (0 matching files), and extracting the logic purely for testability would be a larger change than the tweak. Verified via `tsc --noEmit`.