### PR TITLE
feat(datatypes): datatype persistence to datatypes/*.dt + legacy migration [DOPE-533]

### DIFF
--- a/src/backend/shared/types/PLC/open-plc.ts
+++ b/src/backend/shared/types/PLC/open-plc.ts
@@ -85,6 +85,9 @@ const PLCStructureVariableSchema = z.object({
       }),
     })
     .optional(),
+  // Preserved through load — the .dt serializer emits it as a
+  // trailing (* … *) comment; omitting it here strips it on open.
+  documentation: z.string().optional(),
 })
 const PLCStructureDatatypeSchema = z.object({
   name: z.string(),

--- a/src/backend/shared/utils/__tests__/parse-project-files.test.ts
+++ b/src/backend/shared/utils/__tests__/parse-project-files.test.ts
@@ -823,3 +823,89 @@ describe('parseProjectFiles — POU name derivation', () => {
     expect(result.projectData.pous[0].name).toBe('Derived')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Data type files (datatypes/<Name>.dt) — hydration matrix (DOPE-533)
+// ---------------------------------------------------------------------------
+
+describe('data type file hydration', () => {
+  const legacyEnum = {
+    name: 'Color',
+    derivation: 'enumerated',
+    initialValue: '',
+    values: [{ description: 'Red' }, { description: 'Green' }],
+  }
+
+  const parse = (dataTypeFiles: RawProjectFile[], jsonDataTypes: unknown[] = []) =>
+    parseProjectFiles(
+      '/p',
+      makeProjectJson({ dataTypes: jsonDataTypes }),
+      makeDeviceConfig(),
+      makePinMapping(),
+      [],
+      [],
+      [],
+      '',
+      dataTypeFiles,
+    )
+
+  it('parses .dt files into dataTypes (files win over legacy JSON)', () => {
+    const result = parse(
+      [{ relativePath: 'datatypes/Mode.dt', content: 'TYPE\n  Mode : (Auto, Manual);\nEND_TYPE\n' }],
+      [legacyEnum],
+    )
+    expect(result.projectData.dataTypes).toEqual([
+      {
+        name: 'Mode',
+        derivation: 'enumerated',
+        values: [{ description: 'Auto' }, { description: 'Manual' }],
+        initialValue: '',
+      },
+    ])
+    expect(result.warnings).toBeUndefined()
+    expect(result.unparsedDataTypeFiles).toBeUndefined()
+  })
+
+  it('falls back to legacy project.json dataTypes when no .dt files exist', () => {
+    const result = parse([], [legacyEnum])
+    expect(result.projectData.dataTypes).toEqual([legacyEnum])
+  })
+
+  it('yields an empty list when neither files nor legacy JSON carry types', () => {
+    const result = parse([], [])
+    expect(result.projectData.dataTypes).toEqual([])
+  })
+
+  it('preserves unparseable .dt files raw with a warning instead of dropping them', () => {
+    const broken = { relativePath: 'datatypes/Broken.dt', content: 'TYPE\n  Broken : ???;\nEND_TYPE\n' }
+    const result = parse([broken, { relativePath: 'datatypes/Ok.dt', content: 'TYPE\n  Ok : (A);\nEND_TYPE\n' }])
+    expect(result.projectData.dataTypes.map((d) => d.name)).toEqual(['Ok'])
+    expect(result.unparsedDataTypeFiles).toEqual([broken])
+    expect(result.warnings?.some((w) => w.includes('datatypes/Broken.dt'))).toBe(true)
+  })
+
+  it('treats a declared-name/file-name mismatch as unparseable (raw preserved)', () => {
+    const mismatched = { relativePath: 'datatypes/Alpha.dt', content: 'TYPE\n  Beta : (A);\nEND_TYPE\n' }
+    const result = parse([mismatched])
+    expect(result.projectData.dataTypes).toEqual([])
+    expect(result.unparsedDataTypeFiles).toEqual([mismatched])
+    expect(result.warnings?.some((w) => w.includes('does not match'))).toBe(true)
+  })
+
+  it('keeps struct field documentation through schema validation (legacy JSON)', () => {
+    const structWithDoc = {
+      name: 'Motor',
+      derivation: 'structure',
+      variable: [
+        {
+          name: 'speed',
+          type: { definition: 'base-type', value: 'INT' },
+          initialValue: { simpleValue: { value: '' } },
+          documentation: 'target speed in rpm',
+        },
+      ],
+    }
+    const result = parse([], [structWithDoc])
+    expect(result.projectData.dataTypes).toEqual([structWithDoc])
+  })
+})

--- a/src/backend/shared/utils/parse-project-files.ts
+++ b/src/backend/shared/utils/parse-project-files.ts
@@ -8,6 +8,7 @@
  * The backend only reads raw files from disk; all parsing happens here.
  */
 
