### PR TITLE
feat(datatypes): datatypes/*.dt file-category plumbing [DOPE-532]

### DIFF
--- a/src/backend/editor/services/project-service/index.ts
+++ b/src/backend/editor/services/project-service/index.ts
@@ -468,9 +468,14 @@ class ProjectService {
       // arrays are empty (e.g. fresh library with no servers yet),
       // so callers can rely on them existing.
       await Promise.all(
-        ['pous/programs', 'pous/functions', 'pous/function-blocks', 'devices/servers', 'devices/remote', 'datatypes'].map((d) =>
-          promises.mkdir(join(dir, d), { recursive: true }),
-        ),
+        [
+          'pous/programs',
+          'pous/functions',
+          'pous/function-blocks',
+          'devices/servers',
+          'devices/remote',
+          'datatypes',
+        ].map((d) => promises.mkdir(join(dir, d), { recursive: true })),
       )
 
       // Single source of truth for the file shape lives in the

--- a/src/backend/editor/services/project-service/index.ts
+++ b/src/backend/editor/services/project-service/index.ts
@@ -192,6 +192,7 @@ class ProjectService {
       pouFiles: Array<{ relativePath: string; content: string }>
       serverFiles: Array<{ relativePath: string; content: string }>
       remoteDeviceFiles: Array<{ relativePath: string; content: string }>
+      dataTypeFiles: Array<{ relativePath: string; content: string }>
     }
     error?: { title: string; description: string }
   }> {
@@ -242,6 +243,7 @@ class ProjectService {
       const readDirRecursive = async (
         dirPath: string,
         basePath: string,
+        validExtensions: string[] = VALID_POU_EXTENSIONS,
       ): Promise<Array<{ relativePath: string; content: string }>> => {
         const results: Array<{ relativePath: string; content: string }> = []
         try {
@@ -250,11 +252,11 @@ class ProjectService {
             const fullPath = join(dirPath, entry.name)
             const relPath = join(basePath, entry.name)
             if (entry.isDirectory()) {
-              const subResults = await readDirRecursive(fullPath, relPath)
+              const subResults = await readDirRecursive(fullPath, relPath, validExtensions)
               results.push(...subResults)
             } else if (entry.isFile()) {
               const ext = entry.name.slice(entry.name.lastIndexOf('.'))
-              if (!VALID_POU_EXTENSIONS.includes(ext)) continue
+              if (!validExtensions.includes(ext)) continue
               const content = await promises.readFile(fullPath, 'utf-8')
               results.push({ relativePath: relPath, content })
             }
@@ -285,6 +287,11 @@ class ProjectService {
       const serverFiles = await readDirRecursive(join(projectPath, 'devices', 'servers'), 'devices/servers')
       const remoteDeviceFiles = await readDirRecursive(join(projectPath, 'devices', 'remote'), 'devices/remote')
 
+      // Data type files live at datatypes/<Name>.dt — collected into
+      // their own bucket, never into pouFiles (pou-path detection
+      // throws for paths outside the pou folders).
+      const dataTypeFiles = await readDirRecursive(join(projectPath, 'datatypes'), 'datatypes', ['.dt'])
+
       // Library projects own a `library.json` at the project root.
       // Read it as a plain string (parsing happens upstream in the
       // build pipeline + manifest editor — same convention POUs use:
@@ -310,6 +317,7 @@ class ProjectService {
           pouFiles,
           serverFiles,
           remoteDeviceFiles,
+          dataTypeFiles,
         },
       }
     } catch (error) {
@@ -460,7 +468,7 @@ class ProjectService {
       // arrays are empty (e.g. fresh library with no servers yet),
       // so callers can rely on them existing.
       await Promise.all(
-        ['pous/programs', 'pous/functions', 'pous/function-blocks', 'devices/servers', 'devices/remote'].map((d) =>
+        ['pous/programs', 'pous/functions', 'pous/function-blocks', 'devices/servers', 'devices/remote', 'datatypes'].map((d) =>
           promises.mkdir(join(dir, d), { recursive: true }),
         ),
       )

--- a/src/backend/shared/project/__tests__/iterate-write-project-files.test.ts
+++ b/src/backend/shared/project/__tests__/iterate-write-project-files.test.ts
@@ -18,6 +18,7 @@ const baseFiles: WriteProjectFiles = {
   pouFiles: [],
   serverFiles: [],
   remoteDeviceFiles: [],
+  dataTypeFiles: [],
   deletions: [],
 }
 
@@ -126,6 +127,24 @@ describe('iterateWriteProjectFiles', () => {
         { category: 'remote-device', relativePath: 'devices/remote/bus0.json', content: '{"id":"bus0"}' },
       ])
     })
+
+    it('yields each data type file preserving relativePath verbatim', () => {
+      const entries = collect({
+        ...baseFiles,
+        dataTypeFiles: [
+          { relativePath: 'datatypes/Motor.dt', content: 'TYPE\n  Motor : STRUCT\n  END_STRUCT;\nEND_TYPE\n' },
+          { relativePath: 'datatypes/Color.dt', content: 'TYPE\n  Color : (Red);\nEND_TYPE\n' },
+        ],
+      })
+      expect(entries.filter((e) => e.category === 'data-type')).toEqual([
+        {
+          category: 'data-type',
+          relativePath: 'datatypes/Motor.dt',
+          content: 'TYPE\n  Motor : STRUCT\n  END_STRUCT;\nEND_TYPE\n',
+        },
+        { category: 'data-type', relativePath: 'datatypes/Color.dt', content: 'TYPE\n  Color : (Red);\nEND_TYPE\n' },
+      ])
+    })
   })
 
   describe('whole-project shapes', () => {
@@ -158,7 +177,7 @@ describe('iterateWriteProjectFiles', () => {
   })
 
   describe('ordering', () => {
-    it('emits in a stable order: project.json, device-config, pin-mapping, library-manifest, pous, servers, remote-devices', () => {
+    it('emits in a stable order: project.json, device-config, pin-mapping, library-manifest, pous, servers, remote-devices, data-types', () => {
       const entries = collect({
         ...baseFiles,
         deviceConfig: 'D',
@@ -167,6 +186,7 @@ describe('iterateWriteProjectFiles', () => {
         pouFiles: [{ relativePath: 'pous/programs/a.st', content: 'A' }],
         serverFiles: [{ relativePath: 'devices/servers/s.json', content: 'S' }],
         remoteDeviceFiles: [{ relativePath: 'devices/remote/r.json', content: 'R' }],
+        dataTypeFiles: [{ relativePath: 'datatypes/T.dt', content: 'T' }],
       })
       expect(entries.map((e) => e.category)).toEqual([
         'project-json',
@@ -176,6 +196,7 @@ describe('iterateWriteProjectFiles', () => {
         'pou',
         'server',
         'remote-device',
+        'data-type',
       ])
     })
   })

--- a/src/backend/shared/project/iterate-write-project-files.ts
+++ b/src/backend/shared/project/iterate-write-project-files.ts
@@ -35,6 +35,7 @@ export type WriteProjectFileEntry =
   | { category: 'pou'; relativePath: string; content: string }
   | { category: 'server'; relativePath: string; content: string }
   | { category: 'remote-device'; relativePath: string; content: string }
+  | { category: 'data-type'; relativePath: string; content: string }
 
 /**
  * Yield every file in a WriteProjectFiles as a `WriteProjectFileEntry`.
@@ -66,5 +67,8 @@ export function* iterateWriteProjectFiles(files: WriteProjectFiles): Generator<W
   }
   for (const f of files.remoteDeviceFiles) {
     yield { category: 'remote-device', relativePath: f.relativePath, content: f.content }
+  }
+  for (const f of files.dataTypeFiles) {
+    yield { category: 'data-type', relativePath: f.relativePath, content: f.content }
   }
 }

--- a/src/backend/shared/project/project-files-schema.ts
+++ b/src/backend/shared/project/project-files-schema.ts
@@ -12,6 +12,9 @@ export type ProjectDefaultFilesMapKeys = keyof typeof projectDefaultFilesMapSche
 export type ProjectDefaultFilesMapValues = (typeof projectDefaultFilesMapSchema)[ProjectDefaultFilesMapKeys]
 
 export const projectPouDirectories = ['pous/functions', 'pous/function-blocks', 'pous/programs'] as const
-export const projectDefaultDirectories = ['devices', ...projectPouDirectories] as const
+// Kept out of projectPouDirectories: pou-path detection
+// (detectPouTypeFromPath) must never see datatypes/ entries.
+export const projectDataTypeDirectories = ['datatypes'] as const
+export const projectDefaultDirectories = ['devices', ...projectPouDirectories, ...projectDataTypeDirectories] as const
 export const projectDefaultDirectoriesValidation = [...projectDefaultDirectories, 'build'] as readonly string[]
 export type ProjectDefaultDirectories = (typeof projectDefaultDirectories)[number]

--- a/src/backend/shared/types/PLC/open-plc.ts
+++ b/src/backend/shared/types/PLC/open-plc.ts
@@ -803,7 +803,10 @@ const PLCProjectLibraryRefSchema = z.object({
 type PLCProjectLibraryRef = z.infer<typeof PLCProjectLibraryRefSchema>
 
 const PLCProjectDataSchema = z.object({
-  dataTypes: z.array(PLCDataTypeSchema),
+  // Defaulted: once data types live in datatypes/<Name>.dt files the
+  // field disappears from newly-written project.json (DOPE-385);
+  // legacy projects still carry it and keep validating.
+  dataTypes: z.array(PLCDataTypeSchema).default([]),
   pous: z.array(PLCPouSchema).default([]),
   configuration: PLCConfigurationSchema,
   servers: z.array(PLCServerSchema).optional(),

--- a/src/frontend/services/save-actions.ts
+++ b/src/frontend/services/save-actions.ts
@@ -416,6 +416,8 @@ export async function executeSaveProject(
       pouFiles,
       serverFiles,
       remoteDeviceFiles,
+      // Populated when the .dt write path is switched on (DOPE-533).
+      dataTypeFiles: [],
       deletions: [...pendingDeletions],
     }
 

--- a/src/frontend/utils/PLC/__tests__/data-type-serializer.test.ts
+++ b/src/frontend/utils/PLC/__tests__/data-type-serializer.test.ts
@@ -124,6 +124,23 @@ describe('serializeDataTypesToST', () => {
     )
   })
 
+  it('collapses newlines in structure field documentation', () => {
+    // A multi-line comment would desync serializeDataTypesToLines'
+    // line map and be unreadable by the .dt parser.
+    const dt: PLCDataType = {
+      name: 'Motor',
+      derivation: 'structure',
+      variable: [
+        {
+          name: 'speed',
+          type: { definition: 'base-type', value: 'INT' },
+          documentation: 'target speed\nin rpm',
+        },
+      ],
+    }
+    expect(serializeDataTypesToST([dt])).toContain('    speed : INT; (* target speed in rpm *)\n')
+  })
+
   it('renders structure field documentation as a trailing comment', () => {
     const dt: PLCDataType = {
       name: 'Motor',

--- a/src/frontend/utils/PLC/__tests__/data-type-text-parser.test.ts
+++ b/src/frontend/utils/PLC/__tests__/data-type-text-parser.test.ts
@@ -180,6 +180,11 @@ describe('parseDataTypeFromText errors', () => {
     expect(parseDataTypeFromText('TYPE\n  Color : (Red, 2bad);\nEND_TYPE\n').error).toMatch(/invalid enumeration value/)
   })
 
+  it('rejects invalid structure field names', () => {
+    const badName = 'TYPE\n  P : STRUCT\n    2bad : INT;\n  END_STRUCT;\nEND_TYPE\n'
+    expect(parseDataTypeFromText(badName).error).toMatch(/invalid structure field name: "2bad"/)
+  })
+
   it('rejects unrecognized declarations with a hint', () => {
     expect(parseDataTypeFromText('TYPE\n  Foo\nEND_TYPE\n').error).toMatch(/missing semicolon/)
     expect(parseDataTypeFromText('TYPE\n  Foo Bar;\nEND_TYPE\n').error).toMatch(/missing colon/)

--- a/src/frontend/utils/PLC/data-type-serializer.ts
+++ b/src/frontend/utils/PLC/data-type-serializer.ts
@@ -53,7 +53,9 @@ function renderEnumeratedLines(dt: Extract<PLCDataType, { derivation: 'enumerate
 function renderStructureLines(dt: Extract<PLCDataType, { derivation: 'structure' }>): string[] {
   const fieldLines = dt.variable.map((v) => {
     const init = v.initialValue?.simpleValue?.value ? ` := ${v.initialValue.simpleValue.value}` : ''
-    const doc = v.documentation ? ` (* ${v.documentation} *)` : ''
+    // Newlines collapsed: a multi-line comment would desync the
+    // line map (goto-definition) and be unreadable by the parser.
+    const doc = v.documentation ? ` (* ${v.documentation.replace(/\s*\r?\n\s*/g, ' ')} *)` : ''
     return `    ${v.name} : ${renderVariableType(v.type)}${init};${doc}`
   })
   return [`  ${dt.name} : STRUCT`, ...fieldLines, `  END_STRUCT;`]

--- a/src/frontend/utils/PLC/data-type-text-parser.ts
+++ b/src/frontend/utils/PLC/data-type-text-parser.ts
@@ -70,6 +70,9 @@ function parseStructure(name: string, body: string[]): ParseDataTypeResult {
     if (groups?.name === undefined || type === null) {
       return { error: `invalid structure field: "${line}". Possible cause: ${guessErrorReason(line)}` }
     }
+    if (!identifierRegex.test(groups.name)) {
+      return { error: `invalid structure field name: "${groups.name}"` }
+    }
     variable.push({
       name: groups.name,
       type,

--- a/src/middleware/adapters/editor/__tests__/project-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/project-adapter.test.ts
@@ -97,6 +97,7 @@ const mockRawProjectFiles = {
     ],
     serverFiles: [],
     remoteDeviceFiles: [],
+    dataTypeFiles: [],
   },
 }
 
@@ -367,6 +368,7 @@ describe('createEditorProjectAdapter', () => {
       pouFiles: [{ relativePath: 'pous/programs/main.st', content: 'PROGRAM main\nEND_PROGRAM' }],
       serverFiles: [],
       remoteDeviceFiles: [],
+      dataTypeFiles: [],
       deletions: [],
     }
 

--- a/src/middleware/shared/ports/project-port.ts
+++ b/src/middleware/shared/ports/project-port.ts
@@ -122,6 +122,10 @@ export interface WriteProjectFiles {
   serverFiles: RawProjectFile[]
   /** Remote device config files with pre-serialized JSON content */
   remoteDeviceFiles: RawProjectFile[]
+  /** Data type files (`datatypes/<Name>.dt`) with pre-serialized ST
+   *  `TYPE…END_TYPE` content, one declaration per file.  Empty until
+   *  the `.dt` write path is switched on (DOPE-533). */
+  dataTypeFiles: RawProjectFile[]
   /** Relative paths to delete from disk (e.g. 'pous/programs/OldPou.st') */
   deletions: string[]
 }
@@ -172,6 +176,9 @@ export interface RawProjectFiles {
     serverFiles: RawProjectFile[]
     /** Raw remote device config files from devices/remote/ */
     remoteDeviceFiles: RawProjectFile[]
+    /** Raw data type files from datatypes/ (`.dt`, one ST `TYPE…END_TYPE`
+     *  declaration each).  Empty on projects that predate the format. */
+    dataTypeFiles: RawProjectFile[]
     /** See {@link ProjectResponse.data.canEdit}.  Carried through the
      *  raw layer so adapters that build `ProjectResponse` from a raw
      *  fetch don't have to round-trip the details endpoint twice. */


### PR DESCRIPTION
## Summary

Second groundwork PR for [DOPE-385](https://autonomylogic.atlassian.net/browse/DOPE-385) (subtask [DOPE-532](https://autonomylogic.atlassian.net/browse/DOPE-532)): wires the `datatypes/<Name>.dt` file category end to end **without switching any write behavior on** — `dataTypeFiles` is `[]` everywhere until DOPE-533 flips the write path.

- **Port contracts**: `dataTypeFiles: RawProjectFile[]` added as a *required* field on `WriteProjectFiles` and `RawProjectFiles` (required like `pouFiles`, so TypeScript flags any constructor that forgets it).
- **Shared iterator** (`iterate-write-project-files.ts`): new `data-type` category variant + yield.
- **Raw reader** (`project-service/index.ts` `readRawProjectFiles`): walks root `datatypes/` collecting `.dt` files into their own `dataTypeFiles` bucket — never into `pouFiles` (pou-path detection throws for paths outside the pou folders); `readDirRecursive` gained an extensions parameter.
- **Writer**: defensive mkdir list gains `datatypes`.
- **Directories**: new `projectDataTypeDirectories = ['datatypes']` joined into `projectDefaultDirectories` (kept OUT of `projectPouDirectories`). New projects get an empty `datatypes/` folder.
- **Schema**: `PLCProjectDataSchema.dataTypes` → `.default([])` — legacy project.json keeps validating; migrated projects can omit the field.
- **DOPE-530 review hardening** (deferred findings #1/#2 from #987): the `.dt` parser now rejects invalid struct field names (`2bad : INT;`), and the serializer collapses newlines in field documentation (line-map + round-trip safety).

## Testing

- New tests: `data-type` category in the iterator (incl. ordering), field-name rejection, doc newline collapse; adapter fixtures updated for the required field.
- Affected jest suites green (429 tests across iterator/utils/adapter/save-actions + 54 parse-project-files); `tsc` clean; prettier clean.

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/648

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6Kfu7zebQC3UdeN29tiq

[DOPE-385]: https://autonomylogic.atlassian.net/browse/DOPE-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOPE-532]: https://autonomylogic.atlassian.net/browse/DOPE-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for reading, saving, and writing data type (`.dt`) files in projects.
  - Data type files retain their directory paths and are included in project file processing.
  - New projects now include a dedicated `datatypes` directory.

- **Bug Fixes**
  - Improved structure-field documentation serialization for reliable parsing and line mapping.
  - Invalid structure-field names now produce clear parsing errors.

- **Tests**
  - Added coverage for data type file handling, serialization, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->