### PR TITLE
feat(datatypes): canonical single-type ST serializer + .dt text parser [DOPE-530]

### DIFF
--- a/src/frontend/utils/PLC/__tests__/data-type-serializer.test.ts
+++ b/src/frontend/utils/PLC/__tests__/data-type-serializer.test.ts
@@ -11,7 +11,7 @@
  * one of these up.
  */
 import type { PLCDataType } from '../../../../middleware/shared/ports/types'
-import { serializeDataTypesToLines, serializeDataTypesToST } from '../data-type-serializer'
+import { serializeDataTypesToLines, serializeDataTypesToST, serializeDataTypeToText } from '../data-type-serializer'
 
 const enumerated = (name: string, values: string[], initialValue?: string): PLCDataType => ({
   name,
@@ -88,8 +88,62 @@ describe('serializeDataTypesToST', () => {
   })
 
   it('serialises a multi-dimension array with an initial value', () => {
+    // IEC 61131-3 multi-dimension syntax: one bracket, comma-separated.
     const out = serializeDataTypesToST([array('Matrix', 'REAL', ['0..3', '0..3'], '[0,0,0,0]')])
-    expect(out).toBe('TYPE\n  Matrix : ARRAY [0..3][0..3] OF REAL := [0,0,0,0];\nEND_TYPE\n')
+    expect(out).toBe('TYPE\n  Matrix : ARRAY [0..3, 0..3] OF REAL := [0,0,0,0];\nEND_TYPE\n')
+  })
+
+  it('rebuilds structure array fields from their structured shape', () => {
+    const dt: PLCDataType = {
+      name: 'Rec',
+      derivation: 'structure',
+      variable: [
+        {
+          name: 'samples',
+          type: {
+            definition: 'array',
+            value: 'ARRAY [1..5, 1..3] OF INT',
+            data: {
+              baseType: { definition: 'base-type', value: 'INT' },
+              dimensions: [{ dimension: '1..5' }, { dimension: '1..3' }],
+            },
+          },
+        },
+        // Legacy records may carry an array definition without the
+        // structured `data` — the display value is all we have.
+        { name: 'legacy', type: { definition: 'array', value: 'ARRAY [0..1] OF BOOL' } },
+      ],
+    }
+    expect(serializeDataTypesToST([dt])).toBe(
+      'TYPE\n' +
+        '  Rec : STRUCT\n' +
+        '    samples : ARRAY [1..5, 1..3] OF INT;\n' +
+        '    legacy : ARRAY [0..1] OF BOOL;\n' +
+        '  END_STRUCT;\n' +
+        'END_TYPE\n',
+    )
+  })
+
+  it('renders structure field documentation as a trailing comment', () => {
+    const dt: PLCDataType = {
+      name: 'Motor',
+      derivation: 'structure',
+      variable: [
+        {
+          name: 'speed',
+          type: { definition: 'base-type', value: 'INT' },
+          initialValue: { simpleValue: { value: '100' } },
+          documentation: 'target speed in rpm',
+        },
+      ],
+    }
+    expect(serializeDataTypesToST([dt])).toBe(
+      'TYPE\n' +
+        '  Motor : STRUCT\n' +
+        '    speed : INT := 100; (* target speed in rpm *)\n' +
+        '  END_STRUCT;\n' +
+        'END_TYPE\n',
+    )
   })
 
   it('packs multiple entries in one block in declaration order', () => {
@@ -145,13 +199,30 @@ describe('serializeDataTypesToLines', () => {
 
   it('reports a single line for an array (regardless of dimensions)', () => {
     const entries = serializeDataTypesToLines([array('Buffer', 'INT', ['0..9', '0..3'])])
-    expect(entries).toEqual([{ name: 'Buffer', lines: ['  Buffer : ARRAY [0..9][0..3] OF INT;'] }])
+    expect(entries).toEqual([{ name: 'Buffer', lines: ['  Buffer : ARRAY [0..9, 0..3] OF INT;'] }])
   })
 
   it('drops zero-line entries from the result', () => {
     const unknown = { name: 'Mystery', derivation: 'pointer' } as unknown as PLCDataType
     const entries = serializeDataTypesToLines([unknown, enumerated('Color', ['Red'])])
     expect(entries).toEqual([{ name: 'Color', lines: ['  Color : (Red);'] }])
+  })
+
+  it('serializeDataTypeToText frames a single entry as its own TYPE block', () => {
+    expect(serializeDataTypeToText(enumerated('Color', ['Red', 'Green'], 'Red'))).toBe(
+      'TYPE\n  Color : (Red, Green) := Red;\nEND_TYPE\n',
+    )
+    expect(serializeDataTypeToText(structure('Point', [{ name: 'x', type: 'INT' }]))).toBe(
+      'TYPE\n  Point : STRUCT\n    x : INT;\n  END_STRUCT;\nEND_TYPE\n',
+    )
+    expect(serializeDataTypeToText(array('Buffer', 'INT', ['0..9']))).toBe(
+      'TYPE\n  Buffer : ARRAY [0..9] OF INT;\nEND_TYPE\n',
+    )
+  })
+
+  it('serializeDataTypeToText returns an empty string for an unknown derivation', () => {
+    const unknown = { name: 'Mystery', derivation: 'pointer' } as unknown as PLCDataType
+    expect(serializeDataTypeToText(unknown)).toBe('')
   })
 
   it('lines from serializeDataTypesToLines roundtrip into serializeDataTypesToST', () => {

--- a/src/frontend/utils/PLC/__tests__/data-type-text-parser.test.ts
+++ b/src/frontend/utils/PLC/__tests__/data-type-text-parser.test.ts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Tests for the `.dt` text parser — the inverse of
+ * `serializeDataTypeToText`.  The core invariant is the round-trip:
+ * `parse(serialize(x))` must deep-equal `x` for every shape the
+ * visual editor can build.  Everything else is error reporting.
+ */
+import type { PLCDataType } from '../../../../middleware/shared/ports/types'
+import { serializeDataTypeToText } from '../data-type-serializer'
+import { parseDataTypeFromText } from '../data-type-text-parser'
+
+const roundTrip = (dt: PLCDataType) => parseDataTypeFromText(serializeDataTypeToText(dt), dt.name)
+
+describe('parseDataTypeFromText round-trips', () => {
+  it('round-trips an enumerated type without an initial value', () => {
+    const dt: PLCDataType = {
+      name: 'Color',
+      derivation: 'enumerated',
+      values: [{ description: 'Red' }, { description: 'Green' }, { description: 'Blue' }],
+      initialValue: '',
+    }
+    expect(roundTrip(dt)).toEqual({ dataType: dt })
+  })
+
+  it('round-trips an enumerated type with an initial value', () => {
+    const dt: PLCDataType = {
+      name: 'Mode',
+      derivation: 'enumerated',
+      values: [{ description: 'Auto' }, { description: 'Manual' }],
+      initialValue: 'Auto',
+    }
+    expect(roundTrip(dt)).toEqual({ dataType: dt })
+  })
+
+  it('round-trips an empty enumeration (freshly created in the UI)', () => {
+    const dt: PLCDataType = { name: 'Empty', derivation: 'enumerated', values: [], initialValue: '' }
+    expect(roundTrip(dt)).toEqual({ dataType: dt })
+  })
+
+  it('round-trips a structure with base, user, and array fields', () => {
+    const dt: PLCDataType = {
+      name: 'Motor',
+      derivation: 'structure',
+      variable: [
+        { name: 'speed', type: { definition: 'base-type', value: 'INT' } },
+        { name: 'status', type: { definition: 'user-data-type', value: 'MotorState' } },
+        {
+          name: 'samples',
+          type: {
+            definition: 'array',
+            value: 'ARRAY [1..5, 1..3] OF INT',
+            data: {
+              baseType: { definition: 'base-type', value: 'INT' },
+              dimensions: [{ dimension: '1..5' }, { dimension: '1..3' }],
+            },
+          },
+        },
+      ],
+    }
+    expect(roundTrip(dt)).toEqual({ dataType: dt })
+  })
+
+  it('round-trips structure field initial values and documentation', () => {
+    const dt: PLCDataType = {
+      name: 'Config',
+      derivation: 'structure',
+      variable: [
+        {
+          name: 'rate',
+          type: { definition: 'base-type', value: 'INT' },
+          initialValue: { simpleValue: { value: '100' } },
+          documentation: 'sampling rate in ms',
+        },
+        {
+          name: 'enabled',
+          type: { definition: 'base-type', value: 'BOOL' },
+          initialValue: { simpleValue: { value: 'TRUE' } },
+        },
+      ],
+    }
+    expect(roundTrip(dt)).toEqual({ dataType: dt })
+  })
+
+  it('round-trips an empty structure (freshly created in the UI)', () => {
+    const dt: PLCDataType = { name: 'Shell', derivation: 'structure', variable: [] }
+    expect(roundTrip(dt)).toEqual({ dataType: dt })
+  })
+
+  it('round-trips a single-dimension array', () => {
+    const dt: PLCDataType = {
+      name: 'Buffer',
+      derivation: 'array',
+      baseType: { definition: 'base-type', value: 'INT' },
+      initialValue: '',
+      dimensions: [{ dimension: '0..9' }],
+    }
+    expect(roundTrip(dt)).toEqual({ dataType: dt })
+  })
+
+  it('round-trips a multi-dimension array of a user type with an initial value', () => {
+    const dt: PLCDataType = {
+      name: 'Grid',
+      derivation: 'array',
+      baseType: { definition: 'user-data-type', value: 'Cell' },
+      initialValue: '[c1, c2]',
+      dimensions: [{ dimension: '0..3' }, { dimension: '0..3' }],
+    }
+    expect(roundTrip(dt)).toEqual({ dataType: dt })
+  })
+})
+
+describe('parseDataTypeFromText tolerance', () => {
+  it('accepts keyword-case and whitespace variations', () => {
+    const text = 'type\r\n\r\n  color : (Red, Green) ;\r\nend_type\r\n'
+    const result = parseDataTypeFromText(text)
+    expect(result.error).toBeUndefined()
+    expect(result.dataType).toEqual({
+      name: 'color',
+      derivation: 'enumerated',
+      values: [{ description: 'Red' }, { description: 'Green' }],
+      initialValue: '',
+    })
+  })
+
+  it('accepts a case-insensitive name match and normalises to the expected name', () => {
+    const result = parseDataTypeFromText('TYPE\n  color : (Red);\nEND_TYPE\n', 'Color')
+    expect(result.error).toBeUndefined()
+    expect(result.dataType?.name).toBe('Color')
+  })
+
+  it('accepts END_STRUCT with spaced semicolon and lowercase struct keywords', () => {
+    const text = 'TYPE\n  Point : struct\n    x : int;\n  end_struct ;\nEND_TYPE\n'
+    const result = parseDataTypeFromText(text, 'Point')
+    expect(result.error).toBeUndefined()
+    expect(result.dataType).toEqual({
+      name: 'Point',
+      derivation: 'structure',
+      variable: [{ name: 'x', type: { definition: 'base-type', value: 'INT' } }],
+    })
+  })
+})
+
+describe('parseDataTypeFromText errors', () => {
+  it('rejects an empty file', () => {
+    expect(parseDataTypeFromText('').error).toMatch(/empty file/)
+    expect(parseDataTypeFromText('  \n \n').error).toMatch(/empty file/)
+  })
+
+  it('rejects a missing TYPE frame', () => {
+    expect(parseDataTypeFromText('Color : (Red);\nEND_TYPE\n').error).toMatch(/must start with a TYPE/)
+    expect(parseDataTypeFromText('TYPE\n  Color : (Red);\n').error).toMatch(/must end with END_TYPE/)
+  })
+
+  it('rejects a TYPE block with no declaration', () => {
+    expect(parseDataTypeFromText('TYPE\nEND_TYPE\n').error).toMatch(/declares no data type/)
+  })
+
+  it('rejects more than one declaration per file', () => {
+    const twoEnums = 'TYPE\n  A : (X);\n  B : (Y);\nEND_TYPE\n'
+    expect(parseDataTypeFromText(twoEnums).error).toMatch(/exactly one data type/)
+    const structPlusEnum = 'TYPE\n  P : STRUCT\n    x : INT;\n  END_STRUCT;\n  B : (Y);\nEND_TYPE\n'
+    expect(parseDataTypeFromText(structPlusEnum).error).toMatch(/exactly one data type/)
+  })
+
+  it('rejects a structure without END_STRUCT', () => {
+    expect(parseDataTypeFromText('TYPE\n  P : STRUCT\n    x : INT;\nEND_TYPE\n').error).toMatch(/missing END_STRUCT/)
+  })
+
+  it('rejects invalid structure fields with a hint', () => {
+    const missingSemicolon = 'TYPE\n  P : STRUCT\n    x : INT\n  END_STRUCT;\nEND_TYPE\n'
+    expect(parseDataTypeFromText(missingSemicolon).error).toMatch(/missing semicolon/)
+    const missingColon = 'TYPE\n  P : STRUCT\n    x INT;\n  END_STRUCT;\nEND_TYPE\n'
+    expect(parseDataTypeFromText(missingColon).error).toMatch(/missing colon/)
+    const badFieldType = 'TYPE\n  P : STRUCT\n    x : MY TYPE;\n  END_STRUCT;\nEND_TYPE\n'
+    expect(parseDataTypeFromText(badFieldType).error).toMatch(/invalid structure field/)
+  })
+
+  it('rejects invalid enumeration values', () => {
+    expect(parseDataTypeFromText('TYPE\n  Color : (Red, 2bad);\nEND_TYPE\n').error).toMatch(/invalid enumeration value/)
+  })
+
+  it('rejects unrecognized declarations with a hint', () => {
+    expect(parseDataTypeFromText('TYPE\n  Foo\nEND_TYPE\n').error).toMatch(/missing semicolon/)
+    expect(parseDataTypeFromText('TYPE\n  Foo Bar;\nEND_TYPE\n').error).toMatch(/missing colon/)
+    expect(parseDataTypeFromText('TYPE\n  Foo : ?!;\nEND_TYPE\n').error).toMatch(/unrecognized declaration format/)
+  })
+
+  it('rejects an invalid type name', () => {
+    expect(parseDataTypeFromText('TYPE\n  2bad : (Red);\nEND_TYPE\n').error).toMatch(/invalid type name/)
+  })
+
+  it('rejects a declared name that does not match the expected name', () => {
+    const result = parseDataTypeFromText('TYPE\n  Other : (Red);\nEND_TYPE\n', 'Color')
+    expect(result.error).toMatch(/does not match the expected name "Color"/)
+    expect(result.error).toMatch(/rename the data type via the project tree/)
+  })
+})

--- a/src/frontend/utils/PLC/data-type-serializer.ts
+++ b/src/frontend/utils/PLC/data-type-serializer.ts
@@ -35,6 +35,12 @@
 import type { PLCDataType, PLCVariableType } from '../../../middleware/shared/ports/types'
 
 function renderVariableType(type: PLCVariableType): string {
+  // Rebuild array types from their structured shape — `value` is a
+  // display string that legacy records may hold in a lossy form.
+  if (type.definition === 'array' && type.data) {
+    const dims = type.data.dimensions.map((d) => d.dimension).join(', ')
+    return `ARRAY [${dims}] OF ${type.data.baseType.value}`
+  }
   return type.value
 }
 
@@ -47,15 +53,17 @@ function renderEnumeratedLines(dt: Extract<PLCDataType, { derivation: 'enumerate
 function renderStructureLines(dt: Extract<PLCDataType, { derivation: 'structure' }>): string[] {
   const fieldLines = dt.variable.map((v) => {
     const init = v.initialValue?.simpleValue?.value ? ` := ${v.initialValue.simpleValue.value}` : ''
-    return `    ${v.name} : ${renderVariableType(v.type)}${init};`
+    const doc = v.documentation ? ` (* ${v.documentation} *)` : ''
+    return `    ${v.name} : ${renderVariableType(v.type)}${init};${doc}`
   })
   return [`  ${dt.name} : STRUCT`, ...fieldLines, `  END_STRUCT;`]
 }
 
 function renderArrayLines(dt: Extract<PLCDataType, { derivation: 'array' }>): string[] {
-  const dims = dt.dimensions.map((d) => `[${d.dimension}]`).join('')
+  // IEC 61131-3 multi-dimension syntax: one bracket, comma-separated.
+  const dims = dt.dimensions.map((d) => d.dimension).join(', ')
   const initial = dt.initialValue ? ` := ${dt.initialValue}` : ''
-  return [`  ${dt.name} : ARRAY ${dims} OF ${renderVariableType(dt.baseType)}${initial};`]
+  return [`  ${dt.name} : ARRAY [${dims}] OF ${renderVariableType(dt.baseType)}${initial};`]
 }
 
 function renderDataTypeLines(dt: PLCDataType): string[] {
@@ -114,4 +122,18 @@ export function serializeDataTypesToST(dataTypes: PLCDataType[]): string {
   if (entries.length === 0) return ''
   const body = entries.flatMap((e) => e.lines).join('\n')
   return `TYPE\n${body}\nEND_TYPE\n`
+}
+
+/**
+ * Serialise ONE data type to its on-disk `.dt` file content — a
+ * `TYPE…END_TYPE` block holding a single declaration.  This is the
+ * canonical persistence format (`datatypes/<Name>.dt`); its inverse
+ * is `parseDataTypeFromText` in `data-type-text-parser.ts`, and the
+ * pair must round-trip.  Returns `''` for a derivation that renders
+ * to no lines (unknown shape).
+ */
+export function serializeDataTypeToText(dt: PLCDataType): string {
+  const lines = renderDataTypeLines(dt)
+  if (lines.length === 0) return ''
+  return `TYPE\n${lines.join('\n')}\nEND_TYPE\n`
 }

--- a/src/frontend/utils/PLC/data-type-text-parser.ts
+++ b/src/frontend/utils/PLC/data-type-text-parser.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Parse a single data-type declaration from its on-disk `.dt` text
+ * (an ST `TYPE…END_TYPE` block) back into a `PLCDataType`.
+ *
+ * Inverse of `serializeDataTypeToText` in `data-type-serializer.ts`.
+ * The parser accepts exactly the shapes the serializer emits —
+ * tolerant to whitespace and keyword case — so `parse(serialize(x))`
+ * round-trips.  Anything the visual editor cannot represent is a
+ * parse error, never a silent drop: the code view keeps the user on
+ * the text until it is valid, and the project loader falls back to
+ * preserving the raw file content.
+ *
+ * When `expectedName` is given, the declared name must match it
+ * (case-insensitive) — the file name is the type's identity, so
+ * renaming happens through the project tree, not by editing text.
+ */
+import { baseTypeSchema } from '../../../middleware/shared/ports/plc-schemas'
+import type { PLCDataType, PLCStructureVariable, PLCVariableType } from '../../../middleware/shared/ports/types'
+import { parseArrayType } from '../generate-iec-string-to-variables'
+
+export interface ParseDataTypeResult {
+  dataType?: PLCDataType
+  error?: string
+}
+
+const identifierRegex = /^[A-Za-z_]\w*$/
+
+const structStartRegex = /^(?<name>\w+)\s*:\s*STRUCT$/i
+
+const structEndRegex = /^END_STRUCT\s*;$/i
+
+// Name : (Value1, Value2) := Initial ;
+const enumRegex = /^(?<name>\w+)\s*:\s*\((?<values>[^)]*)\)\s*(?::=\s*(?<initial>[^;]+?))?\s*;$/
+
+// Name : ARRAY [d1, d2] OF Base := Initial ;
+const arrayRegex =
+  /^(?<name>\w+)\s*:\s*(?<type>ARRAY\s*\[[^\]]+\]\s+OF\s+[A-Za-z_][\w.]*)\s*(?::=\s*(?<initial>[^;]+?))?\s*;$/i
+
+// FieldName : Type := Initial ; (* documentation *)
+const fieldRegex =
+  /^(?<name>\w+)\s*:\s*(?<type>[\w\s[\],.]+?)\s*(?::=\s*(?<initial>[^;]+?))?\s*;\s*(?:\(\*\s*(?<documentation>.*?)\s*\*\))?$/
+
+const guessErrorReason = (line: string): string => {
+  if (!line.includes(';')) return 'missing semicolon (;) at the end of the declaration'
+  if (!line.includes(':')) return 'missing colon (:) between name and type'
+  return 'unrecognized declaration format'
+}
+
+function buildFieldType(typeStr: string): PLCVariableType | null {
+  const arrayType = parseArrayType(typeStr)
+  if (arrayType) return arrayType
+  const baseCheck = baseTypeSchema.safeParse(typeStr)
+  if (baseCheck.success) return { definition: 'base-type', value: baseCheck.data }
+  if (identifierRegex.test(typeStr)) return { definition: 'user-data-type', value: typeStr }
+  return null
+}
+
+function parseStructure(name: string, body: string[]): ParseDataTypeResult {
+  const endIndex = body.findIndex((line) => structEndRegex.test(line))
+  if (endIndex === -1) return { error: 'missing END_STRUCT; to close the structure' }
+  if (endIndex !== body.length - 1) return { error: 'a .dt file must declare exactly one data type' }
+
+  const variable: PLCStructureVariable[] = []
+  for (const line of body.slice(1, endIndex)) {
+    const match = fieldRegex.exec(line)
+    const groups = match?.groups
+    const type = groups?.type !== undefined ? buildFieldType(groups.type) : null
+    if (groups?.name === undefined || type === null) {
+      return { error: `invalid structure field: "${line}". Possible cause: ${guessErrorReason(line)}` }
+    }
+    variable.push({
+      name: groups.name,
+      type,
+      ...(groups.initial !== undefined ? { initialValue: { simpleValue: { value: groups.initial.trim() } } } : {}),
+      ...(groups.documentation !== undefined && groups.documentation !== ''
+        ? { documentation: groups.documentation }
+        : {}),
+    })
+  }
+  return { dataType: { name, derivation: 'structure', variable } }
+}
+
+function parseSingleLine(line: string): ParseDataTypeResult {
+  const enumMatch = enumRegex.exec(line)
+  if (enumMatch?.groups?.name !== undefined) {
+    const raw = enumMatch.groups.values.trim()
+    const values = raw === '' ? [] : raw.split(',').map((v) => v.trim())
+    const invalid = values.find((v) => !identifierRegex.test(v))
+    if (invalid !== undefined) return { error: `invalid enumeration value: "${invalid}"` }
+    return {
+      dataType: {
+        name: enumMatch.groups.name,
+        derivation: 'enumerated',
+        values: values.map((description) => ({ description })),
+        initialValue: enumMatch.groups.initial?.trim() ?? '',
+      },
+    }
+  }
+
+  const arrayMatch = arrayRegex.exec(line)
+  if (arrayMatch?.groups?.name !== undefined) {
+    const arrayType = parseArrayType(arrayMatch.groups.type)
+    if (arrayType?.data) {
+      return {
+        dataType: {
+          name: arrayMatch.groups.name,
+          derivation: 'array',
+          baseType: arrayType.data.baseType,
+          initialValue: arrayMatch.groups.initial?.trim() ?? '',
+          dimensions: arrayType.data.dimensions,
+        },
+      }
+    }
+  }
+
+  return { error: `invalid declaration: "${line}". Possible cause: ${guessErrorReason(line)}` }
+}
+
+export function parseDataTypeFromText(content: string, expectedName?: string): ParseDataTypeResult {
+  const lines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+
+  if (lines.length === 0) return { error: 'empty file — expected a TYPE…END_TYPE declaration' }
+  if (!/^TYPE$/i.test(lines[0])) return { error: 'the declaration must start with a TYPE block' }
+  if (!/^END_TYPE$/i.test(lines[lines.length - 1])) return { error: 'the declaration must end with END_TYPE' }
+
+  const body = lines.slice(1, -1)
+  if (body.length === 0) return { error: 'the TYPE block declares no data type' }
+
+  const structMatch = structStartRegex.exec(body[0])
+  const structName = structMatch?.groups?.name
+  const result =
+    structName !== undefined
+      ? parseStructure(structName, body)
+      : body.length > 1
+        ? { error: 'a .dt file must declare exactly one data type' }
+        : parseSingleLine(body[0])
+
+  if (result.dataType === undefined) return result
+  if (!identifierRegex.test(result.dataType.name)) {
+    return { error: `invalid type name: "${result.dataType.name}"` }
+  }
+
+  if (expectedName !== undefined) {
+    if (result.dataType.name.toLowerCase() !== expectedName.toLowerCase()) {
+      return {
+        error: `declared type name "${result.dataType.name}" does not match the expected name "${expectedName}" — rename the data type via the project tree instead`,
+      }
+    }
+    result.dataType.name = expectedName
+  }
+  return result
+}

--- a/src/frontend/utils/generate-iec-string-to-variables.ts
+++ b/src/frontend/utils/generate-iec-string-to-variables.ts
@@ -56,8 +56,9 @@ const hasLibraryPous = (lib: unknown): lib is { pous: Array<{ name: string; type
 /**
  * Parse an array type string like "ARRAY[1..10] OF INT" or "ARRAY[1..10, 1..5] OF MyStruct"
  * Returns null if not an array type, otherwise returns the parsed array type definition.
+ * Also consumed by the data-type text parser (`PLC/data-type-text-parser.ts`).
  */
-const parseArrayType = (typeStr: string): PLCVariable['type'] | null => {
+export const parseArrayType = (typeStr: string): PLCVariable['type'] | null => {
   // Match ARRAY[dimensions] OF baseType, where baseType is an identifier (optionally namespaced)
   const arrayMatch = typeStr.match(/^ARRAY\s*\[([^\]]+)\]\s+OF\s+([A-Za-z_][\w.]*)\s*$/i)
   if (!arrayMatch) return null


### PR DESCRIPTION
## Summary

Groundwork for [DOPE-385](https://autonomylogic.atlassian.net/browse/DOPE-385) (data types stored as `datatypes/<Name>.dt` files, subtask [DOPE-530](https://autonomylogic.atlassian.net/browse/DOPE-530)) — pure `src/frontend/utils/` change, no behavior switch:

- **New `serializeDataTypeToText(dt)`** in `data-type-serializer.ts`: frames ONE data type as its own `TYPE…END_TYPE` block — the canonical `.dt` file content. Delegates to the existing per-derivation renderers so the LSP line map (`serializeDataTypesToLines`) stays the single layout source.
- **New `data-type-text-parser.ts`**: `parseDataTypeFromText(content, expectedName?)`, the round-trip inverse. Accepts exactly the shapes the serializer emits (whitespace/keyword-case tolerant); anything else is a parse error with a `guessErrorReason`-style hint. Declared name must match `expectedName` (case-insensitive, normalized) — one rule serving both file loading and the future code-view rename rejection.
- **Serializer fidelity fixes** (also improve today's LSP synthetic doc):
  - struct array fields are rebuilt from their structured `data` instead of the lossy display `value`;
  - struct field `documentation` is preserved as a trailing `(* … *)` comment;
  - multi-dimension arrays now emit IEC-standard comma form (`ARRAY [0..9, 0..3] OF INT`, was non-standard `[0..9][0..3]`).
- `parseArrayType` exported from `generate-iec-string-to-variables.ts` for reuse (no behavior change).

## Testing

- New parser suite: round-trips (`parse(serialize(x))` deep-equals `x`) for all three derivations × array struct fields × initial values × documentation × empty shapes, plus every error path.
- 100% statements/functions/lines on all touched files (jest + vitest).
- Manual check: multi-dim array / struct-with-doc datatypes referenced from an ST POU — no LSP regressions, goto-def and build OK.

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/647

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6Kfu7zebQC3UdeN29tiq

[DOPE-385]: https://autonomylogic.atlassian.net/browse/DOPE-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOPE-530]: https://autonomylogic.atlassian.net/browse/DOPE-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing IEC data-type declarations into usable data types.
  * Added serialization of individual data types into standalone `TYPE…END_TYPE` blocks.
  * Added support for multi-dimensional arrays, initial values, and structure-field documentation comments.

* **Bug Fixes**
  * Improved handling of structured and legacy array definitions.
  * Added validation with descriptive errors for malformed declarations, invalid fields, duplicate entries, and name mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->