+import { parseDataTypeFromText } from '../../../frontend/utils/PLC/data-type-text-parser'
 import {
   detectLanguageFromExtension,
   findLastEndVarIndex,
@@ -79,6 +80,11 @@ export interface ParsedProjectData {
   devicePinMapping?: DevicePin[] | Record<string, DevicePin[]>
   /** Warnings collected during parsing (e.g. dropped files that failed validation). */
   warnings?: string[]
+  /** `datatypes/*.dt` files that failed to parse (or whose declared
+   *  name mismatched the file name).  Preserved raw so the save flow
+   *  can echo them back verbatim — an unreadable file must never be
+   *  silently dropped from disk. */
+  unparsedDataTypeFiles?: RawProjectFile[]
 }
 
 // ---------------------------------------------------------------------------
@@ -387,6 +393,9 @@ function deduplicatePouFiles(pouFiles: RawProjectFile[]): RawProjectFile[] {
  * @param pouFiles - Raw POU files (.st, .il, .ld, .fbd, .py, .cpp, .json)
  * @param serverFiles - Raw server config files from devices/servers/
  * @param remoteDeviceFiles - Raw remote device config files from devices/remote/
+ * @param libraryManifest - Raw content of library.json (library projects)
+ * @param dataTypeFiles - Raw datatypes/*.dt files; when any are present they
+ *   win over the legacy `project.json` `data.dataTypes` field
  */
 export function parseProjectFiles(
   projectPath: string,
@@ -397,6 +406,7 @@ export function parseProjectFiles(
   serverFiles: RawProjectFile[],
   remoteDeviceFiles: RawProjectFile[],
   libraryManifest: string = '',
+  dataTypeFiles: RawProjectFile[] = [],
 ): ParsedProjectData {
   const warnings: string[] = []
 
@@ -525,6 +535,26 @@ export function parseProjectFiles(
     }
   }
 
+  // Parse data type files (datatypes/<Name>.dt).  Own loop — never
+  // through parsePouFile (pou-path detection throws for datatypes/).
+  // The declared name must match the file name; a mismatch or any
+  // parse failure preserves the raw file so the save flow writes it
+  // back verbatim instead of silently dropping it from disk.
+  const dataTypesFromFiles: PLCDataType[] = []
+  const unparsedDataTypeFiles: RawProjectFile[] = []
+  for (const file of dataTypeFiles) {
+    const expectedName = getBaseNameFromPath(file.relativePath)
+    const result = parseDataTypeFromText(file.content, expectedName)
+    if (result.dataType) {
+      dataTypesFromFiles.push(result.dataType)
+    } else {
+      warnings.push(
+        `Data type file "${file.relativePath}" could not be parsed and was preserved as-is: ${result.error ?? 'unknown error'}`,
+      )
+      unparsedDataTypeFiles.push(file)
+    }
+  }
+
   // Extract project data fields
   const data = project.data ?? {}
   const configuration = (data.configuration ??
@@ -552,7 +582,10 @@ export function parseProjectFiles(
   return {
     meta,
     projectData: {
-      dataTypes: (data.dataTypes as PLCDataType[]) ?? [],
+      // Migration rule: any .dt file present ⇒ the files are the
+      // source of truth; the legacy JSON field is only the fallback
+      // for projects that predate the format.
+      dataTypes: dataTypeFiles.length > 0 ? dataTypesFromFiles : ((data.dataTypes as PLCDataType[]) ?? []),
       pous,
       configurations: configuration,
       servers: servers.length > 0 ? servers : ((data.servers as PLCServer[]) ?? []),
@@ -574,5 +607,6 @@ export function parseProjectFiles(
     deviceConfiguration,
     devicePinMapping,
     warnings: warnings.length > 0 ? warnings : undefined,
+    ...(unparsedDataTypeFiles.length > 0 ? { unparsedDataTypeFiles } : {}),
   }
 }

--- a/src/frontend/components/_molecules/data-types/structure/table/editable-cell.tsx
+++ b/src/frontend/components/_molecules/data-types/structure/table/editable-cell.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import type { PLCStructureVariable } from '../../../../../../middleware/shared/ports/types'
 import type { ProjectResponse } from '../../../../../store/slices/project/types'
 import { cn } from '../../../../../utils/cn'
+import { isLegalIdentifier } from '../../../../../utils/keywords'
 import { InputWithRef } from '../../../../_atoms/input'
 import { useToast } from '../../../../_features/[app]/toast/use-toast'
 
@@ -30,6 +31,14 @@ const EditableNameCell = ({ getValue, row: { index }, column: { id }, table }: I
     const validateVariableName = (name: string, existingVariables: string[], currentName: string) => {
       if (!name.trim()) {
         return { valid: false, message: 'The name cannot be empty' }
+      }
+
+      // Field names are written into datatypes/<Name>.dt as ST text —
+      // an illegal identifier here would serialize to a file that
+      // can't be read back (same rule the .dt parser enforces).
+      const [legal, reason] = isLegalIdentifier(name)
+      if (!legal) {
+        return { valid: false, message: `'${name}' ${reason}` }
       }
 
       if (name !== currentName && existingVariables.includes(name)) {

--- a/src/frontend/services/save-actions.ts
+++ b/src/frontend/services/save-actions.ts
@@ -144,7 +144,10 @@ function* iterateProjectFiles(state: StoreState): Generator<ProjectFileSpec> {
     }
     // Raw .dt files that failed to parse on load — echoed verbatim
     // so an unreadable file is never silently dropped from disk.
+    // A parsed type claiming the same path wins: guards non-UI entry
+    // points (e.g. XML import) from yielding duplicate paths.
     for (const f of state.unparsedDataTypeFiles) {
+      if (project.data.dataTypes.some((dt) => `datatypes/${dt.name}.dt` === f.relativePath)) continue
       yield { path: f.relativePath, content: f.content, category: 'data-type' }
     }
   }

--- a/src/frontend/services/save-actions.ts
+++ b/src/frontend/services/save-actions.ts
@@ -13,14 +13,17 @@
 
 import type { PlatformCapabilities } from '../../middleware/shared/ports/platform-capabilities'
 import type { ProjectPort, RawProjectFile, WriteProjectFiles } from '../../middleware/shared/ports/project-port'
-import type { PLCPou } from '../../middleware/shared/ports/types'
+import type { PLCDataType, PLCPou } from '../../middleware/shared/ports/types'
 import { openPLCStoreBase } from '../store'
 import type { LadderFlowType } from '../store/slices/ladder'
 import { flushFlowWriteBacks } from '../store/slices/shared/flow-writeback'
+import { isDataTypeFilesEnabled } from '../utils/feature-flags'
 import { parseIecStringToVariables } from '../utils/generate-iec-string-to-variables'
 import { generateIecVariablesToString } from '../utils/generate-iec-variables-to-string'
 import { syncNodesWithVariables, syncNodesWithVariablesFBD } from '../utils/graphical/sync-nodes-with-variables'
 import { notifyNoWritePermission } from '../utils/notify-no-write-permission'
+import { serializeDataTypeToText } from '../utils/PLC/data-type-serializer'
+import { parseDataTypeFromText } from '../utils/PLC/data-type-text-parser'
 import { getExtensionFromLanguage, getFolderFromPouType } from '../utils/PLC/pou-file-extensions'
 import { parseGraphicalPouFromString, parseTextualPouFromString } from '../utils/PLC/pou-text-parser'
 import { serializePouToText } from '../utils/PLC/pou-text-serializer'
@@ -46,6 +49,7 @@ type ProjectFileCategory =
   | 'pin-mapping'
   | 'project-json'
   | 'library-manifest'
+  | 'data-type'
 
 type ProjectFileSpec = {
   path: string
@@ -71,7 +75,9 @@ function buildProjectJsonContent(state: StoreState): string {
     {
       meta: { name: project.meta.name, type: metaType },
       data: {
-        dataTypes: project.data.dataTypes,
+        // With .dt persistence on, types live in their own files and
+        // project.json stops carrying them (same shape as `pous`).
+        dataTypes: isDataTypeFilesEnabled() ? [] : project.data.dataTypes,
         pous: [],
         configuration: project.data.configurations,
         libraries,
@@ -92,6 +98,14 @@ function buildPouSpec(pou: PLCPou, state: StoreState): ProjectFileSpec {
     path: `pous/${folder}/${pou.name}${ext}`,
     content: serializePouToText(sanitized),
     category: 'pou',
+  }
+}
+
+function buildDataTypeSpec(dt: PLCDataType): ProjectFileSpec {
+  return {
+    path: `datatypes/${dt.name}.dt`,
+    content: serializeDataTypeToText(dt),
+    category: 'data-type',
   }
 }
 
@@ -122,6 +136,17 @@ function* iterateProjectFiles(state: StoreState): Generator<ProjectFileSpec> {
 
   for (const pou of project.data.pous) {
     yield buildPouSpec(pou, state)
+  }
+
+  if (isDataTypeFilesEnabled()) {
+    for (const dt of project.data.dataTypes) {
+      yield buildDataTypeSpec(dt)
+    }
+    // Raw .dt files that failed to parse on load — echoed verbatim
+    // so an unreadable file is never silently dropped from disk.
+    for (const f of state.unparsedDataTypeFiles) {
+      yield { path: f.relativePath, content: f.content, category: 'data-type' }
+    }
   }
 
   if (!isLibrary) {
@@ -254,7 +279,12 @@ function serializeProjectFile(
     return [{ path: 'library.json', content, category: 'library-manifest' }]
   }
 
-  // data-type, resource: live in project.json
+  if (file.type === 'data-type' && isDataTypeFilesEnabled()) {
+    const dt = project.data.dataTypes.find((d) => d.name === fileName)
+    return dt ? [buildDataTypeSpec(dt)] : []
+  }
+
+  // resource (and data-type while the .dt flag is off): live in project.json
   return [{ path: 'project.json', content: buildProjectJsonContent(state), category: 'project-json' }]
 }
 
@@ -368,6 +398,7 @@ export async function executeSaveProject(
     const pouFiles: RawProjectFile[] = []
     const serverFiles: RawProjectFile[] = []
     const remoteDeviceFiles: RawProjectFile[] = []
+    const dataTypeFiles: RawProjectFile[] = []
     let projectJson = ''
     // `deviceConfig` / `pinMapping` / `libraryManifest` stay
     // `undefined` when the iterator doesn't yield them.  Library
@@ -391,6 +422,9 @@ export async function executeSaveProject(
           break
         case 'remote-device':
           remoteDeviceFiles.push({ relativePath: spec.path, content })
+          break
+        case 'data-type':
+          dataTypeFiles.push({ relativePath: spec.path, content })
           break
         case 'device-config':
           deviceConfig = content
@@ -416,8 +450,7 @@ export async function executeSaveProject(
       pouFiles,
       serverFiles,
       remoteDeviceFiles,
-      // Populated when the .dt write path is switched on (DOPE-533).
-      dataTypeFiles: [],
+      dataTypeFiles,
       deletions: [...pendingDeletions],
     }
 
@@ -435,6 +468,7 @@ export async function executeSaveProject(
         ...pouFiles.map((f) => ({ path: f.relativePath, content: f.content })),
         ...serverFiles.map((f) => ({ path: f.relativePath, content: f.content })),
         ...remoteDeviceFiles.map((f) => ({ path: f.relativePath, content: f.content })),
+        ...dataTypeFiles.map((f) => ({ path: f.relativePath, content: f.content })),
       ]
       state.versionControlActions.recordSavedFiles({
         saved: savedRecords,
@@ -627,12 +661,15 @@ export async function executeSaveFile(
       if (!spec) return fail('Save failed')
       const res = await projectPort.saveFile(joinPath(projectPath, 'library.json'), spec.content)
       if (!res.success) return fail(res.error ?? 'Save failed')
+    } else if (file.type === 'data-type' && isDataTypeFilesEnabled()) {
+      const spec = specs[0]
+      if (!spec) return fail(`Data type "${fileName}" not found.`)
+      const res = await projectPort.saveFile(joinPath(projectPath, 'datatypes', `${fileName}.dt`), spec.content)
+      if (!res.success) return fail(res.error ?? 'Save failed')
     } else {
-      // data-type, resource: live in project.json (legacy whole-file
-      // write).  These editors don't yet have a surgical save path —
-      // they still cross-contaminate each other today, which we accept
-      // until each is migrated to its own read-modify-write branch
-      // mirroring the library-manager case above.
+      // resource (and data-type while the .dt flag is off): live in
+      // project.json (legacy whole-file write) — cross-contamination
+      // accepted until each is migrated to its own branch.
       const spec = specs[0]
       if (!spec) return fail('Save failed')
       const res = await projectPort.saveFile(joinPath(projectPath, 'project.json'), spec.content)
@@ -800,6 +837,34 @@ export async function reloadPouFromDisk(pouName: string, projectPort: ProjectPor
 
     return { success: true }
   } catch {
+    return { success: false }
+  }
+}
+
+/**
+ * Reload a single data type from its `datatypes/<Name>.dt` file,
+ * discarding in-memory changes ("Don't save" on a datatype tab).
+ * Same parser the project-open path uses; the name-must-match-file
+ * rule applies, so a hand-tampered file fails the reload rather than
+ * silently rekeying the type.
+ */
+export async function reloadDataTypeFromDisk(name: string, projectPort: ProjectPort): Promise<{ success: boolean }> {
+  const state = openPLCStoreBase.getState()
+  const dt = state.project.data.dataTypes.find((d) => d.name === name)
+  if (!dt) return { success: false }
+
+  try {
+    const fullPath = joinPath(state.project.meta.path, 'datatypes', `${name}.dt`)
+    const result = await projectPort.readFileContent(fullPath)
+    if (!result.success || !result.content) return { success: false }
+
+    const parsed = parseDataTypeFromText(result.content, name)
+    if (!parsed.dataType) return { success: false }
+
+    state.projectActions.applyDatatypeSnapshot(name, parsed.dataType)
+    return { success: true }
+  } catch (error) {
+    console.error(`Failed to reload data type "${name}" from disk:`, error)
     return { success: false }
   }
 }
@@ -1077,6 +1142,9 @@ export async function reloadFileFromDisk(fileName: string, projectPort: ProjectP
   }
   if (file.type === 'library-manifest') {
     return reloadLibraryManifestFromCleanState(fileName)
+  }
+  if (file.type === 'data-type' && isDataTypeFilesEnabled()) {
+    return reloadDataTypeFromDisk(fileName, projectPort)
   }
   // Everything else routes through the POU-specific reload.  Non-POU
   // file types that need a revert path should add a branch above

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -1129,11 +1129,50 @@ describe('createProjectSlice', () => {
       expect(store.getState().project.data.dataTypes).toHaveLength(0)
     })
 
+    it('queues the datatypes/<name>.dt path for deletion', () => {
+      const dt: PLCDataType = { name: 'MyStruct', derivation: 'structure', variable: [] }
+      store.getState().projectActions.createDatatype({ data: dt })
+      store.getState().projectActions.deleteDatatype('MyStruct')
+      expect(store.getState().pendingDeletions).toContain('datatypes/MyStruct.dt')
+    })
+
     it('does nothing when data type not found', () => {
       const dt: PLCDataType = { name: 'A', derivation: 'structure', variable: [] }
       store.getState().projectActions.createDatatype({ data: dt })
       store.getState().projectActions.deleteDatatype('NonExistent')
       expect(store.getState().project.data.dataTypes).toHaveLength(1)
+    })
+  })
+
+  describe('updateDatatypeName', () => {
+    it('renames the data type and queues the old .dt path for deletion', () => {
+      const dt: PLCDataType = { name: 'OldName', derivation: 'structure', variable: [] }
+      store.getState().projectActions.createDatatype({ data: dt })
+      store.getState().projectActions.updateDatatypeName('OldName', 'NewName')
+      expect(store.getState().project.data.dataTypes[0].name).toBe('NewName')
+      expect(store.getState().pendingDeletions).toContain('datatypes/OldName.dt')
+    })
+
+    it('does nothing when the data type is not found', () => {
+      store.getState().projectActions.updateDatatypeName('Ghost', 'NewName')
+      expect(store.getState().project.data.dataTypes).toHaveLength(0)
+      expect(store.getState().pendingDeletions).toHaveLength(0)
+    })
+  })
+
+  describe('setUnparsedDataTypeFiles', () => {
+    it('replaces the stashed raw .dt files', () => {
+      const raw = [{ relativePath: 'datatypes/Broken.dt', content: 'TYPE garbage' }]
+      store.getState().projectActions.setUnparsedDataTypeFiles(raw)
+      expect(store.getState().unparsedDataTypeFiles).toEqual(raw)
+      store.getState().projectActions.setUnparsedDataTypeFiles([])
+      expect(store.getState().unparsedDataTypeFiles).toEqual([])
+    })
+
+    it('is reset by clearProjects', () => {
+      store.getState().projectActions.setUnparsedDataTypeFiles([{ relativePath: 'datatypes/X.dt', content: 'x' }])
+      store.getState().projectActions.clearProjects()
+      expect(store.getState().unparsedDataTypeFiles).toEqual([])
     })
   })
 

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -479,6 +479,14 @@ describe('createSharedSlice', () => {
         expect(store.getState().project.data.dataTypes).toHaveLength(0)
       })
 
+      it('rejects a name differing only by case (one file per name on case-folding disks)', () => {
+        store.getState().datatypeActions.create({ name: 'Motor', derivation: 'structure' })
+        const result = store.getState().datatypeActions.create({ name: 'motor', derivation: 'structure' })
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('Data type already exists')
+        expect(store.getState().project.data.dataTypes).toHaveLength(1)
+      })
+
       it('creates an enumerated data type', () => {
         const result = store.getState().datatypeActions.create({ name: 'Colors', derivation: 'enumerated' })
         expect(result.ok).toBe(true)
@@ -578,6 +586,27 @@ describe('createSharedSlice', () => {
         expect(result.message).toMatch(/could not be read/)
       })
 
+      it('rejects a rename that collides with another type only by case', () => {
+        store.getState().datatypeActions.create({ name: 'Motor', derivation: 'array' })
+        const result = store.getState().datatypeActions.rename('OldDT', 'motor')
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('Data type name already exists')
+        expect(store.getState().project.data.dataTypes.map((d) => d.name)).toEqual(['OldDT', 'Motor'])
+      })
+
+      it('rejects a case-only rename of the type itself', () => {
+        // Writing olddt.dt then deleting OldDT.dt is the same file
+        // where the filesystem folds case — the type would vanish.
+        const result = store.getState().datatypeActions.rename('OldDT', 'olddt')
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('Data type name already exists')
+      })
+
+      it('allows a no-op rename to the identical name', () => {
+        const result = store.getState().datatypeActions.rename('OldDT', 'OldDT')
+        expect(result.ok).toBe(true)
+      })
+
       it('returns error when new name already exists', () => {
         store.getState().datatypeActions.create({ name: 'Existing', derivation: 'array' })
         const result = store.getState().datatypeActions.rename('OldDT', 'Existing')
@@ -629,6 +658,12 @@ describe('createSharedSlice', () => {
         const result = store.getState().datatypeActions.duplicate('NonExistent', 'Copy')
         expect(result.ok).toBe(false)
         expect(result.message).toBe('Data type not found')
+      })
+
+      it('rejects a duplicate name differing only by case', () => {
+        const result = store.getState().datatypeActions.duplicate('SourceDT', 'sourcedt')
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('Data type name already exists')
       })
 
       it('rejects a duplicate name owned by an unreadable .dt file', () => {

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -469,6 +469,16 @@ describe('createSharedSlice', () => {
         expect(store.getState().project.data.dataTypes[0].derivation).toBe('structure')
       })
 
+      it('rejects a name owned by an unreadable .dt file', () => {
+        store
+          .getState()
+          .projectActions.setUnparsedDataTypeFiles([{ relativePath: 'datatypes/Ghost.dt', content: 'TYPE garbage' }])
+        const result = store.getState().datatypeActions.create({ name: 'Ghost', derivation: 'structure' })
+        expect(result.ok).toBe(false)
+        expect(result.message).toMatch(/could not be read/)
+        expect(store.getState().project.data.dataTypes).toHaveLength(0)
+      })
+
       it('creates an enumerated data type', () => {
         const result = store.getState().datatypeActions.create({ name: 'Colors', derivation: 'enumerated' })
         expect(result.ok).toBe(true)
@@ -559,6 +569,15 @@ describe('createSharedSlice', () => {
         expect(store.getState().pendingDeletions).toContain('datatypes/OldDT.dt')
       })
 
+      it('rejects a name owned by an unreadable .dt file (case-insensitive)', () => {
+        store
+          .getState()
+          .projectActions.setUnparsedDataTypeFiles([{ relativePath: 'datatypes/Ghost.dt', content: 'TYPE garbage' }])
+        const result = store.getState().datatypeActions.rename('OldDT', 'ghost')
+        expect(result.ok).toBe(false)
+        expect(result.message).toMatch(/could not be read/)
+      })
+
       it('returns error when new name already exists', () => {
         store.getState().datatypeActions.create({ name: 'Existing', derivation: 'array' })
         const result = store.getState().datatypeActions.rename('OldDT', 'Existing')
@@ -610,6 +629,15 @@ describe('createSharedSlice', () => {
         const result = store.getState().datatypeActions.duplicate('NonExistent', 'Copy')
         expect(result.ok).toBe(false)
         expect(result.message).toBe('Data type not found')
+      })
+
+      it('rejects a duplicate name owned by an unreadable .dt file', () => {
+        store
+          .getState()
+          .projectActions.setUnparsedDataTypeFiles([{ relativePath: 'datatypes/Ghost.dt', content: 'TYPE garbage' }])
+        const result = store.getState().datatypeActions.duplicate('SourceDT', 'Ghost')
+        expect(result.ok).toBe(false)
+        expect(result.message).toMatch(/could not be read/)
       })
 
       it('returns error when new name already exists', () => {

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -554,6 +554,11 @@ describe('createSharedSlice', () => {
         expect(state.tabs[0].name).toBe('NewDT')
       })
 
+      it('queues the old datatypes/<name>.dt path for deletion', () => {
+        store.getState().datatypeActions.rename('OldDT', 'NewDT')
+        expect(store.getState().pendingDeletions).toContain('datatypes/OldDT.dt')
+      })
+
       it('returns error when new name already exists', () => {
         store.getState().datatypeActions.create({ name: 'Existing', derivation: 'array' })
         const result = store.getState().datatypeActions.rename('OldDT', 'Existing')

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -517,6 +517,7 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
     },
   },
   pendingDeletions: [],
+  unparsedDataTypeFiles: [],
   iecAliasMemory: {},
 
   projectActions: {
@@ -552,6 +553,7 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
             },
           }
           slice.pendingDeletions = []
+          slice.unparsedDataTypeFiles = []
           // Session alias-memory is per-project; drop it on a fresh slate so
           // one project's remembered aliases can't leak into the next.
           slice.iecAliasMemory = {}
@@ -1063,6 +1065,10 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
     deleteDatatype: (name) => {
       setState(
         produce((slice: ProjectSlice) => {
+          // Harmless while the file doesn't exist yet (flag off): the
+          // editor's deletion pass is existence-checked, the web's
+          // relies on delete-by-omission.
+          slice.pendingDeletions.push(`datatypes/${name}.dt`)
           slice.project.data.dataTypes = slice.project.data.dataTypes.filter((d) => d.name !== name)
         }),
       )
@@ -1075,6 +1081,18 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
           if (data) {
             slice.project.data.dataTypes[idx] = data
           }
+        }),
+      )
+    },
+    updateDatatypeName: (oldName, newName) => {
+      setState(
+        produce((slice: ProjectSlice) => {
+          const dt = slice.project.data.dataTypes.find((d) => d.name === oldName)
+          if (!dt) return
+          // Queue the OLD path — the next save serializes the type
+          // under its new name (model: updatePouName).
+          slice.pendingDeletions.push(`datatypes/${oldName}.dt`)
+          dt.name = newName
         }),
       )
     },
@@ -1104,6 +1122,13 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
         produce((slice: ProjectSlice) => {
           const idx = slice.project.data.dataTypes.findIndex((d) => d.name === name)
           if (idx !== -1) slice.project.data.dataTypes[idx] = data
+        }),
+      )
+    },
+    setUnparsedDataTypeFiles: (files) => {
+      setState(
+        produce((slice: ProjectSlice) => {
+          slice.unparsedDataTypeFiles = files
         }),
       )
     },

--- a/src/frontend/store/slices/project/types.ts
+++ b/src/frontend/store/slices/project/types.ts
@@ -1,3 +1,4 @@
+import type { RawProjectFile } from '../../../../middleware/shared/ports/project-port'
 import type {
   EthercatConfig,
   ModbusBufferMapping,
@@ -216,9 +217,15 @@ export type ProjectActions = {
   createDatatype: (dto: DataTypeDTO & { rowToInsert?: number }) => ProjectResponse
   deleteDatatype: (name: string) => void
   updateDatatype: (name: string, data?: PLCDataType) => void
+  /** Rename + queue the old `datatypes/<oldName>.dt` path for deletion
+   *  (model: `updatePouName`).  Reference propagation is DOPE-536. */
+  updateDatatypeName: (oldName: string, newName: string) => void
   createArrayDimension: (args: { name: string; derivation: 'array' | 'enumerated' | 'structure' }) => void
   rearrangeStructureVariables: (args: { associatedDataType?: string; rowId: number; newIndex: number }) => void
   applyDatatypeSnapshot: (name: string, data: PLCDataType) => void
+  /** Stash raw `.dt` files that failed to parse on load so saves echo
+   *  them back verbatim (no silent data loss). */
+  setUnparsedDataTypeFiles: (files: RawProjectFile[]) => void
 
   // Tasks
   createTask: (dto: TaskDTO & { rowToInsert?: number }) => ProjectResponse
@@ -324,6 +331,10 @@ export type ProjectSlice = {
   project: ProjectState
   /** Relative file paths queued for deletion on next full project save. */
   pendingDeletions: string[]
+  /** Raw `datatypes/*.dt` files that failed to parse on load.  Echoed
+   *  back verbatim by the save flow until they parse — an unreadable
+   *  file must never be silently dropped from disk. */
+  unparsedDataTypeFiles: RawProjectFile[]
   /**
    * Session-scoped IEC alias memory: `memoryKey -> alias`, where `memoryKey`
    * is a channel's stable semantic identity (`vpp:moduleId:slot:channel`,

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -64,6 +64,14 @@ function validateElementName(name: string): { ok: true } | { ok: false; message:
 }
 
 /**
+ * Data type names are compared case-insensitively: each one becomes a
+ * `datatypes/<Name>.dt` path, and macOS/Windows fold filename case, so
+ * `Foo` and `foo` would silently overwrite each other on save. IEC
+ * identifiers are case-insensitive anyway.
+ */
+const nameMatches = (a: string, b: string): boolean => a.toLowerCase() === b.toLowerCase()
+
+/**
  * A raw datatypes/<Name>.dt file that failed to parse still owns its
  * name: letting a new data type take it would make the save emit two
  * specs for one path (and the raw echo would win). Case-insensitive —
@@ -255,7 +263,7 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
   datatypeActions: {
     create: ({ name, derivation }) => {
       const state = getState()
-      const existing = state.project.data.dataTypes.find((d) => d.name === name)
+      const existing = state.project.data.dataTypes.find((d) => nameMatches(d.name, name))
       if (existing) return { ok: false, message: 'Data type already exists' }
 
       const fileCollision = collidesWithUnparsedDataTypeFile(state, name)
@@ -294,8 +302,11 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
 
     rename: (oldName, newName) => {
       const state = getState()
-      const existing = state.project.data.dataTypes.find((d) => d.name === newName)
-      if (existing) return { ok: false, message: 'Data type name already exists' }
+      // Includes the type being renamed: a case-only change writes the
+      // new file and then deletes the old path — the same file where
+      // the filesystem folds case.
+      const collides = newName !== oldName && state.project.data.dataTypes.some((d) => nameMatches(d.name, newName))
+      if (collides) return { ok: false, message: 'Data type name already exists' }
 
       const fileCollision = collidesWithUnparsedDataTypeFile(state, newName)
       if (!fileCollision.ok) return fileCollision
@@ -316,7 +327,7 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const source = state.project.data.dataTypes.find((d) => d.name === sourceName)
       if (!source) return { ok: false, message: 'Data type not found' }
 
-      const existing = state.project.data.dataTypes.find((d) => d.name === newName)
+      const existing = state.project.data.dataTypes.find((d) => nameMatches(d.name, newName))
       if (existing) return { ok: false, message: 'Data type name already exists' }
 
       const fileCollision = collidesWithUnparsedDataTypeFile(state, newName)

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -63,6 +63,24 @@ function validateElementName(name: string): { ok: true } | { ok: false; message:
   return legal ? { ok: true } : { ok: false, message: `'${name}' ${reason}` }
 }
 
+/**
+ * A raw datatypes/<Name>.dt file that failed to parse still owns its
+ * name: letting a new data type take it would make the save emit two
+ * specs for one path (and the raw echo would win). Case-insensitive —
+ * the file name is the identity and common filesystems fold case.
+ */
+function collidesWithUnparsedDataTypeFile(state: SharedRootState, name: string): { ok: boolean; message?: string } {
+  const collides = state.unparsedDataTypeFiles.some(
+    (f) => f.relativePath.split('/').pop()?.replace(/\.dt$/i, '').toLowerCase() === name.toLowerCase(),
+  )
+  return collides
+    ? {
+        ok: false,
+        message: `A data type file named "${name}.dt" exists on disk but could not be read — fix or remove it first`,
+      }
+    : { ok: true }
+}
+
 function renameElement(
   state: SharedRootState,
   oldName: string,
@@ -240,6 +258,9 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const existing = state.project.data.dataTypes.find((d) => d.name === name)
       if (existing) return { ok: false, message: 'Data type already exists' }
 
+      const fileCollision = collidesWithUnparsedDataTypeFile(state, name)
+      if (!fileCollision.ok) return fileCollision
+
       const nameCheck = validateElementName(name)
       if (!nameCheck.ok) return nameCheck
 
@@ -276,6 +297,9 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const existing = state.project.data.dataTypes.find((d) => d.name === newName)
       if (existing) return { ok: false, message: 'Data type name already exists' }
 
+      const fileCollision = collidesWithUnparsedDataTypeFile(state, newName)
+      if (!fileCollision.ok) return fileCollision
+
       const datatype = state.project.data.dataTypes.find((d) => d.name === oldName)
       if (!datatype) return { ok: false, message: 'Data type not found' }
 
@@ -294,6 +318,9 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
 
       const existing = state.project.data.dataTypes.find((d) => d.name === newName)
       if (existing) return { ok: false, message: 'Data type name already exists' }
+
+      const fileCollision = collidesWithUnparsedDataTypeFile(state, newName)
+      if (!fileCollision.ok) return fileCollision
 
       const nameCheck = validateElementName(newName)
       if (!nameCheck.ok) return nameCheck

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -279,10 +279,11 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const datatype = state.project.data.dataTypes.find((d) => d.name === oldName)
       if (!datatype) return { ok: false, message: 'Data type not found' }
 
-      const updatedDatatype = { ...datatype, name: newName }
-
       return renameElement(state, oldName, newName, () => {
-        state.projectActions.updateDatatype(oldName, updatedDatatype)
+        // Renames via the dedicated action so the old .dt path gets
+        // queued for deletion — a plain updateDatatype would strand
+        // the old file on disk.
+        state.projectActions.updateDatatypeName(oldName, newName)
       })
     },
 
@@ -615,6 +616,9 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
         meta: data.meta,
         data: data.projectData,
       })
+      // Raw .dt files that failed to parse — stashed so saves echo
+      // them back verbatim; always set so a reopen clears stale ones.
+      getState().projectActions.setUnparsedDataTypeFiles(data.unparsedDataTypeFiles ?? [])
 
       // Add ladder and FBD flows for graphical POUs.
       //

--- a/src/frontend/store/slices/shared/types.ts
+++ b/src/frontend/store/slices/shared/types.ts
@@ -1,3 +1,4 @@
+import type { RawProjectFile } from '../../../../middleware/shared/ports/project-port'
 import type {
   DeviceConfiguration,
   DevicePin,
@@ -134,6 +135,9 @@ export type OpenProjectResponseData = {
   devicePinMapping?: DevicePin[] | Record<string, DevicePin[]>
   /** Warnings from parsing (e.g. dropped files that failed validation). */
   warnings?: string[]
+  /** `datatypes/*.dt` files that failed to parse on load, preserved
+   *  raw so the save flow echoes them back verbatim. */
+  unparsedDataTypeFiles?: RawProjectFile[]
   /**
    * Edit permission flag forwarded from `ProjectResponse.data.canEdit`.
    * `false` puts the workspace in read-only mode; `true` / `undefined`

--- a/src/frontend/utils/PLC/__tests__/data-type-text-parser.test.ts
+++ b/src/frontend/utils/PLC/__tests__/data-type-text-parser.test.ts
@@ -183,6 +183,10 @@ describe('parseDataTypeFromText errors', () => {
   it('rejects invalid structure field names', () => {
     const badName = 'TYPE\n  P : STRUCT\n    2bad : INT;\n  END_STRUCT;\nEND_TYPE\n'
     expect(parseDataTypeFromText(badName).error).toMatch(/invalid structure field name: "2bad"/)
+    // Reserved words are rejected too — same isLegalIdentifier rule
+    // the structure form enforces at entry.
+    const keywordName = 'TYPE\n  P : STRUCT\n    IF : INT;\n  END_STRUCT;\nEND_TYPE\n'
+    expect(parseDataTypeFromText(keywordName).error).toMatch(/invalid structure field name: "IF" — is a reserved word/)
   })
 
   it('rejects unrecognized declarations with a hint', () => {
@@ -193,6 +197,9 @@ describe('parseDataTypeFromText errors', () => {
 
   it('rejects an invalid type name', () => {
     expect(parseDataTypeFromText('TYPE\n  2bad : (Red);\nEND_TYPE\n').error).toMatch(/invalid type name/)
+    expect(parseDataTypeFromText('TYPE\n  ARRAY : (Red);\nEND_TYPE\n').error).toMatch(
+      /invalid type name: "ARRAY" — is a reserved word/,
+    )
   })
 
   it('rejects a declared name that does not match the expected name', () => {

--- a/src/frontend/utils/PLC/data-type-text-parser.ts
+++ b/src/frontend/utils/PLC/data-type-text-parser.ts
@@ -19,6 +19,7 @@
 import { baseTypeSchema } from '../../../middleware/shared/ports/plc-schemas'
 import type { PLCDataType, PLCStructureVariable, PLCVariableType } from '../../../middleware/shared/ports/types'
 import { parseArrayType } from '../generate-iec-string-to-variables'
+import { isLegalIdentifier } from '../keywords'
 
 export interface ParseDataTypeResult {
   dataType?: PLCDataType
@@ -70,8 +71,9 @@ function parseStructure(name: string, body: string[]): ParseDataTypeResult {
     if (groups?.name === undefined || type === null) {
       return { error: `invalid structure field: "${line}". Possible cause: ${guessErrorReason(line)}` }
     }
-    if (!identifierRegex.test(groups.name)) {
-      return { error: `invalid structure field name: "${groups.name}"` }
+    const [fieldNameLegal, fieldNameReason] = isLegalIdentifier(groups.name)
+    if (!fieldNameLegal) {
+      return { error: `invalid structure field name: "${groups.name}" — ${fieldNameReason}` }
     }
     variable.push({
       name: groups.name,
@@ -144,8 +146,12 @@ export function parseDataTypeFromText(content: string, expectedName?: string): P
         : parseSingleLine(body[0])
 
   if (result.dataType === undefined) return result
-  if (!identifierRegex.test(result.dataType.name)) {
-    return { error: `invalid type name: "${result.dataType.name}"` }
+  // Same rule the UI enforces at creation/rename (keywords, literals,
+  // identifier shape) — a hand-written file can't smuggle in a name
+  // the editor would refuse to work with.
+  const [nameLegal, nameReason] = isLegalIdentifier(result.dataType.name)
+  if (!nameLegal) {
+    return { error: `invalid type name: "${result.dataType.name}" — ${nameReason}` }
   }
 
   if (expectedName !== undefined) {

--- a/src/frontend/utils/__tests__/feature-flags.test.ts
+++ b/src/frontend/utils/__tests__/feature-flags.test.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+import { isDataTypeFilesEnabled } from '../feature-flags'
+
+describe('feature flags', () => {
+  it('ships with the .dt data type persistence switched off', () => {
+    // Flipped to true by the DOPE-385 release PR; until then every
+    // build must behave exactly like the legacy project.json format.
+    expect(isDataTypeFilesEnabled()).toBe(false)
+  })
+})

--- a/src/frontend/utils/feature-flags.ts
+++ b/src/frontend/utils/feature-flags.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Compile-time feature switches shared by both IDEs (mirrored file).
+ *
+ * `DATATYPES_DT_FILES` gates the per-type data type persistence
+ * (`datatypes/<Name>.dt`, DOPE-385): the write path and the read
+ * preference both key off it, so a build with the flag off behaves
+ * exactly like the legacy project.json format in every scenario.
+ * Flip the constant in the release PR once the whole DOPE-385 series
+ * has landed.
+ *
+ * Exposed as a function rather than a bare constant so call sites
+ * stay mockable in tests (both flag states need coverage).
+ */
+const DATATYPES_DT_FILES = false
+
+export const isDataTypeFilesEnabled = (): boolean => DATATYPES_DT_FILES

--- a/src/middleware/adapters/editor/project-adapter.ts
+++ b/src/middleware/adapters/editor/project-adapter.ts
@@ -11,6 +11,7 @@
  */
 
 import { parseProjectFiles } from '../../../backend/shared/utils/parse-project-files'
+import { isDataTypeFilesEnabled } from '../../../frontend/utils/feature-flags'
 import type {
   CreatePouParams,
   CreateProjectParams,
@@ -202,6 +203,9 @@ export function createEditorProjectAdapter(): ProjectPort {
         raw.data.serverFiles,
         raw.data.remoteDeviceFiles,
         raw.data.libraryManifest,
+        // .dt files only feed the parser while the flag is on —
+        // off keeps legacy project.json as the source of truth.
+        isDataTypeFilesEnabled() ? raw.data.dataTypeFiles : [],
       )
       return { success: true, data: parsed }
     },
@@ -221,6 +225,9 @@ export function createEditorProjectAdapter(): ProjectPort {
         raw.data.serverFiles,
         raw.data.remoteDeviceFiles,
         raw.data.libraryManifest,
+        // .dt files only feed the parser while the flag is on —
+        // off keeps legacy project.json as the source of truth.
+        isDataTypeFilesEnabled() ? raw.data.dataTypeFiles : [],
       )
       return { success: true, data: parsed }
     },

--- a/src/middleware/adapters/editor/project-adapter.ts
+++ b/src/middleware/adapters/editor/project-adapter.ts
@@ -205,7 +205,9 @@ export function createEditorProjectAdapter(): ProjectPort {
         raw.data.libraryManifest,
         // .dt files only feed the parser while the flag is on —
         // off keeps legacy project.json as the source of truth.
-        isDataTypeFilesEnabled() ? raw.data.dataTypeFiles : [],
+        // Array guard: the IPC payload is a cast, not validated — a
+        // version-skewed main process must not crash project open.
+        isDataTypeFilesEnabled() && Array.isArray(raw.data.dataTypeFiles) ? raw.data.dataTypeFiles : [],
       )
       return { success: true, data: parsed }
     },
@@ -227,7 +229,9 @@ export function createEditorProjectAdapter(): ProjectPort {
         raw.data.libraryManifest,
         // .dt files only feed the parser while the flag is on —
         // off keeps legacy project.json as the source of truth.
-        isDataTypeFilesEnabled() ? raw.data.dataTypeFiles : [],
+        // Array guard: the IPC payload is a cast, not validated — a
+        // version-skewed main process must not crash project open.
+        isDataTypeFilesEnabled() && Array.isArray(raw.data.dataTypeFiles) ? raw.data.dataTypeFiles : [],
       )
       return { success: true, data: parsed }
     },

--- a/src/middleware/shared/ports/project-port.ts
+++ b/src/middleware/shared/ports/project-port.ts
@@ -53,6 +53,9 @@ export interface ProjectResponse {
     devicePinMapping?: DevicePin[] | Record<string, DevicePin[]>
     /** Warnings from parsing (e.g. dropped files that failed validation). */
     warnings?: string[]
+    /** `datatypes/*.dt` files that failed to parse on load, preserved
+     *  raw so the save flow echoes them back verbatim. */
+    unparsedDataTypeFiles?: RawProjectFile[]
     /**
      * Raw file contents as returned by the backend (path → text), captured
      * before parsing. Used by the save flow to upload byte-identical content


### PR DESCRIPTION
## Summary

Third PR of the [DOPE-385](https://autonomylogic.atlassian.net/browse/DOPE-385) series (subtask [DOPE-533](https://autonomylogic.atlassian.net/browse/DOPE-533)): the actual save/load switch to `datatypes/<Name>.dt`, gated by a **new compile-time flag** `isDataTypeFilesEnabled()` in `src/frontend/utils/feature-flags.ts` — **ships off**: the whole persistence path is gated — flag-off builds write and read exactly today's `project.json` payload. Three review fixes go in **always-on** and do change flag-off behavior (all improvements, listed under "Review findings" below): struct-field `documentation` now survives the zod schema (so the first save of a project that has field docs writes them back into `project.json` — a Source Control diff the user didn't cause), struct field names are validated on entry (a field named `IF` was accepted before), and `deleteDatatype` always queues the `.dt` path (harmless: `project-service` existence-checks before `unlink`, and the edge backend ignores `deletions` entirely — its save DTO is `{ files, branch? }`). The release PR at the end of the series flips the constant.

**With the flag on:**
- Full save serializes every data type to `datatypes/<Name>.dt` and writes `dataTypes: []` into project.json (all-or-nothing migration on first save, modeled on the POU pattern). Single-tab save (Ctrl+S on a datatype) writes that type's own file — no more whole-project.json cross-contamination for datatypes.
- Delete queues `datatypes/<name>.dt` for deletion; tree rename goes through the new `projectActions.updateDatatypeName`, which queues the old path (a plain update would strand the old file).
- Load: `parseProjectFiles` gains a 9th param `dataTypeFiles`. Hydration matrix: any `.dt` present → files win; none → legacy JSON fallback; unparseable / name-mismatched file → warning + **raw preservation** (new `unparsedDataTypeFiles` store state, echoed back verbatim by every save so an unreadable file is never silently dropped).
- "Don't save" on a datatype tab reloads from its `.dt` file (`reloadDataTypeFromDisk`).

**Review findings from #988/#648 folded in (always-on, not flag-gated):**
- Zod struct-variable schema now declares `documentation` — it was silently stripped on every load (confirmed by the DOPE-530 tested review).
- Data type and struct **field** names are validated with the full `isLegalIdentifier` rule (reserved words, literals, identifier shape) at the structure form AND in the `.dt` parser backstop — `IF : INT;` can no longer reach a file that fails to reload.
- UI-default `initialValue: { simpleValue: { value: '' } }` shape covered explicitly in the hydration tests.

## Testing

- Hydration-matrix suite in `parse-project-files.test.ts` (files-win / legacy fallback / empty / corrupt-preserved / name-mismatch / documentation-survives) — 100% stmts/funcs/lines on the touched gated files (jest).
- Store tests: deletion queueing, `updateDatatypeName`, `unparsedDataTypeFiles` lifecycle, rename path change.
- Manually validated with the flag on: create/save/reopen, migration of a legacy project, rename/delete, compile parity.
- `tsc`, eslint (0 errors), prettier clean in both repos.

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/651

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6Kfu7zebQC3UdeN29tiq

[DOPE-385]: https://autonomylogic.atlassian.net/browse/DOPE-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOPE-533]: https://autonomylogic.atlassian.net/browse/DOPE-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional support for storing, loading, saving, and reloading data types as `.dt` files.
  - Data type files can replace legacy project data while preserving files that cannot be parsed.
  - Renaming or deleting data types now updates associated files correctly.
  - Structure-field documentation is retained during project operations.

- **Bug Fixes**
  - Invalid or reserved names now show clear validation messages and cannot be saved.
  - Unparseable data type files are preserved rather than discarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## ⚠️ Testing this feature is a one-way trip — use a throwaway project

Once you save with the flag **on**, `project.json` carries `dataTypes: []` and the types live in `.dt` files. Running a **flag-off** build afterwards hydrates from the now-empty legacy field, so the data types disappear from the UI:

- **Desktop:** the `.dt` files stay orphaned on disk, so a flag-on build recovers them.
- **Web:** the save endpoint deletes by omission, so a flag-off save **removes the `.dt` files server-side** and recovery depends on the project's git history.

Don't reopen a flag-on project with a flag-off build. The release PR that flips the constant carries the rollout checklist.
