### PR TITLE
feature(RTOP-193): VPP licensing over the baremetal connection

### DIFF
--- a/configs/webpack/webpack.config.renderer.dev.ts
+++ b/configs/webpack/webpack.config.renderer.dev.ts
@@ -173,6 +173,11 @@ const configuration: webpack.Configuration = {
       // `npm run dev` to point at staging or localhost:
       //   `VPP_CATALOG_URL=http://localhost:3333 npm run dev`
       VPP_CATALOG_URL: '',
+      // Same mechanism for the Edge WEB app (the `/buy` license page), which is
+      // a DIFFERENT origin from the API above.  Falls back to the production
+      // host hardcoded in `system-adapter.ts` when unset:
+      //   `OPENPLC_EDGE_WEB_URL=http://localhost:5173 npm run dev`
+      OPENPLC_EDGE_WEB_URL: '',
     }),
 
     new webpack.DefinePlugin({

--- a/configs/webpack/webpack.config.renderer.prod.ts
+++ b/configs/webpack/webpack.config.renderer.prod.ts
@@ -141,6 +141,10 @@ const configuration: webpack.Configuration = {
       // (`https://api.autonomylogic.com`) wins.  Local/staging
       // builds can prepend `VPP_CATALOG_URL=...` to override.
       VPP_CATALOG_URL: '',
+      // Same for the Edge WEB app host (the `/buy` license page) — a different
+      // origin from the API above.  Unset in release builds → `system-adapter.ts`
+      // falls back to https://edge.autonomylogic.com.
+      OPENPLC_EDGE_WEB_URL: '',
     }),
 
     new MiniCssExtractPlugin({

--- a/resources/sources/Baremetal/Baremetal.ino
+++ b/resources/sources/Baremetal/Baremetal.ino
@@ -29,6 +29,8 @@
 #include "openplc.h"
 #include "defines.h"
 #include "arduino_runtime_glue.h"
+#include "license_gate.h"
+#include "license_store.h"   // license_store_read + LIC_BLOB_SIZE (via license_blob.h)
 
 #if defined(MODBUS_ENABLED) || defined(DEBUGGER_ENABLED)
 #include "ModbusSlave.h"
@@ -134,6 +136,41 @@ void setup()
     // read RUN and start immediately, as they always have.
     runtime_init_plc_state();
 
+    // -----------------------------------------------------------------------
+    // License gate. Hand the stored license blob to the license-core so it can
+    // verify it and arm its demo timer.
+    //
+    // With no license-core linked, `license_gate_init()` is the weak default in
+    // license_gate_weak.cpp and this whole block is a harmless no-op: actuation
+    // then stays unconditionally allowed, i.e. a board that never had licensing
+    // behaves exactly as before. `millis()` gives the core the same time base the
+    // runtime uses, with no esp_timer dependency.
+    //
+    // THE HARDWARE ANCHOR IS NOT PASSED IN. An earlier design read `UniqueID`
+    // here and handed the bytes over, which made the board's IDENTITY a claim
+    // made by the OPEN firmware: licensing hardware you do not own cost one edit
+    // to this file, substituting the target's anchor. The license-core reads the
+    // silicon itself, inside the closed artifact, so there is nothing here to
+    // substitute. (FC 0x48 still REPORTS the anchor to the editor, so a purchase
+    // can be bound to this board — reporting an identity and asserting one are
+    // different things.)
+    // -----------------------------------------------------------------------
+    {
+        // Zero-initialised: on a failed read the core is handed length 0, and a
+        // buffer of indeterminate bytes behind a zero length is the kind of detail
+        // that turns into a hard-to-place bug the first time someone reads past it.
+        uint8_t lic_blob[LIC_BLOB_SIZE] = {0};
+        size_t  lic_len = 0;
+        if (license_store_read(lic_blob, sizeof(lic_blob), &lic_len) != LIC_STORE_OK)
+        {
+            // EMPTY / CORRUPT / UNSUPPORTED / any error: nothing usable was read,
+            // so present a zero-length blob. The core's verify rejects it and
+            // starts the demo window; with no core the weak gate ignores the args.
+            lic_len = 0;
+        }
+
+        license_gate_init(lic_blob, lic_len, (uint32_t)millis());
+    }
 
     #ifdef MODBUS_ENABLED
         #ifdef MBSERIAL

--- a/resources/sources/Baremetal/license_blob.h
+++ b/resources/sources/Baremetal/license_blob.h
@@ -1,0 +1,93 @@
+/*
+license_blob.h - On-device license blob binary layout + storage CRC
+Copyright (C) 2022 OpenPLC - Thiago Alves
+
+The C side of the license blob contract. Cross-pinned to the TypeScript
+serializer (src/backend/shared/debug/license-blob.ts) by the golden vector in
+its __tests__/fixtures/license-golden.json -- a layout change on either side
+must fail a test rather than produce a blob the other end silently rejects.
+Shared by every storage backend (AVR EEPROM, ESP32 NVS) and by the Modbus
+license handlers. Layout is PACKED and LITTLE-ENDIAN for every multi-byte field
+of the struct (magic, crc32). This is INDEPENDENT of the Modbus wire, which
+carries the transfer `len` in BIG-ENDIAN (see modbus_pdu.cpp / modbus_debug.cpp).
+
+    ENDIANNESS DUALITY: blob CONTENT is LITTLE-ENDIAN; the Modbus wire
+    `len` field is BIG-ENDIAN. Do not confuse the two.
+*/
+
+#ifndef LICENSE_BLOB_H
+#define LICENSE_BLOB_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Byte layout (packed, contiguous — no padding):
+//  off  field         type          size  notes
+//   0   magic         uint32_t LE    4    'OPLC' -> bytes 4F 50 4C 43 (LE u32 = 0x434C504F)
+//   4   fmt_version   uint8_t        1
+//   5   key_id        uint8_t        1    signing-key id (rotation)
+//   6   device_id     uint8_t[16]   16
+//  22   product_id    uint8_t[8]     8    vpp id
+//  30   (end of signed payload — payload = 30 bytes)
+//  30   signature     uint8_t[64]   64    ECDSA P-256 r||s raw (not DER)
+//  94   crc32         uint32_t LE    4    over [payload||signature] (offsets 0..93)
+//  98   (end of blob — sizeof(lic_blob_t) == 98)
+
+#pragma pack(push, 1)
+typedef struct {
+    uint32_t magic;          // 'OPLC' -> bytes 4F 50 4C 43 (LE u32 = 0x434C504F)
+    uint8_t  fmt_version;
+    uint8_t  key_id;         // signing-key id (rotation)
+    uint8_t  device_id[16];
+    uint8_t  product_id[8];  // vpp id
+} lic_payload_t;             // 30 bytes
+
+typedef struct __attribute__((packed)) {
+    lic_payload_t payload;   // offsets 0..29
+    uint8_t  signature[64];  // offsets 30..93 (ECDSA P-256 r||s raw)
+    uint32_t crc32;          // offset 94 (covers [payload||signature], 0..93)
+} lic_blob_t;                // 98 bytes
+#pragma pack(pop)
+
+// Belt-and-suspenders: both #pragma pack and __attribute__((packed)) so AVR-GCC
+// and xtensa-GCC (which treat the two differently) both drop the padding.
+
+#define LIC_MAGIC_LE      0x434C504Fu   /* bytes 4F 50 4C 43 */
+#define LIC_BLOB_SIZE     98u
+#define LIC_PAYLOAD_SIZE  30u
+
+// Portable compile-time assert. Every Baremetal .cpp includes this header, so it
+// is compiled as C++, where static_assert is a keyword. _Static_assert is C-only
+// (C11) and the C++ frontend (xtensa/avr gcc) rejects it. Keep the C form for the
+// host golden test, which compiles this header as C11.
+#if defined(__cplusplus)
+    #define LIC_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
+#else
+    #define LIC_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+#endif
+
+LIC_STATIC_ASSERT(sizeof(lic_payload_t) == 30, "lic_payload_t must be 30 bytes");
+LIC_STATIC_ASSERT(sizeof(lic_blob_t)    == 98, "lic_blob_t must be 98 bytes");
+
+// CRC-32/ISO-HDLC (a.k.a. CRC-32, zlib/PKZIP).
+//   poly 0xEDB88320 (reflected) · init 0xFFFFFFFF · refin/refout true · xorout 0xFFFFFFFF
+//   test vector: crc32_iso_hdlc("123456789", 9) == 0xCBF43926
+// Bitwise loop (no 256-entry table) to save flash on AVR — the blob is only 94
+// bytes, so the ~8x/byte cost is negligible. Must match the TS implementation
+// (license-blob.ts crc32IsoHdlc) byte-for-byte.
+static inline uint32_t crc32_iso_hdlc(const uint8_t *data, size_t len)
+{
+    uint32_t crc = 0xFFFFFFFFu;
+    for (size_t i = 0; i < len; i++)
+    {
+        crc ^= (uint32_t)data[i];
+        for (uint8_t b = 0; b < 8; b++)
+        {
+            uint32_t mask = -(int32_t)(crc & 1u);
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return crc ^ 0xFFFFFFFFu;
+}
+
+#endif

--- a/resources/sources/Baremetal/license_gate.h
+++ b/resources/sources/Baremetal/license_gate.h
@@ -1,0 +1,80 @@
+/*
+license_gate.h - License enforcement gate (verify + demo window).
+The closed license-core (prebuilt) provides the STRONG implementation (verify +
+15-minute demo timer). The open firmware ships a weak default that reports
+UNSUPPORTED and allows actuation, so boards without a license-core behave as
+before. The clock is injected (now_ms) so the core stays host-testable.
+*/
+#ifndef LICENSE_GATE_H
+#define LICENSE_GATE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    LIC_GATE_FULL = 0,          /* valid license -> full operation */
+    LIC_GATE_DEMO = 1,          /* no/invalid license -> demo window running */
+    LIC_GATE_DEMO_EXPIRED = 2,  /* demo window elapsed -> actuation must stop */
+    LIC_GATE_UNSUPPORTED = 3,   /* no license-core linked (weak default) -> unenforced */
+} lic_gate_state_t;
+
+/* 15 minutes. Overridable at build (-DLIC_GATE_DEMO_MS=...) for bench tests
+ * that must watch the demo expire in seconds; production keeps the default. */
+#ifndef LIC_GATE_DEMO_MS
+#define LIC_GATE_DEMO_MS 900000u
+#endif
+
+/*
+ * Verify the stored blob once and arm the gate.
+ *   blob / blob_len - the 98 bytes read out of on-device storage.
+ *   now_ms          - injected clock, so the core stays host-testable.
+ *
+ * The device anchor is NOT a parameter: license_core reads it from the silicon
+ * inside the closed artifact. It used to be passed in from the sketch,
+ * which made the identity a claim the open firmware could rewrite.
+ */
+void license_gate_init(const uint8_t *blob, size_t blob_len, uint32_t now_ms);
+lic_gate_state_t license_gate_state(uint32_t now_ms);
+int license_gate_actuation_allowed(uint32_t now_ms);
+
+/*
+ * May outputs be driven RIGHT NOW? Takes no clock on purpose.
+ *
+ * This is the question a signed HAL asks at the top of its own raw output write,
+ * so that calling `hal_write_outputs` directly -- which open code can do, the
+ * symbol is declared in openplc.h -- cannot skip the gate the way it did when the
+ * only check lived inside updateOutputBuffers().
+ *
+ * No now_ms parameter because the caller must not choose the time: an entry point
+ * that accepts a timestamp accepts the boot timestamp forever. The gate reads a
+ * monotonic clock inside the closed artifact instead.
+ *
+ * Returns 1 when actuation is allowed (FULL, or a demo window still running) and
+ * 0 once the demo has expired. Fail-open before init, like
+ * license_gate_actuation_allowed: the firmware always inits in setup.
+ */
+int license_gate_outputs_permitted(void);
+
+#ifndef ARDUINO
+/*
+ * HOST-TEST SEAM, absent from every device build by construction -- `ARDUINO` is
+ * defined for the prebuilt `.a`, so this symbol is not in the artifact a VPP
+ * ships. It has to be absent: `license_gate_init` refuses a second call
+ * specifically so open code cannot re-arm the demo window, and an exported
+ * "forget you were initialised" would hand that back with a nicer name.
+ *
+ * The host tests need it because they exercise FULL, expiry and millis-wrap as
+ * separate scenarios against one set of file-scope statics.
+ */
+void license_gate_reset_for_test(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LICENSE_GATE_H */

--- a/resources/sources/Baremetal/license_gate_weak.cpp
+++ b/resources/sources/Baremetal/license_gate_weak.cpp
@@ -1,0 +1,41 @@
+/*
+license_gate_weak.cpp - Weak fallback for the license enforcement gate.
+Copyright (C) 2022 OpenPLC - Thiago Alves
+
+Guarantees the firmware always links even when no platform VPP provides a real
+license-core. The VPP's prebuilt license-core (.a) defines the STRONG symbols
+(ECDSA verify + 15-minute demo timer), which override these weak defaults at
+link time. When absent, these run: the gate reports LIC_GATE_UNSUPPORTED and
+actuation stays unconditionally allowed, so a board without a license-core
+behaves exactly as it did before licensing existed (no enforcement).
+*/
+#include "license_gate.h"
+
+__attribute__((weak)) void license_gate_init(const uint8_t *blob, size_t blob_len,
+                                             uint32_t now_ms)
+{
+    (void)blob;
+    (void)blob_len;
+    (void)now_ms;
+}
+
+__attribute__((weak)) lic_gate_state_t license_gate_state(uint32_t now_ms)
+{
+    (void)now_ms;
+    return LIC_GATE_UNSUPPORTED;
+}
+
+__attribute__((weak)) int license_gate_actuation_allowed(uint32_t now_ms)
+{
+    (void)now_ms;
+    return 1;
+}
+
+// Same unenforced answer, for the same reason: a board with no license-core is
+// not a board running an expired demo. A licensable VPP overrides this with the
+// strong version from its closed .a, and its HAL asks THAT one before driving a
+// pin — so this default is only ever reached where there is nothing to enforce.
+__attribute__((weak)) int license_gate_outputs_permitted(void)
+{
+    return 1;
+}

--- a/resources/sources/Baremetal/license_store.h
+++ b/resources/sources/Baremetal/license_store.h
@@ -1,0 +1,64 @@
+/*
+license_store.h - Single storage interface for the on-device license blob
+Copyright (C) 2022 OpenPLC - Thiago Alves
+
+The one point of contact for persisting the license blob. The closed license-core
+CONSUMES this interface; the open-source firmware IMPLEMENTS it (per-arch backend,
+each self-gated on its ARDUINO_ARCH_* macro: ESP32 NVS / ESP8266 emulated-EEPROM /
+AVR EEPROM).
+
+license_store_read validates magic + crc32 internally, so it returns semantic
+status (EMPTY / CORRUPT). ECDSA verify lives ABOVE this layer (out of scope here).
+*/
+
+#ifndef LICENSE_STORE_H
+#define LICENSE_STORE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "license_blob.h"
+#include "modbus_types.h"   // MB_DEBUG_* status codes for lic_status_to_mb()
+
+typedef enum {
+    LIC_STORE_OK        = 0,  // operation done; for read: valid blob (magic+crc match)
+    LIC_STORE_EMPTY     = 1,  // virgin storage: magic absent OR key/region never written
+    LIC_STORE_CORRUPT   = 2,  // magic present but crc32 mismatch
+    LIC_STORE_IO_ERROR  = 3,  // backend failure (NVS begin/commit; EEPROM unavailable)
+    LIC_STORE_TOO_LARGE = 4,  // len > backend capacity (write) or > caller buffer (read)
+    LIC_STORE_UNSUPPORTED = 5,// no backend on this board (weak default): licensing FCs degrade gracefully
+} lic_store_status_t;
+
+// Write `len` raw bytes. Validates len <= capacity (else TOO_LARGE).
+// Does NOT validate magic/crc/signature (integrity is checked on read / at verify).
+lic_store_status_t license_store_write(const uint8_t *blob, size_t len);
+
+// Read the blob into `out` (capacity `cap`). Writes the read size into *out_len.
+// EMPTY if virgin, CORRUPT if magic ok but crc fails, TOO_LARGE if cap < stored size.
+lic_store_status_t license_store_read(uint8_t *out, size_t cap, size_t *out_len);
+
+// Erase the license (NVS remove / EEPROM zero the length). Idempotent.
+lic_store_status_t license_store_erase(void);
+
+// Map a storage status to the Modbus debug status byte returned on the wire.
+//   OK        -> MB_DEBUG_SUCCESS             (0x7E)
+//   TOO_LARGE -> MB_DEBUG_ERROR_OUT_OF_BOUNDS (0x81, reused)
+//   IO_ERROR  -> MB_DEBUG_ERROR_OUT_OF_MEMORY (0x82, reused)
+//   EMPTY       -> MB_DEBUG_LIC_EMPTY           (0x83)
+//   CORRUPT     -> MB_DEBUG_LIC_CORRUPT         (0x84)
+//   UNSUPPORTED -> MB_DEBUG_LIC_UNSUPPORTED     (0x85)
+static inline uint8_t lic_status_to_mb(lic_store_status_t st)
+{
+    switch (st)
+    {
+        case LIC_STORE_OK:          return MB_DEBUG_SUCCESS;
+        case LIC_STORE_TOO_LARGE:   return MB_DEBUG_ERROR_OUT_OF_BOUNDS;
+        case LIC_STORE_IO_ERROR:    return MB_DEBUG_ERROR_OUT_OF_MEMORY;
+        case LIC_STORE_EMPTY:       return MB_DEBUG_LIC_EMPTY;
+        case LIC_STORE_CORRUPT:     return MB_DEBUG_LIC_CORRUPT;
+        case LIC_STORE_UNSUPPORTED: return MB_DEBUG_LIC_UNSUPPORTED;
+        default:                    return MB_DEBUG_ERROR_OUT_OF_MEMORY;
+    }
+}
+
+#endif

--- a/resources/sources/Baremetal/license_store_weak.cpp
+++ b/resources/sources/Baremetal/license_store_weak.cpp
@@ -1,0 +1,19 @@
+/*
+license_store_weak.cpp - Weak fallback backend for the license store.
+Copyright (C) 2022 OpenPLC - Thiago Alves
+
+Guarantees the firmware always links even when no platform VPP provides a real
+backend. A VPP that ships license_store_<arch>.cpp defines the STRONG symbols,
+which override these weak defaults at link time. When absent, these run and
+report LIC_STORE_UNSUPPORTED, so the licensing FCs degrade gracefully.
+*/
+#include "license_store.h"
+
+__attribute__((weak)) lic_store_status_t license_store_write(const uint8_t *, size_t)
+{ return LIC_STORE_UNSUPPORTED; }
+
+__attribute__((weak)) lic_store_status_t license_store_read(uint8_t *, size_t, size_t *out_len)
+{ if (out_len) *out_len = 0; return LIC_STORE_UNSUPPORTED; }
+
+__attribute__((weak)) lic_store_status_t license_store_erase(void)
+{ return LIC_STORE_UNSUPPORTED; }

--- a/resources/sources/Baremetal/modbus_debug.cpp
+++ b/resources/sources/Baremetal/modbus_debug.cpp
@@ -1,9 +1,10 @@
 /*
-modbus_debug.cpp - OpenPLC always-on debugger function codes (0x41-0x48)
+modbus_debug.cpp - OpenPLC always-on debugger function codes (0x41-0x4B)
 Copyright (C) 2022 OpenPLC - Thiago Alves
 */
 
 #include "modbus_debug.h"
+#include "license_store.h"   // license_store_read/write + lic_status_to_mb
 // Debug surface comes via the extern "C" shims in arduino_runtime_glue.h
 // (openplc_debug_*, scan_counter) so this TU stays free of strucpp's
 // template-heavy headers and compiles cleanly under arduino-cli's default C++
@@ -432,4 +433,87 @@ void debugGetBoardId()
     mb_frame[3] = 0; // no unique-id support on this core
     mb_frame_len = 4;
 #endif
+}
+
+// ---------------------------------------------------------------------------
+// On-device license storage (FC 0x49 write / 0x4A read)
+//
+// These two only MOVE BYTES. They do not verify a signature and do not decide
+// anything about execution: that is the closed license-core's job, via
+// license_gate.h. Keeping them dumb is what lets the open firmware carry them.
+// ---------------------------------------------------------------------------
+
+// PDU request:  [FC][len:u16 BE][blob...]   (dispatcher passes `len` already unpacked)
+// PDU response: [FC][STATUS]
+//
+// NOTE on endianness: `len` on the wire is BIG-ENDIAN (matches every other debug
+// FC, e.g. GET_LIST/SET). The blob CONTENT it carries is little-endian — the two
+// are independent. `blob` points at mb_frame[4], and the response is only written
+// after license_store_write has consumed it, so there is no overlap hazard.
+void debugWriteLicense(uint16_t len, const uint8_t *blob)
+{
+    // The license blob is a FIXED 98 bytes; anything else is not one, so refuse
+    // before the store ever sees it. Two separate problems close here.
+    //
+    // 1. CONTRACT. The two targets disagreed about this exact field: the Linux
+    //    runtime answers LIC_CORRUPT for len != 98, while bare metal used to pass
+    //    `len` straight through — so [0x49][len=0x0004][4 bytes] came back
+    //    SUCCESS. One command, two contracts, and the editor believing whichever
+    //    target it happened to be talking to.
+    //
+    // 2. OVERREAD. `len` is read from mb_frame[2..3] and can be up to 0xFFFF,
+    //    while `blob` points into `mb_frame`, a static buffer of MAX_MB_FRAME
+    //    (128 on 328P, 256 elsewhere). Over RTU this was already unreachable:
+    //    mb_pdu_request_len() computes 6 + len, modbus_serial.cpp drops any frame
+    //    whose expected length exceeds MAX_MB_FRAME, and it waits for the bytes to
+    //    actually arrive. Over TCP nothing checked it: modbus_tcp.cpp bounds only
+    //    the MBAP length (mb_frame_len) and never cross-checks it against this
+    //    field, so a 6-byte packet declaring len = 0xFFFF would make
+    //    license_store_write read ~64 KB past the frame. Testing `len` here is the
+    //    one check that covers both transports at once.
+    if ((size_t)len != (size_t)LIC_BLOB_SIZE)
+    {
+        mb_frame[1] = MB_FC_DEBUG_WRITE_LICENSE;
+        mb_frame[2] = lic_status_to_mb(LIC_STORE_CORRUPT);
+        mb_frame_len = 3;
+        return;
+    }
+
+    lic_store_status_t st = license_store_write(blob, (size_t)len);
+    mb_frame[1] = MB_FC_DEBUG_WRITE_LICENSE;
+    mb_frame[2] = lic_status_to_mb(st);
+    mb_frame_len = 3;
+}
+
+// PDU request:  [FC]
+// PDU response (OK):                  [FC][STATUS][len:u16 BE][blob...]
+// PDU response (EMPTY/CORRUPT/error): [FC][STATUS]   (no len, no blob)
+//
+// Absolute mb_frame indices (index 0 is the slave id, the PDU starts at 1,
+// exactly like debugGetBoardId): FC@1, STATUS@2, len@3..4 (BIG-ENDIAN), blob@5.
+//
+// The store reads straight into &mb_frame[5]: the frame IS the static buffer, so
+// there is no malloc on AVR. READ carries no request payload, so writing at [5]
+// cannot clobber an input. `out_len` is unknown until after the read, and the len
+// field lives at [3..4] — BEFORE the blob — so filling it afterwards never
+// overlaps the blob bytes. A 98-byte blob fits MAX_MB_FRAME comfortably.
+void debugReadLicense(void)
+{
+    size_t out_len = 0;
+    lic_store_status_t st =
+        license_store_read(&mb_frame[5], MAX_MB_FRAME - 5, &out_len);
+
+    mb_frame[1] = MB_FC_DEBUG_READ_LICENSE;
+    mb_frame[2] = lic_status_to_mb(st);
+    if (st == LIC_STORE_OK)
+    {
+        // len BIG-ENDIAN at [3..4] (blob content stays little-endian).
+        mb_frame[3] = (uint8_t)((out_len >> 8) & 0xFF);
+        mb_frame[4] = (uint8_t)(out_len & 0xFF);
+        mb_frame_len = 5 + out_len;
+    }
+    else
+    {
+        mb_frame_len = 3;   // [FC][STATUS] only
+    }
 }

--- a/resources/sources/Baremetal/modbus_debug.h
+++ b/resources/sources/Baremetal/modbus_debug.h
@@ -1,5 +1,5 @@
 /*
-modbus_debug.h - OpenPLC always-on debugger function codes (0x41-0x48, 0x4B)
+modbus_debug.h - OpenPLC always-on debugger function codes (0x41-0x4B)
 Copyright (C) 2022 OpenPLC - Thiago Alves
 
 The debugger PDU handlers, dispatched from process_mbpacket. Kept ungated: the
@@ -24,6 +24,10 @@ void debugGetMd5(void *endianness);
 void debugGetStatus(void);
 void debugGetVersion(void);
 void debugGetBoardId(void);
+// On-device license storage (0x49/0x4A). `len` is the BIG-ENDIAN wire length
+// (already unpacked by the dispatcher); the blob CONTENT is little-endian.
+void debugWriteLicense(uint16_t len, const uint8_t *blob);  // 0x49
+void debugReadLicense(void);                                // 0x4A
 // FC 0x4B -- set the runtime run/stop state. Command only; the state is read
 // back through debugGetStatus (FC 0x46), which reports it.
 void plcSetState(uint8_t desired);

--- a/resources/sources/Baremetal/modbus_pdu.cpp
+++ b/resources/sources/Baremetal/modbus_pdu.cpp
@@ -40,7 +40,13 @@ int32_t mb_pdu_request_len(const uint8_t *f, uint16_t n)
         case MB_FC_DEBUG_GET_STATUS:
         case MB_FC_DEBUG_GET_VERSION:
         case MB_FC_DEBUG_GET_BOARD_ID:
+        case MB_FC_DEBUG_READ_LICENSE:
             return 4;                                   // [id][fc][crc:2]
+        case MB_FC_DEBUG_WRITE_LICENSE:
+            if (n < 4) return 0;                        // len (BE) lives at f[2..3]
+            // [id][fc][len:2][blob:len][crc:2] -> overhead 6 + blob len.
+            // NOTE: len is BIG-ENDIAN on the wire (blob content is little-endian).
+            return 6 + (int32_t)(((uint16_t)f[2] << 8) | f[3]);
         case MB_FC_PLC_SET_STATE:
             return 5;                                   // [id][fc][state:1][crc:2]
         default:
@@ -63,6 +69,8 @@ bool mb_pdu_skips_crc(uint8_t fc)
         case MB_FC_DEBUG_GET_STATUS:
         case MB_FC_DEBUG_GET_VERSION:
         case MB_FC_DEBUG_GET_BOARD_ID:
+        case MB_FC_DEBUG_WRITE_LICENSE:
+        case MB_FC_DEBUG_READ_LICENSE:
             return true;
         default:
             return false;
@@ -176,6 +184,20 @@ void process_mbpacket()
 
         case MB_FC_DEBUG_GET_BOARD_ID:
             debugGetBoardId();
+        break;
+
+        case MB_FC_DEBUG_WRITE_LICENSE:
+        {
+            // PDU: [FC:1][len:u16 BE][blob...]
+            // len is BIG-ENDIAN (same convention as GET_LIST/SET); the blob
+            // CONTENT it carries is little-endian.
+            uint16_t lic_len = (uint16_t)mb_frame[2] << 8 | (uint16_t)mb_frame[3];
+            debugWriteLicense(lic_len, &mb_frame[4]);
+        }
+        break;
+
+        case MB_FC_DEBUG_READ_LICENSE:
+            debugReadLicense();
         break;
 
         case MB_FC_PLC_SET_STATE:

--- a/resources/sources/Baremetal/modbus_types.h
+++ b/resources/sources/Baremetal/modbus_types.h
@@ -41,6 +41,15 @@ protocol, transport, register and debug layers agree on the same contracts.
 #define MB_DEBUG_SUCCESS                 0x7E
 #define MB_DEBUG_ERROR_OUT_OF_BOUNDS     0x81
 #define MB_DEBUG_ERROR_OUT_OF_MEMORY     0x82
+// License storage semantic states. The editor distinguishes all three: EMPTY and
+// CORRUPT both mean "recover from the backend", while UNSUPPORTED means the board
+// cannot hold a license at all and buying one would not help. They don't collide
+// with Modbus exceptions (0x01-0x04) nor 0x7E/0x81/0x82.
+#define MB_DEBUG_LIC_EMPTY               0x83
+#define MB_DEBUG_LIC_CORRUPT             0x84
+// No license-store backend on this board (weak default): the licensing FCs
+// degrade gracefully instead of failing as a transport error.
+#define MB_DEBUG_LIC_UNSUPPORTED         0x85
 // MB_FC_PLC_SET_STATE only: a RUN request was refused because the hardware mode
 // switch reads STOP. The editor turns this into a "flip the switch to RUN"
 // warning rather than a generic failure. It doesn't collide with Modbus
@@ -82,6 +91,8 @@ enum {
     MB_FC_DEBUG_GET_STATUS = 0x46, // Debug get PLC status (running, scan tick, uptime)
     MB_FC_DEBUG_GET_VERSION = 0x47, // Debug get runtime firmware version
     MB_FC_DEBUG_GET_BOARD_ID = 0x48, // Debug get unique hardware board ID
+    MB_FC_DEBUG_WRITE_LICENSE = 0x49, // Debug write license blob to on-device storage
+    MB_FC_DEBUG_READ_LICENSE  = 0x4A, // Debug read license blob from on-device storage
     MB_FC_PLC_SET_STATE       = 0x4B, // Set the runtime run/stop state
 };
 

--- a/resources/sources/arduino/openplc.h
+++ b/resources/sources/arduino/openplc.h
@@ -122,6 +122,31 @@ uint8_t hardwareStateSwitch(void);
  * HAL with no LED reads nothing and the runtime never knows the difference.
  * ---------------------------------------------------------------------- */
 uint8_t runtime_get_plc_state(void);
+
+/* ---- Raw I/O ops, for LICENSABLE VPP targets only ----------------------
+ * Two mutually exclusive shapes exist, and there is deliberately NO weak
+ * fallback for the gated wrappers above:
+ *
+ *   - Licensable VPP HAL: defines ONLY these raw ops. The gated
+ *     updateInputBuffers / updateOutputBuffers come from inside the closed
+ *     license-core .a, which asks license_gate_actuation_allowed() and then
+ *     calls hal_read_inputs / hal_write_outputs — or hal_disable_all_outputs
+ *     once the demo window has expired.
+ *
+ *   - Every other HAL (the bundled resources/sources/hal/*.cpp, and any
+ *     unlicensed VPP): defines updateInput/OutputBuffers itself and leaves
+ *     these raw ops undeclared-but-unused. No gate is involved.
+ *
+ * THE CONSEQUENCE IS THE POINT: dropping the license-core .a from a licensable
+ * VPP does not silently degrade to unenforced I/O — the firmware fails to LINK,
+ * with undefined updateInputBuffers / updateOutputBuffers. The only weak
+ * defaults shipped are license_gate_weak.cpp (gate query -> UNSUPPORTED,
+ * actuation allowed) and license_store_weak.cpp (blob store -> UNSUPPORTED),
+ * which keep NON-licensable boards linking; neither provides these wrappers.
+ * ---------------------------------------------------------------------- */
+void hal_read_inputs(void);
+void hal_write_outputs(void);
+void hal_disable_all_outputs(void);
 #ifdef __cplusplus
 }
 #endif

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -2566,6 +2566,60 @@ class CompilerModule {
           strucppRuntimeHeaders: v4Layout,
           boardHalContent,
         })
+
+        // VPP-provided license-store backend source(s). Mirrors the HAL read
+        // above: each path is an absolute one `BoardInfoResolver` produced from
+        // `device.hal.licenseStore` through the same traversal-guarded
+        // `resolvePackageRelativePath`.
+        //
+        // Unlike the HAL (which lands at the canonical `src/arduino.cpp`), these
+        // keep their distinctive basenames and land in the SKETCH directory next
+        // to `license_store.h` / `license_blob.h`, so their
+        // `#include "license_store.h"` resolves and they define the STRONG
+        // `license_store_*` symbols that override the skeleton's
+        // `license_store_weak.cpp`. Boards without a VPP backend inject nothing
+        // and link the weak default, which answers LIC_UNSUPPORTED.
+        //
+        // A read failure is a WARNING, not a hard stop, and the asymmetry with the
+        // HAL check above is deliberate: a missing HAL means no I/O at all, while a
+        // missing store backend means the board answers "cannot store a licence" —
+        // degraded, correctly reported to the editor, and still a working PLC.
+        for (const licenseStoreFile of boardInfo.licenseStoreFiles ?? []) {
+          try {
+            const content = await readFile(licenseStoreFile, 'utf-8')
+            firmwareSkeleton[`examples/Baremetal/${path.basename(licenseStoreFile)}`] = content
+            // Logged on SUCCESS, not only on failure. Without this line the build
+            // output is identical whether the backend went in or not, and the only
+            // symptom of it missing appears much later and somewhere else: the
+            // board answers LIC_UNSUPPORTED and the editor says "this device
+            // cannot store a licence" — which reads as a hardware limitation
+            // rather than a firmware that was built without the backend.
+            _mainProcessPort.postMessage({
+              logLevel: 'info',
+              message: `License store backend included: ${path.basename(licenseStoreFile)}`,
+            })
+          } catch (lsErr) {
+            _mainProcessPort.postMessage({
+              logLevel: 'warning',
+              message:
+                `Could not read license-store backend at ${licenseStoreFile}: ${getErrorMessage(lsErr)}. ` +
+                'This board will report that it cannot store a licence.',
+            })
+          }
+        }
+        // A licensable board that resolves NO backend is a manifest fault: every
+        // licensable VPP targets hardware that persists a licence, so the storage
+        // source is not optional for one. Saying it here is far cheaper than
+        // deducing it from a badge three steps later.
+        if (boardInfo.capabilities?.isLicensable === true && (boardInfo.licenseStoreFiles ?? []).length === 0) {
+          _mainProcessPort.postMessage({
+            logLevel: 'warning',
+            message:
+              `Board "${boardTarget}" belongs to a licensed VPP but its manifest declares no ` +
+              '`hal.licenseStore`. Every licensed VPP needs one, so this is a packaging fault: the ' +
+              'firmware will link the weak default and report that its licence storage is missing.',
+          })
+        }
       }
       try {
         // `devices/pin-mapping.json` ships in one of two shapes (the

--- a/src/backend/editor/library-manager/desktop-catalog-transport.ts
+++ b/src/backend/editor/library-manager/desktop-catalog-transport.ts
@@ -20,6 +20,7 @@
 import https from 'https'
 
 import type { CatalogQueryParams, CatalogTransportPort } from '../../../middleware/shared/ports/catalog-transport-port'
+import { defaultPortFor, httpModuleFor } from '../utils/http-module'
 
 /** Default base URL when no env override is set. */
 const DEFAULT_EDGE_API_URL = 'https://api.autonomylogic.com'
@@ -77,7 +78,7 @@ function requestText(url: string, signal?: AbortSignal): Promise<string> {
     const parsed = new URL(url)
     const reqOptions: https.RequestOptions = {
       hostname: parsed.hostname,
-      port: parsed.port || undefined,
+      port: parsed.port || defaultPortFor(parsed),
       path: parsed.pathname + parsed.search,
       method: 'GET',
       headers: {
@@ -86,7 +87,8 @@ function requestText(url: string, signal?: AbortSignal): Promise<string> {
       },
     }
 
-    const req = https.request(reqOptions, (res) => {
+    // Scheme-driven, so OPENPLC_EDGE_API_URL can point at a local http backend.
+    const req = httpModuleFor(parsed).request(reqOptions, (res) => {
       // Accumulate as a single utf-8 string instead of buffering raw
       // chunks — sidesteps the Buffer[] vs Uint8Array[] friction in
       // recent @types/node and matches the existing httpRequest in

--- a/src/backend/editor/license/__tests__/device-identity.test.ts
+++ b/src/backend/editor/license/__tests__/device-identity.test.ts
@@ -1,0 +1,34 @@
+import { deriveDeviceId, deriveVppId } from '../device-identity'
+
+describe('deriveDeviceId', () => {
+  it('derives the golden 16-byte device id for the real NodeMCU anchor', () => {
+    // Anchor 00 b1 8c ed is the real NodeMCU hardware anchor. The golden
+    // value below is the deterministic sha256("openplc-dev-v1|"||anchor)[:16].
+    const anchor = Uint8Array.from([0, 177, 140, 237])
+    expect(deriveDeviceId(anchor)).toBe('659a3520540f803625ddc34081e893d3')
+  })
+
+  it('returns 32 lowercase hex chars (16 bytes)', () => {
+    const id = deriveDeviceId(Uint8Array.from([1, 2, 3]))
+    expect(id).toMatch(/^[0-9a-f]{32}$/)
+  })
+
+  it('is deterministic and domain-separated by the prefix', () => {
+    const anchor = Uint8Array.from([0, 177, 140, 237])
+    // Same anchor -> same id.
+    expect(deriveDeviceId(anchor)).toBe(deriveDeviceId(Uint8Array.from([0, 177, 140, 237])))
+    // A different anchor -> different id.
+    expect(deriveDeviceId(anchor)).not.toBe(deriveDeviceId(Uint8Array.from([0, 177, 140, 238])))
+  })
+})
+
+describe('deriveVppId', () => {
+  it('derives the golden 8-byte vpp id for the espressif package', () => {
+    // Golden value = sha256("com.openplc.espressif")[:8], hex.
+    expect(deriveVppId('com.openplc.espressif')).toBe('29a17c7c2486d355')
+  })
+
+  it('returns 16 lowercase hex chars (8 bytes)', () => {
+    expect(deriveVppId('com.openplc.espressif')).toMatch(/^[0-9a-f]{16}$/)
+  })
+})

--- a/src/backend/editor/license/__tests__/license-activation-client.test.ts
+++ b/src/backend/editor/license/__tests__/license-activation-client.test.ts
@@ -1,0 +1,262 @@
+import { EventEmitter } from 'events'
+import http from 'http'
+import https from 'https'
+
+import { checkDeviceActivation } from '../license-activation-client'
+
+/**
+ * Fake `request`: invokes the response callback synchronously and emits the given
+ * status/body when `req.end()` is called, so `postJson`'s promise resolves without
+ * a real socket. Returns the `req` mock so tests can assert on the body written.
+ */
+function mockResponse(statusCode: number, jsonBody: unknown, mod: typeof https | typeof http = https) {
+  const req = Object.assign(new EventEmitter(), { write: jest.fn(), end: jest.fn(), setTimeout: jest.fn() })
+  jest.spyOn(mod, 'request').mockImplementation(((_options: unknown, callback: (res: unknown) => void) => {
+    const res = Object.assign(new EventEmitter(), { statusCode, statusMessage: 'OK', setEncoding: jest.fn() })
+    callback(res)
+    req.end.mockImplementation(() => {
+      res.emit('data', JSON.stringify(jsonBody))
+      res.emit('end')
+    })
+    return req as unknown as ReturnType<typeof https.request>
+  }) as typeof https.request)
+  return req
+}
+
+const INPUT = {
+  deviceId: '659a3520540f803625ddc34081e893d3',
+  packageId: 'com.openplc.espressif-licensed',
+}
+
+/** The golden 98-byte blob, hex — same vector as `license-golden.json`. */
+const GOLDEN_HEX =
+  '4f504c430100000102030405060708090a0b0c0d0e0fa0a1a2a3a4a5a6a711111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111b6311445'
+
+const GOLDEN_B64 = Buffer.from(GOLDEN_HEX, 'hex').toString('base64')
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('checkDeviceActivation', () => {
+  it('sends only { deviceId, packageId } and returns the decoded 98-byte blob', async () => {
+    const req = mockResponse(200, {
+      statusCode: 200,
+      data: { licensed: true, deviceId: INPUT.deviceId, vppId: INPUT.packageId, license: GOLDEN_B64 },
+    })
+
+    const result = await checkDeviceActivation(INPUT)
+
+    expect(result.licensed).toBe(true)
+    expect(result.license).toHaveLength(98)
+    expect(Buffer.from(result.license ?? []).toString('hex')).toBe(GOLDEN_HEX)
+
+    // Whole-key equality, not a per-field check: an extra field creeping back in
+    // (a nonce, a signature, a client-declared hwClass) has to fail here.
+    const sent = JSON.parse((req.write as jest.Mock).mock.calls[0][0] as string) as Record<string, unknown>
+    expect(Object.keys(sent).sort()).toEqual(['deviceId', 'packageId'])
+  })
+
+  it('passes through licensed:false with a reason (no purchase on record)', async () => {
+    mockResponse(200, { statusCode: 200, data: { licensed: false, reason: 'no active subscription' } })
+
+    const result = await checkDeviceActivation(INPUT)
+
+    // `reason` present and `error` absent is what tells the caller demo mode is
+    // the CORRECT outcome, rather than a failure to reach the backend.
+    expect(result.licensed).toBe(false)
+    expect(result.reason).toBe('no active subscription')
+    expect(result.error).toBeUndefined()
+    expect(result.license).toBeUndefined()
+  })
+
+  it('reports a non-2xx as an error, not as "no purchase"', async () => {
+    // A 404 (unknown package), 429 (rate limited) or 503 (no signer) must NOT
+    // read as "this device has no license" — that is how someone who already paid
+    // gets told to buy again.
+    mockResponse(404, { statusCode: 404, data: { message: 'Unknown VPP' } })
+
+    const result = await checkDeviceActivation(INPUT)
+
+    expect(result.licensed).toBe(false)
+    expect(result.error).toMatch(/404/)
+    expect(result.reason).toBeUndefined()
+  })
+
+  it('reports a transport failure as an error rather than throwing', async () => {
+    jest.spyOn(https, 'request').mockImplementation(((_options: unknown, _callback: unknown) => {
+      const emitter = new EventEmitter()
+      const req = Object.assign(emitter, {
+        write: jest.fn(),
+        end: jest.fn(() => {
+          emitter.emit('error', new Error('ECONNREFUSED'))
+        }),
+        setTimeout: jest.fn(),
+      })
+      return req as unknown as ReturnType<typeof https.request>
+    }) as typeof https.request)
+
+    const result = await checkDeviceActivation(INPUT)
+
+    expect(result.licensed).toBe(false)
+    expect(result.error).toMatch(/ECONNREFUSED/)
+  })
+
+  it('rejects a response whose shape is off-contract', async () => {
+    mockResponse(200, { statusCode: 200, data: { somethingElse: true } })
+
+    const result = await checkDeviceActivation(INPUT)
+
+    expect(result.licensed).toBe(false)
+    expect(result.error).toMatch(/Unexpected activation response shape/)
+  })
+
+  it('rejects licensed:true with no license field', async () => {
+    mockResponse(200, { statusCode: 200, data: { licensed: true } })
+
+    const result = await checkDeviceActivation(INPUT)
+
+    expect(result.licensed).toBe(false)
+    expect(result.error).toMatch(/missing license blob/)
+  })
+
+  it('rejects a blob that does not decode to exactly 98 bytes', async () => {
+    // `Buffer.from(s, 'base64')` never throws — it skips invalid characters and
+    // tolerates missing padding — so without an explicit length check a truncated
+    // field reaches the device as a short blob and comes back as a LIC_CORRUPT
+    // rejection that blames the hardware.
+    const truncated = Buffer.from(GOLDEN_HEX, 'hex').subarray(0, 40).toString('base64')
+    mockResponse(200, { statusCode: 200, data: { licensed: true, license: truncated } })
+
+    const result = await checkDeviceActivation(INPUT)
+
+    expect(result.licensed).toBe(false)
+    expect(result.error).toMatch(/40 bytes, expected 98/)
+    expect(result.license).toBeUndefined()
+  })
+
+  it('rejects a license field that is not base64 at all', async () => {
+    mockResponse(200, { statusCode: 200, data: { licensed: true, license: '!!!not base64!!!' } })
+
+    const result = await checkDeviceActivation(INPUT)
+
+    expect(result.licensed).toBe(false)
+    expect(result.error).toMatch(/expected 98/)
+  })
+
+  it('accepts a response that is not wrapped in the { statusCode, data } envelope', async () => {
+    mockResponse(200, { licensed: true, license: GOLDEN_B64 })
+
+    const result = await checkDeviceActivation(INPUT)
+
+    expect(result.licensed).toBe(true)
+    expect(result.license).toHaveLength(98)
+  })
+})
+
+/**
+ * There is NO dev license-minting path in this module.
+ *
+ * The removed mock (`OPLC_LICENSE_MOCK` / `OPLC_LICENSE_MOCK_KEY`) signed real,
+ * device-bound blobs a board would accept as FULL. It was compiled out of
+ * production builds, but it still shipped in dev builds and was one key leak away
+ * from unlimited offline licenses outside purchase and outside revocation.
+ *
+ * These tests assert the ABSENCE. A happy-path test would pass just as well with
+ * the mock silently reintroduced.
+ */
+describe('checkDeviceActivation (no dev mock)', () => {
+  const originalMock = process.env.OPLC_LICENSE_MOCK
+  const originalKey = process.env.OPLC_LICENSE_MOCK_KEY
+
+  afterEach(() => {
+    if (originalMock === undefined) delete process.env.OPLC_LICENSE_MOCK
+    else process.env.OPLC_LICENSE_MOCK = originalMock
+    if (originalKey === undefined) delete process.env.OPLC_LICENSE_MOCK_KEY
+    else process.env.OPLC_LICENSE_MOCK_KEY = originalKey
+  })
+
+  it('still calls the backend, and honours its answer, with OPLC_LICENSE_MOCK=licensed set', async () => {
+    process.env.OPLC_LICENSE_MOCK = 'licensed'
+    mockResponse(200, { statusCode: 200, data: { licensed: false } })
+
+    const result = await checkDeviceActivation(INPUT)
+
+    // If a mock were reachable this would be `true` with a minted blob.
+    expect(https.request).toHaveBeenCalled()
+    expect(result.licensed).toBe(false)
+    expect(result.license).toBeUndefined()
+  })
+
+  it('still calls the backend with OPLC_LICENSE_MOCK=demo set', async () => {
+    process.env.OPLC_LICENSE_MOCK = 'demo'
+    mockResponse(200, { statusCode: 200, data: { licensed: true, license: GOLDEN_B64 } })
+
+    const result = await checkDeviceActivation(INPUT)
+
+    // A `demo` short-circuit would have returned licensed:false without a request.
+    expect(https.request).toHaveBeenCalled()
+    expect(result.licensed).toBe(true)
+  })
+})
+
+/**
+ * NO proof of possession.
+ *
+ * The activate request used to be preceded by `POST /vpp-licenses/challenge` and
+ * to carry `nonce` + `signature` signed by a keypair derived from the hardware
+ * anchor. All of it is gone: on bare metal the anchor is read inside the closed
+ * license-core and the blob is bound to `deviceId`, so the silicon is what proves
+ * possession. This asserts the absence.
+ */
+describe('checkDeviceActivation (no proof of possession)', () => {
+  it('makes exactly one request, and it is the activate', async () => {
+    const hits: string[] = []
+    jest.spyOn(https, 'request').mockImplementation(((options: unknown, callback: (res: unknown) => void) => {
+      hits.push(options && typeof options === 'object' && 'path' in options ? String(options.path) : '')
+      const req = Object.assign(new EventEmitter(), { write: jest.fn(), end: jest.fn(), setTimeout: jest.fn() })
+      const res = Object.assign(new EventEmitter(), { statusCode: 200, statusMessage: 'OK', setEncoding: jest.fn() })
+      callback(res)
+      req.end.mockImplementation(() => {
+        res.emit('data', JSON.stringify({ statusCode: 200, data: { licensed: true, license: GOLDEN_B64 } }))
+        res.emit('end')
+      })
+      return req as unknown as ReturnType<typeof https.request>
+    }) as typeof https.request)
+
+    const result = await checkDeviceActivation(INPUT)
+
+    expect(result.licensed).toBe(true)
+    // A reintroduced challenge round-trip would show up as a second hit even if
+    // the flow still succeeded.
+    expect(hits).toEqual(['/vpp-licenses/activate'])
+  })
+})
+
+/**
+ * Scheme-driven module selection is what makes local end-to-end testing possible:
+ * `OPENPLC_EDGE_API_URL=http://localhost:3333` must open a PLAIN socket. Sending a
+ * TLS ClientHello to it dies with EPROTO, the catch turns that into a generic
+ * failure, and the editor silently falls back to demo — so the one contract most
+ * worth exercising locally could not be exercised at all.
+ */
+describe('checkDeviceActivation (base URL scheme)', () => {
+  const original = process.env.OPENPLC_EDGE_API_URL
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.OPENPLC_EDGE_API_URL
+    else process.env.OPENPLC_EDGE_API_URL = original
+  })
+
+  it('uses node:http (not https) for an http base URL', async () => {
+    process.env.OPENPLC_EDGE_API_URL = 'http://localhost:3333'
+    const httpsSpy = jest.spyOn(https, 'request')
+    mockResponse(200, { statusCode: 200, data: { licensed: true, license: GOLDEN_B64 } }, http)
+
+    const result = await checkDeviceActivation(INPUT)
+
+    expect(http.request).toHaveBeenCalled()
+    expect(httpsSpy).not.toHaveBeenCalled()
+    expect(result.licensed).toBe(true)
+  })
+})

--- a/src/backend/editor/license/__tests__/license-flow.test.ts
+++ b/src/backend/editor/license/__tests__/license-flow.test.ts
@@ -1,0 +1,425 @@
+import { serializeLicenseBlob } from '../../../shared/debug/license-blob'
+import type { DebugLicenseReadResult, DebugLicenseWriteResult } from '../../../shared/debug/types'
+import { deriveDeviceId, deriveVppId } from '../device-identity'
+import {
+  inspectDeviceLicense,
+  type LicenseReadWritable,
+  resolveDeviceLicense,
+  verifyStoredLicenseBlob,
+} from '../license-flow'
+
+jest.mock('../license-activation-client', () => ({
+  checkDeviceActivation: jest.fn(),
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { checkDeviceActivation } = require('../license-activation-client') as {
+  checkDeviceActivation: jest.Mock
+}
+
+const LIC_SUCCESS = 0x7e
+const LIC_EMPTY = 0x83
+const LIC_UNSUPPORTED = 0x85
+
+/** The real NodeMCU hardware anchor, and the ids that derive from it. */
+const ANCHOR = Uint8Array.from([0, 177, 140, 237])
+const PACKAGE_ID = 'com.openplc.espressif-licensed'
+const DEVICE_ID = deriveDeviceId(ANCHOR)
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  return out
+}
+
+/** A well-formed 98-byte blob for the given device + package. */
+function blobFor({ deviceId = DEVICE_ID, packageId = PACKAGE_ID }: { deviceId?: string; packageId?: string } = {}) {
+  return serializeLicenseBlob({
+    magic: 0, // forced to the canonical magic by the serializer
+    fmtVersion: 1,
+    keyId: 0,
+    deviceId: hexToBytes(deviceId),
+    productId: hexToBytes(deriveVppId(packageId)),
+    signature: new Uint8Array(64).fill(7),
+    crc32: 0, // recomputed by the serializer
+  })
+}
+
+/** A scripted transport: successive readLicense() calls pop the queue. */
+function transport(script: {
+  reads: DebugLicenseReadResult[]
+  write?: DebugLicenseWriteResult
+}): LicenseReadWritable & { writes: Uint8Array[]; readCount: () => number } {
+  const reads = [...script.reads]
+  const writes: Uint8Array[] = []
+  let readCount = 0
+  return {
+    writes,
+    readCount: () => readCount,
+    readLicense: () => {
+      readCount++
+      const next = reads.shift()
+      if (!next) throw new Error('test transport: unexpected extra readLicense()')
+      return Promise.resolve(next)
+    },
+    writeLicense: (blob: Uint8Array) => {
+      writes.push(blob)
+      return Promise.resolve(script.write ?? { success: true, status: LIC_SUCCESS })
+    },
+  }
+}
+
+beforeEach(() => {
+  checkDeviceActivation.mockReset()
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// verifyStoredLicenseBlob
+// ---------------------------------------------------------------------------
+
+describe('verifyStoredLicenseBlob', () => {
+  it('accepts a blob bound to this device and this package', () => {
+    expect(verifyStoredLicenseBlob(blobFor(), DEVICE_ID, PACKAGE_ID)).toEqual({ ok: true })
+  })
+
+  it('rejects a blob bound to ANOTHER device (the clone case)', () => {
+    // Valid bytes, wrong board. The device answers 0x7E for it and the closed
+    // gate answers DEVICE_MISMATCH — believing the status byte here is what makes
+    // the badge say "Licensed" on a board running demo.
+    const other = deriveDeviceId(Uint8Array.from([9, 9, 9, 9]))
+    const verdict = verifyStoredLicenseBlob(blobFor({ deviceId: other }), DEVICE_ID, PACKAGE_ID)
+
+    expect(verdict).toEqual({ ok: false, reason: `stored license is bound to device ${other}, not ${DEVICE_ID}` })
+  })
+
+  it('rejects a blob issued for another VPP', () => {
+    const verdict = verifyStoredLicenseBlob(blobFor({ packageId: 'com.openplc.other-licensed' }), DEVICE_ID, PACKAGE_ID)
+
+    expect(verdict.ok).toBe(false)
+    if (!verdict.ok) expect(verdict.reason).toMatch(/stored license is for product/)
+  })
+
+  it('rejects a blob whose crc32 does not cover its bytes (tampered or truncated in place)', () => {
+    const tampered = blobFor()
+    tampered[40] ^= 0xff // flip a signature byte; the stored crc32 no longer matches
+
+    const verdict = verifyStoredLicenseBlob(tampered, DEVICE_ID, PACKAGE_ID)
+
+    expect(verdict.ok).toBe(false)
+    if (!verdict.ok) expect(verdict.reason).toMatch(/crc32/)
+  })
+
+  it('rejects a blob with no OPLC magic', () => {
+    const noMagic = blobFor()
+    noMagic[0] = 0x00
+
+    const verdict = verifyStoredLicenseBlob(noMagic, DEVICE_ID, PACKAGE_ID)
+
+    expect(verdict.ok).toBe(false)
+    // Magic is checked before crc32, so the message names the real problem.
+    if (!verdict.ok) expect(verdict.reason).toMatch(/no OPLC magic/)
+  })
+
+  it('rejects a short or absent blob rather than parsing past the end', () => {
+    expect(verifyStoredLicenseBlob(undefined, DEVICE_ID, PACKAGE_ID)).toEqual({
+      ok: false,
+      reason: 'stored license is 0 bytes, expected 98',
+    })
+    expect(verifyStoredLicenseBlob(blobFor().subarray(0, 40), DEVICE_ID, PACKAGE_ID)).toEqual({
+      ok: false,
+      reason: 'stored license is 40 bytes, expected 98',
+    })
+  })
+
+  it('leaves productId unverified when no package id is known, rather than assuming it good', () => {
+    const foreign = blobFor({ packageId: 'com.openplc.other-licensed' })
+
+    expect(verifyStoredLicenseBlob(foreign, DEVICE_ID, undefined)).toEqual({ ok: true })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveDeviceLicense
+// ---------------------------------------------------------------------------
+
+describe('resolveDeviceLicense', () => {
+  it('reports an already-stored license without asking the backend', async () => {
+    const link = transport({ reads: [{ success: true, status: LIC_SUCCESS, blob: blobFor() }] })
+
+    const result = await resolveDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result).toEqual({ deviceId: DEVICE_ID, outcome: { state: 'licensed', how: 'already-stored' } })
+    expect(checkDeviceActivation).not.toHaveBeenCalled()
+    expect(link.writes).toHaveLength(0)
+  })
+
+  it('recovers from the backend when storage is empty, then re-reads to confirm', async () => {
+    const blob = blobFor()
+    checkDeviceActivation.mockResolvedValue({ licensed: true, license: Array.from(blob) })
+    const link = transport({
+      reads: [
+        { success: true, status: LIC_EMPTY, empty: true },
+        { success: true, status: LIC_SUCCESS, blob },
+      ],
+    })
+
+    const result = await resolveDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result).toEqual({ deviceId: DEVICE_ID, outcome: { state: 'licensed', how: 'activated' } })
+    expect(checkDeviceActivation).toHaveBeenCalledWith({ deviceId: DEVICE_ID, packageId: PACKAGE_ID })
+    expect(Array.from(link.writes[0])).toEqual(Array.from(blob))
+    // Two reads: the initial probe and the mandatory read-back.
+    expect(link.readCount()).toBe(2)
+  })
+
+  it('FALLS THROUGH to recovery when the device reports a license that does not verify', async () => {
+    // 0x7E with a blob for another board. This is the case recovery exists for:
+    // believing the status byte would skip the only automatic repair path and
+    // leave the board in demo with a "Licensed" badge.
+    const foreign = blobFor({ deviceId: deriveDeviceId(Uint8Array.from([1, 2, 3, 4])) })
+    const good = blobFor()
+    checkDeviceActivation.mockResolvedValue({ licensed: true, license: Array.from(good) })
+    const link = transport({
+      reads: [
+        { success: true, status: LIC_SUCCESS, blob: foreign },
+        { success: true, status: LIC_SUCCESS, blob: good },
+      ],
+    })
+
+    const result = await resolveDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(checkDeviceActivation).toHaveBeenCalled()
+    expect(result.outcome).toEqual({ state: 'licensed', how: 'activated' })
+  })
+
+  it('reports unlicensed (demo + buy) when the backend says there is no purchase', async () => {
+    checkDeviceActivation.mockResolvedValue({ licensed: false, reason: 'no active subscription' })
+    const link = transport({ reads: [{ success: true, status: LIC_EMPTY, empty: true }] })
+
+    const result = await resolveDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    // `entitlementChecked: true` is what earns the UI the right to offer a
+    // purchase: the backend WAS asked and said no.
+    expect(result.outcome).toEqual({
+      state: 'unlicensed',
+      entitlementChecked: true,
+      backendReason: 'no active subscription',
+    })
+    expect(link.writes).toHaveLength(0)
+  })
+
+  it('reports check-failed — NOT unlicensed — when the backend could not be reached', async () => {
+    // The distinction that matters most in this module: collapsing a transport
+    // failure into "no purchase" tells someone who already paid to buy again.
+    checkDeviceActivation.mockResolvedValue({ licensed: false, error: 'Activation request failed: 429' })
+    const link = transport({ reads: [{ success: true, status: LIC_EMPTY, empty: true }] })
+
+    const result = await resolveDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result.outcome).toEqual({ state: 'check-failed', error: 'Activation request failed: 429' })
+  })
+
+  it('reports unsupported when the device has no storage backend', async () => {
+    const link = transport({ reads: [{ success: true, status: LIC_UNSUPPORTED, unsupported: true }] })
+
+    const result = await resolveDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result).toEqual({ deviceId: DEVICE_ID, outcome: { state: 'unsupported' } })
+    expect(checkDeviceActivation).not.toHaveBeenCalled()
+  })
+
+  it('never derives an id from an empty anchor', async () => {
+    // sha256(prefix || <nothing>) is a CONSTANT: every board without a unique id
+    // would share one device id, so one purchase would license the whole fleet.
+    const link = transport({ reads: [] })
+
+    const result = await resolveDeviceLicense(link, { anchor: new Uint8Array(0), packageId: PACKAGE_ID })
+
+    expect(result.deviceId).toBeUndefined()
+    expect(result.outcome.state).toBe('check-failed')
+    if (result.outcome.state === 'check-failed') {
+      expect(result.outcome.error).toMatch(/no unique hardware id/)
+    }
+    expect(link.readCount()).toBe(0)
+    expect(checkDeviceActivation).not.toHaveBeenCalled()
+  })
+
+  it('reports check-failed when the device does not answer the read at all', async () => {
+    const link = transport({ reads: [{ success: false, error: 'Request timeout' }] })
+
+    const result = await resolveDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result).toEqual({ deviceId: DEVICE_ID, outcome: { state: 'check-failed', error: 'Request timeout' } })
+  })
+
+  it('does not assert possession when the write succeeds but the read-back does not verify', async () => {
+    // 0x49 only stores bytes — no target validates them on write. A blob truncated
+    // in flight would otherwise read as "Licensed" while the board runs demo.
+    const good = blobFor()
+    const truncated = blobFor().subarray(0, 60)
+    checkDeviceActivation.mockResolvedValue({ licensed: true, license: Array.from(good) })
+    const link = transport({
+      reads: [
+        { success: true, status: LIC_EMPTY, empty: true },
+        { success: true, status: LIC_SUCCESS, blob: truncated },
+      ],
+    })
+
+    const result = await resolveDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result.outcome.state).toBe('check-failed')
+    if (result.outcome.state === 'check-failed') {
+      expect(result.outcome.error).toMatch(/written but could not be confirmed on the device/)
+    }
+  })
+
+  it('does not assert possession when the read-back itself fails', async () => {
+    checkDeviceActivation.mockResolvedValue({ licensed: true, license: Array.from(blobFor()) })
+    const link = transport({
+      reads: [
+        { success: true, status: LIC_EMPTY, empty: true },
+        { success: false, error: 'Request timeout' },
+      ],
+    })
+
+    const result = await resolveDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result.outcome.state).toBe('check-failed')
+    if (result.outcome.state === 'check-failed') {
+      expect(result.outcome.error).toMatch(/the read-back failed/)
+    }
+  })
+
+  it('reports unsupported when the WRITE is the thing that reveals no storage backend', async () => {
+    checkDeviceActivation.mockResolvedValue({ licensed: true, license: Array.from(blobFor()) })
+    const link = transport({
+      reads: [{ success: true, status: LIC_EMPTY, empty: true }],
+      write: { success: true, status: LIC_UNSUPPORTED, unsupported: true },
+    })
+
+    const result = await resolveDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result.outcome).toEqual({ state: 'unsupported' })
+  })
+
+  it('reports check-failed when the write is refused', async () => {
+    checkDeviceActivation.mockResolvedValue({ licensed: true, license: Array.from(blobFor()) })
+    const link = transport({
+      reads: [{ success: true, status: LIC_EMPTY, empty: true }],
+      write: { success: false, error: 'ERROR_OUT_OF_MEMORY' },
+    })
+
+    const result = await resolveDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result.outcome).toEqual({ state: 'check-failed', error: 'ERROR_OUT_OF_MEMORY' })
+  })
+
+  it('reports check-failed when the backend claims licensed but returns no blob', async () => {
+    checkDeviceActivation.mockResolvedValue({ licensed: true })
+    const link = transport({ reads: [{ success: true, status: LIC_EMPTY, empty: true }] })
+
+    const result = await resolveDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result.outcome.state).toBe('check-failed')
+    if (result.outcome.state === 'check-failed') {
+      expect(result.outcome.error).toMatch(/no blob to write/)
+    }
+    expect(link.writes).toHaveLength(0)
+  })
+
+  it('turns an unexpected throw from the transport into check-failed, never a rejection', async () => {
+    const link: LicenseReadWritable = {
+      readLicense: () => Promise.reject(new Error('port closed')),
+      writeLicense: () => Promise.resolve({ success: true }),
+    }
+
+    const result = await resolveDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result).toEqual({ deviceId: DEVICE_ID, outcome: { state: 'check-failed', error: 'port closed' } })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// inspectDeviceLicense — read + verify, never the network
+// ---------------------------------------------------------------------------
+
+describe('inspectDeviceLicense', () => {
+  it('confirms a stored, verified license', async () => {
+    const link = transport({ reads: [{ success: true, status: LIC_SUCCESS, blob: blobFor() }] })
+
+    const result = await inspectDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result).toEqual({ deviceId: DEVICE_ID, outcome: { state: 'licensed', how: 'already-stored' } })
+  })
+
+  it('NEVER contacts the backend, even when the device holds nothing', async () => {
+    const link = transport({ reads: [{ success: true, status: LIC_EMPTY, empty: true }] })
+
+    await inspectDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    // The whole point of this entry point: cheap enough for a screen open.
+    expect(checkDeviceActivation).not.toHaveBeenCalled()
+    expect(link.writes).toHaveLength(0)
+  })
+
+  it('reports unlicensed with entitlementChecked:false, so the UI offers a refresh and not a purchase', async () => {
+    // Nobody has asked whether a purchase exists. Rendering this as "buy a
+    // license" would be a guess, and the wrong one for anyone who already paid.
+    const link = transport({ reads: [{ success: true, status: LIC_EMPTY, empty: true }] })
+
+    const result = await inspectDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result.outcome).toEqual({ state: 'unlicensed', entitlementChecked: false })
+  })
+
+  it('treats a stored blob that fails verification as not licensed, not as licensed', async () => {
+    const foreign = blobFor({ deviceId: deriveDeviceId(Uint8Array.from([1, 2, 3, 4])) })
+    const link = transport({ reads: [{ success: true, status: LIC_SUCCESS, blob: foreign }] })
+
+    const result = await inspectDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result.outcome).toEqual({ state: 'unlicensed', entitlementChecked: false })
+  })
+
+  it('reports unsupported when the device has no storage backend', async () => {
+    const link = transport({ reads: [{ success: true, status: LIC_UNSUPPORTED, unsupported: true }] })
+
+    const result = await inspectDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result.outcome).toEqual({ state: 'unsupported' })
+  })
+
+  it('reports check-failed when the device does not answer', async () => {
+    const link = transport({ reads: [{ success: false, error: 'Request timeout' }] })
+
+    const result = await inspectDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result.outcome).toEqual({ state: 'check-failed', error: 'Request timeout' })
+  })
+
+  it('refuses an empty anchor without reading anything', async () => {
+    const link = transport({ reads: [] })
+
+    const result = await inspectDeviceLicense(link, { anchor: new Uint8Array(0), packageId: PACKAGE_ID })
+
+    expect(result.deviceId).toBeUndefined()
+    expect(result.outcome.state).toBe('check-failed')
+    expect(link.readCount()).toBe(0)
+  })
+
+  it('turns an unexpected throw into check-failed', async () => {
+    const link: LicenseReadWritable = {
+      readLicense: () => Promise.reject(new Error('port closed')),
+      writeLicense: () => Promise.resolve({ success: true }),
+    }
+
+    const result = await inspectDeviceLicense(link, { anchor: ANCHOR, packageId: PACKAGE_ID })
+
+    expect(result).toEqual({ deviceId: DEVICE_ID, outcome: { state: 'check-failed', error: 'port closed' } })
+  })
+})

--- a/src/backend/editor/license/device-identity.ts
+++ b/src/backend/editor/license/device-identity.ts
@@ -1,0 +1,72 @@
+/**
+ * License-identity derivation helpers.
+ *
+ * Both identifiers are deterministic SHA-256 digests, truncated to a
+ * fixed prefix and hex-encoded. They run in the Electron **main**
+ * process during the licensing routine, so they use `node:crypto`
+ * directly.
+ *
+ * This module lives under `backend/editor` (not the byte-identical
+ * `backend/shared` surface): `backend/shared` must compile identically
+ * for both openplc-editor and openplc-web and therefore cannot depend
+ * on `node:crypto`. The derivation only ever runs main-side, so an
+ * editor-only home is the correct boundary.
+ *
+ * CROSS-REPO CONTRACT. `deriveDeviceId` output is the PRIMARY KEY the
+ * autonomy-edge backend stores a purchase and a license against, and it
+ * accepts only LOWERCASE hex (`canonical-device-id.ts` there). `digest('hex')`
+ * is already lowercase, so this holds by construction — but nothing downstream
+ * may upper-case it: a purchase recorded as `7146…E5` and an activation for
+ * `7146…e5` become two devices, the customer pays, the seat check finds
+ * nothing, and the board runs demo with no error saying why.
+ */
+
+import { createHash } from 'node:crypto'
+
+/** Domain-separation prefix for the device-id digest. Mixed
+ *  in as raw ASCII bytes ahead of the hardware anchor so the same anchor
+ *  can never collide with any other `sha256`-derived identifier. */
+const DEVICE_ID_PREFIX = 'openplc-dev-v1|'
+
+/** Device id = first 16 bytes of the digest (matches `lic_blob_t.deviceId`). */
+const DEVICE_ID_BYTES = 16
+
+/** VPP id = first 8 bytes of the digest (matches `lic_blob_t.productId`). */
+const VPP_ID_BYTES = 8
+
+/**
+ * Derive the 16-byte device identifier from a hardware anchor.
+ *
+ * `deviceId = sha256("openplc-dev-v1|" || anchor)[:16]`, hex-encoded
+ * (32 lowercase hex chars). The prefix is concatenated as ASCII bytes
+ * directly in front of the anchor bytes in a single buffer, so the
+ * hash input is exactly `<prefix bytes><anchor bytes>`.
+ */
+export function deriveDeviceId(anchor: Uint8Array): string {
+  // Single contiguous buffer: <prefix ASCII bytes><anchor bytes>. Built as
+  // a plain Uint8Array (the prefix is ASCII, so its UTF-8 encoding is
+  // byte-for-byte the ASCII bytes) to hand `createHash` a plain Uint8Array.
+  const prefix = Uint8Array.from(DEVICE_ID_PREFIX, (c) => c.charCodeAt(0))
+  const input = new Uint8Array(prefix.length + anchor.length)
+  input.set(prefix, 0)
+  input.set(anchor, prefix.length)
+  return createHash('sha256')
+    .update(input)
+    .digest('hex')
+    .slice(0, DEVICE_ID_BYTES * 2)
+}
+
+/**
+ * Derive the 8-byte VPP (product) identifier from a package id.
+ *
+ * `vppId = sha256(packageId)[:8]`, hex-encoded (16 lowercase hex
+ * chars). Must match `product_id[8]` of the on-device license blob
+ * so the firmware can bind a written license to its VPP.
+ */
+export function deriveVppId(packageId: string): string {
+  // Hash the package id as its UTF-8 (== ASCII) bytes.
+  return createHash('sha256')
+    .update(packageId)
+    .digest('hex')
+    .slice(0, VPP_ID_BYTES * 2)
+}

--- a/src/backend/editor/license/license-activation-client.ts
+++ b/src/backend/editor/license/license-activation-client.ts
@@ -1,0 +1,200 @@
+/**
+ * Device license-activation client — the editor's only call to the licensing
+ * backend.
+ *
+ * `POST {edge}/vpp-licenses/activate` with `{ deviceId, packageId }` answers
+ * `{ licensed, deviceId, vppId, license }`, where `license` is the signed 98-byte
+ * blob base64-encoded. The route is PUBLIC and rate-limited: the editor has no
+ * login, and authorization is the seat/entitlement check server-side, not a
+ * token. It is idempotent — an already-licensed device gets the same blob back
+ * without consuming another seat — which is what makes it safe to call on every
+ * connect.
+ *
+ * NO PROOF OF POSSESSION. The activate body carries no nonce or signature. What
+ * makes that safe is the bare-metal premise: the hardware anchor is read INSIDE
+ * the closed license-core and the blob is bound to `deviceId`, so a blob only
+ * ever runs FULL on the silicon it names. Handing one to whoever knows the id
+ * benefits nobody with different hardware.
+ *
+ * WHAT THAT COSTS, EXPLICITLY: `/activate` is a blob distributor keyed on a
+ * PUBLIC identifier, which allows early harvesting (collect blobs now, use them
+ * the day forging an identity gets cheap) and works as an inventory oracle. Both
+ * are accepted, and both depend on the anchor staying unforgeable.
+ *
+ * NO DEV MOCK. An earlier revision carried a dev-build-only signer
+ * (`OPLC_LICENSE_MOCK` / `OPLC_LICENSE_MOCK_KEY`) that minted real, device-bound
+ * blobs locally. It is deliberately absent: the local test path now runs the REAL
+ * backend against the REAL per-VPP key (see `scripts/seed-vpp-licensing-local.ts`
+ * in autonomy-edge), so the mock bought nothing a developer needs while putting a
+ * license-minting path one key leak away from unlimited offline licenses. Point
+ * `OPENPLC_EDGE_API_URL` at the local backend instead — `httpModuleFor` makes a
+ * plain-http base URL work.
+ *
+ * Runs main-side: uses `node:http`/`node:https` and the same base-URL /
+ * `{ statusCode, data }` envelope conventions as the library catalog client.
+ */
+
+import { LIC_BLOB_SIZE } from '../../shared/debug/license-blob'
+import { getEdgeApiBaseUrl } from '../library-manager/desktop-catalog-transport'
+import { defaultPortFor, httpModuleFor } from '../utils/http-module'
+
+/**
+ * Input to `checkDeviceActivation` — exactly the two fields the wire accepts.
+ *
+ * There is deliberately no `vppId` or `keyId` here. Both existed only to feed the
+ * removed dev signer: `ActivateVppLicenseDto` has no such field, and the backend
+ * derives its own product and signing-key material from `packageId`. Keeping them
+ * would advertise a choice the caller does not have.
+ */
+export interface DeviceActivationInput {
+  /** 16-byte device id, LOWERCASE hex (from `deriveDeviceId`). */
+  deviceId: string
+  /** VPP package id (e.g. `com.openplc.espressif-licensed`) — `package.id`. */
+  packageId: string
+}
+
+/**
+ * Result of an activation check. Best-effort: transport / backend errors surface
+ * as `{ licensed: false, error }` rather than throwing, so the licensing routine
+ * can degrade without a hard failure.
+ *
+ * `reason` and `error` are SEPARATE on purpose and callers must keep them apart.
+ * `reason` is the backend's business answer ("no purchase on record") and means
+ * demo mode is correct. `error` means we never got an answer — a 429 from the
+ * rate limiter, a 503 when no signer is configured, a 404 for an unknown package,
+ * a dropped connection. Collapsing the two tells someone who already owns a
+ * license to go buy one.
+ */
+export interface DeviceActivationResult {
+  licensed: boolean
+  /** License blob bytes (98 B) when `licensed` — ready to write via FC 0x49. */
+  license?: number[]
+  /** Backend-supplied reason (e.g. "no active subscription"). */
+  reason?: string
+  /** Populated on transport / backend failure (best-effort path). */
+  error?: string
+}
+
+/** The exact JSON body `ActivateVppLicenseDto` accepts. */
+interface EdgeActivationRequestBody {
+  deviceId: string
+  packageId: string
+}
+
+/** Response shape from the edge activation endpoint. */
+interface EdgeActivationResponse {
+  licensed: boolean
+  /** 98-byte license blob, base64-encoded. */
+  license?: string
+  reason?: string
+}
+
+const ACTIVATE_PATH = '/vpp-licenses/activate'
+const REQUEST_TIMEOUT_MS = 30_000
+
+/**
+ * Ask the backend whether this device is entitled to a license for this VPP, and
+ * get the signed blob when it is.
+ *
+ * Any failure (route missing → 404, network, non-2xx, bad JSON, wrong blob size)
+ * resolves to `{ licensed: false, error }` — never throws.
+ */
+export async function checkDeviceActivation(input: DeviceActivationInput): Promise<DeviceActivationResult> {
+  try {
+    const body: EdgeActivationRequestBody = { deviceId: input.deviceId, packageId: input.packageId }
+    const raw = await postJson(`${getEdgeApiBaseUrl()}${ACTIVATE_PATH}`, body)
+    const data = unwrapHttpEnvelope(raw) as Partial<EdgeActivationResponse> | undefined
+
+    if (!data || typeof data.licensed !== 'boolean') {
+      return { licensed: false, error: 'Unexpected activation response shape' }
+    }
+    if (!data.licensed) return { licensed: false, reason: data.reason }
+    if (typeof data.license !== 'string') {
+      return { licensed: false, error: 'Activation response missing license blob' }
+    }
+
+    // `Buffer.from(s, 'base64')` NEVER throws: the decoder silently skips invalid
+    // characters and tolerates missing padding, so a truncated or corrupted field
+    // yields a SHORT buffer instead of an error. Writing that to the device
+    // produces a LIC_CORRUPT rejection whose message points at the hardware,
+    // giving no hint that the backend sent something malformed. Check the length.
+    const blob = Buffer.from(data.license, 'base64')
+    if (blob.length !== LIC_BLOB_SIZE) {
+      return {
+        licensed: false,
+        error: `Activation response license blob is ${blob.length} bytes, expected ${LIC_BLOB_SIZE}`,
+      }
+    }
+
+    return { licensed: true, license: Array.from(blob), reason: data.reason }
+  } catch (err) {
+    return { licensed: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+function postJson(url: string, body: unknown): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url)
+    const payload = JSON.stringify(body)
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Content-Length': String(Buffer.byteLength(payload)),
+      Accept: 'application/json',
+      'User-Agent': 'OpenPLC-Editor/license-activation',
+    }
+    // Sent when available. The route is anonymous today; an account token, when
+    // there is an authority to issue one, ties the purchase to a user. Without it
+    // the request still goes out and a 401/404 lands on the best-effort path.
+    const token = process.env.OPENPLC_EDGE_TOKEN?.trim()
+    if (token) headers.Authorization = `Bearer ${token}`
+
+    // Scheme-driven, so OPENPLC_EDGE_API_URL can point at a local http backend
+    // for end-to-end testing. Production hosts stay https either way.
+    const req = httpModuleFor(parsed).request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port || defaultPortFor(parsed),
+        path: parsed.pathname + parsed.search,
+        method: 'POST',
+        headers,
+      },
+      (res) => {
+        let responseBody = ''
+        res.setEncoding('utf-8')
+        res.on('data', (chunk: string) => {
+          responseBody += chunk
+        })
+        res.on('end', () => {
+          const status = res.statusCode ?? 0
+          if (status < 200 || status >= 300) {
+            reject(new Error(`Activation request failed: ${status} ${res.statusMessage ?? ''}`.trim()))
+            return
+          }
+          try {
+            resolve(JSON.parse(responseBody))
+          } catch (err) {
+            reject(
+              new Error(`Activation response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`),
+            )
+          }
+        })
+      },
+    )
+
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      req.destroy(new Error(`Activation request timed out after ${REQUEST_TIMEOUT_MS}ms`))
+    })
+    req.on('error', (err) => reject(err))
+    req.write(payload)
+    req.end()
+  })
+}
+
+/** autonomy-edge wraps JSON responses in `{ statusCode, data }`. Unwrap once so
+ *  callers see the payload; off-spec responses fall through unchanged. */
+function unwrapHttpEnvelope(raw: unknown): unknown {
+  if (raw && typeof raw === 'object' && 'data' in raw && 'statusCode' in raw) {
+    return (raw as { data: unknown }).data
+  }
+  return raw
+}

--- a/src/backend/editor/license/license-flow.ts
+++ b/src/backend/editor/license/license-flow.ts
@@ -1,0 +1,344 @@
+/**
+ * The VPP licensing machine: read what the device holds, decide whether to
+ * believe it, and recover from the backend when it is absent or wrong.
+ *
+ * Runs over an ALREADY-CONNECTED transport — it neither connects nor
+ * disconnects. The caller holds the link open, so classification, the on-device
+ * read (0x4A), the backend call and the write (0x49) all happen over a SINGLE
+ * port open. Pure orchestration over the transport plus the activation client, so
+ * it is unit-testable with mocks, and it never throws: every failure resolves to
+ * an outcome.
+ *
+ * Lives under `backend/editor` rather than the byte-identical `backend/shared`
+ * surface because it depends on `deriveDeviceId`, which needs `node:crypto`.
+ */
+
+import type { DeviceLicenseReport, DeviceLicenseState } from '../../../middleware/shared/ports/device-port'
+import { crc32IsoHdlc, deserializeLicenseBlob, LIC_BLOB_SIZE, LIC_MAGIC_LE } from '../../shared/debug/license-blob'
+import type { DebugLicenseReadResult, DebugLicenseWriteResult } from '../../shared/debug/types'
+import { deriveDeviceId, deriveVppId } from './device-identity'
+import { checkDeviceActivation } from './license-activation-client'
+
+/** Just enough of a transport to run the licensing FCs. */
+export interface LicenseReadWritable {
+  readLicense(): Promise<DebugLicenseReadResult>
+  writeLicense(blob: Uint8Array): Promise<DebugLicenseWriteResult>
+}
+
+/** SUCCESS status byte of a read-license (0x4A) response = a stored license. */
+const LIC_STATUS_SUCCESS = 0x7e
+/** LIC_UNSUPPORTED status byte (no on-device storage backend). */
+const LIC_STATUS_UNSUPPORTED = 0x85
+/** crc32 covers `[payload || signature]` = offsets 0..93; it never covers itself. */
+const LIC_CRC_COVERAGE = 94
+
+/**
+ * The outcome shape is the PORT's `DeviceLicenseState`, not a private one.
+ *
+ * Deliberately not a second type mapped at the IPC boundary: the union's whole
+ * value is that `unlicensed` (the backend says there is no purchase) and
+ * `check-failed` (we could not find out) cannot be collapsed into each other, and
+ * a hand-written mapper between two near-identical unions is exactly where that
+ * distinction gets quietly lost. One type, one meaning, all the way to the badge.
+ */
+export type { DeviceLicenseReport, DeviceLicenseState }
+
+export interface DeviceLicenseInput {
+  /** Raw hardware anchor bytes from the board-id read (FC 0x48). */
+  anchor: Uint8Array
+  /** Reverse-domain VPP package id (`package.id`) from `resolveLicensingTarget`. */
+  packageId: string
+}
+
+/**
+ * Verify a blob the device handed back on 0x4A: magic, crc32, `deviceId` and
+ * `productId`.
+ *
+ * WHY THIS EXISTS. The `0x7E` status byte does NOT mean "the stored license is
+ * good" — the two targets disagree about what it means. Bare metal validates
+ * magic + crc32 inside its store read; the Linux runtime checks ONLY that the
+ * file is 98 bytes long. So on a Pi a blob cloned from another board, or one
+ * half-written, answers `0x7E`. A caller that believed it would report
+ * `already-licensed` and NEVER ASK THE BACKEND — skipping the one automatic
+ * repair path there is. The closed license-core then refuses the blob and the
+ * board runs demo, stopping actuation 15 minutes in, while the badge says
+ * "Licensed".
+ *
+ * WHAT IT PROVES AND WHAT IT DOES NOT. It proves the bytes are a well-formed
+ * license FOR THIS DEVICE AND THIS VPP: length, magic, crc32 over 0..93, the
+ * 16-byte `deviceId` equal to the id derived from the anchor we just read, and
+ * the 8-byte `productId` equal to the id derived from this package. It does NOT
+ * verify the ECDSA signature or the `keyId`, so it cannot say the closed gate
+ * will run FULL — only the license-core can. Anything asserted in the UI must
+ * stay inside that boundary, which is why the badge says "Licensed" (possession)
+ * and never "Full mode" (execution).
+ *
+ * `productId` is checked only when a `packageId` is known; without one there is
+ * nothing to compare against and the field is left unverified rather than
+ * assumed good.
+ *
+ * Built on the shared `license-blob.ts` (`deserializeLicenseBlob`,
+ * `crc32IsoHdlc`) rather than a second parser: that module is byte-identical
+ * with openplc-web and cross-pinned to the C struct by a golden vector. A
+ * private re-implementation here is exactly the divergence this avoids.
+ */
+export function verifyStoredLicenseBlob(
+  blob: Uint8Array | undefined,
+  deviceIdHex: string,
+  packageId: string | undefined,
+): { ok: true } | { ok: false; reason: string } {
+  if (!blob || blob.length !== LIC_BLOB_SIZE) {
+    // A 0x7E with no (or a short) blob is itself off-contract: the parser only
+    // fills `blob` when the device sent all `len` bytes. Treat as unverified.
+    return { ok: false, reason: `stored license is ${blob?.length ?? 0} bytes, expected ${LIC_BLOB_SIZE}` }
+  }
+
+  const parsed = deserializeLicenseBlob(blob)
+
+  if (parsed.magic !== LIC_MAGIC_LE) {
+    return { ok: false, reason: 'stored license has no OPLC magic' }
+  }
+
+  const expectedCrc = crc32IsoHdlc(blob.subarray(0, LIC_CRC_COVERAGE))
+  if (parsed.crc32 !== expectedCrc) {
+    return { ok: false, reason: 'stored license fails its crc32 (truncated or corrupted)' }
+  }
+
+  const blobDeviceId = bytesToHex(parsed.deviceId)
+  if (blobDeviceId !== deviceIdHex) {
+    // The clone case: valid bytes, wrong board. The gate answers DEVICE_MISMATCH.
+    return { ok: false, reason: `stored license is bound to device ${blobDeviceId}, not ${deviceIdHex}` }
+  }
+
+  if (packageId) {
+    const expectedProductId = deriveVppId(packageId)
+    const blobProductId = bytesToHex(parsed.productId)
+    if (blobProductId !== expectedProductId) {
+      return { ok: false, reason: `stored license is for product ${blobProductId}, not ${expectedProductId}` }
+    }
+  }
+
+  return { ok: true }
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = ''
+  for (const byte of bytes) out += byte.toString(16).padStart(2, '0')
+  return out
+}
+
+/**
+ * Run the licensing step for a licensable board over a live link.
+ *
+ * The caller has already decided the board is licensable
+ * (`resolveLicensingTarget`) and already read its anchor while classifying the
+ * link, so no round trip is repeated here.
+ *
+ * Sequence:
+ *   1. Derive `deviceId` from the anchor. No anchor -> `check-failed`.
+ *   2. Read 0x4A. `LIC_UNSUPPORTED` -> `unsupported`.
+ *   3. If a blob came back, VERIFY it. Good -> `licensed / already-stored`.
+ *      Bad -> fall through to recovery, which is the only automatic repair.
+ *   4. Ask the backend. No entitlement -> `unlicensed`. Failure -> `check-failed`.
+ *   5. Write 0x49, then RE-READ and re-verify. Never trust the write.
+ */
+export async function resolveDeviceLicense(
+  transport: LicenseReadWritable,
+  input: DeviceLicenseInput,
+): Promise<DeviceLicenseReport> {
+  const identity = deriveIdentity(input.anchor)
+  if ('outcome' in identity) return identity
+  const { deviceId } = identity
+
+  try {
+    const stored = await readAndVerify(transport, deviceId, input)
+    if (stored.kind !== 'absent') return { deviceId, outcome: stored.outcome }
+
+    return await recoverLicense(transport, { deviceId, packageId: input.packageId })
+  } catch (error) {
+    return { deviceId, outcome: { state: 'check-failed', error: errorMessage(error) } }
+  }
+}
+
+/**
+ * Read what the device is holding and verify it — WITHOUT contacting the backend.
+ *
+ * Answers "is this board licensed right now?", which is the question the badge
+ * asks. Cheap enough for a screen open or a poll, because it is one Modbus frame
+ * and some arithmetic.
+ *
+ * Note what it CANNOT say: `unlicensed` here always carries
+ * `entitlementChecked: false`, because nobody has asked whether a purchase
+ * exists. A caller that rendered that as "buy a license" would be guessing —
+ * offer a refresh instead.
+ */
+export async function inspectDeviceLicense(
+  transport: LicenseReadWritable,
+  input: DeviceLicenseInput,
+): Promise<DeviceLicenseReport> {
+  const identity = deriveIdentity(input.anchor)
+  if ('outcome' in identity) return identity
+  const { deviceId } = identity
+
+  try {
+    const stored = await readAndVerify(transport, deviceId, input)
+    if (stored.kind === 'absent') {
+      return { deviceId, outcome: { state: 'unlicensed', entitlementChecked: false, ...stored.detail } }
+    }
+    return { deviceId, outcome: stored.outcome }
+  } catch (error) {
+    return { deviceId, outcome: { state: 'check-failed', error: errorMessage(error) } }
+  }
+}
+
+/**
+ * Derive the licensing identity, or explain why there is none.
+ *
+ * An anchor of zero bytes is a REAL reply, not a failure: cores without
+ * ArduinoUniqueID support, and boards that opt out with `OPENPLC_NO_UNIQUE_ID`,
+ * answer `id_len = 0` rather than fail to compile, and the link classifier
+ * correctly counts that as "firmware present".
+ *
+ * It is fatal HERE, and must be caught before deriving anything, because
+ * `sha256(prefix || <nothing>)` is a CONSTANT: every such board would share one
+ * device id, so one purchase would license an entire fleet and a license issued
+ * for one board would verify on all of them.
+ */
+function deriveIdentity(anchor: Uint8Array): { deviceId: string } | DeviceLicenseReport {
+  if (anchor.length === 0) {
+    return {
+      outcome: {
+        state: 'check-failed',
+        error:
+          'this board reports no unique hardware id, so no license can be bound to it. ' +
+          'A licensed VPP requires a board whose core exposes a unique id.',
+      },
+    }
+  }
+  return { deviceId: deriveDeviceId(anchor) }
+}
+
+/**
+ * The read-and-verify step both entry points share.
+ *
+ * `absent` is not an outcome: it means "the device holds nothing usable", and what
+ * that IMPLIES differs between the two callers — a refresh recovers from it, an
+ * inspect can only report it. Returning a marker instead of an outcome is what
+ * keeps that decision at the call site instead of buried here.
+ */
+type StoredLicenseVerdict =
+  | { kind: 'settled'; outcome: DeviceLicenseState }
+  | { kind: 'absent'; detail?: { backendReason?: string } }
+
+async function readAndVerify(
+  transport: LicenseReadWritable,
+  deviceId: string,
+  input: DeviceLicenseInput,
+): Promise<StoredLicenseVerdict> {
+  const stored = await transport.readLicense()
+
+  if (!stored.success) {
+    return {
+      kind: 'settled',
+      outcome: { state: 'check-failed', error: stored.error ?? 'the device did not answer 0x4A' },
+    }
+  }
+
+  if (stored.status === LIC_STATUS_UNSUPPORTED || stored.unsupported) {
+    return { kind: 'settled', outcome: { state: 'unsupported' } }
+  }
+
+  if (stored.status === LIC_STATUS_SUCCESS) {
+    const verdict = verifyStoredLicenseBlob(stored.blob, deviceId, input.packageId)
+    if (verdict.ok) return { kind: 'settled', outcome: { state: 'licensed', how: 'already-stored' } }
+
+    // Deliberately NOT a failure: a stored blob that does not verify is the case
+    // recovery exists for (a clone, a half-written file, a licence for another
+    // VPP). Treating it as absent is the only automatic way this board gets a
+    // good one. Logged because it is worth seeing in the console.
+    console.warn(
+      `[license] the device reported a stored license but it did not verify (${verdict.reason}) — ` +
+        'treating it as absent.',
+    )
+  }
+
+  return { kind: 'absent' }
+}
+
+/**
+ * Ask the backend for a license and write it. Reached when the device holds
+ * nothing usable — empty, corrupt, or a blob that failed verification.
+ */
+async function recoverLicense(
+  transport: LicenseReadWritable,
+  input: { deviceId: string; packageId: string },
+): Promise<DeviceLicenseReport> {
+  const { deviceId, packageId } = input
+  const activation = await checkDeviceActivation({ deviceId, packageId })
+
+  if (!activation.licensed) {
+    // A transport/backend failure is NOT the same as "no purchase on record".
+    // `checkDeviceActivation` already separates `reason` (business) from `error`
+    // (transport); honour the distinction instead of discarding it one layer up.
+    if (activation.error) {
+      return { deviceId, outcome: { state: 'check-failed', error: activation.error } }
+    }
+    // The backend WAS asked and said no. `entitlementChecked: true` is what earns
+    // the UI the right to offer a purchase.
+    return { deviceId, outcome: { state: 'unlicensed', entitlementChecked: true, backendReason: activation.reason } }
+  }
+
+  if (!activation.license) {
+    // Licensed on the backend's word but no blob to write. Nothing to store, and
+    // nothing we can assert about the device — the board will run demo, so say we
+    // could not confirm rather than claiming either state.
+    return {
+      deviceId,
+      outcome: { state: 'check-failed', error: 'the backend reported a license but returned no blob to write' },
+    }
+  }
+
+  const write = await transport.writeLicense(Uint8Array.from(activation.license))
+
+  if (write.unsupported) {
+    return { deviceId, outcome: { state: 'unsupported' } }
+  }
+  if (!write.success) {
+    return { deviceId, outcome: { state: 'check-failed', error: write.error ?? 'the license write failed' } }
+  }
+
+  // RE-READ; do not trust the write. 0x49 only STORES bytes: no target checks
+  // magic, crc32, `deviceId` or `productId` on write. So `write.success` alone
+  // says nothing about what the board now holds, and asserting possession from it
+  // means a blob truncated in flight, or signed for another device, reads as
+  // "Licensed" while the board runs demo.
+  const readBack = await transport.readLicense()
+  if (!readBack.success) {
+    return {
+      deviceId,
+      outcome: {
+        state: 'check-failed',
+        error: `the license was written but could not be confirmed: the read-back failed (${readBack.error ?? 'no reply'})`,
+      },
+    }
+  }
+
+  const verdict = verifyStoredLicenseBlob(
+    readBack.status === LIC_STATUS_SUCCESS ? readBack.blob : undefined,
+    deviceId,
+    packageId,
+  )
+  if (verdict.ok) return { deviceId, outcome: { state: 'licensed', how: 'activated' } }
+
+  return {
+    deviceId,
+    outcome: {
+      state: 'check-failed',
+      error: `the license was written but could not be confirmed on the device: ${verdict.reason}`,
+    },
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/src/backend/editor/modbus/__tests__/read-license-framing.test.ts
+++ b/src/backend/editor/modbus/__tests__/read-license-framing.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression test for size-aware RTU framing.
+ *
+ * The RTU client used to detect end-of-frame purely by a 10ms idle timeout. A
+ * large variable-length response — the 98-byte license blob — arriving in
+ * multiple chunks at 9600 baud, where FTDI/CH340 latency timers push inter-chunk
+ * gaps to ~16ms, was cut at the first chunk ("Incomplete license blob, got 25").
+ * `readLicense()` now passes an `expectedTotalLength` predictor (SUCCESS → total
+ * = 7 + len) so the read completes once the whole frame has arrived, regardless
+ * of the gaps between chunks.
+ *
+ * This test injects a fake serial port that emits the response in two chunks
+ * with a REAL 20ms gap (> FRAME_COMPLETE_TIMEOUT_MS = 10ms) and asserts the blob
+ * is reassembled intact.
+ */
+
+import { EventEmitter } from 'node:events'
+
+import golden from '../../../shared/debug/__tests__/fixtures/license-golden.json'
+import { ModbusRtuClient } from '../modbus-rtu-client'
+
+const DEBUG_READ_LICENSE = 0x4a
+const STATUS_SUCCESS = 0x7e
+const SLAVE_ID = 1
+
+/** 98-byte golden license blob (`lic_blob_t` serialization). blob[0] === 0x4f ('O'). */
+function goldenBlob(): Buffer {
+  return Buffer.from(golden.expectedBytesHex, 'hex')
+}
+
+/**
+ * Build the raw on-the-wire RTU READ_LICENSE frame:
+ * `[id][FC=0x4a][STATUS=0x7e][len:u16 BE][blob...][crc:2]`.
+ */
+function buildReadLicenseFrame(blob: Buffer): Buffer {
+  const frame = Buffer.alloc(3 + 2 + blob.length + 2)
+  frame.writeUInt8(SLAVE_ID, 0)
+  frame.writeUInt8(DEBUG_READ_LICENSE, 1)
+  frame.writeUInt8(STATUS_SUCCESS, 2)
+  frame.writeUInt16BE(blob.length, 3)
+  blob.copy(frame as unknown as Uint8Array, 5)
+  // CRC bytes: the debugger treats a CRC mismatch as non-fatal, so any 2 bytes
+  // work here — the client strips them regardless.
+  frame.writeUInt16BE(0x0000, 5 + blob.length)
+  return frame
+}
+
+/**
+ * EventEmitter-based fake serial port matching the surface `sendRequestImpl`
+ * uses: on('data'/'error'), once, removeListener, write, flush, isOpen.
+ */
+class FakeSerialPort extends EventEmitter {
+  isOpen = true
+  emitPlan: (() => void) | null = null
+
+  write(_data: Uint8Array, callback?: (err?: Error | null) => void) {
+    callback?.(null)
+    // Kick off the chunked response once the request has been written.
+    this.emitPlan?.()
+  }
+
+  flush(callback?: (err?: Error | null) => void) {
+    callback?.(null)
+  }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('ModbusRtuClient.readLicense — size-aware multi-chunk framing', () => {
+  it('reassembles the full 98-byte blob when the frame arrives in two chunks with a >idle-timeout gap', async () => {
+    const blob = goldenBlob()
+    expect(blob.length).toBe(98)
+
+    const frame = buildReadLicenseFrame(blob)
+    // Split so the first chunk (25 bytes) is well short of the 105-byte frame and
+    // the second arrives after a gap larger than FRAME_COMPLETE_TIMEOUT_MS.
+    const firstChunk = frame.subarray(0, 25)
+    const restChunk = frame.subarray(25)
+
+    const port = new FakeSerialPort()
+    port.emitPlan = () => {
+      setTimeout(() => port.emit('data', Buffer.from(firstChunk)), 0)
+      // Real 20ms gap > 10ms idle timeout: the old code truncated here.
+      void sleep(20).then(() => port.emit('data', Buffer.from(restChunk)))
+    }
+
+    const client = new ModbusRtuClient({ port: 'x', baudRate: 9600, slaveId: SLAVE_ID, timeout: 500 })
+    // Inject the fake port directly, bypassing connect().
+    ;(client as unknown as { serialPort: unknown }).serialPort = port
+
+    const result = await client.readLicense()
+
+    expect(result.success).toBe(true)
+    expect(result.blob).toBeDefined()
+    expect(result.blob?.length).toBe(98)
+    expect(result.blob?.[0]).toBe(0x4f)
+    expect(Buffer.from(result.blob ?? []).equals(blob as unknown as Uint8Array)).toBe(true)
+  })
+
+  it('completes a non-SUCCESS reply without waiting for a length that never comes', async () => {
+    // LIC_EMPTY is [id][FC][STATUS][crc:2] = 5 bytes and carries no len/blob. The
+    // predictor must recognise that from the STATUS byte alone; keying off `len`
+    // would stall until the request timeout.
+    const frame = Buffer.from([SLAVE_ID, DEBUG_READ_LICENSE, 0x83, 0x00, 0x00])
+
+    const port = new FakeSerialPort()
+    port.emitPlan = () => {
+      setTimeout(() => port.emit('data', Buffer.from(frame)), 0)
+    }
+
+    const client = new ModbusRtuClient({ port: 'x', baudRate: 9600, slaveId: SLAVE_ID, timeout: 500 })
+    ;(client as unknown as { serialPort: unknown }).serialPort = port
+
+    const result = await client.readLicense()
+
+    expect(result.success).toBe(true)
+    expect(result.empty).toBe(true)
+    expect(result.blob).toBeUndefined()
+  })
+})

--- a/src/backend/editor/modbus/modbus-client.ts
+++ b/src/backend/editor/modbus/modbus-client.ts
@@ -2,12 +2,18 @@ import {
   buildGetBoardIdRequest,
   buildGetStatusRequest,
   buildPlcSetStateRequest,
+  buildReadLicenseRequest,
+  buildWriteLicenseRequest,
   parseGetBoardIdResponse,
   parseGetStatusResponse,
   parsePlcSetStateResponse,
+  parseReadLicenseResponse,
+  parseWriteLicenseResponse,
 } from '@root/backend/shared/debug/modbus-pdu'
 import type {
   DebugBoardIdResult,
+  DebugLicenseReadResult,
+  DebugLicenseWriteResult,
   DebugStatusResult,
   DeviceModbusTransport,
   Md5ProbeResult,
@@ -27,6 +33,10 @@ export enum ModbusFunctionCode {
   DEBUG_GET_STATUS = 0x46,
   DEBUG_GET_VERSION = 0x47,
   DEBUG_GET_BOARD_ID = 0x48,
+  /** Store a license blob on the device. Write-only; the read back is 0x4A. */
+  DEBUG_WRITE_LICENSE = 0x49,
+  /** Read the stored license blob back off the device. */
+  DEBUG_READ_LICENSE = 0x4a,
   /** Set the runtime run/stop state. Reads go through DEBUG_GET_STATUS (0x46),
    *  which already reports it. */
   PLC_SET_STATE = 0x4b,
@@ -36,6 +46,12 @@ export enum ModbusDebugResponse {
   SUCCESS = 0x7e,
   ERROR_OUT_OF_BOUNDS = 0x81,
   ERROR_OUT_OF_MEMORY = 0x82,
+  /** DEBUG_READ_LICENSE only: virgin storage — no license provisioned. */
+  LIC_EMPTY = 0x83,
+  /** DEBUG_READ_LICENSE only: the magic matched but the crc32 did not. */
+  LIC_CORRUPT = 0x84,
+  /** Licensing FCs: the target has no on-device license-store backend. */
+  LIC_UNSUPPORTED = 0x85,
   /** PLC_SET_STATE only: a RUN request was refused because the hardware mode
    *  switch reads STOP. */
   REFUSED_BY_SWITCH = 0x86,
@@ -472,6 +488,54 @@ export class ModbusTcpClient implements DeviceModbusTransport {
         return { success: false, error: 'Transaction ID mismatch' }
       }
       return parsePlcSetStateResponse(Uint8Array.prototype.slice.call(data, 7))
+    } catch (error) {
+      return { success: false, error: getErrorMessage(error) }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // On-device license storage (FC 0x49/0x4A). TCP frame: [MBAP:6][FC@7][...].
+  // The wire `len` is BIG-ENDIAN (matches the other FCs) while the blob content
+  // it frames is little-endian — do not confuse the two.
+  //
+  // No size-aware framing is needed here, unlike RTU: `sendTcpRequest` reads the
+  // MBAP length field, so a 98-byte blob is already framed by the protocol.
+  // -------------------------------------------------------------------------
+
+  /**
+   * FC 0x49 — store a license blob. Storing is NOT validation (see the RTU
+   * client): read the blob back to learn what the board actually holds.
+   */
+  async writeLicense(blob: Uint8Array): Promise<DebugLicenseWriteResult> {
+    if (!this.socket) return { success: false, error: 'Not connected to target' }
+    try {
+      const { request, transactionId } = this.buildTcpFrame(buildWriteLicenseRequest(blob))
+      const data = await this.sendTcpRequest(request)
+      if (data.length < 9) {
+        return { success: false, error: `Invalid response: too short (${data.length} bytes, need at least 9)` }
+      }
+      if (data.readUInt16BE(0) !== transactionId) {
+        return { success: false, error: 'Transaction ID mismatch' }
+      }
+      return parseWriteLicenseResponse(Uint8Array.prototype.slice.call(data, 7))
+    } catch (error) {
+      return { success: false, error: getErrorMessage(error) }
+    }
+  }
+
+  /** FC 0x4A — read the stored license blob back. */
+  async readLicense(): Promise<DebugLicenseReadResult> {
+    if (!this.socket) return { success: false, error: 'Not connected to target' }
+    try {
+      const { request, transactionId } = this.buildTcpFrame(buildReadLicenseRequest())
+      const data = await this.sendTcpRequest(request)
+      if (data.length < 9) {
+        return { success: false, error: `Invalid response: too short (${data.length} bytes, need at least 9)` }
+      }
+      if (data.readUInt16BE(0) !== transactionId) {
+        return { success: false, error: 'Transaction ID mismatch' }
+      }
+      return parseReadLicenseResponse(Uint8Array.prototype.slice.call(data, 7))
     } catch (error) {
       return { success: false, error: getErrorMessage(error) }
     }

--- a/src/backend/editor/modbus/modbus-rtu-client.ts
+++ b/src/backend/editor/modbus/modbus-rtu-client.ts
@@ -4,12 +4,18 @@ import {
   buildGetBoardIdRequest,
   buildGetStatusRequest,
   buildPlcSetStateRequest,
+  buildReadLicenseRequest,
+  buildWriteLicenseRequest,
   parseGetBoardIdResponse,
   parseGetStatusResponse,
   parsePlcSetStateResponse,
+  parseReadLicenseResponse,
+  parseWriteLicenseResponse,
 } from '@root/backend/shared/debug/modbus-pdu'
 import type {
   DebugBoardIdResult,
+  DebugLicenseReadResult,
+  DebugLicenseWriteResult,
   DebugStatusResult,
   DeviceModbusTransport,
   Md5ProbeResult,
@@ -29,6 +35,30 @@ interface ModbusRtuClientOptions {
   timeout: number
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   serialPort?: any // Pre-built serial port (e.g. VirtualSerialPort for simulator)
+}
+
+interface SendRequestOptions {
+  /**
+   * Optional size-aware end-of-frame predictor. Given the raw accumulated
+   * response buffer (the on-the-wire RTU frame, BEFORE the 6-byte TCP-compat
+   * padding `sendRequestImpl` prepends), returns the total number of bytes the
+   * complete frame is expected to have, or `null` when not enough bytes have
+   * arrived yet to make that call.
+   *
+   * WHY THIS EXISTS. The default framing declares the frame complete after
+   * `FRAME_COMPLETE_TIMEOUT_MS` of silence, which is only sound while a frame
+   * arrives faster than the gap it is measured against. A 98-byte license blob at
+   * 9600 baud takes ~102 ms to clock out, and the serial layer delivers it in
+   * several chunks whose inter-chunk gaps exceed 10 ms — so the idle timeout fires
+   * mid-frame and the response is TRUNCATED. The truncation is silent: the parser
+   * sees a short buffer and reports a malformed license, which points the blame at
+   * the board.
+   *
+   * With a predictor, the request completes as soon as the declared length has
+   * fully arrived, and a known-incomplete frame keeps waiting instead of being cut
+   * off. Callers that omit it fall back to the unchanged idle-timeout framing.
+   */
+  expectedTotalLength?: (raw: Buffer) => number | null
 }
 
 const ARDUINO_BOOTLOADER_DELAY_MS = 2500
@@ -177,16 +207,16 @@ export class ModbusRtuClient implements DeviceModbusTransport {
 
   private sendRequestMutex: Promise<void> = Promise.resolve()
 
-  private async sendRequest(request: Buffer): Promise<Buffer> {
+  private async sendRequest(request: Buffer, opts?: SendRequestOptions): Promise<Buffer> {
     return new Promise<Buffer>((resolve, reject) => {
       this.sendRequestMutex = this.sendRequestMutex.then(
-        () => this.sendRequestImpl(request).then(resolve, reject),
-        () => this.sendRequestImpl(request).then(resolve, reject),
+        () => this.sendRequestImpl(request, opts).then(resolve, reject),
+        () => this.sendRequestImpl(request, opts).then(resolve, reject),
       )
     })
   }
 
-  private async sendRequestImpl(request: Buffer): Promise<Buffer> {
+  private async sendRequestImpl(request: Buffer, opts?: SendRequestOptions): Promise<Buffer> {
     if (!this.serialPort || !this.serialPort.isOpen) {
       throw new Error('Serial port is not open')
     }
@@ -211,35 +241,63 @@ export class ModbusRtuClient implements DeviceModbusTransport {
         reject(new Error('Request timeout'))
       }, this.timeout)
 
+      // Strip the 2-byte CRC trailer, prepend the 6-byte TCP-compat padding the
+      // rest of the client expects, and resolve. Shared by both the size-aware
+      // completion and the idle-timeout fallback so they frame identically.
+      const complete = () => {
+        clearTimeout(timeoutHandle)
+        cleanup()
+
+        if (responseBuffer.length < 5) {
+          reject(new Error('Response too short'))
+          return
+        }
+
+        const receivedCrc = responseBuffer.readUInt16BE(responseBuffer.length - 2)
+        const calculatedCrc = this.calculateCrc(responseBuffer.slice(0, responseBuffer.length - 2))
+
+        if (receivedCrc !== calculatedCrc) {
+          // OpenPLC debugger ignores CRC errors — mismatch is non-fatal
+        }
+
+        const responseWithoutCrc = responseBuffer.slice(0, responseBuffer.length - 2)
+        const paddedResponse = Buffer.alloc(6 + responseWithoutCrc.length)
+        paddedResponse.fill(0, 0, 6)
+        responseWithoutCrc.copy(paddedResponse as unknown as Uint8Array, 6)
+
+        resolve(paddedResponse)
+      }
+
       const onData = (data: Buffer) => {
         responseBuffer = Buffer.concat([responseBuffer, data] as unknown as Uint8Array[])
 
+        // Size-aware framing (opt-in): once the caller can predict the full frame
+        // length, complete as soon as it has fully arrived, and while the frame is
+        // known-incomplete keep waiting for the remaining bytes rather than letting
+        // the idle timeout truncate a multi-chunk response.
+        if (opts?.expectedTotalLength) {
+          const expected = opts.expectedTotalLength(responseBuffer)
+          if (expected !== null) {
+            if (frameCompleteTimeout) {
+              clearTimeout(frameCompleteTimeout)
+              frameCompleteTimeout = null
+            }
+            if (responseBuffer.length >= expected) {
+              complete()
+            }
+            return
+          }
+        }
+
+        // Fallback: idle-timeout end-of-frame detection (unchanged default for
+        // callers that pass no predictor, or before the predictor has enough
+        // bytes to decide).
         if (frameCompleteTimeout) {
           clearTimeout(frameCompleteTimeout)
         }
 
         frameCompleteTimeout = setTimeout(() => {
-          clearTimeout(timeoutHandle)
-          cleanup()
-
-          if (responseBuffer.length < 5) {
-            reject(new Error('Response too short'))
-            return
-          }
-
-          const receivedCrc = responseBuffer.readUInt16BE(responseBuffer.length - 2)
-          const calculatedCrc = this.calculateCrc(responseBuffer.slice(0, responseBuffer.length - 2))
-
-          if (receivedCrc !== calculatedCrc) {
-            // OpenPLC debugger ignores CRC errors — mismatch is non-fatal
-          }
-
-          const responseWithoutCrc = responseBuffer.slice(0, responseBuffer.length - 2)
-          const paddedResponse = Buffer.alloc(6 + responseWithoutCrc.length)
-          paddedResponse.fill(0, 0, 6)
-          responseWithoutCrc.copy(paddedResponse as unknown as Uint8Array, 6)
-
-          resolve(paddedResponse)
+          complete()
         }, FRAME_COMPLETE_TIMEOUT_MS)
       }
 
@@ -348,7 +406,19 @@ export class ModbusRtuClient implements DeviceModbusTransport {
       }
 
       const request = this.assembleRequest(functionCode, data)
-      const response = await this.sendRequest(request)
+      const response = await this.sendRequest(request, {
+        // Raw RTU frame (SUCCESS): id@0, FC@1, STATUS@2, lastIndex u16 @3..4,
+        // tick u32 @5..8, responseSize u16BE @9..10, data @11.., crc 2 -> total =
+        // 11 + responseSize + 2 = 13 + responseSize. A non-SUCCESS response is
+        // [id][FC][STATUS][crc:2] = 5 bytes, so key off STATUS. (Mirrors the C
+        // runtime's debugGetTraceList: mb_frame_len = 11 + responseSize, else 3.)
+        expectedTotalLength: (raw) => {
+          if (raw.length < 3) return null
+          if (raw.readUInt8(2) !== (ModbusDebugResponse.SUCCESS as number)) return 5
+          if (raw.length < 11) return null
+          return 13 + raw.readUInt16BE(9)
+        },
+      })
 
       if (response.length < 9) {
         return { success: false, error: `Invalid response: too short (${response.length} bytes, need at least 9)` }
@@ -462,6 +532,72 @@ export class ModbusRtuClient implements DeviceModbusTransport {
       }
 
       return { success: true }
+    } catch (error) {
+      return { success: false, error: getErrorMessage(error) }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // On-device license storage (FC 0x49/0x4A). Response offsets account for the
+  // 6-byte TCP-compat padding sendRequestImpl prepends: FC@7, status@8, payload@9+.
+  // The wire `len` is BIG-ENDIAN (matches the other FCs) while the blob content
+  // it frames is little-endian — do not confuse the two.
+  // -------------------------------------------------------------------------
+
+  /**
+   * FC 0x49 — store a license blob. Storing is NOT validation: no target checks
+   * magic, crc32, `deviceId` or `productId` here, so a `success: true` means only
+   * that the bytes were accepted. Callers that need to know what the board holds
+   * read it back with `readLicense()`.
+   */
+  async writeLicense(blob: Uint8Array): Promise<DebugLicenseWriteResult> {
+    try {
+      // buildWriteLicenseRequest() returns [FC][len:u16BE][blob]; assembleRequest
+      // writes the FC + slaveId itself, so hand it only the trailing payload.
+      const pdu = buildWriteLicenseRequest(blob)
+      const payload = Buffer.from(pdu.subarray(1))
+      const request = this.assembleRequest(ModbusFunctionCode.DEBUG_WRITE_LICENSE, payload)
+      const response = await this.sendRequest(request)
+
+      if (response.length < 9) {
+        return { success: false, error: `Invalid response: too short (${response.length} bytes, need at least 9)` }
+      }
+
+      // Strip the 6-byte TCP-compat padding; the pure PDU starts at offset 7.
+      return parseWriteLicenseResponse(Uint8Array.prototype.slice.call(response, 7))
+    } catch (error) {
+      return { success: false, error: getErrorMessage(error) }
+    }
+  }
+
+  /**
+   * FC 0x4A — read the stored license blob back. Uses the size-aware framing: a
+   * 98-byte blob does not arrive inside one idle window at low baud rates, and the
+   * default framing would truncate it silently (see `SendRequestOptions`).
+   */
+  async readLicense(): Promise<DebugLicenseReadResult> {
+    try {
+      const pdu = buildReadLicenseRequest()
+      const payload = Buffer.from(pdu.subarray(1)) // bare [FC]; no trailing payload
+      const request = this.assembleRequest(ModbusFunctionCode.DEBUG_READ_LICENSE, payload)
+      const response = await this.sendRequest(request, {
+        // Raw RTU frame: id@0, FC@1, STATUS@2, len u16BE @3..4, blob @5.., crc 2.
+        // SUCCESS -> total = 1+1+1+2+len+2 = 7+len. A non-SUCCESS response carries
+        // no len/blob ([id][FC][STATUS][crc:2] = 5 bytes), so key off STATUS.
+        expectedTotalLength: (raw) => {
+          if (raw.length < 3) return null
+          if (raw.readUInt8(2) !== (ModbusDebugResponse.SUCCESS as number)) return 5
+          if (raw.length < 5) return null
+          return 7 + raw.readUInt16BE(3)
+        },
+      })
+
+      if (response.length < 9) {
+        return { success: false, error: `Invalid response: too short (${response.length} bytes, need at least 9)` }
+      }
+
+      // Strip the 6-byte TCP-compat padding; parse the pure PDU from offset 7.
+      return parseReadLicenseResponse(Uint8Array.prototype.slice.call(response, 7))
     } catch (error) {
       return { success: false, error: getErrorMessage(error) }
     }

--- a/src/backend/editor/utils/__tests__/http-module.test.ts
+++ b/src/backend/editor/utils/__tests__/http-module.test.ts
@@ -1,0 +1,38 @@
+import http from 'http'
+import https from 'https'
+
+import { defaultPortFor, httpModuleFor } from '../http-module'
+
+describe('httpModuleFor', () => {
+  it('returns the http module for an http: URL', () => {
+    expect(httpModuleFor('http://localhost:3333/vpp-licenses/activate')).toBe(http)
+  })
+
+  it('returns the https module for an https: URL', () => {
+    expect(httpModuleFor('https://api.autonomylogic.com/vpp-licenses/activate')).toBe(https)
+  })
+
+  it('accepts an already-parsed URL', () => {
+    expect(httpModuleFor(new URL('http://127.0.0.1:3333/x'))).toBe(http)
+  })
+
+  // An unparseable or exotic URL must never silently downgrade to plaintext.
+  it('falls back to https for an unparseable URL', () => {
+    expect(httpModuleFor('not a url')).toBe(https)
+  })
+
+  it('falls back to https for a non-http(s) scheme', () => {
+    expect(httpModuleFor('ftp://example.com/x')).toBe(https)
+  })
+})
+
+describe('defaultPortFor', () => {
+  it('is 80 for http and 443 for https', () => {
+    expect(defaultPortFor('http://localhost/x')).toBe(80)
+    expect(defaultPortFor('https://localhost/x')).toBe(443)
+  })
+
+  it('falls back to 443 when the URL cannot be parsed', () => {
+    expect(defaultPortFor('not a url')).toBe(443)
+  })
+})

--- a/src/backend/editor/utils/http-module.ts
+++ b/src/backend/editor/utils/http-module.ts
@@ -1,0 +1,46 @@
+/**
+ * Pick the Node request module that matches a URL's scheme.
+ *
+ * The edge clients (`desktop-catalog-transport`, `license-activation-client`)
+ * were both written against `https.request` directly. That is right for
+ * production — every deployed edge host is HTTPS — but it makes the base-URL
+ * override (`OPENPLC_EDGE_API_URL`) a lie: pointing it at a local backend
+ * (`http://localhost:3333`, the port the autonomy-edge dev server binds) sends
+ * a TLS ClientHello to a plain HTTP socket. The connection dies with EPROTO /
+ * ECONNRESET, the client's catch turns that into a generic failure, and the
+ * editor silently falls back to demo mode. The result is that the one contract
+ * we most need to exercise end-to-end cannot be exercised locally at all.
+ *
+ * `http.request` and `https.request` share a call signature, so a scheme-driven
+ * lookup is a drop-in for either call site.
+ */
+
+import http from 'http'
+import https from 'https'
+
+/** Node's `http`/`https` share the `request` signature we rely on. */
+export type NodeRequestModule = Pick<typeof https, 'request'>
+
+/**
+ * The request module for `url`'s scheme. Defaults to `https` for anything that
+ * is not explicitly `http:` — an unparseable or exotic URL should not silently
+ * downgrade to plaintext.
+ */
+export function httpModuleFor(url: string | URL): NodeRequestModule {
+  try {
+    const parsed = typeof url === 'string' ? new URL(url) : url
+    return parsed.protocol === 'http:' ? http : https
+  } catch {
+    return https
+  }
+}
+
+/** Default port for a URL that does not carry one, by scheme. */
+export function defaultPortFor(url: string | URL): number {
+  try {
+    const parsed = typeof url === 'string' ? new URL(url) : url
+    return parsed.protocol === 'http:' ? 80 : 443
+  } catch {
+    return 443
+  }
+}

--- a/src/backend/shared/debug/__tests__/fixtures/license-golden.json
+++ b/src/backend/shared/debug/__tests__/fixtures/license-golden.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Golden cross-language fixture for lic_blob_t (OLS-14). Shared by the TS test (license-blob.test.ts) and the C host-test (T04). 'input' is the structured license; 'expectedBytesHex' is the deterministic 98-byte LE serialization produced by serializeLicenseBlob; 'expectedCrc32' is CRC-32/ISO-HDLC over [payload||signature] (offsets 0..93). Any byte here MUST match both the TS serializer and the C memcpy of the packed struct. Do not hand-edit expectedBytesHex.",
+  "input": {
+    "magic": 1129074767,
+    "fmtVersion": 1,
+    "keyId": 0,
+    "deviceId": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    "productId": [160, 161, 162, 163, 164, 165, 166, 167],
+    "signature": [
+      17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
+      17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
+      17, 17, 17, 17, 17, 17, 17, 17
+    ],
+    "crc32": 0
+  },
+  "expectedBytesHex": "4f504c430100000102030405060708090a0b0c0d0e0fa0a1a2a3a4a5a6a711111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111b6311445",
+  "expectedCrc32": 1158951350
+}

--- a/src/backend/shared/debug/__tests__/license-blob-c-parity.test.ts
+++ b/src/backend/shared/debug/__tests__/license-blob-c-parity.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Cross-language parity between the TypeScript license-blob codec and the C
+ * struct the firmware compiles.
+ *
+ * WHY THIS EXISTS. The blob crosses a language boundary: the editor serializes it
+ * in TypeScript, the board parses it as `lic_blob_t`. A layout disagreement does
+ * not fail loudly — it produces a blob the board stores happily and the
+ * license-core then rejects, which surfaces as "the device says it is licensed and
+ * still runs demo". That is the single most expensive way for these two files to
+ * drift, so it must fail a test instead.
+ *
+ * WHAT THIS CAN AND CANNOT CATCH. It reads `license_blob.h` as text and asserts
+ * the two sides agree on the sizes, the offsets, the magic and the CRC parameters.
+ * It cannot catch a compiler that inserts padding — but nothing needs to: the
+ * header carries both `#pragma pack` and `__attribute__((packed))`, plus
+ * `LIC_STATIC_ASSERT` on both struct sizes, so padding fails the FIRMWARE BUILD
+ * on the device toolchain rather than shipping.
+ *
+ * A real C host-test compiling the header and comparing bytes against
+ * `license-golden.json` would be stronger and is the right follow-up; the repo has
+ * no C test harness to hang one on today.
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { crc32IsoHdlc, LIC_BLOB_SIZE, LIC_MAGIC_LE, LIC_PAYLOAD_SIZE } from '../license-blob'
+
+const HEADER_PATH = join(__dirname, '..', '..', '..', '..', '..', 'resources', 'sources', 'Baremetal', 'license_blob.h')
+
+const header = readFileSync(HEADER_PATH, 'utf-8')
+
+/** Read a `#define NAME 0x...u` / decimal value out of the C header. */
+function cDefine(name: string): number {
+  const match = new RegExp(`#define\\s+${name}\\s+(0x[0-9A-Fa-f]+|\\d+)u?`).exec(header)
+  if (!match) throw new Error(`${name} not found in license_blob.h`)
+  return Number(match[1])
+}
+
+describe('license_blob.h ↔ license-blob.ts parity', () => {
+  it('agrees on the blob and payload sizes', () => {
+    expect(cDefine('LIC_BLOB_SIZE')).toBe(LIC_BLOB_SIZE)
+    expect(cDefine('LIC_PAYLOAD_SIZE')).toBe(LIC_PAYLOAD_SIZE)
+  })
+
+  it('agrees on the little-endian magic', () => {
+    expect(cDefine('LIC_MAGIC_LE')).toBe(LIC_MAGIC_LE)
+  })
+
+  it('declares the struct fields in the order and widths the TS serializer writes', () => {
+    // The offsets the TS side writes at, as the header's own layout table states
+    // them. Parsed from the table rather than from the struct so a change to
+    // either the table or the struct that leaves them disagreeing shows up here —
+    // the table is what a firmware author reads.
+    const expected: Array<[string, number, number]> = [
+      ['magic', 0, 4],
+      ['fmt_version', 4, 1],
+      ['key_id', 5, 1],
+      ['device_id', 6, 16],
+      ['product_id', 22, 8],
+      ['signature', 30, 64],
+      ['crc32', 94, 4],
+    ]
+
+    for (const [field, offset, size] of expected) {
+      const row = new RegExp(`^//\\s*${offset}\\s+${field}\\s+\\S+.*?\\s${size}\\s`, 'm')
+      expect(header).toMatch(row)
+    }
+  })
+
+  it('carries the static assertions that make padding a build failure, not a runtime surprise', () => {
+    // These are what stop a toolchain that ignores one of the two packing
+    // directives from silently producing a 100-byte struct.
+    expect(header).toMatch(/LIC_STATIC_ASSERT\(sizeof\(lic_payload_t\)\s*==\s*30/)
+    expect(header).toMatch(/LIC_STATIC_ASSERT\(sizeof\(lic_blob_t\)\s*==\s*98/)
+    expect(header).toMatch(/#pragma pack\(push, 1\)/)
+    // Anchored to the DECLARATION, not just a mention: the header also discusses
+    // the attribute in prose, so a looser match passed even after the struct lost
+    // it. AVR-GCC and xtensa-GCC honour the two directives differently, which is
+    // why both are required rather than either.
+    expect(header).toMatch(/typedef struct __attribute__\(\(packed\)\) \{/)
+  })
+
+  it('uses the same CRC-32/ISO-HDLC parameters on both sides', () => {
+    // The reflected polynomial and the init/xorout constants. A different
+    // polynomial produces a blob whose crc32 the board rejects as CORRUPT — the
+    // failure mode that looks like flaky hardware.
+    expect(header).toMatch(/0xEDB88320u/)
+    expect(header).toMatch(/crc\s*=\s*0xFFFFFFFFu/)
+    expect(header).toMatch(/crc\s*\^\s*0xFFFFFFFFu/)
+
+    // And the header documents the canonical test vector the TS side satisfies,
+    // so both implementations are pinned to the same published value.
+    expect(header).toContain('0xCBF43926')
+    expect(crc32IsoHdlc(Uint8Array.from([...'123456789'].map((c) => c.charCodeAt(0))))).toBe(0xcbf43926)
+  })
+
+  it('states the endianness duality that the two layers must not confuse', () => {
+    // The blob content is little-endian; the Modbus `len` framing it is
+    // big-endian. Every place this was got wrong cost a debugging session.
+    expect(header).toMatch(/blob CONTENT is LITTLE-ENDIAN/)
+  })
+})

--- a/src/backend/shared/debug/__tests__/license-blob-c-parity.test.ts
+++ b/src/backend/shared/debug/__tests__/license-blob-c-parity.test.ts
@@ -21,12 +21,32 @@
  * no C test harness to hang one on today.
  */
 
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { crc32IsoHdlc, LIC_BLOB_SIZE, LIC_MAGIC_LE, LIC_PAYLOAD_SIZE } from '../license-blob'
 
-const HEADER_PATH = join(__dirname, '..', '..', '..', '..', '..', 'resources', 'sources', 'Baremetal', 'license_blob.h')
+/**
+ * This test file is byte-identical across openplc-editor and openplc-web, but the
+ * firmware sources it reads are NOT in the same place: the sync gate maps the
+ * editor's `resources/sources/Baremetal` onto the web's `src/assets/firmware/
+ * Baremetal` (MAPPED_SURFACES in compare-surfaces.py) rather than mirroring the
+ * path. So resolve whichever one this checkout has.
+ *
+ * Deliberately throws when neither exists instead of skipping. A parity test that
+ * quietly disappears when it cannot find the header is worse than no test: the
+ * suite goes green while the layout it is supposed to pin drifts unwatched.
+ */
+const HEADER_CANDIDATES = [
+  join(__dirname, '..', '..', '..', '..', '..', 'resources', 'sources', 'Baremetal', 'license_blob.h'),
+  join(__dirname, '..', '..', '..', '..', 'assets', 'firmware', 'Baremetal', 'license_blob.h'),
+]
+
+const HEADER_PATH = HEADER_CANDIDATES.find((candidate) => existsSync(candidate))
+
+if (HEADER_PATH === undefined) {
+  throw new Error(`license_blob.h not found. Looked in:\n${HEADER_CANDIDATES.join('\n')}`)
+}
 
 const header = readFileSync(HEADER_PATH, 'utf-8')
 

--- a/src/backend/shared/debug/__tests__/license-blob.test.ts
+++ b/src/backend/shared/debug/__tests__/license-blob.test.ts
@@ -1,0 +1,140 @@
+// jsdom (editor's Jest environment) doesn't ship TextEncoder by default —
+// polyfill from Node's util before the CRC test vector uses it.
+import { TextEncoder as NodeTextEncoder } from 'node:util'
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  ;(globalThis as { TextEncoder: typeof TextEncoder }).TextEncoder = NodeTextEncoder as unknown as typeof TextEncoder
+}
+
+import {
+  crc32IsoHdlc,
+  deserializeLicenseBlob,
+  LIC_BLOB_SIZE,
+  LIC_MAGIC_LE,
+  LIC_PAYLOAD_SIZE,
+  type LicenseBlob,
+  serializeLicenseBlob,
+} from '../license-blob'
+import golden from './fixtures/license-golden.json'
+
+const TextEnc = globalThis.TextEncoder
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return out
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+/** Build the LicenseBlob input from the shared golden fixture. */
+function goldenInput(): LicenseBlob {
+  return {
+    magic: golden.input.magic,
+    fmtVersion: golden.input.fmtVersion,
+    keyId: golden.input.keyId,
+    deviceId: Uint8Array.from(golden.input.deviceId),
+    productId: Uint8Array.from(golden.input.productId),
+    signature: Uint8Array.from(golden.input.signature),
+    crc32: golden.input.crc32,
+  }
+}
+
+describe('crc32IsoHdlc', () => {
+  it('matches the canonical CRC-32/ISO-HDLC test vector for "123456789"', () => {
+    const crc = crc32IsoHdlc(new TextEnc().encode('123456789'))
+    expect(crc).toBe(0xcbf43926)
+  })
+
+  it('returns an unsigned 32-bit value', () => {
+    const crc = crc32IsoHdlc(new TextEnc().encode('123456789'))
+    expect(crc).toBeGreaterThanOrEqual(0)
+    expect(crc).toBeLessThanOrEqual(0xffffffff)
+  })
+
+  it('produces 0 for an empty input (init ^ xorout)', () => {
+    // CRC of no data: 0xFFFFFFFF ^ 0xFFFFFFFF === 0.
+    expect(crc32IsoHdlc(new Uint8Array())).toBe(0)
+  })
+})
+
+describe('constants', () => {
+  it('mirror the C struct sizes and magic', () => {
+    expect(LIC_BLOB_SIZE).toBe(98)
+    expect(LIC_PAYLOAD_SIZE).toBe(30)
+    expect(LIC_MAGIC_LE).toBe(0x434c504f)
+  })
+})
+
+describe('serializeLicenseBlob', () => {
+  it('produces exactly the golden fixture bytes', () => {
+    const bytes = serializeLicenseBlob(goldenInput())
+    expect(bytes).toHaveLength(LIC_BLOB_SIZE)
+    expect(bytesToHex(bytes)).toBe(golden.expectedBytesHex)
+  })
+
+  it('writes the magic as the four bytes 4F 50 4C 43', () => {
+    const bytes = serializeLicenseBlob(goldenInput())
+    expect(Array.from(bytes.subarray(0, 4))).toEqual([0x4f, 0x50, 0x4c, 0x43])
+  })
+
+  it('recomputes crc32 over [payload||signature] and stores it LE at offset 94', () => {
+    const bytes = serializeLicenseBlob(goldenInput())
+    const view = new DataView(bytes.buffer)
+    const storedCrc = view.getUint32(94, true)
+    expect(storedCrc).toBe(golden.expectedCrc32)
+    // Independent recomputation over offsets 0..93 must agree.
+    expect(crc32IsoHdlc(bytes.subarray(0, 94))).toBe(golden.expectedCrc32)
+  })
+
+  it('ignores the crc32 field on the input (always recomputes)', () => {
+    const tampered = goldenInput()
+    tampered.crc32 = 0xdeadbeef
+    const bytes = serializeLicenseBlob(tampered)
+    expect(new DataView(bytes.buffer).getUint32(94, true)).toBe(golden.expectedCrc32)
+  })
+})
+
+describe('deserializeLicenseBlob', () => {
+  it('reproduces the golden input from the golden bytes', () => {
+    const parsed = deserializeLicenseBlob(hexToBytes(golden.expectedBytesHex))
+    expect(parsed.magic).toBe(LIC_MAGIC_LE)
+    expect(parsed.fmtVersion).toBe(golden.input.fmtVersion)
+    expect(parsed.keyId).toBe(golden.input.keyId)
+    expect(Array.from(parsed.deviceId)).toEqual(golden.input.deviceId)
+    expect(Array.from(parsed.productId)).toEqual(golden.input.productId)
+    expect(Array.from(parsed.signature)).toEqual(golden.input.signature)
+    expect(parsed.crc32).toBe(golden.expectedCrc32)
+  })
+
+  it('throws on a truncated buffer', () => {
+    expect(() => deserializeLicenseBlob(new Uint8Array(LIC_BLOB_SIZE - 1))).toThrow(/too short/)
+  })
+})
+
+describe('round-trip serialize -> deserialize', () => {
+  it('is identical for all fields (magic and crc32 canonicalized)', () => {
+    const input = goldenInput()
+    const parsed = deserializeLicenseBlob(serializeLicenseBlob(input))
+
+    // magic is forced to canonical LIC_MAGIC_LE on serialize; input already uses it.
+    expect(parsed.magic).toBe(input.magic)
+    expect(parsed.fmtVersion).toBe(input.fmtVersion)
+    expect(parsed.keyId).toBe(input.keyId)
+    expect(Array.from(parsed.deviceId)).toEqual(Array.from(input.deviceId))
+    expect(Array.from(parsed.productId)).toEqual(Array.from(input.productId))
+    expect(Array.from(parsed.signature)).toEqual(Array.from(input.signature))
+    // crc32 is recomputed on serialize; the round-tripped value is the real crc.
+    expect(parsed.crc32).toBe(golden.expectedCrc32)
+  })
+
+  it('re-serializes the deserialized blob to the same bytes (byte-stable)', () => {
+    const bytes = hexToBytes(golden.expectedBytesHex)
+    const reserialized = serializeLicenseBlob(deserializeLicenseBlob(bytes))
+    expect(bytesToHex(reserialized)).toBe(golden.expectedBytesHex)
+  })
+})

--- a/src/backend/shared/debug/__tests__/modbus-pdu.test.ts
+++ b/src/backend/shared/debug/__tests__/modbus-pdu.test.ts
@@ -17,13 +17,17 @@ import {
   buildGetMd5Request,
   buildGetStatusRequest,
   buildGetVersionRequest,
+  buildReadLicenseRequest,
   buildSetVariableRequest,
+  buildWriteLicenseRequest,
   parseGetBoardIdResponse,
   parseGetListResponse,
   parseGetMd5Response,
   parseGetStatusResponse,
   parseGetVersionResponse,
+  parseReadLicenseResponse,
   parseSetVariableResponse,
+  parseWriteLicenseResponse,
   responseFunctionCode,
 } from '../modbus-pdu'
 
@@ -392,5 +396,177 @@ describe('responseFunctionCode', () => {
 
   it('returns undefined for an empty buffer', () => {
     expect(responseFunctionCode(new Uint8Array(0))).toBeUndefined()
+  })
+})
+describe('buildWriteLicenseRequest', () => {
+  it('emits [FC][len:U16BE][blob] with big-endian length', () => {
+    // 260-byte blob proves the length is BE (0x01 0x04), not LE.
+    const blob = new Uint8Array(260).fill(0xab)
+    blob[0] = 0x4f // 'O' — magic first byte, sanity marker
+    const buf = buildWriteLicenseRequest(blob)
+    expect(buf).toHaveLength(3 + 260)
+    expect(buf[0]).toBe(ModbusFunctionCode.DEBUG_WRITE_LICENSE)
+    expect(buf[1]).toBe(0x01) // len hi
+    expect(buf[2]).toBe(0x04) // len lo (260 = 0x0104)
+    expect(buf[3]).toBe(0x4f)
+    expect(buf[buf.length - 1]).toBe(0xab)
+  })
+
+  it('handles a zero-length blob', () => {
+    const buf = buildWriteLicenseRequest(new Uint8Array(0))
+    expect(buf).toHaveLength(3)
+    expect(buf[1]).toBe(0)
+    expect(buf[2]).toBe(0)
+  })
+})
+
+describe('parseWriteLicenseResponse', () => {
+  it('returns success on SUCCESS status', () => {
+    const buf = new Uint8Array([ModbusFunctionCode.DEBUG_WRITE_LICENSE, ModbusDebugResponse.SUCCESS])
+    const result = parseWriteLicenseResponse(buf)
+    expect(result.success).toBe(true)
+    expect(result.status).toBe(ModbusDebugResponse.SUCCESS)
+  })
+
+  it('surfaces an out-of-bounds (TOO_LARGE, 0x81) status as failure', () => {
+    const buf = new Uint8Array([ModbusFunctionCode.DEBUG_WRITE_LICENSE, ModbusDebugResponse.ERROR_OUT_OF_BOUNDS])
+    const result = parseWriteLicenseResponse(buf)
+    expect(result.success).toBe(false)
+    expect(result.status).toBe(ModbusDebugResponse.ERROR_OUT_OF_BOUNDS)
+    expect(result.error).toBe('ERROR_OUT_OF_BOUNDS')
+  })
+
+  it('surfaces an out-of-memory (0x82) status as failure', () => {
+    const buf = new Uint8Array([ModbusFunctionCode.DEBUG_WRITE_LICENSE, ModbusDebugResponse.ERROR_OUT_OF_MEMORY])
+    const result = parseWriteLicenseResponse(buf)
+    expect(result.success).toBe(false)
+    expect(result.status).toBe(ModbusDebugResponse.ERROR_OUT_OF_MEMORY)
+    expect(result.error).toBe('ERROR_OUT_OF_MEMORY')
+  })
+
+  it('treats LIC_EMPTY / LIC_CORRUPT statuses on a WRITE response as failures (not valid write states)', () => {
+    // EMPTY/CORRUPT are read-side device states; a WRITE that echoes them is
+    // not SUCCESS, so the write must be reported as failed.
+    const empty = parseWriteLicenseResponse(
+      new Uint8Array([ModbusFunctionCode.DEBUG_WRITE_LICENSE, ModbusDebugResponse.LIC_EMPTY]),
+    )
+    expect(empty.success).toBe(false)
+    expect(empty.status).toBe(ModbusDebugResponse.LIC_EMPTY)
+
+    const corrupt = parseWriteLicenseResponse(
+      new Uint8Array([ModbusFunctionCode.DEBUG_WRITE_LICENSE, ModbusDebugResponse.LIC_CORRUPT]),
+    )
+    expect(corrupt.success).toBe(false)
+    expect(corrupt.status).toBe(ModbusDebugResponse.LIC_CORRUPT)
+  })
+
+  it('classifies LIC_UNSUPPORTED (0x85) as success + unsupported (no backend)', () => {
+    const buf = new Uint8Array([ModbusFunctionCode.DEBUG_WRITE_LICENSE, ModbusDebugResponse.LIC_UNSUPPORTED])
+    const result = parseWriteLicenseResponse(buf)
+    expect(result.success).toBe(true)
+    expect(result.status).toBe(ModbusDebugResponse.LIC_UNSUPPORTED)
+    expect(result.unsupported).toBe(true)
+  })
+
+  it('rejects a function-code mismatch', () => {
+    const buf = new Uint8Array([ModbusFunctionCode.DEBUG_READ_LICENSE, ModbusDebugResponse.SUCCESS])
+    expect(parseWriteLicenseResponse(buf).success).toBe(false)
+  })
+
+  it('rejects a too-short frame', () => {
+    expect(parseWriteLicenseResponse(new Uint8Array([ModbusFunctionCode.DEBUG_WRITE_LICENSE])).success).toBe(false)
+  })
+})
+
+describe('buildReadLicenseRequest', () => {
+  it('emits a bare [FC] frame', () => {
+    const buf = buildReadLicenseRequest()
+    expect(buf).toHaveLength(1)
+    expect(buf[0]).toBe(ModbusFunctionCode.DEBUG_READ_LICENSE)
+  })
+})
+
+describe('parseReadLicenseResponse', () => {
+  it('extracts the blob on SUCCESS using a BE length', () => {
+    const blob = new Uint8Array([0x4f, 0x50, 0x4c, 0x43, 0xde, 0xad])
+    const buf = new Uint8Array(4 + blob.length)
+    buf[0] = ModbusFunctionCode.DEBUG_READ_LICENSE
+    buf[1] = ModbusDebugResponse.SUCCESS
+    buf[2] = 0x00 // len hi
+    buf[3] = blob.length // len lo
+    buf.set(blob, 4)
+    const result = parseReadLicenseResponse(buf)
+    expect(result.success).toBe(true)
+    expect(result.empty).toBeUndefined()
+    expect(result.corrupt).toBeUndefined()
+    expect(result.blob).toBeDefined()
+    expect(Array.from(result.blob ?? [])).toEqual(Array.from(blob))
+    // magic first byte survives the round-trip (endianness sanity)
+    expect(result.blob?.[0]).toBe(0x4f)
+  })
+
+  it('classifies LIC_EMPTY as success + empty (no blob)', () => {
+    const buf = new Uint8Array([ModbusFunctionCode.DEBUG_READ_LICENSE, ModbusDebugResponse.LIC_EMPTY])
+    const result = parseReadLicenseResponse(buf)
+    expect(result.success).toBe(true)
+    expect(result.empty).toBe(true)
+    expect(result.blob).toBeUndefined()
+  })
+
+  it('classifies LIC_CORRUPT as success + corrupt (no blob)', () => {
+    const buf = new Uint8Array([ModbusFunctionCode.DEBUG_READ_LICENSE, ModbusDebugResponse.LIC_CORRUPT])
+    const result = parseReadLicenseResponse(buf)
+    expect(result.success).toBe(true)
+    expect(result.corrupt).toBe(true)
+    expect(result.blob).toBeUndefined()
+  })
+
+  it('classifies LIC_UNSUPPORTED as success + unsupported (no blob)', () => {
+    const buf = new Uint8Array([ModbusFunctionCode.DEBUG_READ_LICENSE, ModbusDebugResponse.LIC_UNSUPPORTED])
+    const result = parseReadLicenseResponse(buf)
+    expect(result.success).toBe(true)
+    expect(result.unsupported).toBe(true)
+    expect(result.blob).toBeUndefined()
+  })
+
+  it('surfaces an out-of-bounds (TOO_LARGE, 0x81) status as failure with no blob', () => {
+    const buf = new Uint8Array([ModbusFunctionCode.DEBUG_READ_LICENSE, ModbusDebugResponse.ERROR_OUT_OF_BOUNDS])
+    const result = parseReadLicenseResponse(buf)
+    expect(result.success).toBe(false)
+    expect(result.status).toBe(ModbusDebugResponse.ERROR_OUT_OF_BOUNDS)
+    expect(result.error).toBe('ERROR_OUT_OF_BOUNDS')
+    expect(result.blob).toBeUndefined()
+  })
+
+  it('surfaces an out-of-memory (0x82) status as failure', () => {
+    const buf = new Uint8Array([ModbusFunctionCode.DEBUG_READ_LICENSE, ModbusDebugResponse.ERROR_OUT_OF_MEMORY])
+    const result = parseReadLicenseResponse(buf)
+    expect(result.success).toBe(false)
+    expect(result.status).toBe(ModbusDebugResponse.ERROR_OUT_OF_MEMORY)
+  })
+
+  it('rejects a function-code mismatch', () => {
+    const buf = new Uint8Array([ModbusFunctionCode.DEBUG_WRITE_LICENSE, ModbusDebugResponse.SUCCESS])
+    expect(parseReadLicenseResponse(buf).success).toBe(false)
+  })
+
+  it('flags a truncated blob', () => {
+    const buf = new Uint8Array([ModbusFunctionCode.DEBUG_READ_LICENSE, ModbusDebugResponse.SUCCESS, 0x00, 0x08, 0x01])
+    const result = parseReadLicenseResponse(buf)
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/Incomplete license blob/)
+  })
+
+  it('flags a success frame missing the length field', () => {
+    const buf = new Uint8Array([ModbusFunctionCode.DEBUG_READ_LICENSE, ModbusDebugResponse.SUCCESS])
+    const result = parseReadLicenseResponse(buf)
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/at least 4/)
+  })
+
+  it('rejects a frame with no status byte at all', () => {
+    const result = parseReadLicenseResponse(new Uint8Array([ModbusFunctionCode.DEBUG_READ_LICENSE]))
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/too short/)
   })
 })

--- a/src/backend/shared/debug/__tests__/websocket-debug-transport-license.test.ts
+++ b/src/backend/shared/debug/__tests__/websocket-debug-transport-license.test.ts
@@ -7,10 +7,20 @@
  * serial and TCP clients send, so a network target licenses through one code path
  * instead of a second, medium-specific one. The runtime answers these FCs at the
  * webserver level (covered by the runtime's own tests).
+ *
+ * MOCKING, IN BOTH RUNNERS. This file is on the byte-identical shared surface, so
+ * it runs under Vitest (web) and Jest (editor, which aliases `vi` to `jest`).
+ * Hence `vi.mock`, never `jest.mock` — the latter is undefined in Vitest, the
+ * factory never installs, and the real socket.io-client tries to dial a server.
+ *
+ * The `import { WebSocketDebugTransport }` below sits AFTER the `vi.mock` call,
+ * and that position is LOAD-BEARING:
+ *   - Vitest hoists `vi.mock` above the imports, so it would work either way.
+ *   - The editor's Jest does NOT hoist it (ts-jest only hoists literal
+ *     `jest.mock`), so the call has to physically precede the import.
+ * Do not move it into the import block at the top.
  */
 import type { Socket } from 'socket.io-client'
-
-import { WebSocketDebugTransport } from '../websocket-debug-transport'
 
 type Handler = (arg: unknown) => void
 type Responder = (commandHex: string) => { success: boolean; data?: string; error?: string }
@@ -48,9 +58,12 @@ function makeFakeSocket(responder: Responder): Socket {
 
 let currentResponder: Responder = () => ({ success: false, error: 'no responder' })
 
-jest.mock('socket.io-client', () => ({
-  io: jest.fn(() => makeFakeSocket((cmd) => currentResponder(cmd))),
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => makeFakeSocket((cmd) => currentResponder(cmd))),
 }))
+
+// Deliberately AFTER `vi.mock` — see the module docstring.
+import { WebSocketDebugTransport } from '../websocket-debug-transport'
 
 async function connected(): Promise<WebSocketDebugTransport> {
   const transport = new WebSocketDebugTransport({ host: '127.0.0.1', port: 8443, token: 'jwt' })

--- a/src/backend/shared/debug/__tests__/websocket-debug-transport-license.test.ts
+++ b/src/backend/shared/debug/__tests__/websocket-debug-transport-license.test.ts
@@ -1,0 +1,137 @@
+/**
+ * License function codes (0x49 write / 0x4A read) over the runtime-v4 debug
+ * WebSocket. Mocks socket.io-client so the test exercises the REAL PDU framing:
+ * builder -> spaced-hex envelope -> canned runtime response -> parser.
+ *
+ * This is the editor side of the transport-agnostic activation: the same PDUs the
+ * serial and TCP clients send, so a network target licenses through one code path
+ * instead of a second, medium-specific one. The runtime answers these FCs at the
+ * webserver level (covered by the runtime's own tests).
+ */
+import type { Socket } from 'socket.io-client'
+
+import { WebSocketDebugTransport } from '../websocket-debug-transport'
+
+type Handler = (arg: unknown) => void
+type Responder = (commandHex: string) => { success: boolean; data?: string; error?: string }
+
+/**
+ * Fake Socket.IO socket: auto-connects and answers `debug_command` with whatever
+ * the active responder returns for the PDU it was handed.
+ */
+function makeFakeSocket(responder: Responder): Socket {
+  const handlers: Record<string, Handler[]> = {}
+  const socket = {
+    on(event: string, cb: Handler) {
+      ;(handlers[event] ||= []).push(cb)
+      if (event === 'connected') setTimeout(() => cb({ status: 'ok' }), 0)
+      return socket
+    },
+    off(event: string, cb: Handler) {
+      handlers[event] = (handlers[event] || []).filter((h) => h !== cb)
+      return socket
+    },
+    emit(event: string, payload: { command: string }) {
+      if (event === 'debug_command') {
+        const resp = responder(payload.command)
+        setTimeout(() => (handlers['debug_response'] || []).forEach((h) => h(resp)), 0)
+      }
+      return socket
+    },
+    disconnect() {
+      return socket
+    },
+    io: { on() {} },
+  }
+  return socket as unknown as Socket
+}
+
+let currentResponder: Responder = () => ({ success: false, error: 'no responder' })
+
+jest.mock('socket.io-client', () => ({
+  io: jest.fn(() => makeFakeSocket((cmd) => currentResponder(cmd))),
+}))
+
+async function connected(): Promise<WebSocketDebugTransport> {
+  const transport = new WebSocketDebugTransport({ host: '127.0.0.1', port: 8443, token: 'jwt' })
+  await transport.connect()
+  return transport
+}
+
+function toSpacedHex(bytes: number[]): string {
+  return bytes.map((b) => b.toString(16).toUpperCase().padStart(2, '0')).join(' ')
+}
+
+describe('WebSocketDebugTransport license function codes', () => {
+  it('readLicense (0x4A) parses a full 98-byte blob on SUCCESS', async () => {
+    const blob = new Uint8Array(98)
+    for (let i = 0; i < blob.length; i++) blob[i] = i & 0xff
+    currentResponder = () => ({ success: true, data: toSpacedHex([0x4a, 0x7e, 0x00, 98, ...blob]) })
+
+    const transport = await connected()
+    const result = await transport.readLicense()
+
+    expect(result.success).toBe(true)
+    expect(result.blob?.length).toBe(98)
+    expect(Array.from(result.blob ?? [])).toEqual(Array.from(blob))
+  })
+
+  it('readLicense (0x4A) maps LIC_EMPTY to a valid empty state, not an error', async () => {
+    currentResponder = () => ({ success: true, data: '4A 83' })
+
+    const transport = await connected()
+    const result = await transport.readLicense()
+
+    expect(result.success).toBe(true)
+    expect(result.empty).toBe(true)
+    expect(result.blob).toBeUndefined()
+  })
+
+  it('readLicense (0x4A) maps LIC_UNSUPPORTED to a valid state (no store backend)', async () => {
+    currentResponder = () => ({ success: true, data: '4A 85' })
+
+    const transport = await connected()
+    const result = await transport.readLicense()
+
+    expect(result.success).toBe(true)
+    expect(result.unsupported).toBe(true)
+  })
+
+  it('writeLicense (0x49) frames [FC][len:u16BE][blob] and parses SUCCESS', async () => {
+    const sent: string[] = []
+    currentResponder = (cmd) => {
+      sent.push(cmd)
+      return { success: true, data: '49 7E' }
+    }
+
+    const transport = await connected()
+    const result = await transport.writeLicense(new Uint8Array(98).fill(0xab))
+
+    const parts = sent[0].split(' ')
+    expect(parts[0]).toBe('49')
+    expect(parts[1]).toBe('00') // len high
+    expect(parts[2]).toBe('62') // len low (98)
+    expect(parts).toHaveLength(3 + 98)
+    expect(result.success).toBe(true)
+  })
+
+  it('surfaces a runtime-side error as a structured failure rather than throwing', async () => {
+    currentResponder = () => ({ success: false, error: 'no license backend wired' })
+
+    const transport = await connected()
+    const result = await transport.readLicense()
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('no license backend wired')
+  })
+
+  it('refuses both calls when the socket is not connected', async () => {
+    const transport = new WebSocketDebugTransport({ host: '127.0.0.1', port: 8443, token: 'jwt' })
+
+    await expect(transport.readLicense()).resolves.toEqual({ success: false, error: 'Not connected to target' })
+    await expect(transport.writeLicense(new Uint8Array(98))).resolves.toEqual({
+      success: false,
+      error: 'Not connected to target',
+    })
+  })
+})

--- a/src/backend/shared/debug/index.ts
+++ b/src/backend/shared/debug/index.ts
@@ -1,2 +1,17 @@
+export {
+  crc32IsoHdlc,
+  deserializeLicenseBlob,
+  LIC_BLOB_SIZE,
+  LIC_MAGIC_LE,
+  LIC_PAYLOAD_SIZE,
+  type LicenseBlob,
+  serializeLicenseBlob,
+} from './license-blob'
 export { ModbusRtuTransport } from './modbus-rtu-transport'
-export type { DebugSetResult, DebugTransport, DebugTransportResult } from './types'
+export type {
+  DebugLicenseReadResult,
+  DebugLicenseWriteResult,
+  DebugSetResult,
+  DebugTransport,
+  DebugTransportResult,
+} from './types'

--- a/src/backend/shared/debug/license-blob.ts
+++ b/src/backend/shared/debug/license-blob.ts
@@ -1,0 +1,147 @@
+/**
+ * TS mirror of the firmware `lic_blob_t` on-device license blob (OLS-02).
+ *
+ * Byte-identical to the C struct in `resources/sources/Baremetal/license_blob.h`.
+ * All multi-byte fields are **little-endian**, written explicitly through a
+ * `DataView` so the result never depends on the host byte order.
+ *
+ * The cross-language pin is `__tests__/fixtures/license-golden.json`: the same
+ * vector is asserted by this module's test and by the firmware host-test, so a
+ * layout change on either side fails a test instead of producing a blob the
+ * board silently rejects.
+ *
+ * Blob layout (98 bytes, packed, no padding):
+ *
+ *   | Offset | Field       | Type          | Size |
+ *   |-------:|-------------|---------------|-----:|
+ *   | 0      | magic       | uint32 LE     | 4    |  'OPLC' -> bytes 4F 50 4C 43
+ *   | 4      | fmtVersion  | uint8         | 1    |
+ *   | 5      | keyId       | uint8         | 1    |  signing-key id (rotation)
+ *   | 6      | deviceId    | uint8[16]     | 16   |
+ *   | 22     | productId   | uint8[8]      | 8    |  vpp id
+ *   | 30     | signature   | uint8[64]     | 64   |  ECDSA P-256 r||s raw
+ *   | 94     | crc32       | uint32 LE     | 4    |  CRC-32/ISO-HDLC over [payload||signature] (0..93)
+ *   | 98     | (end)       |               |      |
+ *
+ * The signed payload is offsets 0..29 (30 bytes). The crc32 covers
+ * `[payload || signature]` = offsets 0..93 (94 bytes) and never itself.
+ */
+
+/** Total blob size in bytes (`sizeof(lic_blob_t)`). */
+export const LIC_BLOB_SIZE = 98
+/** Signed payload size in bytes (`sizeof(lic_payload_t)`). */
+export const LIC_PAYLOAD_SIZE = 30
+/**
+ * Magic as a little-endian uint32. The first four bytes of the blob are
+ * always `4F 50 4C 43` ('OPLC'); read as an LE uint32 that is 0x434C504F.
+ */
+export const LIC_MAGIC_LE = 0x434c504f
+
+// Field offsets (mirror the C struct exactly).
+const OFF_MAGIC = 0
+const OFF_FMT_VERSION = 4
+const OFF_KEY_ID = 5
+const OFF_DEVICE_ID = 6
+const OFF_PRODUCT_ID = 22
+const OFF_SIGNATURE = 30
+const OFF_CRC32 = 94
+
+const DEVICE_ID_SIZE = 16
+const PRODUCT_ID_SIZE = 8
+const SIGNATURE_SIZE = 64
+
+export interface LicenseBlob {
+  /** LE uint32 magic; canonical value is `LIC_MAGIC_LE` (0x434C504F). */
+  magic: number
+  fmtVersion: number
+  /** signing-key id (enables signing-key rotation). */
+  keyId: number
+  /** 16-byte device identifier. */
+  deviceId: Uint8Array
+  /** 8-byte product identifier (vpp id). */
+  productId: Uint8Array
+  /** 64-byte ECDSA P-256 signature (r||s, raw). */
+  signature: Uint8Array
+  /** CRC-32/ISO-HDLC over `[payload||signature]`. */
+  crc32: number
+}
+
+// ---------------------------------------------------------------------------
+// CRC-32/ISO-HDLC (a.k.a. CRC-32, zlib/PKZIP)
+//   poly (reflected) 0xEDB88320 · init 0xFFFFFFFF · refin/refout true · xorout 0xFFFFFFFF
+//   test vector: crc32IsoHdlc("123456789") === 0xCBF43926
+// Same definition as the firmware bitwise implementation — the golden test
+// proves cross-language parity.
+// ---------------------------------------------------------------------------
+
+/** Compute CRC-32/ISO-HDLC over `data`, returned as an unsigned 32-bit number. */
+export function crc32IsoHdlc(data: Uint8Array): number {
+  let crc = 0xffffffff
+  for (let i = 0; i < data.length; i++) {
+    crc ^= data[i]
+    for (let bit = 0; bit < 8; bit++) {
+      // Reflected: process LSB first, XOR with poly when the low bit is set.
+      crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+// ---------------------------------------------------------------------------
+// Serialize / deserialize
+// ---------------------------------------------------------------------------
+
+function copyFixed(dst: Uint8Array, offset: number, src: Uint8Array, size: number): void {
+  // Copy at most `size` bytes; a short source leaves the rest zero-filled.
+  dst.set(src.subarray(0, size), offset)
+}
+
+/**
+ * Serialize a `LicenseBlob` into its 98-byte on-wire representation.
+ *
+ * All multi-byte fields are written little-endian via explicit
+ * `DataView.setUint32(off, v, true)`. The `magic` is forced to the canonical
+ * `LIC_MAGIC_LE`, and the `crc32` is **recomputed** over `[payload||signature]`
+ * (offsets 0..93) — the `crc32` field on the input is ignored.
+ */
+export function serializeLicenseBlob(b: LicenseBlob): Uint8Array {
+  const out = new Uint8Array(LIC_BLOB_SIZE)
+  const view = new DataView(out.buffer)
+
+  view.setUint32(OFF_MAGIC, LIC_MAGIC_LE, true)
+  out[OFF_FMT_VERSION] = b.fmtVersion & 0xff
+  out[OFF_KEY_ID] = b.keyId & 0xff
+  copyFixed(out, OFF_DEVICE_ID, b.deviceId, DEVICE_ID_SIZE)
+  copyFixed(out, OFF_PRODUCT_ID, b.productId, PRODUCT_ID_SIZE)
+  copyFixed(out, OFF_SIGNATURE, b.signature, SIGNATURE_SIZE)
+
+  // Recompute crc32 over [payload || signature] = offsets 0..93 (94 bytes).
+  const crc = crc32IsoHdlc(out.subarray(0, OFF_CRC32))
+  view.setUint32(OFF_CRC32, crc, true)
+
+  return out
+}
+
+/**
+ * Deserialize a 98-byte blob into a `LicenseBlob`. All multi-byte fields are
+ * read little-endian. `deviceId` / `productId` / `signature` are fresh copies
+ * (not views onto `buf`). Does not validate magic or crc32 — that is the
+ * caller's / firmware's responsibility.
+ */
+export function deserializeLicenseBlob(buf: Uint8Array): LicenseBlob {
+  if (buf.length < LIC_BLOB_SIZE) {
+    throw new Error(`Invalid license blob: too short (${buf.length} bytes, expected ${LIC_BLOB_SIZE})`)
+  }
+
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
+
+  return {
+    magic: view.getUint32(OFF_MAGIC, true),
+    fmtVersion: buf[OFF_FMT_VERSION],
+    keyId: buf[OFF_KEY_ID],
+    deviceId: buf.slice(OFF_DEVICE_ID, OFF_DEVICE_ID + DEVICE_ID_SIZE),
+    productId: buf.slice(OFF_PRODUCT_ID, OFF_PRODUCT_ID + PRODUCT_ID_SIZE),
+    signature: buf.slice(OFF_SIGNATURE, OFF_SIGNATURE + SIGNATURE_SIZE),
+    crc32: view.getUint32(OFF_CRC32, true),
+  }
+}

--- a/src/backend/shared/debug/modbus-pdu.ts
+++ b/src/backend/shared/debug/modbus-pdu.ts
@@ -26,6 +26,18 @@
  *   plcSetState request:  [FC=0x4b] [state: U8]   (0 = STOP, 1 = RUN)
  *   plcSetState response: [FC=0x4b] [status] [plcState: U8] [switchPosition: U8]
  *
+ *   writeLicense request:  [FC=0x49] [len: U16BE] [blob...]
+ *   writeLicense response: [FC=0x49] [status]
+ *
+ *   readLicense request:   [FC=0x4a]
+ *   readLicense response:  [FC=0x4a] [status] [len: U16BE] [blob...]   (SUCCESS)
+ *                          [FC=0x4a] [status]                          (otherwise)
+ *
+ * The license `len` is BIG-ENDIAN like every other length on this wire, while
+ * the blob it frames is little-endian content (see license-blob.ts). The two
+ * conventions coexist by design: the framing is Modbus, the payload is a C
+ * struct.
+ *
  *   set request:   [FC=0x42] [arr: U8] [elem: U16BE] [force: U8] [dataLen: U16BE] [value...]
  *   set response:  [FC=0x42] [status]
  *
@@ -47,6 +59,8 @@ import { detectTargetEndian, type TargetEndian } from '../../../frontend/utils/e
 import { ModbusDebugResponse, ModbusFunctionCode, PlcRuntimeState } from '../simulator/types'
 import type {
   DebugBoardIdResult,
+  DebugLicenseReadResult,
+  DebugLicenseWriteResult,
   DebugSetResult,
   DebugStatusResult,
   DebugTransportResult,
@@ -164,6 +178,29 @@ export function buildGetVersionRequest(): Uint8Array {
 export function buildGetBoardIdRequest(): Uint8Array {
   const buf = alloc(1)
   writeU8(buf, 0, ModbusFunctionCode.DEBUG_GET_BOARD_ID)
+  return buf
+}
+
+/**
+ * Build a write-license request (FC 0x49).
+ * PDU: `[FC][len:U16BE][blob...]`.
+ *
+ * The `len` on the wire is BIG-ENDIAN (matches every other debug FC), even
+ * though the blob *content* is little-endian (see license-blob.ts). Do not
+ * confuse the two: `writeU16BE` is deliberate here.
+ */
+export function buildWriteLicenseRequest(blob: Uint8Array): Uint8Array {
+  const buf = alloc(3 + blob.length)
+  writeU8(buf, 0, ModbusFunctionCode.DEBUG_WRITE_LICENSE)
+  writeU16BE(buf, 1, blob.length)
+  buf.set(blob, 3)
+  return buf
+}
+
+/** Build a read-license request (FC 0x4A). Bare `[FC]` PDU — no payload. */
+export function buildReadLicenseRequest(): Uint8Array {
+  const buf = alloc(1)
+  writeU8(buf, 0, ModbusFunctionCode.DEBUG_READ_LICENSE)
   return buf
 }
 
@@ -386,6 +423,90 @@ export function parseGetBoardIdResponse(data: Uint8Array): DebugBoardIdResult {
   const boardId = data.slice(3, 3 + idLen)
   const boardIdHex = Array.from(boardId, (b) => b.toString(16).padStart(2, '0')).join('')
   return { success: true, boardId, boardIdHex }
+}
+
+/**
+ * Parse a write-license response (FC 0x49).
+ * Layout: `[FC][status]`. SUCCESS → `{ success: true, status }`. LIC_UNSUPPORTED
+ * (the board has no backend) is a valid device state → `{ success: true,
+ * unsupported: true }`, not a transport error. Any other non-SUCCESS status is a
+ * device-side failure surfaced as `{ success: false, error }`.
+ */
+export function parseWriteLicenseResponse(data: Uint8Array): DebugLicenseWriteResult {
+  if (data.length < 2) {
+    return { success: false, error: `Invalid response: too short (${data.length} bytes)` }
+  }
+
+  const fc = readU8(data, 0)
+  const status = readU8(data, 1)
+
+  if (fc !== ModbusFunctionCode.DEBUG_WRITE_LICENSE) {
+    return { success: false, error: 'Function code mismatch' }
+  }
+
+  if (status === ModbusDebugResponse.LIC_UNSUPPORTED) {
+    return { success: true, status, unsupported: true }
+  }
+
+  if (status !== ModbusDebugResponse.SUCCESS) {
+    return { success: false, status, error: statusError(status) }
+  }
+
+  return { success: true, status }
+}
+
+/**
+ * Parse a read-license response (FC 0x4A).
+ * Layout (OK):    `[FC][status=SUCCESS][len:U16BE][blob...]`.
+ * Layout (other): `[FC][status]` — no len, no blob.
+ *
+ * `len` is BIG-ENDIAN (readU16BE) — the wire convention — while the blob it
+ * frames is little-endian content. LIC_EMPTY / LIC_CORRUPT / LIC_UNSUPPORTED are
+ * valid device states (`success: true` with the corresponding flag), not
+ * transport errors.
+ */
+export function parseReadLicenseResponse(data: Uint8Array): DebugLicenseReadResult {
+  if (data.length < 2) {
+    return { success: false, error: `Invalid response: too short (${data.length} bytes)` }
+  }
+
+  const fc = readU8(data, 0)
+  const status = readU8(data, 1)
+
+  if (fc !== ModbusFunctionCode.DEBUG_READ_LICENSE) {
+    return { success: false, error: 'Function code mismatch' }
+  }
+
+  if (status === ModbusDebugResponse.LIC_EMPTY) {
+    return { success: true, status, empty: true }
+  }
+
+  if (status === ModbusDebugResponse.LIC_CORRUPT) {
+    return { success: true, status, corrupt: true }
+  }
+
+  if (status === ModbusDebugResponse.LIC_UNSUPPORTED) {
+    return { success: true, status, unsupported: true }
+  }
+
+  if (status !== ModbusDebugResponse.SUCCESS) {
+    return { success: false, status, error: statusError(status) }
+  }
+
+  if (data.length < 4) {
+    return { success: false, status, error: `Incomplete license response (${data.length} bytes, expected at least 4)` }
+  }
+
+  const len = readU16BE(data, 2)
+  if (data.length < 4 + len) {
+    return {
+      success: false,
+      status,
+      error: `Incomplete license blob (expected ${len} bytes, got ${data.length - 4})`,
+    }
+  }
+
+  return { success: true, status, blob: data.slice(4, 4 + len) }
 }
 
 /**

--- a/src/backend/shared/debug/types.ts
+++ b/src/backend/shared/debug/types.ts
@@ -71,6 +71,48 @@ export interface DebugBoardIdResult {
 }
 
 /**
+ * Result of a write-license call (FC 0x49). The device stores the raw blob
+ * bytes; `status` is the ModbusDebugResponse code the target returned
+ * (SUCCESS/ERROR_OUT_OF_BOUNDS/ERROR_OUT_OF_MEMORY). `unsupported` (status
+ * LIC_UNSUPPORTED) means the board has no license-store backend — a valid
+ * device state (`success: true`), not a transport failure.
+ *
+ * A `success: true` here means ONLY "the bytes were accepted for storage". No
+ * target validates magic, crc32, `deviceId` or `productId` on write, so a caller
+ * that needs to know what the board now holds must read it back (FC 0x4A) and
+ * verify — see the write path in the licensing flow.
+ */
+export interface DebugLicenseWriteResult {
+  success: boolean
+  status?: number
+  unsupported?: boolean
+  error?: string
+}
+
+/**
+ * Result of a read-license call (FC 0x4A). `blob` is present only on SUCCESS.
+ * `empty` (status LIC_EMPTY) means virgin storage — no license provisioned;
+ * `corrupt` (status LIC_CORRUPT) means the magic matched but the crc32 failed.
+ * `unsupported` (status LIC_UNSUPPORTED) means the board has no license-store
+ * backend at all. All three are `success: true` — they are valid device
+ * states, not transport failures — the caller distinguishes via the flags.
+ *
+ * A SUCCESS status does NOT mean the stored license is good: the two targets
+ * disagree about what they check before answering it (bare metal validates magic
+ * + crc32; the Linux runtime only checks the file length). Callers must verify
+ * the returned bytes themselves.
+ */
+export interface DebugLicenseReadResult {
+  success: boolean
+  status?: number
+  empty?: boolean
+  corrupt?: boolean
+  unsupported?: boolean
+  blob?: Uint8Array
+  error?: string
+}
+
+/**
  * Result of an MD5-probe call.  The `md5` is the runtime's program hash;
  * `targetEndian` is the byte order detected from the 2-byte sentinel the
  * runtime writes into the response trailer via a native `uint16_t*`
@@ -128,6 +170,15 @@ export interface DeviceChannelTransport {
   /** Run/stop command (FC 0x4b). Reads go through `getStatus()`. Optional for
    *  the same reason as `getStatus`. */
   setPlcState?(state: PlcRuntimeState.RUNNING | PlcRuntimeState.STOPPED): Promise<PlcControlResult>
+  /** Read the stored VPP license blob (FC 0x4A). Optional here because not every
+   *  medium carries it — but unlike run/stop, every medium that CAN is expected
+   *  to: licensing is a property of the device, not of the target family, so the
+   *  Modbus clients and the runtime-v4 WebSocket all implement it (see
+   *  `DeviceModbusTransport`, where it is required). */
+  readLicense?(): Promise<DebugLicenseReadResult>
+  /** Store a VPP license blob (FC 0x49). Optional for the same reason as
+   *  `readLicense`. Storing does not validate — read back to confirm. */
+  writeLicense?(blob: Uint8Array): Promise<DebugLicenseWriteResult>
 }
 
 /**
@@ -175,6 +226,12 @@ export interface DeviceDebugChannel extends DeviceChannelTransport {
  * `DeviceChannelTransport`: both Modbus clients implement run/stop, and only the
  * runtime-v4 WebSocket (a different protocol, driving run/stop over REST) does
  * not.
+ *
+ * `readLicense` / `writeLicense` are required for a different reason: the license
+ * FCs are transport-agnostic by design, so device activation runs identically on
+ * serial and on TCP. A Modbus link that could not carry them would give the
+ * licensing flow a second, target-dependent shape — which is the divergence the
+ * one-transport-interface refactor exists to prevent.
  */
 export interface DeviceModbusTransport
   extends Omit<DebugTransport, 'getVariablesList' | 'setVariable'>,
@@ -182,6 +239,8 @@ export interface DeviceModbusTransport
   getBoardId(): Promise<DebugBoardIdResult>
   getStatus(): Promise<DebugStatusResult>
   setPlcState(state: PlcRuntimeState.RUNNING | PlcRuntimeState.STOPPED): Promise<PlcControlResult>
+  readLicense(): Promise<DebugLicenseReadResult>
+  writeLicense(blob: Uint8Array): Promise<DebugLicenseWriteResult>
   /**
    * The two payload-carrying operations, restated for the main process.
    *

--- a/src/backend/shared/debug/websocket-debug-transport.ts
+++ b/src/backend/shared/debug/websocket-debug-transport.ts
@@ -26,12 +26,24 @@ import { getErrorMessage } from '../../../frontend/utils/get-error-message'
 import {
   buildGetListRequest,
   buildGetMd5Request,
+  buildReadLicenseRequest,
   buildSetVariableRequest,
+  buildWriteLicenseRequest,
   parseGetListResponse,
   parseGetMd5Response,
+  parseReadLicenseResponse,
   parseSetVariableResponse,
+  parseWriteLicenseResponse,
 } from './modbus-pdu'
-import type { DebugSetResult, DebugTransport, DebugTransportResult, DeviceDebugChannel, Md5ProbeResult } from './types'
+import type {
+  DebugLicenseReadResult,
+  DebugLicenseWriteResult,
+  DebugSetResult,
+  DebugTransport,
+  DebugTransportResult,
+  DeviceDebugChannel,
+  Md5ProbeResult,
+} from './types'
 
 const REQUEST_TIMEOUT_MS = 5000
 const CONNECT_TIMEOUT_MS = 5000
@@ -145,6 +157,28 @@ export class WebSocketDebugTransport implements DebugTransport, DeviceDebugChann
     )
   }
 
+  // License function codes (0x49/0x4A), byte-identical to the serial/TCP
+  // clients: the runtime answers them at the webserver level, but the editor sees
+  // ONE transport-agnostic contract, so the licensing flow has a single shape on
+  // every target instead of a network-specific branch.
+  //
+  // `getBoardId` (0x48) stays absent on purpose: a runtime-v4 target's identity
+  // comes from the REST login, so it never answers that FC. That is why
+  // `DeviceChannelTransport` declares the license methods optional — this class
+  // implements the pair it can serve without claiming the one it cannot.
+
+  async readLicense(): Promise<DebugLicenseReadResult> {
+    if (!this.socket) return { success: false, error: 'Not connected to target' }
+
+    return this.sendCommand(buildReadLicenseRequest(), (bytes) => parseReadLicenseResponse(bytes), 'resolve')
+  }
+
+  async writeLicense(blob: Uint8Array): Promise<DebugLicenseWriteResult> {
+    if (!this.socket) return { success: false, error: 'Not connected to target' }
+
+    return this.sendCommand(buildWriteLicenseRequest(blob), (bytes) => parseWriteLicenseResponse(bytes), 'resolve')
+  }
+
   /**
    * Send a Modbus PDU over the `debug_command` event and parse the
    * matching `debug_response`.  `errorMode` controls whether a
@@ -157,11 +191,9 @@ export class WebSocketDebugTransport implements DebugTransport, DeviceDebugChann
    * client method routes through here, so the hex encoding /
    * timeout / event registration logic lives in exactly one place.
    */
-  private sendCommand<T extends DebugTransportResult | DebugSetResult>(
-    pdu: Uint8Array,
-    parse: (bytes: Uint8Array) => T,
-    errorMode: 'resolve',
-  ): Promise<T>
+  private sendCommand<
+    T extends DebugTransportResult | DebugSetResult | DebugLicenseReadResult | DebugLicenseWriteResult,
+  >(pdu: Uint8Array, parse: (bytes: Uint8Array) => T, errorMode: 'resolve'): Promise<T>
   private sendCommand<T extends Md5ProbeResult>(
     pdu: Uint8Array,
     parse: (bytes: Uint8Array) => T,

--- a/src/backend/shared/hardware/__tests__/board-info-resolver.test.ts
+++ b/src/backend/shared/hardware/__tests__/board-info-resolver.test.ts
@@ -360,6 +360,87 @@ describe('BoardInfoResolver', () => {
       ])
     })
 
+    // ---------------------------------------------------------------------
+    // Licensing fields (hal.licenseStore / hal.licenseKeyId)
+    //
+    // `hal.licenseStore` resolves to BUILD INPUTS and nothing else. There is no
+    // capability mirroring it: every licensable VPP targets hardware that
+    // persists a licence, so a second derived boolean would be true wherever
+    // `isLicensable` is. These pin that the paths resolve and that the
+    // capability block is passed through untouched.
+    // ---------------------------------------------------------------------
+
+    /** A licensed-VPP device, with whatever licensing fields the test is about. */
+    function licensedDevice(hal: Record<string, unknown>) {
+      return {
+        id: 'esp32-generic',
+        name: 'ESP32 Generic',
+        preview: 'p.png',
+        target: { type: 'arduino-cli', core: 'esp32:esp32', platform: 'esp32:esp32:esp32' },
+        hal: { type: 'arduino-hal', source: 'hal/arduino/esp32.cpp', ...hal },
+        capabilities: { isLicensable: true },
+      } as PackageManifest['devices'][number]
+    }
+
+    function resolveLicensed(hal: Record<string, unknown>) {
+      const pkg = makePkg()
+      const manifest = makeManifest({ devices: [licensedDevice(hal)] })
+      return makeResolver({}, makePackageManager([pkg], { [pkg.packageId]: manifest })).resolve('ESP32 Generic')
+    }
+
+    it('resolves hal.licenseStore to package-relative paths and flips the licenseStore capability', () => {
+      const info = resolveLicensed({
+        licenseStore: 'hal/arduino/license_store_esp32.cpp',
+        licenseKeyId: 'espressif-licensed-2026',
+      })
+
+      // Asserted through the same platform-supplied resolver the production code
+      // is handed, which is the actual contract — hard-coding a joined path bakes
+      // in POSIX assumptions the resolver does not make.
+      expect(info.licenseStoreFiles).toEqual([packageRelative(PKG_PATH, 'hal/arduino/license_store_esp32.cpp')])
+      expect(info.licenseKeyId).toBe('espressif-licensed-2026')
+      // The capability block is whatever the manifest declared — nothing derived
+      // into it, so it cannot disagree with `licenseStoreFiles`.
+      expect(info.capabilities).toEqual({ isLicensable: true })
+    })
+
+    it('accepts hal.licenseStore as an array of sources', () => {
+      const info = resolveLicensed({ licenseStore: ['hal/a.cpp', 'hal/b.cpp'] })
+
+      expect(info.licenseStoreFiles).toEqual([
+        packageRelative(PKG_PATH, 'hal/a.cpp'),
+        packageRelative(PKG_PATH, 'hal/b.cpp'),
+      ])
+      expect(info.capabilities).toEqual({ isLicensable: true })
+    })
+
+    it('resolves no store files for a licensable VPP that ships no backend', () => {
+      // A PACKAGING fault, not a device state: the compiler warns, and the board
+      // links the weak default and reports its storage as missing.
+      const info = resolveLicensed({})
+
+      expect(info.licenseStoreFiles).toBeUndefined()
+      expect(info.capabilities).toEqual({ isLicensable: true })
+    })
+
+    it('treats a blank licenseStore as absent rather than resolving it to the package root', () => {
+      // `''` would resolve to PKG_PATH itself and read as "storage present",
+      // advertising a backend that is not there.
+      const info = resolveLicensed({ licenseStore: '   ' })
+
+      expect(info.licenseStoreFiles).toBeUndefined()
+    })
+
+    it('does not invent a capability block for a device that declares nothing', () => {
+      const pkg = makePkg()
+      const manifest = makeManifest()
+      const info = makeResolver({}, makePackageManager([pkg], { [pkg.packageId]: manifest })).resolve('Arduino Mega')
+
+      expect(info.capabilities).toBeUndefined()
+      expect(info.licenseStoreFiles).toBeUndefined()
+      expect(info.licenseKeyId).toBeUndefined()
+    })
+
     it('omits platformOptions when the manifest does not declare any', () => {
       const pkg = makePkg()
       const manifest = makeManifest({

--- a/src/backend/shared/hardware/board-info-resolver.ts
+++ b/src/backend/shared/hardware/board-info-resolver.ts
@@ -160,6 +160,21 @@ export interface BoardBuildInfo {
    *  library dir, linked via a 2nd `--library`. Its presence marks an arduino
    *  prebuilt board (the source HAL still compiles as the integration layer). */
   precompiledLibraryDir?: string
+  /** Resolved paths of the VPP's on-device license-storage backend sources
+   *  (`device.hal.licenseStore`), injected into the Baremetal sketch so they
+   *  define the STRONG `license_store_*` symbols over the weak default.
+   *
+   *  This is the ONE representation of "this VPP ships storage". There is
+   *  deliberately no capability mirroring it: every licensable VPP targets
+   *  hardware that persists a licence, so a second derived boolean would be
+   *  true wherever `isLicensable` is and only add a way for the two to
+   *  disagree. */
+  licenseStoreFiles?: string[]
+  /** Per-VPP signing key id (`device.hal.licenseKeyId`). Informational in the
+   *  editor: the activation request carries only `{ deviceId, packageId }` and
+   *  the backend resolves its own key. Carried for the build side and for
+   *  diagnosing a board that stores a blob and still runs demo. */
+  licenseKeyId?: string
   /** Exact Arduino core version to install/verify before linking a prebuilt
    *  arduino library (ABI-locked). From `target.coreVersion`. */
   coreVersion?: string
@@ -303,6 +318,17 @@ export class BoardInfoResolver {
     if (flags) info.compilerFlags = flags
     if (device.hal.define) info.define = device.hal.define
     if (device.hal.extraArduinoLibraries) info.extraArduinoLibraries = device.hal.extraArduinoLibraries
+    if (device.hal.licenseKeyId) info.licenseKeyId = device.hal.licenseKeyId
+
+    // `hal.licenseStore` resolves to build inputs and nothing else. It used to
+    // ALSO derive a `capabilities.licenseStore` boolean; that is gone, because
+    // every licensable VPP targets hardware that persists a licence, so the
+    // boolean was true wherever `isLicensable` was and its only job was one
+    // diagnostic sentence.
+    const licenseStoreFiles = normalizeToArray(device.hal.licenseStore)
+    if (licenseStoreFiles.length > 0) {
+      info.licenseStoreFiles = licenseStoreFiles.map((file) => resolveRel(pkg.path, file))
+    }
     if (device.capabilities) info.capabilities = device.capabilities
 
     if (device.hal.pluginType === 'python' || device.hal.pluginType === 'native') {
@@ -340,4 +366,15 @@ export class BoardInfoResolver {
     if (ld) out.ld_flags = ld
     return out
   }
+}
+
+/**
+ * A manifest field declared as `string | string[]` as a flat list of non-empty
+ * entries. Blank strings are dropped rather than resolved: a `licenseStore: ""`
+ * would otherwise resolve to the package root and read as "storage present".
+ */
+function normalizeToArray(value: string | string[] | undefined): string[] {
+  if (value === undefined) return []
+  const list = Array.isArray(value) ? value : [value]
+  return list.filter((entry) => entry.trim().length > 0)
 }

--- a/src/backend/shared/simulator/__tests__/modbus-rtu-client.test.ts
+++ b/src/backend/shared/simulator/__tests__/modbus-rtu-client.test.ts
@@ -1159,4 +1159,133 @@ describe('ModbusRtuClient', () => {
       expect(result.error).toContain('timeout')
     })
   })
+
+  // -----------------------------------------------------------------------
+  // On-device license storage (FC 0x49 write / 0x4A read)
+  //
+  // The end-to-end coverage against a real license store needs firmware built
+  // with the store backend compiled in, so without these the wire framing here
+  // is unexercised on an ordinary test run.
+  // -----------------------------------------------------------------------
+  describe('writeLicense / readLicense', () => {
+    /** A recognisable 98-byte blob whose first byte is the 'O' of the LE magic. */
+    function sampleBlob(): Uint8Array {
+      const blob = new Uint8Array(98)
+      for (let i = 0; i < blob.length; i++) blob[i] = i & 0xff
+      blob[0] = 0x4f
+      return blob
+    }
+
+    it('frames a write as [FC][len:u16BE][blob] and reports SUCCESS', async () => {
+      await connectClient()
+      const blob = sampleBlob()
+      const written: number[][] = []
+      port._interceptWrite = (data: Uint8Array) => {
+        written.push(Array.from(data))
+        setTimeout(
+          () =>
+            port._emit(
+              'data',
+              buildResponse(1, ModbusFunctionCode.DEBUG_WRITE_LICENSE, new Uint8Array([ModbusDebugResponse.SUCCESS])),
+            ),
+          0,
+        )
+      }
+
+      const result = await client.writeLicense(blob)
+
+      // [slaveId][FC][len hi][len lo][blob...] + CRC. The length is BIG-endian
+      // even though the blob content it frames is little-endian.
+      expect(written[0][1]).toBe(ModbusFunctionCode.DEBUG_WRITE_LICENSE)
+      expect(written[0][2]).toBe(0x00)
+      expect(written[0][3]).toBe(98)
+      expect(written[0][4]).toBe(0x4f)
+      expect(result).toMatchObject({ success: true, status: ModbusDebugResponse.SUCCESS })
+    })
+
+    it('reports LIC_UNSUPPORTED on a write as a valid device state, not a failure', async () => {
+      await connectClient()
+      autoRespond(
+        buildResponse(1, ModbusFunctionCode.DEBUG_WRITE_LICENSE, new Uint8Array([ModbusDebugResponse.LIC_UNSUPPORTED])),
+      )
+
+      const result = await client.writeLicense(sampleBlob())
+
+      expect(result).toMatchObject({ success: true, unsupported: true })
+    })
+
+    it('reads the stored blob back byte-for-byte', async () => {
+      await connectClient()
+      const blob = sampleBlob()
+      const payload = new Uint8Array(3 + blob.length)
+      payload[0] = ModbusDebugResponse.SUCCESS
+      payload[1] = 0x00 // len hi
+      payload[2] = blob.length // len lo
+      payload.set(blob, 3)
+      autoRespond(buildResponse(1, ModbusFunctionCode.DEBUG_READ_LICENSE, payload))
+
+      const result = await client.readLicense()
+
+      expect(result.success).toBe(true)
+      expect(Array.from(result.blob ?? [])).toEqual(Array.from(blob))
+      // The LE uint32 magic 0x434C504F serializes to 4F 50 4C 43, so a leading
+      // 0x4F proves the byte order survived the write -> store -> read path.
+      expect(result.blob?.[0]).toBe(0x4f)
+    })
+
+    it('classifies LIC_EMPTY as virgin storage rather than an error', async () => {
+      await connectClient()
+      autoRespond(
+        buildResponse(1, ModbusFunctionCode.DEBUG_READ_LICENSE, new Uint8Array([ModbusDebugResponse.LIC_EMPTY])),
+      )
+
+      const result = await client.readLicense()
+
+      expect(result).toMatchObject({ success: true, empty: true })
+      expect(result.blob).toBeUndefined()
+    })
+
+    it('classifies LIC_CORRUPT as a valid device state rather than an error', async () => {
+      await connectClient()
+      autoRespond(
+        buildResponse(1, ModbusFunctionCode.DEBUG_READ_LICENSE, new Uint8Array([ModbusDebugResponse.LIC_CORRUPT])),
+      )
+
+      const result = await client.readLicense()
+
+      expect(result).toMatchObject({ success: true, corrupt: true })
+    })
+
+    it('rejects a read whose declared length exceeds the bytes received', async () => {
+      await connectClient()
+      // len says 98, only 2 blob bytes follow — the truncation must be reported,
+      // not silently handed on as a short "license".
+      autoRespond(
+        buildResponse(
+          1,
+          ModbusFunctionCode.DEBUG_READ_LICENSE,
+          new Uint8Array([ModbusDebugResponse.SUCCESS, 0x00, 98, 0x4f, 0x50]),
+        ),
+      )
+
+      const result = await client.readLicense()
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Incomplete license blob')
+    })
+
+    it('returns an error on a read timeout', async () => {
+      await connectClient()
+      const result = await client.readLicense()
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('timeout')
+    })
+
+    it('returns an error on a write timeout', async () => {
+      await connectClient()
+      const result = await client.writeLicense(sampleBlob())
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('timeout')
+    })
+  })
 })

--- a/src/backend/shared/simulator/modbus-rtu-client.ts
+++ b/src/backend/shared/simulator/modbus-rtu-client.ts
@@ -1,5 +1,18 @@
-import { buildPlcSetStateRequest, parsePlcSetStateResponse } from '@root/backend/shared/debug/modbus-pdu'
-import type { DebugStatusResult, Md5ProbeResult, PlcControlResult } from '@root/backend/shared/debug/types'
+import {
+  buildPlcSetStateRequest,
+  buildReadLicenseRequest,
+  buildWriteLicenseRequest,
+  parsePlcSetStateResponse,
+  parseReadLicenseResponse,
+  parseWriteLicenseResponse,
+} from '@root/backend/shared/debug/modbus-pdu'
+import type {
+  DebugLicenseReadResult,
+  DebugLicenseWriteResult,
+  DebugStatusResult,
+  Md5ProbeResult,
+  PlcControlResult,
+} from '@root/backend/shared/debug/types'
 import { detectTargetEndian } from '@root/frontend/utils/endian'
 
 import { ModbusDebugResponse, ModbusFunctionCode, PlcRuntimeState } from './types'
@@ -586,6 +599,50 @@ export class ModbusRtuClient {
         return { success: false, error: `Invalid response: too short (${response.length} bytes)` }
       }
       return parsePlcSetStateResponse(response.subarray(7))
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) }
+    }
+  }
+
+  /**
+   * FC 0x49 DEBUG_WRITE_LICENSE. Storing is not validation — read the blob back
+   * to learn what the target now holds.
+   */
+  async writeLicense(blob: Uint8Array): Promise<DebugLicenseWriteResult> {
+    try {
+      // buildWriteLicenseRequest returns [FC][len:u16BE][blob]; assembleRequest
+      // writes the FC + slaveId itself, so hand it only the trailing payload.
+      const pdu = buildWriteLicenseRequest(blob)
+      const response = await this.sendRequest(
+        this.assembleRequest(ModbusFunctionCode.DEBUG_WRITE_LICENSE, pdu.subarray(1)),
+      )
+      if (response.length < 9) {
+        return { success: false, error: `Invalid response: too short (${response.length} bytes, need at least 9)` }
+      }
+      return parseWriteLicenseResponse(response.subarray(7))
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) }
+    }
+  }
+
+  /**
+   * FC 0x4A DEBUG_READ_LICENSE. Bare `[FC]` request; the response carries the
+   * blob framed by a big-endian length (the content itself is little-endian).
+   *
+   * No size-aware framing here, unlike the editor's serial client: this transport
+   * runs against an in-process virtual port, so a 98-byte reply arrives in one
+   * piece and there is no inter-chunk gap to be truncated by.
+   */
+  async readLicense(): Promise<DebugLicenseReadResult> {
+    try {
+      const pdu = buildReadLicenseRequest()
+      const response = await this.sendRequest(
+        this.assembleRequest(ModbusFunctionCode.DEBUG_READ_LICENSE, pdu.subarray(1)),
+      )
+      if (response.length < 9) {
+        return { success: false, error: `Invalid response: too short (${response.length} bytes, need at least 9)` }
+      }
+      return parseReadLicenseResponse(response.subarray(7))
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : String(error) }
     }

--- a/src/backend/shared/simulator/types.ts
+++ b/src/backend/shared/simulator/types.ts
@@ -7,6 +7,12 @@ export enum ModbusFunctionCode {
   DEBUG_GET_STATUS = 0x46,
   DEBUG_GET_VERSION = 0x47,
   DEBUG_GET_BOARD_ID = 0x48,
+  /** Store a license blob on the device (VPP licensing). Write-only: the read
+   *  back is DEBUG_READ_LICENSE, and it is a SEPARATE round trip on purpose —
+   *  0x49 only stores bytes, it validates nothing. */
+  DEBUG_WRITE_LICENSE = 0x49,
+  /** Read the stored license blob back off the device. */
+  DEBUG_READ_LICENSE = 0x4a,
   /** Set the runtime run/stop state. Reads go through DEBUG_GET_STATUS (0x46),
    *  which already reports the state — there is deliberately no second FC for
    *  querying it. */
@@ -17,6 +23,13 @@ export enum ModbusDebugResponse {
   SUCCESS = 0x7e,
   ERROR_OUT_OF_BOUNDS = 0x81,
   ERROR_OUT_OF_MEMORY = 0x82,
+  /** DEBUG_READ_LICENSE only: virgin storage — no license has been provisioned. */
+  LIC_EMPTY = 0x83,
+  /** DEBUG_READ_LICENSE only: the magic matched but the crc32 did not. */
+  LIC_CORRUPT = 0x84,
+  /** Licensing FCs: the target has no on-device license-store backend at all.
+   *  A valid device state, not a transport failure. */
+  LIC_UNSUPPORTED = 0x85,
   /** PLC_SET_STATE only: a RUN request was refused because the hardware mode
    *  switch reads STOP. */
   REFUSED_BY_SWITCH = 0x86,

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/__tests__/device-license-status.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/__tests__/device-license-status.test.tsx
@@ -94,6 +94,35 @@ describe('DeviceLicenseStatus', () => {
     }
   })
 
+  it('keeps the details OUT of the layout flow, so opening them cannot move the page', () => {
+    // The regression this exists for: the panel used to be a conditional <div>
+    // next to the trigger, so opening it grew the connect row by ~140px and
+    // pushed "Specs" and the board image down. A portalled popover renders under
+    // document.body, so the row's own subtree never changes.
+    const { container } = render(
+      <DeviceLicenseStatus
+        report={{ deviceId: DEVICE_ID, outcome: { state: 'licensed', how: 'already-stored' } }}
+        isChecking={false}
+        buyUrl={BUY_URL}
+        onBuy={jest.fn()}
+        onRecheck={jest.fn()}
+      />,
+    )
+
+    const before = container.innerHTML
+    expand()
+
+    // The panel is visible…
+    expect(screen.getByText('Device ID')).toBeTruthy()
+    // …and it is NOT inside the component's own container.
+    expect(container.querySelector('code')).toBeNull()
+    // The trigger's subtree is byte-identical apart from the attributes Radix
+    // toggles on it (aria-expanded / data-state).
+    expect(before.replace(/(aria-expanded|data-state)="[^"]*"/g, '')).toBe(
+      container.innerHTML.replace(/(aria-expanded|data-state)="[^"]*"/g, ''),
+    )
+  })
+
   describe('details panel', () => {
     it('exposes the device id and copies it on request', () => {
       const writeText = jest.fn().mockResolvedValue(undefined)

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/__tests__/device-license-status.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/__tests__/device-license-status.test.tsx
@@ -1,0 +1,185 @@
+import type { DeviceLicenseReport } from '@root/middleware/shared/ports/device-port'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { DeviceLicenseStatus } from '../components/device-license-status'
+
+const DEVICE_ID = '659a3520540f803625ddc34081e893d3'
+const BUY_URL = `https://edge.example.com/buy?vppId=com.openplc.espressif-licensed&deviceId=${DEVICE_ID}`
+
+function setup(report: DeviceLicenseReport | null, overrides: { isChecking?: boolean; buyUrl?: string | null } = {}) {
+  const onBuy = jest.fn()
+  const onRecheck = jest.fn()
+  render(
+    <DeviceLicenseStatus
+      report={report}
+      isChecking={overrides.isChecking ?? false}
+      // `??` would be wrong here: an explicit `buyUrl: null` is a case under test.
+      buyUrl={'buyUrl' in overrides ? (overrides.buyUrl ?? null) : BUY_URL}
+      onBuy={onBuy}
+      onRecheck={onRecheck}
+    />,
+  )
+  return { onBuy, onRecheck }
+}
+
+function expand() {
+  fireEvent.click(screen.getByRole('button', { name: 'Licence status' }))
+}
+
+describe('DeviceLicenseStatus', () => {
+  it('renders nothing before any licensing call has landed', () => {
+    // The state every non-licensable board stays in, and a licensable one before
+    // Connect. A placeholder badge would invite the user to read meaning into a
+    // check that never happened.
+    const { container } = render(
+      <DeviceLicenseStatus report={null} isChecking={false} buyUrl={null} onBuy={jest.fn()} onRecheck={jest.fn()} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows progress while a check is in flight with nothing known yet', () => {
+    setup(null, { isChecking: true })
+    expect(screen.getByText('Checking licence…')).toBeTruthy()
+  })
+
+  it('labels a stored, verified licence as Licensed', () => {
+    setup({ deviceId: DEVICE_ID, outcome: { state: 'licensed', how: 'already-stored' } })
+    expect(screen.getByText('Licensed')).toBeTruthy()
+  })
+
+  it('labels a definitive negative as Not licensed', () => {
+    setup({ deviceId: DEVICE_ID, outcome: { state: 'unlicensed', entitlementChecked: true } })
+    expect(screen.getByText('Not licensed')).toBeTruthy()
+  })
+
+  it('labels an unanswered check as a FAILURE, not as Not licensed', () => {
+    // Three states, deliberately not two: collapsing these either tells a paying
+    // customer to buy again or hides a real failure behind a reassuring badge.
+    setup({ outcome: { state: 'check-failed', error: 'Request timeout' } })
+    expect(screen.getByText('Licence check failed')).toBeTruthy()
+    expect(screen.queryByText('Not licensed')).toBeNull()
+  })
+
+  it('labels missing storage as a FIRMWARE fault, distinctly from having no licence', () => {
+    // "Not storable" read as a hardware limitation and sent us looking at a
+    // NodeMCU that stores licences fine — the image was built without the backend.
+    setup({ deviceId: DEVICE_ID, outcome: { state: 'unsupported' } })
+    expect(screen.getByText('Storage missing')).toBeTruthy()
+    expect(screen.queryByText('Not licensed')).toBeNull()
+  })
+
+  it('never claims to know the execution mode the board is running in', () => {
+    // The editor verifies POSSESSION, not the ECDSA signature — it cannot know
+    // whether the closed licence-core will run FULL. No label may say otherwise.
+    const outcomes: DeviceLicenseReport['outcome'][] = [
+      { state: 'licensed', how: 'already-stored' },
+      { state: 'licensed', how: 'activated' },
+      { state: 'unlicensed', entitlementChecked: true },
+      { state: 'unsupported' },
+      { state: 'check-failed', error: 'x' },
+    ]
+
+    for (const outcome of outcomes) {
+      const { container, unmount } = render(
+        <DeviceLicenseStatus
+          report={{ deviceId: DEVICE_ID, outcome }}
+          isChecking={false}
+          buyUrl={BUY_URL}
+          onBuy={jest.fn()}
+          onRecheck={jest.fn()}
+        />,
+      )
+      expect(container.textContent ?? '').not.toMatch(/full mode|unlocked|demo mode/i)
+      unmount()
+    }
+  })
+
+  describe('details panel', () => {
+    it('exposes the device id and copies it on request', () => {
+      const writeText = jest.fn().mockResolvedValue(undefined)
+      Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+
+      setup({ deviceId: DEVICE_ID, outcome: { state: 'licensed', how: 'already-stored' } })
+      expand()
+
+      // The id is what a support ticket needs and what the /buy page accepts pasted.
+      expect(screen.getByText(DEVICE_ID)).toBeTruthy()
+      fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+      expect(writeText).toHaveBeenCalledWith(DEVICE_ID)
+    })
+
+    it('omits the device id when there was no anchor to derive one from', () => {
+      setup({ outcome: { state: 'check-failed', error: 'no unique hardware id' } })
+      expand()
+      expect(screen.queryByText('Device ID')).toBeNull()
+    })
+
+    it('always offers a re-check', () => {
+      const { onRecheck } = setup({ deviceId: DEVICE_ID, outcome: { state: 'check-failed', error: 'x' } })
+      expand()
+      fireEvent.click(screen.getByRole('button', { name: 'Check again' }))
+      expect(onRecheck).toHaveBeenCalledTimes(1)
+    })
+
+    it('disables the re-check while one is already running', () => {
+      setup({ deviceId: DEVICE_ID, outcome: { state: 'unlicensed', entitlementChecked: true } }, { isChecking: true })
+      expand()
+      expect(screen.getByRole('button', { name: 'Check again' }).hasAttribute('disabled')).toBe(true)
+    })
+
+    it('offers a purchase ONLY when the backend confirmed there is no entitlement', () => {
+      const { onBuy } = setup({ deviceId: DEVICE_ID, outcome: { state: 'unlicensed', entitlementChecked: true } })
+      expand()
+      fireEvent.click(screen.getByRole('button', { name: 'Buy licence' }))
+      expect(onBuy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT offer a purchase when nobody asked whether one exists', () => {
+      // Offering to buy here is a guess, and the wrong one for anyone who paid.
+      setup({ deviceId: DEVICE_ID, outcome: { state: 'unlicensed', entitlementChecked: false } })
+      expand()
+      expect(screen.queryByRole('button', { name: 'Buy licence' })).toBeNull()
+    })
+
+    it('does NOT offer a purchase when the check failed', () => {
+      setup({ outcome: { state: 'check-failed', error: 'Activation request failed: 429' } })
+      expand()
+      expect(screen.queryByRole('button', { name: 'Buy licence' })).toBeNull()
+    })
+
+    it('does NOT offer a purchase when the device cannot store a licence', () => {
+      // Buying would not make the device able to store one.
+      setup({ deviceId: DEVICE_ID, outcome: { state: 'unsupported' } })
+      expand()
+      expect(screen.queryByRole('button', { name: 'Buy licence' })).toBeNull()
+    })
+
+    it('hides the purchase button when no valid link could be built', () => {
+      setup({ deviceId: DEVICE_ID, outcome: { state: 'unlicensed', entitlementChecked: true } }, { buyUrl: null })
+      expand()
+      expect(screen.queryByRole('button', { name: 'Buy licence' })).toBeNull()
+    })
+
+    it('tells an unsupported device to rebuild, and does not blame the hardware', () => {
+      setup({ deviceId: DEVICE_ID, outcome: { state: 'unsupported' } })
+      expand()
+      expect(screen.getByText(/rebuild and upload/i)).toBeTruthy()
+      expect(screen.getByText(/This hardware supports it/)).toBeTruthy()
+    })
+
+    it("quotes the backend's reason when it gave one", () => {
+      setup({
+        deviceId: DEVICE_ID,
+        outcome: { state: 'unlicensed', entitlementChecked: true, backendReason: 'no active subscription' },
+      })
+      expand()
+      expect(screen.getByText(/no active subscription/)).toBeTruthy()
+    })
+
+    it('states that a failed check is not the same as having no licence', () => {
+      setup({ outcome: { state: 'check-failed', error: 'Request timeout' } })
+      expand()
+      expect(screen.getByText(/not the same as having no licence/)).toBeTruthy()
+    })
+  })
+})

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/board.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/board.tsx
@@ -29,15 +29,6 @@ import { DeviceEditorSlot } from '../../../../../_templates/[editors]/device-edi
 import { DeviceLicenseStatus } from './components/device-license-status'
 import { PinMappingTable } from './components/pin-mapping-table'
 
-/**
- * Confirms the held device link on the device screen: a quiet, monochrome line
- * that appears once Connect has settled on a channel a firmware answered.
- */
-function DeviceConnectedIndicator({ isConnected }: { isConnected: boolean }) {
-  if (!isConnected) return null
-  return <span className='font-caption text-cp-xs font-medium text-neutral-600 dark:text-neutral-400'>Connected</span>
-}
-
 const Board = memo(function () {
   const capabilities = useCapabilities()
   const device = useDevice()
@@ -640,13 +631,8 @@ const Board = memo(function () {
                 onConnect={handleConnectToRuntime}
                 onDisconnect={handleConnectToRuntime}
               >
-                {connectionStatus === 'connected' && (
-                  <>
-                    {plcStatus && (
-                      <span className='text-xs text-neutral-600 dark:text-neutral-400'>| PLC: {plcStatus}</span>
-                    )}
-                    <DeviceConnectedIndicator isConnected={connectionStatus === 'connected'} />
-                  </>
+                {connectionStatus === 'connected' && plcStatus && (
+                  <span className='text-xs text-neutral-600 dark:text-neutral-400'>PLC: {plcStatus}</span>
                 )}
               </DeviceConnectButton>
             </>
@@ -725,11 +711,10 @@ const Board = memo(function () {
                   ? { blockedReason: 'Select a communication port first' }
                   : {})}
               >
-                <DeviceConnectedIndicator isConnected={isConnected} />
-                {/* Licensing sits next to the link indicator because they answer
-                    adjacent questions about the same device — but it renders
-                    nothing at all unless this board's VPP is sold licensed AND a
-                    check has landed, so a free board's screen is unchanged. */}
+                {/* Licensing sits in the connect row because it answers an adjacent
+                    question about the same device -- but it renders nothing at all
+                    unless this board's VPP is sold licensed AND a check has landed,
+                    so a free board's row is unchanged. */}
                 {licensing.isLicensable ? (
                   <DeviceLicenseStatus
                     report={licensing.report}

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/board.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/board.tsx
@@ -9,6 +9,7 @@ import { MinusIcon } from '../../../../../../assets/icons/interface/Minus'
 import { PlusIcon } from '../../../../../../assets/icons/interface/Plus'
 import { RefreshIcon } from '../../../../../../assets/icons/interface/Refresh'
 import { useDeviceConnect } from '../../../../../../hooks/use-device-connect'
+import { useDeviceLicense } from '../../../../../../hooks/use-device-license'
 import { boardSelectors, pinSelectors } from '../../../../../../hooks/use-store-selectors'
 import { useOpenPLCStore } from '../../../../../../store'
 import type { RuntimeConnection } from '../../../../../../store/slices/device/types'
@@ -25,6 +26,7 @@ import { Modal, ModalContent, ModalFooter, ModalHeader, ModalTitle } from '../..
 import { PluginStatsPanel } from '../../../../../_molecules/plugin-stats-panel'
 import { ScanCycleStats } from '../../../../../_molecules/scan-cycle-stats'
 import { DeviceEditorSlot } from '../../../../../_templates/[editors]/device-editor-slot'
+import { DeviceLicenseStatus } from './components/device-license-status'
 import { PinMappingTable } from './components/pin-mapping-table'
 
 /**
@@ -70,6 +72,10 @@ const Board = memo(function () {
     isConnected,
     status: serialStatus,
   } = useDeviceConnect(currentBoardInfo)
+
+  // VPP licensing. Inert for every board whose VPP is not sold licensed, which is
+  // every built-in board — `isLicensable` gates the whole affordance.
+  const licensing = useDeviceLicense(currentBoardInfo)
 
   // Whether this target exposes the GPIO pin-mapping table. Arduino boards
   // enable it via their preset; runtime-v4 GPIO boards (e.g. the Raspberry
@@ -720,6 +726,19 @@ const Board = memo(function () {
                   : {})}
               >
                 <DeviceConnectedIndicator isConnected={isConnected} />
+                {/* Licensing sits next to the link indicator because they answer
+                    adjacent questions about the same device — but it renders
+                    nothing at all unless this board's VPP is sold licensed AND a
+                    check has landed, so a free board's screen is unchanged. */}
+                {licensing.isLicensable ? (
+                  <DeviceLicenseStatus
+                    report={licensing.report}
+                    isChecking={licensing.isChecking}
+                    buyUrl={licensing.buyUrl}
+                    onBuy={() => void licensing.buy()}
+                    onRecheck={() => void licensing.refresh()}
+                  />
+                ) : null}
               </DeviceConnectButton>
             </>
           ) : null}

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/components/device-license-status.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/components/device-license-status.tsx
@@ -19,6 +19,7 @@
  * buy again or hides a real failure behind a reassuring badge.
  */
 
+import * as Popover from '@radix-ui/react-popover'
 import type { DeviceLicenseReport } from '@root/middleware/shared/ports/device-port'
 import { useState } from 'react'
 
@@ -131,7 +132,6 @@ function describeOutcome(report: DeviceLicenseReport): {
 }
 
 export function DeviceLicenseStatus({ report, isChecking, buyUrl, onBuy, onRecheck }: DeviceLicenseStatusProps) {
-  const [expanded, setExpanded] = useState(false)
   const [copied, setCopied] = useState(false)
 
   // Nothing has run: every non-licensable board stays here, and so does a
@@ -154,34 +154,56 @@ export function DeviceLicenseStatus({ report, isChecking, buyUrl, onBuy, onReche
   const offerPurchase = !!buyUrl && report.outcome.state === 'unlicensed' && report.outcome.entitlementChecked === true
 
   return (
-    <div className='flex flex-col gap-1'>
-      <button
-        type='button'
-        aria-label='Licence status'
-        aria-expanded={expanded}
-        onClick={() => setExpanded((open) => !open)}
-        className='flex w-fit items-center gap-1 font-caption text-cp-xs font-medium text-neutral-600 dark:text-neutral-400'
-      >
-        {isChecking ? <ShieldUnknownIcon size={10} /> : <Icon size={10} />}
-        <span className={cn(negative && 'border-b border-dashed border-neutral-400 dark:border-neutral-700')}>
-          {isChecking ? 'Checking licence…' : label}
-        </span>
-      </button>
+    // Radix Popover, PORTALLED. The details used to be a conditional <div> in the
+    // flow, which is what broke the layout: opening it pushed "Specs" and the
+    // board image down and displaced the Connected label, because the panel is
+    // ~140px tall and this badge sits inside the connect row. A portalled popover
+    // is out of the flow entirely, so the row never changes height.
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <button
+          type='button'
+          aria-label='Licence status'
+          className={cn(
+            'flex w-fit items-center gap-1 font-caption text-cp-xs font-medium outline-none',
+            negative
+              ? 'text-neutral-700 hover:text-neutral-950 dark:text-neutral-300 dark:hover:text-white'
+              : 'text-neutral-600 hover:text-neutral-950 dark:text-neutral-400 dark:hover:text-white',
+          )}
+        >
+          {isChecking ? <ShieldUnknownIcon size={10} /> : <Icon size={10} />}
+          <span className={cn(negative && 'border-b border-dashed border-neutral-400 dark:border-neutral-700')}>
+            {isChecking ? 'Checking licence…' : label}
+          </span>
+        </button>
+      </Popover.Trigger>
 
-      {expanded ? (
-        <div className='flex flex-col gap-2 rounded-md border border-neutral-200 p-2 dark:border-neutral-800'>
-          <div className='flex items-center gap-1.5 text-neutral-700 dark:text-neutral-300'>
-            <Icon />
-            <span className='font-caption text-cp-xs font-medium'>{label}</span>
+      <Popover.Portal>
+        <Popover.Content
+          side='bottom'
+          align='start'
+          sideOffset={8}
+          // Fixed width so the panel's own content can never stretch the trigger
+          // row, and a high z so it clears the board image next to it.
+          className='box z-[100] flex w-[300px] flex-col gap-3 rounded-lg bg-white p-4 dark:bg-neutral-950'
+        >
+          <div className='flex items-center gap-2.5'>
+            <span className='flex h-[30px] w-[30px] flex-none items-center justify-center rounded-md border border-neutral-100 text-neutral-950 dark:border-neutral-850 dark:text-white'>
+              <Icon />
+            </span>
+            <div className='min-w-0'>
+              <p className='font-caption text-cp-base font-semibold text-neutral-950 dark:text-white'>{label}</p>
+              <p className='whitespace-pre-line break-words font-caption text-cp-sm text-neutral-600 dark:text-neutral-400'>
+                {detail}
+              </p>
+            </div>
           </div>
-
-          <p className='whitespace-pre-line font-caption text-cp-xs text-neutral-500 dark:text-neutral-400'>{detail}</p>
 
           {deviceId ? (
             <div className='flex flex-col gap-1'>
               <span className='font-caption text-cp-xs text-neutral-500 dark:text-neutral-500'>Device ID</span>
-              <div className='flex items-center gap-2'>
-                <code className='break-all font-mono text-cp-xs text-neutral-700 dark:text-neutral-300'>
+              <div className='flex items-start gap-2'>
+                <code className='min-w-0 break-all font-mono text-cp-xs text-neutral-700 dark:text-neutral-300'>
                   {deviceId}
                 </code>
                 <button
@@ -219,8 +241,8 @@ export function DeviceLicenseStatus({ report, isChecking, buyUrl, onBuy, onReche
               </button>
             ) : null}
           </div>
-        </div>
-      ) : null}
-    </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
   )
 }

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/components/device-license-status.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/components/device-license-status.tsx
@@ -1,0 +1,226 @@
+/**
+ * Licence status for the device screen: a quiet, monochrome line next to
+ * "Connected", plus a details panel with the device id and the actions the
+ * outcome warrants.
+ *
+ * WHAT "LICENSED" IS ALLOWED TO MEAN HERE. It means the main process read the
+ * blob off the device (FC 0x4A) and verified its magic, crc32, `deviceId` and
+ * `productId` — i.e. the device HOLDS a well-formed licence for this board and
+ * this VPP. The ECDSA signature and the key id are NOT checked (only the closed
+ * license-core can), so a blob signed by a key the board does not trust would
+ * read "Licensed" here and the board would still run demo.
+ *
+ * Therefore every label in this component is about POSSESSION — Licensed / Not
+ * licensed / Licence check failed — and never about EXECUTION. No string here may
+ * say "full mode", "unlocked" or "running in demo": the editor cannot know that.
+ *
+ * THREE states, deliberately not two. "Not licensed" is an ANSWER; "Licence check
+ * failed" is the ABSENCE of one. Collapsing them either tells a paying customer to
+ * buy again or hides a real failure behind a reassuring badge.
+ */
+
+import type { DeviceLicenseReport } from '@root/middleware/shared/ports/device-port'
+import { useState } from 'react'
+
+import { cn } from '../../../../../../../utils/cn'
+
+/** Filled shield + check — "this device holds a licence". */
+function ShieldLicensedIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox='0 0 16 16' fill='none' aria-hidden='true'>
+      <path d='M8 1.5 13 3.2v4.1c0 3.2-2.1 6-5 7.2-2.9-1.2-5-4-5-7.2V3.2L8 1.5Z' fill='currentColor' />
+      <path d='M5.8 8.1 7.2 9.5l3-3.1' stroke='#fff' strokeWidth='1.4' strokeLinecap='round' strokeLinejoin='round' />
+    </svg>
+  )
+}
+
+/** Outline shield + dash — "no licence on this device". */
+function ShieldUnlicensedIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox='0 0 16 16' fill='none' aria-hidden='true'>
+      <path
+        d='M8 1.5 13 3.2v4.1c0 3.2-2.1 6-5 7.2-2.9-1.2-5-4-5-7.2V3.2L8 1.5Z'
+        stroke='currentColor'
+        strokeWidth='1.3'
+      />
+      <path d='M5.9 8h4.2' stroke='currentColor' strokeWidth='1.3' strokeLinecap='round' />
+    </svg>
+  )
+}
+
+/** Outline shield + question — "we could not tell". */
+function ShieldUnknownIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox='0 0 16 16' fill='none' aria-hidden='true'>
+      <path
+        d='M8 1.5 13 3.2v4.1c0 3.2-2.1 6-5 7.2-2.9-1.2-5-4-5-7.2V3.2L8 1.5Z'
+        stroke='currentColor'
+        strokeWidth='1.3'
+      />
+      <path
+        d='M6.7 6.3a1.3 1.3 0 0 1 2.6.2c0 .9-1.3 1-1.3 2'
+        stroke='currentColor'
+        strokeWidth='1.2'
+        strokeLinecap='round'
+      />
+      <circle cx='8' cy='10.7' r='0.65' fill='currentColor' />
+    </svg>
+  )
+}
+
+export interface DeviceLicenseStatusProps {
+  /** Null before any licensing call has landed — nothing is rendered. */
+  report: DeviceLicenseReport | null
+  isChecking: boolean
+  /** Null when no valid purchase link can be built; the button is then hidden. */
+  buyUrl: string | null
+  onBuy: () => void
+  onRecheck: () => void
+}
+
+/** The label + icon for an outcome. One place, so no branch can drift. */
+function describeOutcome(report: DeviceLicenseReport): {
+  label: string
+  Icon: typeof ShieldLicensedIcon
+  /** Whether the label reads as a definitive negative (drives the dashed underline). */
+  negative: boolean
+  detail: string
+} {
+  switch (report.outcome.state) {
+    case 'licensed':
+      return {
+        label: 'Licensed',
+        Icon: ShieldLicensedIcon,
+        negative: false,
+        detail:
+          report.outcome.how === 'activated'
+            ? 'A licence was just written to this device and read back to confirm it.'
+            : 'This device is holding a licence issued for it and for this VPP.',
+      }
+    case 'unlicensed':
+      return {
+        label: 'Not licensed',
+        Icon: ShieldUnlicensedIcon,
+        negative: true,
+        detail: report.outcome.entitlementChecked
+          ? `No licence is registered for this device.${
+              report.outcome.backendReason ? ` The licence server said: ${report.outcome.backendReason}` : ''
+            }`
+          : 'This device is not holding a valid licence. Nobody has checked yet whether one was purchased for it.',
+      }
+    case 'unsupported':
+      // The label points at the FIRMWARE, not the board. "Not storable" read as a
+      // hardware limitation and cost a debugging session on a NodeMCU that stores
+      // licences fine — the image was simply built without the backend.
+      return {
+        label: 'Storage missing',
+        Icon: ShieldUnknownIcon,
+        negative: false,
+        detail:
+          'The firmware running on this device reports no licence storage. This hardware supports it, ' +
+          'so the image was built without the storage backend — rebuild and upload.',
+      }
+    case 'check-failed':
+      return {
+        label: 'Licence check failed',
+        Icon: ShieldUnknownIcon,
+        negative: false,
+        detail: `${report.outcome.error}\n\nThis is not the same as having no licence — nothing on the device has changed.`,
+      }
+  }
+}
+
+export function DeviceLicenseStatus({ report, isChecking, buyUrl, onBuy, onRecheck }: DeviceLicenseStatusProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  // Nothing has run: every non-licensable board stays here, and so does a
+  // licensable one before Connect. Showing a placeholder badge would invite the
+  // user to read meaning into a check that never happened.
+  if (!report) {
+    return isChecking ? (
+      <span className='font-caption text-cp-xs font-medium text-neutral-500 dark:text-neutral-500'>
+        Checking licence…
+      </span>
+    ) : null
+  }
+
+  const { label, Icon, negative, detail } = describeOutcome(report)
+  const deviceId = report.deviceId
+
+  // The purchase button appears ONLY where buying is the honest next step: the
+  // backend was asked and reported no entitlement. On `check-failed` or an
+  // unchecked `unlicensed` it would be a guess, and a costly one.
+  const offerPurchase = !!buyUrl && report.outcome.state === 'unlicensed' && report.outcome.entitlementChecked === true
+
+  return (
+    <div className='flex flex-col gap-1'>
+      <button
+        type='button'
+        aria-label='Licence status'
+        aria-expanded={expanded}
+        onClick={() => setExpanded((open) => !open)}
+        className='flex w-fit items-center gap-1 font-caption text-cp-xs font-medium text-neutral-600 dark:text-neutral-400'
+      >
+        {isChecking ? <ShieldUnknownIcon size={10} /> : <Icon size={10} />}
+        <span className={cn(negative && 'border-b border-dashed border-neutral-400 dark:border-neutral-700')}>
+          {isChecking ? 'Checking licence…' : label}
+        </span>
+      </button>
+
+      {expanded ? (
+        <div className='flex flex-col gap-2 rounded-md border border-neutral-200 p-2 dark:border-neutral-800'>
+          <div className='flex items-center gap-1.5 text-neutral-700 dark:text-neutral-300'>
+            <Icon />
+            <span className='font-caption text-cp-xs font-medium'>{label}</span>
+          </div>
+
+          <p className='whitespace-pre-line font-caption text-cp-xs text-neutral-500 dark:text-neutral-400'>{detail}</p>
+
+          {deviceId ? (
+            <div className='flex flex-col gap-1'>
+              <span className='font-caption text-cp-xs text-neutral-500 dark:text-neutral-500'>Device ID</span>
+              <div className='flex items-center gap-2'>
+                <code className='break-all font-mono text-cp-xs text-neutral-700 dark:text-neutral-300'>
+                  {deviceId}
+                </code>
+                <button
+                  type='button'
+                  className='shrink-0 font-caption text-cp-xs text-brand hover:underline'
+                  onClick={() => {
+                    // The id is what a support ticket needs, and what the purchase
+                    // page accepts pasted. Copy failures are silent on purpose:
+                    // clipboard permission is not something the user can act on
+                    // here, and the id is selectable next to the button anyway.
+                    void navigator.clipboard?.writeText(deviceId).then(
+                      () => setCopied(true),
+                      () => undefined,
+                    )
+                  }}
+                >
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          <div className='flex items-center gap-3'>
+            <button
+              type='button'
+              disabled={isChecking}
+              onClick={onRecheck}
+              className='font-caption text-cp-xs text-neutral-600 hover:underline disabled:opacity-50 dark:text-neutral-400'
+            >
+              Check again
+            </button>
+            {offerPurchase ? (
+              <button type='button' onClick={onBuy} className='font-caption text-cp-xs text-brand hover:underline'>
+                Buy licence
+              </button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/frontend/components/_molecules/device-connect-button/__tests__/device-connect-button.test.tsx
+++ b/src/frontend/components/_molecules/device-connect-button/__tests__/device-connect-button.test.tsx
@@ -30,11 +30,13 @@ describe('DeviceConnectButton', () => {
     expect(onConnect).not.toHaveBeenCalled()
   })
 
-  it('confirms a live connection on screen', () => {
-    // The baremetal copy never showed this, so a connected device looked the same
-    // as a disconnected one apart from the button label.
+  it('does not repeat the connection state next to the button', () => {
+    // The button label IS the state: it reads "Disconnect" when connected. A second
+    // "Connected" beside it said the same thing twice, and on the device screen it
+    // sat next to the licence badge making the row read as three separate facts.
     render(<DeviceConnectButton status='connected' onConnect={jest.fn()} onDisconnect={jest.fn()} />)
-    expect(screen.getByText('● Connected')).not.toBeNull()
+    expect(screen.getByRole('button', { name: 'Disconnect' })).not.toBeNull()
+    expect(screen.queryByText(/Connected/)).toBeNull()
   })
 
   it('reports a failed attempt', () => {

--- a/src/frontend/components/_molecules/device-connect-button/index.tsx
+++ b/src/frontend/components/_molecules/device-connect-button/index.tsx
@@ -59,7 +59,10 @@ const DeviceConnectButton = ({
         {isConnecting ? 'Connecting...' : isConnected ? 'Disconnect' : 'Connect'}
       </button>
 
-      {isConnected && <span className='text-xs text-green-600 dark:text-green-400'>● Connected</span>}
+      {/* No "Connected" confirmation: the button itself reads "Disconnect" when
+          connected, so a second label said the same thing twice. The ERROR state
+          below stays, because there the button reads "Connect" and the failure
+          would otherwise be invisible. */}
       {status === 'error' && <span className='text-xs text-red-600 dark:text-red-400'>● Connection failed</span>}
       {children}
     </div>

--- a/src/frontend/hooks/__tests__/use-device-connect.test.ts
+++ b/src/frontend/hooks/__tests__/use-device-connect.test.ts
@@ -16,14 +16,22 @@ const mockSetDeviceConnectionStatus = jest.fn((status: string, port: string | nu
 /** The status the store ended up in — what the Connect button actually reads. */
 const currentStatus = (): string => (mockState.deviceConnection as { status: string }).status
 
+const mockStartLicenseCheck = jest.fn()
+const mockSetLicenseReport = jest.fn()
+const mockClearDeviceLicense = jest.fn()
+
 const mockState: Record<string, unknown> = {
   deviceDefinitions: { configuration: { deviceBoard: 'Test Board', communicationPort: 'COM5', vendorScreenData: {} } },
   deviceConnection: { status: 'disconnected', port: null },
+  deviceLicense: { phase: 'idle', report: null },
   runtimeConnection: { ipAddress: '192.168.0.128', jwtToken: 'jwt-tok' },
   modalActions: { openModal: mockOpenModal },
   consoleActions: { addLog: mockAddLog },
   deviceActions: {
     setDeviceConnectionStatus: mockSetDeviceConnectionStatus,
+    startDeviceLicenseCheck: mockStartLicenseCheck,
+    setDeviceLicenseReport: mockSetLicenseReport,
+    clearDeviceLicense: mockClearDeviceLicense,
   },
 }
 
@@ -47,12 +55,22 @@ const serialCandidate = {
 /** Shape the hook consumes: what can be tried now, and what needs input first. */
 let mockResolution: unknown = { candidates: [serialCandidate], awaitingInput: [] }
 
+const mockReadLicense = jest.fn()
+const mockRefreshLicense = jest.fn()
+const mockOpenExternalLink = jest.fn().mockResolvedValue({ success: true })
+
 jest.mock('../../store', () => ({ useOpenPLCStore: mockUseOpenPLCStore }))
 jest.mock('@root/middleware/shared/providers/platform-context', () => ({
   useDevice: () => ({
     connect: mockConnect,
     disconnect: mockDisconnect,
     onConnectionStatus: mockOnConnectionStatus,
+    readLicense: mockReadLicense,
+    refreshLicense: mockRefreshLicense,
+  }),
+  useSystem: () => ({
+    getEdgeFrontendUrl: () => 'https://edge.example.com',
+    openExternalLink: mockOpenExternalLink,
   }),
 }))
 jest.mock('../../services/device-link-resolution', () => ({
@@ -277,6 +295,165 @@ describe('useDeviceConnect', () => {
       await result.current.connect()
       expect(currentStatus()).toBe('connecting')
       expect(mockSetDeviceConnectionStatus).not.toHaveBeenCalledWith('disconnected', null)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // VPP licensing
+  // -----------------------------------------------------------------------
+  describe('licensing', () => {
+    /** A board whose VPP is sold licensed. `board` above deliberately is not. */
+    const licensedBoard = {
+      compiler: 'arduino-cli',
+      core: 'esp32:esp32',
+      preview: '',
+      specs: {},
+      debug: {},
+      capabilities: { isLicensable: true },
+      vpp: {
+        packageId: 'com.openplc.espressif-licensed',
+        vendor: 'Espressif',
+        deviceId: 'esp32-generic',
+        packagePath: '/pkg',
+        screens: {},
+        moduleSystem: { enabled: false, maxSlots: 0, modules: [] },
+      },
+    } as unknown as BoardInfo
+
+    it('runs NO licensing traffic for a board whose VPP is not sold licensed', async () => {
+      // The common case, and the reason licensability is the first gate: a free
+      // board's connect must be exactly what it was before licensing existed.
+      mockConnect.mockResolvedValue({ status: 'connected-with-firmware' })
+
+      const { result } = renderHook(() => useDeviceConnect(board))
+      await result.current.connect()
+
+      expect(mockRefreshLicense).not.toHaveBeenCalled()
+      expect(mockReadLicense).not.toHaveBeenCalled()
+      expect(mockOpenModal).not.toHaveBeenCalled()
+    })
+
+    it('settles the licence over the held link after a successful connect', async () => {
+      mockConnect.mockResolvedValue({ status: 'connected-with-firmware' })
+      mockRefreshLicense.mockResolvedValue({
+        deviceId: '659a3520540f803625ddc34081e893d3',
+        outcome: { state: 'licensed', how: 'already-stored' },
+      })
+
+      const { result } = renderHook(() => useDeviceConnect(licensedBoard))
+      await result.current.connect()
+
+      expect(mockRefreshLicense).toHaveBeenCalledWith({ packageId: 'com.openplc.espressif-licensed' })
+      expect(mockSetLicenseReport).toHaveBeenCalledWith({
+        deviceId: '659a3520540f803625ddc34081e893d3',
+        outcome: { state: 'licensed', how: 'already-stored' },
+      })
+      // A licensed device is a silent success — no dialog on every connect.
+      expect(mockOpenModal).not.toHaveBeenCalled()
+    })
+
+    it('does not touch licensing when no firmware answered', async () => {
+      // There is nothing to ask: the flash dialog is the whole message, and a
+      // licence dialog stacked on top of it would bury it.
+      mockConnect.mockResolvedValue({ status: 'no-firmware' })
+
+      const { result } = renderHook(() => useDeviceConnect(licensedBoard))
+      await result.current.connect()
+
+      expect(mockRefreshLicense).not.toHaveBeenCalled()
+      expect(mockOpenModal.mock.calls[0][1]).toMatchObject({ title: 'No Firmware Detected' })
+    })
+
+    it('does not touch licensing when the device never answered at all', async () => {
+      mockConnect.mockResolvedValue({ status: 'no-response' })
+
+      const { result } = renderHook(() => useDeviceConnect(licensedBoard))
+      await result.current.connect()
+
+      expect(mockRefreshLicense).not.toHaveBeenCalled()
+    })
+
+    it('prompts about demo mode and offers a purchase when the backend reports no entitlement', async () => {
+      mockConnect.mockResolvedValue({ status: 'connected-with-firmware' })
+      mockRefreshLicense.mockResolvedValue({
+        deviceId: '659a3520540f803625ddc34081e893d3',
+        outcome: { state: 'unlicensed', entitlementChecked: true },
+      })
+
+      const { result } = renderHook(() => useDeviceConnect(licensedBoard))
+      await result.current.connect()
+
+      const [, props] = mockOpenModal.mock.calls[0]
+      expect(props).toMatchObject({ title: 'No Licence For This Device' })
+      expect((props as { buttons: string[] }).buttons).toEqual(['Buy Licence', 'Continue in Demo Mode'])
+
+      // Buying opens the device-BOUND purchase page: the id derived main-side is
+      // what makes the purchase attach to this board rather than to nothing.
+      latestOnResponse()(0)
+      await Promise.resolve()
+      expect(mockOpenExternalLink).toHaveBeenCalledWith(
+        'https://edge.example.com/buy?vppId=com.openplc.espressif-licensed&deviceId=659a3520540f803625ddc34081e893d3',
+      )
+    })
+
+    it('reports a failed check as a failure, never as "not licensed"', async () => {
+      mockConnect.mockResolvedValue({ status: 'connected-with-firmware' })
+      mockRefreshLicense.mockResolvedValue({
+        outcome: { state: 'check-failed', error: 'Activation request failed: 429' },
+      })
+
+      const { result } = renderHook(() => useDeviceConnect(licensedBoard))
+      await result.current.connect()
+
+      const [, props] = mockOpenModal.mock.calls[0]
+      expect(props).toMatchObject({ title: 'Licence Check Failed' })
+      expect((props as { buttons: string[] }).buttons).not.toContain('Buy Licence')
+    })
+
+    it('re-runs the flow when the user retries, and explains the NEW outcome', async () => {
+      // What makes a purchase completed in the browser land without a reconnect.
+      mockConnect.mockResolvedValue({ status: 'connected-with-firmware' })
+      mockRefreshLicense
+        .mockResolvedValueOnce({ outcome: { state: 'check-failed', error: 'Request timeout' } })
+        .mockResolvedValueOnce({
+          deviceId: '659a3520540f803625ddc34081e893d3',
+          outcome: { state: 'licensed', how: 'activated' },
+        })
+
+      const { result } = renderHook(() => useDeviceConnect(licensedBoard))
+      await result.current.connect()
+      expect(mockOpenModal).toHaveBeenCalledTimes(1)
+
+      latestOnResponse()(0)
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(mockRefreshLicense).toHaveBeenCalledTimes(2)
+      // The retry succeeded, and success is silent — no second dialog.
+      expect(mockOpenModal).toHaveBeenCalledTimes(1)
+    })
+
+    it('turns a rejected licensing IPC call into check-failed rather than losing it', async () => {
+      mockConnect.mockResolvedValue({ status: 'connected-with-firmware' })
+      mockRefreshLicense.mockRejectedValue(new Error('bridge is gone'))
+
+      const { result } = renderHook(() => useDeviceConnect(licensedBoard))
+      await result.current.connect()
+
+      expect(mockSetLicenseReport).toHaveBeenCalledWith({
+        outcome: { state: 'check-failed', error: 'bridge is gone' },
+      })
+      expect(mockOpenModal.mock.calls[0][1]).toMatchObject({ title: 'Licence Check Failed' })
+    })
+
+    it('drops the licence on a DELIBERATE disconnect', async () => {
+      // The user is done with this device; a badge left behind would assert
+      // possession for hardware nothing is talking to. A link that merely DROPS
+      // keeps it — that is the device slice's job, not this hook's.
+      const { result } = renderHook(() => useDeviceConnect(licensedBoard))
+      await result.current.disconnect()
+
+      expect(mockClearDeviceLicense).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/frontend/hooks/use-device-connect.ts
+++ b/src/frontend/hooks/use-device-connect.ts
@@ -21,6 +21,8 @@ import { useCallback } from 'react'
 import { resolveDeviceLinkWithUx } from '../services/device-link-resolution'
 import { useOpenPLCStore } from '../store'
 import { requestDeviceFlash } from '../utils/device-connect-events'
+import { explainLicenseOutcome } from '../utils/license-outcome-dialog'
+import { useDeviceLicense } from './use-device-license'
 
 export interface UseDeviceConnectResult {
   /** Open + hold the link for the given board. Never throws. */
@@ -38,7 +40,9 @@ export function useDeviceConnect(boardInfo: BoardInfo | undefined): UseDeviceCon
   const device = useDevice()
   const openModal = useOpenPLCStore((s) => s.modalActions.openModal)
   const setDeviceConnectionStatus = useOpenPLCStore((s) => s.deviceActions.setDeviceConnectionStatus)
+  const clearDeviceLicense = useOpenPLCStore((s) => s.deviceActions.clearDeviceLicense)
   const status = useOpenPLCStore((s) => s.deviceConnection.status)
+  const licensing = useDeviceLicense(boardInfo)
 
   const connect = useCallback(async (): Promise<void> => {
     const deviceBoard = useOpenPLCStore.getState().deviceDefinitions.configuration.deviceBoard
@@ -119,6 +123,32 @@ export function useDeviceConnect(boardInfo: BoardInfo | undefined): UseDeviceCon
             if (buttonIndex === 0) requestDeviceFlash()
           },
         })
+        return
+      }
+
+      // The link is up and a firmware answered. If this board's VPP is sold
+      // licensed, settle its licence now — over the link that is already open.
+      //
+      // AWAITED, not fired and forgotten: the whole flow runs on one held Modbus
+      // link, and letting the connect return first invites the user to click
+      // Upload or Debug into the middle of a read/write sequence. It is also why
+      // this is the LAST thing connect does — a non-licensable board (the common
+      // case) never reaches it, and pays nothing.
+      if (licensing.isLicensable) {
+        const report = await licensing.refresh()
+        if (report) {
+          explainLicenseOutcome(report, {
+            openModal,
+            buy: licensing.buy,
+            // A retry re-runs the flow and explains the NEW outcome, so a
+            // transient failure or a purchase completed in the browser resolves
+            // without disconnecting.
+            retry: async () => {
+              const next = await licensing.refresh()
+              if (next) explainLicenseOutcome(next, { openModal, buy: licensing.buy })
+            },
+          })
+        }
       }
     } finally {
       // 'connecting' is set OPTIMISTICALLY above, and normally only the main process
@@ -140,12 +170,17 @@ export function useDeviceConnect(boardInfo: BoardInfo | undefined): UseDeviceCon
         setDeviceConnectionStatus('disconnected', null)
       }
     }
-  }, [boardInfo, device, openModal, setDeviceConnectionStatus])
+  }, [boardInfo, device, licensing, openModal, setDeviceConnectionStatus])
 
   const disconnect = useCallback(async (): Promise<void> => {
     await device.disconnect()
     setDeviceConnectionStatus('disconnected', null)
-  }, [device, setDeviceConnectionStatus])
+    // A DELIBERATE disconnect is the one link event that should drop the licence
+    // too: the user is done with this device, and leaving a badge behind would
+    // assert possession for hardware nothing is talking to. A link that merely
+    // DROPS keeps it — see `clearDeviceConnection` in the device slice.
+    clearDeviceLicense()
+  }, [clearDeviceLicense, device, setDeviceConnectionStatus])
 
   return {
     connect,

--- a/src/frontend/hooks/use-device-license.ts
+++ b/src/frontend/hooks/use-device-license.ts
@@ -1,0 +1,161 @@
+/**
+ * useDeviceLicense — the renderer side of the VPP licensing flow.
+ *
+ * Owns the four things the UI needs and nothing else:
+ *   - whether licensing applies to this board at all (`isLicensable`);
+ *   - the last landed report, from the store;
+ *   - `check()` (read + verify, local) and `refresh()` (full flow, may reach the
+ *     network and write);
+ *   - `buy()`, which opens the device-bound purchase page.
+ *
+ * Deliberately NOT folded into `useDeviceConnect`: that hook is about resolving
+ * and holding a link, this one about what the device is entitled to run. The only
+ * coupling is one call after a successful connect.
+ */
+import type { DeviceLicenseReport } from '@root/middleware/shared/ports/device-port'
+import type { BoardInfo } from '@root/middleware/shared/ports/types'
+import { useDevice, useSystem } from '@root/middleware/shared/providers/platform-context'
+import { resolveLicensingTarget } from '@root/middleware/shared/utils/licensing'
+import { useCallback, useMemo } from 'react'
+
+import { useOpenPLCStore } from '../store'
+import { buildLicenseBuyUrl } from '../utils/license-buy-url'
+
+export interface UseDeviceLicenseResult {
+  /** Whether the selected board's VPP participates in licensing at all. When
+   *  false every other member here is inert and the UI shows nothing. */
+  isLicensable: boolean
+  /** Set when the manifest is broken: declares licensable with no package id. */
+  configurationError: string | null
+  /** The last landed report, or null before anything has run. */
+  report: DeviceLicenseReport | null
+  /** True while a call is in flight. */
+  isChecking: boolean
+  /**
+   * Read + verify what the device holds. Local only, never the network.
+   *
+   * Returns the report as well as storing it, so a caller that must ACT on the
+   * outcome (the connect flow, which prompts about demo mode) does not have to
+   * read it back out of the store — a read that races the very set it follows.
+   * `null` when licensing does not apply to this board.
+   */
+  check: () => Promise<DeviceLicenseReport | null>
+  /** Full flow: read, verify, and recover from the backend when needed. */
+  refresh: () => Promise<DeviceLicenseReport | null>
+  /**
+   * The purchase link for the report currently in the store — what the badge's
+   * button uses. Null when no valid link can be built.
+   */
+  buyUrl: string | null
+  /**
+   * Open the device-bound purchase page.
+   *
+   * `deviceId` is a parameter, not read from the store, and that is load-bearing.
+   * A caller reached straight out of a licensing call — the demo dialog the connect
+   * flow opens — is holding a report the store has only just been told about, and
+   * the closure it captured still sees the PREVIOUS value (null, on a first
+   * connect). Taking the id explicitly is what stops "Buy Licence" from silently
+   * doing nothing on the one path where it matters most.
+   */
+  buy: (deviceId?: string) => Promise<void>
+}
+
+export function useDeviceLicense(boardInfo: BoardInfo | undefined): UseDeviceLicenseResult {
+  const device = useDevice()
+  const system = useSystem()
+  const startCheck = useOpenPLCStore((s) => s.deviceActions.startDeviceLicenseCheck)
+  const setReport = useOpenPLCStore((s) => s.deviceActions.setDeviceLicenseReport)
+  const phase = useOpenPLCStore((s) => s.deviceLicense.phase)
+  const report = useOpenPLCStore((s) => s.deviceLicense.report)
+
+  const target = useMemo(() => resolveLicensingTarget(boardInfo), [boardInfo])
+
+  /**
+   * Run one licensing call, whichever it is.
+   *
+   * `startCheck` before and `setReport` after, unconditionally — an early return
+   * on a non-licensable board would leave `phase: 'checking'` set forever, and the
+   * UI disables its actions on that.
+   */
+  const run = useCallback(
+    async (which: 'check' | 'refresh'): Promise<DeviceLicenseReport | null> => {
+      if (!target.licensable) return null
+
+      const call = which === 'check' ? device.readLicense : device.refreshLicense
+      if (!call) {
+        // A platform that holds no device link (the port declares both optional).
+        // Reported rather than ignored: silence here reads as "no license".
+        const report: DeviceLicenseReport = {
+          outcome: { state: 'check-failed', error: 'This platform cannot check device licenses.' },
+        }
+        setReport(report)
+        return report
+      }
+
+      startCheck()
+      const request = { packageId: target.packageId }
+      try {
+        const report = await call(request)
+        setReport(report)
+        return report
+      } catch (error) {
+        // The IPC call itself failed. Still a report, and still `check-failed`:
+        // the badge must never fall back to "not licensed" because a channel died.
+        const report: DeviceLicenseReport = {
+          outcome: { state: 'check-failed', error: error instanceof Error ? error.message : String(error) },
+        }
+        setReport(report)
+        return report
+      }
+    },
+    [device.readLicense, device.refreshLicense, setReport, startCheck, target],
+  )
+
+  const check = useCallback(() => run('check'), [run])
+  const refresh = useCallback(() => run('refresh'), [run])
+
+  /**
+   * Build the purchase link for a given device id.
+   *
+   * A purchase must be BOUND to a device, and the id is derived main-side, so
+   * there is nothing to bind to before a report has landed — hence null. The
+   * builder also refuses an id the `/buy` page would reject, so a malformed one
+   * yields no button rather than a dead end.
+   */
+  const urlFor = useCallback(
+    (deviceId: string | undefined): string | null => {
+      if (!target.licensable) return null
+      return buildLicenseBuyUrl({ baseUrl: system.getEdgeFrontendUrl(), vppId: target.packageId, deviceId })
+    },
+    [system, target],
+  )
+
+  /** The link for whatever is in the store — what the badge's button uses. */
+  const buyUrl = useMemo(() => urlFor(report?.deviceId), [report?.deviceId, urlFor])
+
+  const buy = useCallback(
+    async (deviceId?: string): Promise<void> => {
+      // Prefer the id the CALLER is holding. See the docstring on `buy` above:
+      // the dialog opened right after a licensing call has the fresh report, while
+      // this hook's closure still sees the previous one.
+      const url = urlFor(deviceId ?? report?.deviceId)
+      if (!url) return
+      await system.openExternalLink(url)
+    },
+    [report?.deviceId, system, urlFor],
+  )
+
+  return {
+    isLicensable: target.licensable,
+    configurationError:
+      !target.licensable && target.reason === 'no-package-id'
+        ? 'This board declares a licensed VPP but its package is missing an id. The VPP package needs fixing.'
+        : null,
+    report,
+    isChecking: phase === 'checking',
+    check,
+    refresh,
+    buyUrl,
+    buy,
+  }
+}

--- a/src/frontend/store/__tests__/device-slice.test.ts
+++ b/src/frontend/store/__tests__/device-slice.test.ts
@@ -349,6 +349,34 @@ describe('createDeviceSlice', () => {
       expect(store.getState().deviceLicense).toEqual({ phase: 'idle', report: null })
     })
 
+    it('clearDeviceBoard change drops the licence — it was verified against the OLD board', () => {
+      // setDeviceBoard already wipes everything else that is board-specific
+      // (platform options, the pin-table row, vendor-screen data). A licence
+      // report is just as board-specific: it was verified against the previous
+      // board's deviceId and its VPP's productId. Kept across a switch, the badge
+      // asserts possession for hardware that is no longer selected, and the buy
+      // link is built from the NEW package id and the OLD device id.
+      const store = makeStore()
+      store.getState().deviceActions.setDeviceBoard('ESP8266 NodeMCU')
+      store.getState().deviceActions.setDeviceLicenseReport(LICENSED)
+
+      store.getState().deviceActions.setDeviceBoard('Raspberry Pi 4')
+
+      expect(store.getState().deviceLicense).toEqual({ phase: 'idle', report: null })
+    })
+
+    it('leaves the licence alone when setDeviceBoard is called with the same board', () => {
+      // The device screen re-sets the board on several paths; only an actual
+      // change invalidates the licence.
+      const store = makeStore()
+      store.getState().deviceActions.setDeviceBoard('ESP8266 NodeMCU')
+      store.getState().deviceActions.setDeviceLicenseReport(LICENSED)
+
+      store.getState().deviceActions.setDeviceBoard('ESP8266 NodeMCU')
+
+      expect(store.getState().deviceLicense.report).toEqual(LICENSED)
+    })
+
     it('clearDeviceDefinitions clears licensing — a new project may select another board', () => {
       // A "Licensed" badge carried across a project close would be an assertion
       // about hardware that is not even connected.

--- a/src/frontend/store/__tests__/device-slice.test.ts
+++ b/src/frontend/store/__tests__/device-slice.test.ts
@@ -252,6 +252,111 @@ describe('createDeviceSlice', () => {
         debugTransport: null,
       })
     })
+
+    it('clearDeviceConnection leaves licensing alone — the link and the entitlement are separate facts', () => {
+      // A link that drops and comes back does not change what the device is
+      // entitled to run. Clearing the licence here would make the badge blank on
+      // every reconnect and force a needless round trip to learn nothing new.
+      const store = makeStore()
+      store.getState().deviceActions.setDeviceLicenseReport({
+        deviceId: '659a3520540f803625ddc34081e893d3',
+        outcome: { state: 'licensed', how: 'already-stored' },
+      })
+      store.getState().deviceActions.clearDeviceConnection()
+      expect(store.getState().deviceLicense.report?.outcome).toEqual({ state: 'licensed', how: 'already-stored' })
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // VPP licensing
+  // -----------------------------------------------------------------------
+  describe('device licensing', () => {
+    const LICENSED = {
+      deviceId: '659a3520540f803625ddc34081e893d3',
+      outcome: { state: 'licensed' as const, how: 'already-stored' as const },
+    }
+
+    it('starts idle with nothing known', () => {
+      // The state every non-licensable board stays in: nothing runs, so nothing is
+      // known, and the UI shows no licensing affordance at all.
+      expect(makeStore().getState().deviceLicense).toEqual({ phase: 'idle', report: null })
+    })
+
+    it('startDeviceLicenseCheck marks the call in flight', () => {
+      const store = makeStore()
+      store.getState().deviceActions.startDeviceLicenseCheck()
+      expect(store.getState().deviceLicense).toEqual({ phase: 'checking', report: null })
+    })
+
+    it('startDeviceLicenseCheck KEEPS the last report instead of blanking it', () => {
+      // Blanking would make the badge flicker Licensed -> nothing -> Licensed on
+      // every refresh, and a refresh that failed would leave the UI knowing LESS
+      // than before it asked. `phase` is what says "asking".
+      const store = makeStore()
+      store.getState().deviceActions.setDeviceLicenseReport(LICENSED)
+      store.getState().deviceActions.startDeviceLicenseCheck()
+      expect(store.getState().deviceLicense).toEqual({ phase: 'checking', report: LICENSED })
+    })
+
+    it('setDeviceLicenseReport lands the report and settles the phase', () => {
+      const store = makeStore()
+      store.getState().deviceActions.startDeviceLicenseCheck()
+      store.getState().deviceActions.setDeviceLicenseReport(LICENSED)
+      expect(store.getState().deviceLicense).toEqual({ phase: 'done', report: LICENSED })
+    })
+
+    it('preserves the outcome union verbatim, including the entitlement distinction', () => {
+      // The whole point of the union surviving to the store: the UI branches on
+      // `entitlementChecked` to decide between offering a purchase and offering a
+      // re-check. A store that flattened this to a boolean would lose it.
+      const store = makeStore()
+      store.getState().deviceActions.setDeviceLicenseReport({
+        deviceId: '659a3520540f803625ddc34081e893d3',
+        outcome: { state: 'unlicensed', entitlementChecked: false },
+      })
+      expect(store.getState().deviceLicense.report?.outcome).toEqual({
+        state: 'unlicensed',
+        entitlementChecked: false,
+      })
+
+      store.getState().deviceActions.setDeviceLicenseReport({
+        deviceId: '659a3520540f803625ddc34081e893d3',
+        outcome: { state: 'unlicensed', entitlementChecked: true, backendReason: 'no active subscription' },
+      })
+      expect(store.getState().deviceLicense.report?.outcome).toEqual({
+        state: 'unlicensed',
+        entitlementChecked: true,
+        backendReason: 'no active subscription',
+      })
+    })
+
+    it('keeps a check-failed outcome distinct from unlicensed', () => {
+      const store = makeStore()
+      store.getState().deviceActions.setDeviceLicenseReport({
+        outcome: { state: 'check-failed', error: 'Activation request failed: 429' },
+      })
+      expect(store.getState().deviceLicense.report?.outcome).toEqual({
+        state: 'check-failed',
+        error: 'Activation request failed: 429',
+      })
+      expect(store.getState().deviceLicense.report?.deviceId).toBeUndefined()
+    })
+
+    it('clearDeviceLicense resets to idle/null', () => {
+      const store = makeStore()
+      store.getState().deviceActions.setDeviceLicenseReport(LICENSED)
+      store.getState().deviceActions.clearDeviceLicense()
+      expect(store.getState().deviceLicense).toEqual({ phase: 'idle', report: null })
+    })
+
+    it('clearDeviceDefinitions clears licensing — a new project may select another board', () => {
+      // A "Licensed" badge carried across a project close would be an assertion
+      // about hardware that is not even connected.
+      const store = makeStore()
+      store.getState().deviceActions.setDeviceLicenseReport(LICENSED)
+      store.getState().deviceActions.clearDeviceDefinitions()
+      expect(store.getState().deviceLicense).toEqual({ phase: 'idle', report: null })
+    })
   })
 
   // -----------------------------------------------------------------------

--- a/src/frontend/store/__tests__/device-types.test.ts
+++ b/src/frontend/store/__tests__/device-types.test.ts
@@ -193,12 +193,16 @@ describe('Device slice types', () => {
           includeEthercatStatsInPolling: false,
         },
         deviceConnection: { status: 'disconnected', port: null, transport: null, debugTransport: null },
+        deviceLicense: { phase: 'idle', report: null },
       }
       expect(state.deviceAvailableOptions).toBeDefined()
       expect(state.deviceDefinitions).toBeDefined()
       expect(state.deviceUpdated).toBeDefined()
       expect(state.runtimeConnection).toBeDefined()
       expect(state.deviceConnection).toBeDefined()
+      // Licensing is its own top-level key, not a field on the connection: the
+      // link being up and the device being entitled change for unrelated reasons.
+      expect(state.deviceLicense).toBeDefined()
     })
   })
 

--- a/src/frontend/store/slices/device/index.ts
+++ b/src/frontend/store/slices/device/index.ts
@@ -5,6 +5,7 @@ export type {
   DeviceAvailableOptions,
   DeviceConnection,
   DeviceConnectionStatus,
+  DeviceLicenseInfo,
   DevicePinMapping,
   DeviceSlice,
   DeviceState,

--- a/src/frontend/store/slices/device/slice.ts
+++ b/src/frontend/store/slices/device/slice.ts
@@ -67,6 +67,11 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
     debugTransport: null,
   },
 
+  deviceLicense: {
+    phase: 'idle',
+    report: null,
+  },
+
   deviceActions: {
     setAvailableOptions: ({ availableBoards, availableCommunicationPorts }): void => {
       setState(
@@ -116,7 +121,7 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
     },
     clearDeviceDefinitions: (): void => {
       setState(
-        produce(({ deviceDefinitions, runtimeConnection, deviceConnection }: DeviceSlice) => {
+        produce(({ deviceDefinitions, runtimeConnection, deviceConnection, deviceLicense }: DeviceSlice) => {
           deviceDefinitions.configuration = defaultDeviceConfiguration
           deviceDefinitions.pinMapping = {
             pinsByBoard: {},
@@ -139,6 +144,12 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
           deviceConnection.port = null
           deviceConnection.transport = null
           deviceConnection.debugTransport = null
+          // Same for licensing, and for a sharper reason: the next project may
+          // select a different board entirely, and a "Licensed" badge carried over
+          // from the previous one would be an assertion about hardware that is not
+          // even connected.
+          deviceLicense.phase = 'idle'
+          deviceLicense.report = null
         }),
       )
     },
@@ -564,6 +575,30 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
           deviceConnection.port = null
           deviceConnection.transport = null
           deviceConnection.debugTransport = null
+        }),
+      )
+    },
+    startDeviceLicenseCheck: (): void => {
+      setState(
+        produce(({ deviceLicense }: DeviceSlice) => {
+          deviceLicense.phase = 'checking'
+          // `report` is deliberately left alone — see the action's docstring.
+        }),
+      )
+    },
+    setDeviceLicenseReport: (report): void => {
+      setState(
+        produce(({ deviceLicense }: DeviceSlice) => {
+          deviceLicense.phase = 'done'
+          deviceLicense.report = report
+        }),
+      )
+    },
+    clearDeviceLicense: (): void => {
+      setState(
+        produce(({ deviceLicense }: DeviceSlice) => {
+          deviceLicense.phase = 'idle'
+          deviceLicense.report = null
         }),
       )
     },

--- a/src/frontend/store/slices/device/slice.ts
+++ b/src/frontend/store/slices/device/slice.ts
@@ -381,7 +381,7 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
     setDeviceBoard: (deviceBoard): void => {
       const previousBoard = getState().deviceDefinitions.configuration.deviceBoard
       setState(
-        produce(({ deviceDefinitions, deviceUpdated }: DeviceSlice) => {
+        produce(({ deviceDefinitions, deviceUpdated, deviceLicense }: DeviceSlice) => {
           deviceUpdated.updated = true
           // Wipe platformOption selections when the board changes — they're
           // declared per-board in the VPP manifest, so a `cpu=atmega328old`
@@ -407,6 +407,14 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
             const cfg = deviceDefinitions.configuration
             syncActiveBoardVendorBucket(cfg)
             cfg.vendorScreenData = { ...(cfg.vendorScreenDataByBoard?.[deviceBoard] ?? {}) }
+            // A licence report is board-specific for the same reason all of the
+            // above is: it was verified against the PREVIOUS board's `deviceId`
+            // and its VPP's `productId`. Carried across a switch, the badge
+            // asserts possession for hardware that is no longer selected, and
+            // the buy link gets built from the NEW package id paired with the
+            // OLD device id — binding a purchase to the wrong board.
+            deviceLicense.phase = 'idle'
+            deviceLicense.report = null
           }
           deviceDefinitions.configuration.deviceBoard = deviceBoard
         }),

--- a/src/frontend/store/slices/device/types.ts
+++ b/src/frontend/store/slices/device/types.ts
@@ -1,3 +1,4 @@
+import type { DeviceLicenseReport } from '../../../../middleware/shared/ports/device-port'
 import type { EtherCATRuntimeStatusResponse } from '../../../../middleware/shared/ports/ethercat-types'
 import type {
   BoardInfo,
@@ -119,6 +120,34 @@ export type DeviceConnection = {
 }
 
 // ---------------------------------------------------------------------------
+// VPP licensing
+// ---------------------------------------------------------------------------
+
+/**
+ * What the UI knows about the connected device's VPP license.
+ *
+ * Separate from `deviceConnection` on purpose: that is about whether the LINK is
+ * up, this is about what the device is entitled to run. They change for unrelated
+ * reasons — a link can drop and come back without the license changing, and a
+ * license can be recovered without the link ever moving — and merging them made
+ * every reader of one depend on the other.
+ *
+ * `report` is null until a licensing call has landed, which is also the state for
+ * every non-licensable board: nothing runs, so nothing is known, and the UI shows
+ * no licensing affordance at all.
+ */
+export type DeviceLicenseInfo = {
+  /** In flight, so the UI can show progress and refuse to start a second one. */
+  phase: 'idle' | 'checking' | 'done'
+  /**
+   * The last landed report from `readLicense` / `refreshLicense`. Carries the
+   * outcome union and the derived `deviceId` (which the renderer cannot compute —
+   * it needs `node:crypto` — and which feeds the copy button and the buy link).
+   */
+  report: DeviceLicenseReport | null
+}
+
+// ---------------------------------------------------------------------------
 // Device state
 // ---------------------------------------------------------------------------
 
@@ -134,6 +163,7 @@ export type DeviceState = {
   }
   runtimeConnection: RuntimeConnection
   deviceConnection: DeviceConnection
+  deviceLicense: DeviceLicenseInfo
 }
 
 // ---------------------------------------------------------------------------
@@ -212,6 +242,20 @@ export type DeviceActions = {
   ) => void
   /** Reset the serial link to disconnected/null. */
   clearDeviceConnection: () => void
+  /**
+   * Mark a licensing call as in flight.
+   *
+   * Deliberately KEEPS the last report rather than clearing it. Blanking it would
+   * make the badge flicker from "Licensed" to nothing and back on every refresh —
+   * and worse, a refresh that fails would leave the UI with less information than
+   * it had before asking. The `phase` is what says "asking"; the report stays as
+   * the last thing actually known.
+   */
+  startDeviceLicenseCheck: () => void
+  /** Land a finished licensing call: `phase='done'`, store the report. */
+  setDeviceLicenseReport: (report: DeviceLicenseReport) => void
+  /** Reset licensing to `idle`/null — on disconnect, board change, project close. */
+  clearDeviceLicense: () => void
   setVendorScreenData: (persistenceKey: string, data: unknown) => void
   /** Restore `vendorScreenData[k]` for every k in `ownedKeys`: from
    *  `snapshot[k]` when present, else by deleting the key.  Used by

--- a/src/frontend/utils/__tests__/license-buy-url.test.ts
+++ b/src/frontend/utils/__tests__/license-buy-url.test.ts
@@ -1,0 +1,85 @@
+import { buildLicenseBuyUrl } from '../license-buy-url'
+
+const DEVICE_ID = '7146518f9842adacfadc731ee7f546e5'
+const VPP_ID = 'com.openplc.raspberry-pi-licensed'
+
+describe('buildLicenseBuyUrl', () => {
+  it('builds the purchase link the /buy page accepts', () => {
+    const url = buildLicenseBuyUrl({ baseUrl: 'https://edge.autonomylogic.com', vppId: VPP_ID, deviceId: DEVICE_ID })
+    expect(url).toBe(`https://edge.autonomylogic.com/buy?vppId=${encodeURIComponent(VPP_ID)}&deviceId=${DEVICE_ID}`)
+  })
+
+  it('points at a local Edge app when the base URL does', () => {
+    expect(buildLicenseBuyUrl({ baseUrl: 'http://localhost:5173', vppId: VPP_ID, deviceId: DEVICE_ID })).toBe(
+      `http://localhost:5173/buy?vppId=${encodeURIComponent(VPP_ID)}&deviceId=${DEVICE_ID}`,
+    )
+  })
+
+  it('tolerates a trailing slash on the base URL', () => {
+    expect(
+      buildLicenseBuyUrl({ baseUrl: 'https://edge.autonomylogic.com//', vppId: VPP_ID, deviceId: DEVICE_ID }),
+    ).toBe(`https://edge.autonomylogic.com/buy?vppId=${encodeURIComponent(VPP_ID)}&deviceId=${DEVICE_ID}`)
+  })
+
+  // An Edge app hosted under a sub-path must keep it: `new URL('/buy', base)`
+  // would silently drop the prefix and 404.
+  it('keeps a base path instead of resolving to the origin root', () => {
+    expect(buildLicenseBuyUrl({ baseUrl: 'https://example.com/edge', vppId: VPP_ID, deviceId: DEVICE_ID })).toBe(
+      `https://example.com/edge/buy?vppId=${encodeURIComponent(VPP_ID)}&deviceId=${DEVICE_ID}`,
+    )
+  })
+
+  // The web build can be configured with a same-origin prefix
+  // (`VITE_EDGE_FRONTEND_URL=/`), which is not a parseable absolute URL.
+  it.each([
+    ['/', `/buy?vppId=${encodeURIComponent(VPP_ID)}&deviceId=${DEVICE_ID}`],
+    ['', `/buy?vppId=${encodeURIComponent(VPP_ID)}&deviceId=${DEVICE_ID}`],
+    ['/edge', `/edge/buy?vppId=${encodeURIComponent(VPP_ID)}&deviceId=${DEVICE_ID}`],
+  ])('falls back to a root-relative link for the same-origin prefix %p', (baseUrl, expected) => {
+    expect(buildLicenseBuyUrl({ baseUrl, vppId: VPP_ID, deviceId: DEVICE_ID })).toBe(expected)
+  })
+
+  it('percent-encodes a vppId carrying URL-significant characters', () => {
+    const url = buildLicenseBuyUrl({ baseUrl: 'https://e.test', vppId: 'com.a b&c', deviceId: DEVICE_ID })
+    expect(url).toBe(`https://e.test/buy?vppId=com.a+b%26c&deviceId=${DEVICE_ID}`)
+  })
+
+  // Returning null (instead of a partial link) is the point: the /buy page can
+  // only answer "Invalid purchase link", so the caller must explain instead.
+  it.each([
+    ['no vppId', { vppId: undefined, deviceId: DEVICE_ID }],
+    ['blank vppId', { vppId: '   ', deviceId: DEVICE_ID }],
+    ['no deviceId', { vppId: VPP_ID, deviceId: undefined }],
+    ['blank deviceId', { vppId: VPP_ID, deviceId: '' }],
+    ['deviceId too short', { vppId: VPP_ID, deviceId: DEVICE_ID.slice(0, 31) }],
+    ['deviceId too long', { vppId: VPP_ID, deviceId: `${DEVICE_ID}00` }],
+    ['deviceId not hex', { vppId: VPP_ID, deviceId: 'z146518f9842adacfadc731ee7f546e5' }],
+    // The hardware anchor is a different value AND a different length — the
+    // guard is what keeps a mislabelled field from reaching a purchase.
+    ['the hardware anchor instead of the deviceId', { vppId: VPP_ID, deviceId: '38363235383037623061383361653764aa' }],
+  ])('refuses to build a link with %s', (_label, ids) => {
+    expect(buildLicenseBuyUrl({ baseUrl: 'https://edge.autonomylogic.com', ...ids })).toBeNull()
+  })
+
+  it('accepts an uppercase deviceId, matching the page guard', () => {
+    const url = buildLicenseBuyUrl({ baseUrl: 'https://e.test', vppId: VPP_ID, deviceId: DEVICE_ID.toUpperCase() })
+    expect(url).toBe(`https://e.test/buy?vppId=${encodeURIComponent(VPP_ID)}&deviceId=${DEVICE_ID.toUpperCase()}`)
+  })
+
+  it('trims surrounding whitespace off both ids', () => {
+    const url = buildLicenseBuyUrl({ baseUrl: 'https://e.test', vppId: ` ${VPP_ID} `, deviceId: ` ${DEVICE_ID} ` })
+    expect(url).toBe(`https://e.test/buy?vppId=${encodeURIComponent(VPP_ID)}&deviceId=${DEVICE_ID}`)
+  })
+
+  // The link carries EXACTLY the two ids the /buy page reads. It used to also
+  // carry `devicePublicKey`, because the purchase was the moment that bound a
+  // proof-of-possession key to a device (ADR-0002). That key is gone: on bare
+  // metal the anchor is read inside the closed license-core and the blob is bound
+  // to `deviceId`, so possession is proven by the silicon, not by a signature.
+  // Asserted as a WHOLE-STRING equality on purpose — a `toContain` would let a
+  // third parameter creep back in without failing.
+  it('carries no query parameter beyond the two ids', () => {
+    const url = buildLicenseBuyUrl({ baseUrl: 'https://e.test', vppId: VPP_ID, deviceId: DEVICE_ID })
+    expect(url).toBe(`https://e.test/buy?vppId=${encodeURIComponent(VPP_ID)}&deviceId=${DEVICE_ID}`)
+  })
+})

--- a/src/frontend/utils/__tests__/license-outcome-dialog.test.ts
+++ b/src/frontend/utils/__tests__/license-outcome-dialog.test.ts
@@ -1,0 +1,192 @@
+import type { DeviceLicenseReport } from '@root/middleware/shared/ports/device-port'
+
+import { explainLicenseOutcome, type OpenLicenseDialog } from '../license-outcome-dialog'
+
+type DialogProps = Parameters<OpenLicenseDialog>[1]
+
+function harness() {
+  const opened: DialogProps[] = []
+  const openModal: OpenLicenseDialog = (_name, props) => {
+    opened.push(props)
+  }
+  const buy = jest.fn(() => Promise.resolve())
+  const retry = jest.fn(() => Promise.resolve())
+  return { opened, openModal, buy, retry }
+}
+
+function report(outcome: DeviceLicenseReport['outcome']): DeviceLicenseReport {
+  return { deviceId: '659a3520540f803625ddc34081e893d3', outcome }
+}
+
+describe('explainLicenseOutcome', () => {
+  it('says NOTHING when the device is licensed', () => {
+    // A dialog confirming a licence nobody asked about would fire on every single
+    // connect to a licensed board.
+    const { opened, openModal, buy, retry } = harness()
+
+    const shown = explainLicenseOutcome(report({ state: 'licensed', how: 'already-stored' }), {
+      openModal,
+      buy,
+      retry,
+    })
+
+    expect(shown).toBe(false)
+    expect(opened).toHaveLength(0)
+  })
+
+  it('is silent for a freshly activated licence too', () => {
+    const { opened, openModal, buy } = harness()
+
+    explainLicenseOutcome(report({ state: 'licensed', how: 'activated' }), { openModal, buy })
+
+    expect(opened).toHaveLength(0)
+  })
+
+  describe('unlicensed with the entitlement CHECKED', () => {
+    it('offers to buy, and buying is what the first button does', () => {
+      const { opened, openModal, buy, retry } = harness()
+
+      explainLicenseOutcome(report({ state: 'unlicensed', entitlementChecked: true }), { openModal, buy, retry })
+
+      expect(opened).toHaveLength(1)
+      expect(opened[0].buttons).toEqual(['Buy Licence', 'Continue in Demo Mode'])
+      opened[0].onResponse(0)
+      expect(buy).toHaveBeenCalledTimes(1)
+      expect(retry).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when the user chooses demo mode', () => {
+      const { opened, openModal, buy } = harness()
+
+      explainLicenseOutcome(report({ state: 'unlicensed', entitlementChecked: true }), { openModal, buy })
+      opened[0].onResponse(1)
+
+      expect(buy).not.toHaveBeenCalled()
+    })
+
+    it("quotes the backend's own wording when it gave one", () => {
+      const { opened, openModal, buy } = harness()
+
+      explainLicenseOutcome(
+        report({ state: 'unlicensed', entitlementChecked: true, backendReason: 'no active subscription' }),
+        { openModal, buy },
+      )
+
+      expect(opened[0].message).toContain('no active subscription')
+    })
+  })
+
+  describe('unlicensed with the entitlement NOT checked', () => {
+    it('offers a re-check and NOT a purchase', () => {
+      // Nobody asked whether a purchase exists. Offering to buy here is the worst
+      // thing this flow can do to someone who already paid.
+      const { opened, openModal, buy, retry } = harness()
+
+      explainLicenseOutcome(report({ state: 'unlicensed', entitlementChecked: false }), { openModal, buy, retry })
+
+      expect(opened[0].buttons).toEqual(['Check For Licence', 'Continue in Demo Mode'])
+      expect(opened[0].buttons).not.toContain('Buy Licence')
+      opened[0].onResponse(0)
+      expect(retry).toHaveBeenCalledTimes(1)
+      expect(buy).not.toHaveBeenCalled()
+    })
+
+    it('degrades to a plain acknowledgement when no retry is available', () => {
+      const { opened, openModal, buy } = harness()
+
+      explainLicenseOutcome(report({ state: 'unlicensed', entitlementChecked: false }), { openModal, buy })
+
+      expect(opened[0].buttons).toEqual(['OK'])
+      // Pressing the only button must not silently trigger anything.
+      opened[0].onResponse(0)
+      expect(buy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('unsupported', () => {
+    it('never offers a purchase — buying would not make the device able to store one', () => {
+      const { opened, openModal, buy, retry } = harness()
+
+      explainLicenseOutcome(report({ state: 'unsupported' }), { openModal, buy, retry })
+
+      expect(opened[0].buttons).toEqual(['OK'])
+      opened[0].onResponse(0)
+      expect(buy).not.toHaveBeenCalled()
+      expect(retry).not.toHaveBeenCalled()
+    })
+
+    it('names the firmware and tells the user to rebuild, without blaming the hardware', () => {
+      const { opened, openModal, buy } = harness()
+
+      explainLicenseOutcome(report({ state: 'unsupported' }), { openModal, buy })
+
+      expect(opened[0].message).toMatch(/rebuild and\s+upload/i)
+      expect(opened[0].message).toContain('This hardware supports it')
+      // The old wording ("This Device Cannot Store A Licence") read as a hardware
+      // limitation and cost a debugging session.
+      expect(opened[0].title).not.toMatch(/cannot store/i)
+    })
+  })
+
+  describe('check-failed', () => {
+    it('says we could not tell, states it is NOT the same as unlicensed, and offers a retry', () => {
+      const { opened, openModal, buy, retry } = harness()
+
+      explainLicenseOutcome(report({ state: 'check-failed', error: 'Activation request failed: 429' }), {
+        openModal,
+        buy,
+        retry,
+      })
+
+      expect(opened[0].type).toBe('error')
+      expect(opened[0].message).toContain('Activation request failed: 429')
+      expect(opened[0].message).toContain('NOT the same as having no licence')
+      expect(opened[0].buttons).toEqual(['Try Again', 'Continue'])
+      opened[0].onResponse(0)
+      expect(retry).toHaveBeenCalledTimes(1)
+      // Never a purchase: we do not know that a purchase is what is missing.
+      expect(buy).not.toHaveBeenCalled()
+    })
+
+    it('never labels the failure as "not licensed"', () => {
+      const { opened, openModal, buy } = harness()
+
+      explainLicenseOutcome(report({ state: 'check-failed', error: 'Request timeout' }), { openModal, buy })
+
+      expect(opened[0].title).not.toMatch(/not licen/i)
+      expect(opened[0].buttons).not.toContain('Buy Licence')
+    })
+  })
+
+  describe('demo-mode wording', () => {
+    it('is explicit that the DEVICE enforces demo mode, not the editor', () => {
+      // Saying or implying the editor gates the upload would be false: it uploads
+      // either way, and the licence-core on the device is what limits actuation.
+      const { opened, openModal, buy } = harness()
+
+      explainLicenseOutcome(report({ state: 'unlicensed', entitlementChecked: true }), { openModal, buy })
+
+      expect(opened[0].message).toContain('enforced on the device, not by the editor')
+      expect(opened[0].message).toContain('build and upload')
+    })
+
+    it('never claims to know the execution mode the board is running in', () => {
+      // The editor verifies POSSESSION, not the signature — it cannot know whether
+      // the closed core will run FULL. No branch may assert an execution mode.
+      const { opened, openModal, buy, retry } = harness()
+      const outcomes: DeviceLicenseReport['outcome'][] = [
+        { state: 'unlicensed', entitlementChecked: true },
+        { state: 'unlicensed', entitlementChecked: false },
+        { state: 'unsupported' },
+        { state: 'check-failed', error: 'x' },
+      ]
+
+      for (const outcome of outcomes) explainLicenseOutcome(report(outcome), { openModal, buy, retry })
+
+      for (const props of opened) {
+        expect(props.title).not.toMatch(/full mode|unlocked/i)
+        expect(props.message).not.toMatch(/full mode|unlocked/i)
+      }
+    })
+  })
+})

--- a/src/frontend/utils/license-buy-url.ts
+++ b/src/frontend/utils/license-buy-url.ts
@@ -1,0 +1,57 @@
+/**
+ * Buy-license deep link (D68a) — carries the device INTO the Edge purchase page.
+ *
+ * The page is `/buy` on the Edge **web app** (not the API host), and it needs
+ * both ids up front: it validates `deviceId` against `/^[0-9a-fA-F]{32}$/` and
+ * resolves the VPP through `GET vpp-catalog/v1/vpps/:vppId`. That `vppId` is the
+ * **reverse-domain package id** (`package.id`, e.g.
+ * `com.openplc.raspberry-pi-licensed`) — NOT a database id — which is exactly
+ * what the editor already holds as `boardInfo.vpp.packageId`, so no lookup is
+ * needed to build the link.
+ *
+ * A link missing either id lands the buyer on "Invalid purchase link" with no
+ * way forward, so an incomplete input resolves to `null` here and the caller
+ * says something useful instead of opening a dead end.
+ */
+
+export interface LicenseBuyLinkInput {
+  /** Absolute base URL of the Edge web app, or a same-origin prefix on web. */
+  baseUrl: string
+  /** Reverse-domain package id of the licensable VPP (`package.id`). */
+  vppId: string | undefined
+  /** The derived licensing identity (32 hex chars), NOT the hardware anchor. */
+  deviceId: string | undefined
+}
+
+/** Mirrors the `/buy` page's own guard — reject before navigating, not after. */
+const DEVICE_ID_RE = /^[0-9a-f]{32}$/i
+
+function withoutTrailingSlash(base: string): string {
+  return base.replace(/\/+$/, '')
+}
+
+/**
+ * Build the `/buy?vppId=…&deviceId=…` URL, or `null` when the ids can't produce
+ * a link the purchase page will accept.
+ */
+export function buildLicenseBuyUrl({ baseUrl, vppId, deviceId }: LicenseBuyLinkInput): string | null {
+  const vpp = vppId?.trim()
+  const device = deviceId?.trim()
+  if (!vpp || !device || !DEVICE_ID_RE.test(device)) return null
+
+  const query = new URLSearchParams({ vppId: vpp, deviceId: device }).toString()
+  const path = `${withoutTrailingSlash(baseUrl)}/buy`
+
+  try {
+    // Single-argument form on purpose: it preserves a base path, so an Edge app
+    // hosted under a sub-path still gets `/prefix/buy` instead of `/buy`.
+    const url = new URL(path)
+    url.search = query
+    return url.toString()
+  } catch {
+    // Not absolute — the web build can be configured with a same-origin prefix
+    // (`VITE_EDGE_FRONTEND_URL=/`). A root-relative link is correct there; the
+    // editor never reaches this branch (its adapter always yields an origin).
+    return `${path}?${query}`
+  }
+}

--- a/src/frontend/utils/license-outcome-dialog.ts
+++ b/src/frontend/utils/license-outcome-dialog.ts
@@ -1,0 +1,137 @@
+/**
+ * Turn a licensing outcome into what the user is told — and what they are offered.
+ *
+ * Pure decision, separate from the hook that calls it, because this is where the
+ * union's distinctions become promises to a customer and each branch has to be
+ * defensible on its own:
+ *
+ *   licensed          → say nothing. A silent success is the correct UX; a dialog
+ *                       confirming a licence nobody asked about is noise on every
+ *                       single connect.
+ *   unlicensed + checked   → demo mode, and OFFER TO BUY. The backend was asked
+ *                       and said there is no purchase, so this is the one branch
+ *                       where pointing at a purchase page is honest.
+ *   unlicensed + NOT checked → demo mode, but offer to CHECK AGAIN, not to buy.
+ *                       Nobody asked whether a purchase exists; telling someone
+ *                       who already paid to pay again is the worst thing this
+ *                       flow can do.
+ *   unsupported       → the device cannot store a licence. Buying would not help,
+ *                       so no purchase is offered; the detail (when present) names
+ *                       a build mismatch, which is actionable.
+ *   check-failed      → say we could not tell, and offer a retry. Never present
+ *                       this as "not licensed".
+ *
+ * The demo-mode wording is deliberate about WHO enforces it: the closed
+ * license-core inside the VPP does, on the device. The editor uploads either way —
+ * it does not gate the build on a licence, and saying it might would be false.
+ */
+
+import type { DeviceLicenseReport, DeviceLicenseState } from '@root/middleware/shared/ports/device-port'
+
+/** The subset of the modal action this needs, so tests need no store. */
+export type OpenLicenseDialog = (
+  name: 'debugger-message',
+  props: {
+    type: 'error' | 'warning' | 'question' | 'info'
+    title: string
+    message: string
+    buttons: string[]
+    onResponse: (buttonIndex: number) => void
+  },
+) => void
+
+export interface LicenseDialogHandlers {
+  openModal: OpenLicenseDialog
+  /**
+   * Open the device-bound purchase page for `deviceId`.
+   *
+   * The id is passed IN rather than looked up by the handler, because this dialog
+   * is opened straight out of a licensing call and the handler's own view of the
+   * current report is one render behind — so a lookup would find nothing on a
+   * first connect and the button would do nothing.
+   */
+  buy: (deviceId?: string) => Promise<void>
+  /** Re-run the full licensing flow (offered on a failed or unchecked outcome). */
+  retry?: () => Promise<void>
+}
+
+const DEMO_EXPLANATION =
+  'The device will run in DEMO mode: the VPP stops driving outputs a few minutes after each start. ' +
+  'You can still build and upload — the licence is enforced on the device, not by the editor.'
+
+/**
+ * Show the dialog this outcome warrants, if any. Returns whether one was opened,
+ * which is what makes "licensed is silent" testable rather than assumed.
+ */
+export function explainLicenseOutcome(report: DeviceLicenseReport, handlers: LicenseDialogHandlers): boolean {
+  const { openModal, buy, retry } = handlers
+  const outcome: DeviceLicenseState = report.outcome
+
+  switch (outcome.state) {
+    case 'licensed':
+      // Silence on purpose. See the module docstring.
+      return false
+
+    case 'unlicensed': {
+      if (outcome.entitlementChecked) {
+        const reason = outcome.backendReason ? `\n\nThe licence server said: ${outcome.backendReason}` : ''
+        openModal('debugger-message', {
+          type: 'warning',
+          title: 'No Licence For This Device',
+          message: `This VPP is a paid product and no licence is registered for this device.${reason}\n\n${DEMO_EXPLANATION}`,
+          buttons: ['Buy Licence', 'Continue in Demo Mode'],
+          onResponse: (buttonIndex: number) => {
+            if (buttonIndex === 0) void buy(report.deviceId)
+          },
+        })
+        return true
+      }
+
+      // Nobody asked the backend. Offer a check, NOT a purchase.
+      openModal('debugger-message', {
+        type: 'warning',
+        title: 'No Licence Stored On This Device',
+        message: `This device is not holding a valid licence for this VPP. It may simply not have been activated yet.\n\n${DEMO_EXPLANATION}`,
+        buttons: retry ? ['Check For Licence', 'Continue in Demo Mode'] : ['OK'],
+        onResponse: (buttonIndex: number) => {
+          if (retry && buttonIndex === 0) void retry()
+        },
+      })
+      return true
+    }
+
+    case 'unsupported':
+      // Unconditional wording, and it names the FIRMWARE. Every licensable VPP
+      // targets hardware that persists a licence, so a board answering this was
+      // built without its storage backend — "your hardware cannot do this" would
+      // be false, and it is the message that sent us looking at a NodeMCU that
+      // stores licences perfectly well.
+      openModal('debugger-message', {
+        type: 'warning',
+        title: 'Licence Storage Missing From This Firmware',
+        message:
+          'The firmware running on this device reports no licence storage, so a licence cannot be ' +
+          'written to it.\n\nThis hardware supports it — every licensed VPP targets hardware that ' +
+          'does. The image on the board was built without the storage backend, so rebuild and ' +
+          `upload it.\n\n${DEMO_EXPLANATION}`,
+        // No purchase offered: buying would not fix a firmware built wrong.
+        buttons: ['OK'],
+        onResponse: () => undefined,
+      })
+      return true
+
+    case 'check-failed':
+      openModal('debugger-message', {
+        type: 'error',
+        title: 'Licence Check Failed',
+        message:
+          `The editor could not determine whether this device holds a licence.\n\n${outcome.error}\n\n` +
+          'This is NOT the same as having no licence — nothing has changed on the device.',
+        buttons: retry ? ['Try Again', 'Continue'] : ['OK'],
+        onResponse: (buttonIndex: number) => {
+          if (retry && buttonIndex === 0) void retry()
+        },
+      })
+      return true
+  }
+}

--- a/src/main/modules/ipc/__tests__/device-license.handler.test.ts
+++ b/src/main/modules/ipc/__tests__/device-license.handler.test.ts
@@ -1,0 +1,263 @@
+/**
+ * The two licensing IPC handlers, over a fake held link.
+ *
+ * What is worth testing HERE (as opposed to in `license-flow`, which owns the
+ * decision logic) is the wiring: that the handlers take the CONTROL channel
+ * rather than opening a connection, that a missing link is reported as
+ * `check-failed` and never as "not licensed", that the anchor is read fresh, that
+ * the compound sequence is guarded, and that device traffic is noted so the
+ * liveness poll does not declare a healthy link lost mid-sequence.
+ */
+
+import MainProcessBridge from '../main'
+
+jest.mock('electron', () => ({
+  app: { getPath: jest.fn(() => '/tmp') },
+  dialog: {},
+  nativeTheme: { shouldUseDarkColors: false, themeSource: 'system' },
+  shell: { openExternal: jest.fn() },
+}))
+
+jest.mock('@root/backend/editor/ethercat', () => ({ ESIService: jest.fn() }))
+jest.mock('@root/backend/editor/library-manager/desktop-catalog-transport', () => ({
+  createDesktopCatalogTransport: jest.fn(() => ({})),
+}))
+jest.mock('@root/backend/editor/utils/runtime-https-config', () => ({ getRuntimeHttpsOptions: jest.fn(() => ({})) }))
+jest.mock('@root/backend/shared/ethercat/esi-parser-main', () => ({ parseESIDeviceFull: jest.fn() }))
+jest.mock('@root/backend/shared/library/public-catalog-client', () => ({ listPublicLibraries: jest.fn() }))
+jest.mock('../../../../backend/editor/library-manager', () => ({
+  LibraryManagerModule: jest.fn(() => ({ loadEnabledArchives: jest.fn(() => ({ archives: [], missing: [] })) })),
+}))
+jest.mock('../../../../backend/editor/package-manager', () => ({ PackageManagerModule: jest.fn(() => ({})) }))
+jest.mock('../../../../backend/editor/services', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}))
+jest.mock('../../../../backend/editor/utils', () => ({ getOpenProjectPath: jest.fn(), getProjectPath: jest.fn() }))
+jest.mock('../../../../backend/shared/simulator/simulator-module', () => ({
+  SimulatorModule: jest.fn(() => ({ stop: jest.fn() })),
+}))
+
+jest.mock('../../../../backend/editor/license/license-flow', () => ({
+  inspectDeviceLicense: jest.fn(),
+  resolveDeviceLicense: jest.fn(),
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const licenseFlow = require('../../../../backend/editor/license/license-flow') as {
+  inspectDeviceLicense: jest.Mock
+  resolveDeviceLicense: jest.Mock
+}
+
+const REQUEST = { packageId: 'com.openplc.espressif-licensed' }
+const ANCHOR = Uint8Array.from([0, 177, 140, 237])
+
+function createBridge() {
+  return new MainProcessBridge({
+    ipcMain: {},
+    mainWindow: { isDestroyed: jest.fn(() => false), isMaximized: jest.fn(() => false) },
+    projectService: {},
+    store: { get: jest.fn(() => undefined) },
+    menuBuilder: {},
+    pouService: {},
+    compilerModule: {},
+    hardwareModule: { isSerialPortPresent: jest.fn(() => true) },
+  } as never)
+}
+
+/** Install a fake held CONTROL client on the bridge's session manager. */
+function holdClient(
+  bridge: ReturnType<typeof createBridge>,
+  client: { getBoardId: jest.Mock; readLicense?: jest.Mock; writeLicense?: jest.Mock },
+) {
+  const session = (bridge as unknown as { deviceSession: { getClient: () => unknown; noteTraffic: () => void } })
+    .deviceSession
+  jest.spyOn(session, 'getClient').mockReturnValue(client)
+  return jest.spyOn(session, 'noteTraffic')
+}
+
+function boardIdClient(overrides: Partial<{ getBoardId: jest.Mock }> = {}) {
+  return {
+    getBoardId: jest.fn(() => Promise.resolve({ success: true, boardId: ANCHOR })),
+    readLicense: jest.fn(),
+    writeLicense: jest.fn(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  licenseFlow.inspectDeviceLicense.mockReset()
+  licenseFlow.resolveDeviceLicense.mockReset()
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('device:read-license', () => {
+  it('reads the anchor off the held link and hands it to the inspect flow', async () => {
+    const bridge = createBridge()
+    const client = boardIdClient()
+    const noteTraffic = holdClient(bridge, client)
+    licenseFlow.inspectDeviceLicense.mockResolvedValue({
+      deviceId: 'abc',
+      outcome: { state: 'licensed', how: 'already-stored' },
+    })
+
+    const result = await bridge.handleDeviceReadLicense({} as never, REQUEST)
+
+    expect(client.getBoardId).toHaveBeenCalledTimes(1)
+    expect(licenseFlow.inspectDeviceLicense).toHaveBeenCalledWith(client, { ...REQUEST, anchor: ANCHOR })
+    expect(result).toEqual({ deviceId: 'abc', outcome: { state: 'licensed', how: 'already-stored' } })
+    // The board-id read is device traffic; not noting it lets the liveness poll
+    // fall due behind it and declare a healthy link lost.
+    expect(noteTraffic).toHaveBeenCalled()
+  })
+
+  it('reports check-failed — never "not licensed" — when no link is held', async () => {
+    const bridge = createBridge()
+    // No client installed: getClient() returns null.
+
+    const result = await bridge.handleDeviceReadLicense({} as never, REQUEST)
+
+    expect(result.outcome.state).toBe('check-failed')
+    expect(licenseFlow.inspectDeviceLicense).not.toHaveBeenCalled()
+  })
+
+  it('reports check-failed when the device will not answer the board-id read', async () => {
+    const bridge = createBridge()
+    const client = boardIdClient({
+      getBoardId: jest.fn(() => Promise.resolve({ success: false, error: 'Request timeout' })),
+    })
+    holdClient(bridge, client)
+
+    const result = await bridge.handleDeviceReadLicense({} as never, REQUEST)
+
+    expect(result.outcome).toEqual({ state: 'check-failed', error: 'Request timeout' })
+    expect(licenseFlow.inspectDeviceLicense).not.toHaveBeenCalled()
+  })
+
+  it('passes an empty anchor through rather than inventing one', async () => {
+    // A board answering id_len = 0 is a real reply; the flow is the layer that
+    // knows it cannot be licensed, and it must get the chance to say so.
+    const bridge = createBridge()
+    const client = boardIdClient({ getBoardId: jest.fn(() => Promise.resolve({ success: true })) })
+    holdClient(bridge, client)
+    licenseFlow.inspectDeviceLicense.mockResolvedValue({ outcome: { state: 'check-failed', error: 'no unique id' } })
+
+    await bridge.handleDeviceReadLicense({} as never, REQUEST)
+
+    expect(licenseFlow.inspectDeviceLicense).toHaveBeenCalledWith(client, {
+      ...REQUEST,
+      anchor: new Uint8Array(0),
+    })
+  })
+
+  it('turns an unexpected throw into check-failed instead of rejecting the IPC call', async () => {
+    const bridge = createBridge()
+    holdClient(bridge, boardIdClient())
+    licenseFlow.inspectDeviceLicense.mockRejectedValue(new Error('port closed'))
+
+    const result = await bridge.handleDeviceReadLicense({} as never, REQUEST)
+
+    expect(result.outcome).toEqual({ state: 'check-failed', error: 'port closed' })
+  })
+})
+
+describe('device:refresh-license', () => {
+  it('runs the full flow over the held link and notes the traffic', async () => {
+    const bridge = createBridge()
+    const client = boardIdClient()
+    const noteTraffic = holdClient(bridge, client)
+    licenseFlow.resolveDeviceLicense.mockResolvedValue({
+      deviceId: 'abc',
+      outcome: { state: 'licensed', how: 'activated' },
+    })
+
+    const result = await bridge.handleDeviceRefreshLicense({} as never, REQUEST)
+
+    expect(licenseFlow.resolveDeviceLicense).toHaveBeenCalledWith(client, { ...REQUEST, anchor: ANCHOR })
+    expect(result.outcome).toEqual({ state: 'licensed', how: 'activated' })
+    // Once for the anchor read, once after the sequence: the sequence spans an
+    // HTTP round trip, which is long enough for the poll to fall due inside it.
+    expect(noteTraffic.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('refuses a second concurrent sequence rather than interleaving it', async () => {
+    // The frame mutex cannot see a SEQUENCE: two refreshes would each send atomic
+    // frames while interleaving a read and a write of the same license, one
+    // reading back the other's blob and drawing a conclusion about it.
+    const bridge = createBridge()
+    holdClient(bridge, boardIdClient())
+
+    let release: (() => void) | undefined
+    let entered = false
+    licenseFlow.resolveDeviceLicense.mockImplementation(() => {
+      entered = true
+      return new Promise((resolve) => {
+        release = () => resolve({ deviceId: 'abc', outcome: { state: 'licensed', how: 'activated' } })
+      })
+    })
+
+    const first = bridge.handleDeviceRefreshLicense({} as never, REQUEST)
+    // Let the first sequence get past its anchor read and INTO the flow before
+    // racing it; asserting on a call that has not been reached yet would test the
+    // scheduler rather than the guard.
+    while (!entered) await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const second = await bridge.handleDeviceRefreshLicense({} as never, REQUEST)
+
+    expect(second.outcome).toEqual({
+      state: 'check-failed',
+      error: 'A license check is already running on this device.',
+    })
+    expect(licenseFlow.resolveDeviceLicense).toHaveBeenCalledTimes(1)
+
+    release?.()
+    await expect(first).resolves.toMatchObject({ outcome: { state: 'licensed' } })
+  })
+
+  it('clears the sequence guard after a failure, so a retry is possible', async () => {
+    const bridge = createBridge()
+    holdClient(bridge, boardIdClient())
+    licenseFlow.resolveDeviceLicense.mockRejectedValueOnce(new Error('port closed'))
+
+    const failed = await bridge.handleDeviceRefreshLicense({} as never, REQUEST)
+    expect(failed.outcome).toEqual({ state: 'check-failed', error: 'port closed' })
+
+    // A guard left set by a throw would strand the device: every later attempt
+    // would answer "already running" with nothing actually running.
+    licenseFlow.resolveDeviceLicense.mockResolvedValue({
+      deviceId: 'abc',
+      outcome: { state: 'unlicensed', entitlementChecked: true },
+    })
+    const retried = await bridge.handleDeviceRefreshLicense({} as never, REQUEST)
+
+    expect(retried.outcome).toEqual({ state: 'unlicensed', entitlementChecked: true })
+  })
+
+  it('reports check-failed when no link is held', async () => {
+    const bridge = createBridge()
+
+    const result = await bridge.handleDeviceRefreshLicense({} as never, REQUEST)
+
+    expect(result.outcome.state).toBe('check-failed')
+    expect(licenseFlow.resolveDeviceLicense).not.toHaveBeenCalled()
+  })
+
+  it('does not consume the sequence guard when there is no link to run on', async () => {
+    const bridge = createBridge()
+
+    await bridge.handleDeviceRefreshLicense({} as never, REQUEST)
+
+    // The guard is taken AFTER the channel check, so a disconnected device does
+    // not leave it set for the next attempt.
+    holdClient(bridge, boardIdClient())
+    licenseFlow.resolveDeviceLicense.mockResolvedValue({
+      deviceId: 'abc',
+      outcome: { state: 'licensed', how: 'activated' },
+    })
+    const result = await bridge.handleDeviceRefreshLicense({} as never, REQUEST)
+
+    expect(result.outcome).toEqual({ state: 'licensed', how: 'activated' })
+  })
+})

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -13,6 +13,7 @@ import { PlcRuntimeState } from '@root/backend/shared/simulator/types'
 import { PLCProjectData } from '@root/backend/shared/types/PLC/open-plc'
 import { getErrorMessage } from '@root/frontend/utils/get-error-message'
 import { RuntimeLogEntry } from '@root/middleware/shared/ports'
+import type { DeviceLicenseReport, DeviceLicenseRequest } from '@root/middleware/shared/ports/device-port'
 import type {
   EtherCATRuntimeStatusResponse,
   EtherCATScanRequest,
@@ -66,6 +67,7 @@ import {
   modbusTransportKind,
 } from '../../../backend/editor/hardware/device-transport-factory'
 import { LibraryManagerModule } from '../../../backend/editor/library-manager'
+import { inspectDeviceLicense, resolveDeviceLicense } from '../../../backend/editor/license/license-flow'
 import { PackageManagerModule } from '../../../backend/editor/package-manager'
 import { logger } from '../../../backend/editor/services'
 import {
@@ -1081,6 +1083,10 @@ class MainProcessBridge implements MainIpcModule {
     this.registerHandle('device:connect', this.handleDeviceConnect)
     this.registerHandle('device:disconnect', this.handleDeviceDisconnect)
     this.registerHandle('device:release-serial-port', this.handleDeviceReleaseSerialPort)
+    // VPP licensing over the HELD link — callable any time the device is
+    // connected, deliberately not folded into `device:connect`. See the handlers.
+    this.registerHandle('device:read-license', this.handleDeviceReadLicense)
+    this.registerHandle('device:refresh-license', this.handleDeviceRefreshLicense)
     this.registerHandle('session:open-runtime', this.handleOpenRuntimeSession)
     this.registerHandle('session:close-runtime', this.handleCloseRuntimeSession)
 
@@ -2406,6 +2412,112 @@ class MainProcessBridge implements MainIpcModule {
     this.deviceLinkProbe = null
     this.tracedChannelUses.clear()
     return { success: true }
+  }
+
+  // ===================== VPP LICENSING OVER THE HELD LINK =====================
+  //
+  // WHY THESE ARE ON-DEMAND, AND NOT PART OF `device:connect`.
+  //
+  // Two reasons, both learned the hard way. First, `refreshLicense` reaches the
+  // NETWORK: folding it into connect makes every connect to a licensed board wait
+  // on an HTTP round trip that may be rate-limited or time out, and a connect that
+  // hangs looks like a broken cable. Second, a purchase happens AFTER the user has
+  // already been told they are in demo mode — with licensing bolted to connect, the
+  // only way to pick up a licence they just bought is to disconnect and reconnect,
+  // or reflash. Exposing the step means the buy dialog can simply call it again on
+  // the link that is already open.
+  //
+  // Both ride the CONTROL channel (`requireControl`): the license FCs are ordinary
+  // frames on the same held Modbus link as run/stop and the status poll, so they
+  // queue behind the same mutex and need no connection of their own.
+
+  /**
+   * True while a COMPOUND licensing sequence is running over the held client.
+   *
+   * The transports already serialise individual FRAMES, and that is not enough
+   * here. `refreshLicense` is read -> HTTP -> write -> read, and two of them
+   * running at once would each see perfectly atomic frames while interleaving a
+   * read and a write of the SAME license — one sequence reading back the other's
+   * blob and drawing a conclusion about it. The frame mutex cannot see the
+   * sequence, so the sequence needs its own guard.
+   */
+  private deviceLicenseSequenceInFlight = false
+
+  /**
+   * Read the anchor the licensing identity derives from, over the held link.
+   *
+   * Read FRESH on every licensing call rather than cached at connect. The anchor
+   * IS the device identity, and a board swapped on the same serial path would
+   * otherwise inherit the previous one's — deciding a license question for
+   * hardware that is no longer there. One extra frame on an operation that already
+   * spends several is not worth that risk.
+   */
+  private async readLicenseAnchor(client: DeviceModbusTransport): Promise<{ anchor: Uint8Array } | { error: string }> {
+    const board = await client.getBoardId()
+    if (!board.success) return { error: board.error ?? 'the device did not answer the board-id read' }
+    this.deviceSession.noteTraffic()
+    return { anchor: board.boardId ?? new Uint8Array(0) }
+  }
+
+  /**
+   * `device:read-license` — what license is this board holding right now?
+   *
+   * Read + verify only; never contacts the backend, so it is cheap enough for a
+   * screen open. It answers the question the badge asks, which `device:connect`
+   * deliberately does not.
+   */
+  handleDeviceReadLicense = async (
+    _event: IpcMainInvokeEvent,
+    request: DeviceLicenseRequest,
+  ): Promise<DeviceLicenseReport> => {
+    const control = this.requireControl('read license')
+    if ('error' in control) return { outcome: { state: 'check-failed', error: control.error } }
+
+    try {
+      const anchor = await this.readLicenseAnchor(control.client)
+      if ('error' in anchor) return { outcome: { state: 'check-failed', error: anchor.error } }
+
+      return await inspectDeviceLicense(control.client, { ...request, anchor: anchor.anchor })
+    } catch (error) {
+      return { outcome: { state: 'check-failed', error: getErrorMessage(error) } }
+    }
+  }
+
+  /**
+   * `device:refresh-license` — the full flow, including the backend recovery.
+   *
+   * Called after a connect to a licensable board, and again after a purchase so a
+   * device gets its license without disconnecting or reflashing.
+   */
+  handleDeviceRefreshLicense = async (
+    _event: IpcMainInvokeEvent,
+    request: DeviceLicenseRequest,
+  ): Promise<DeviceLicenseReport> => {
+    const control = this.requireControl('refresh license')
+    if ('error' in control) return { outcome: { state: 'check-failed', error: control.error } }
+
+    if (this.deviceLicenseSequenceInFlight) {
+      // Reported rather than queued: the caller is a button or a connect, and a
+      // second answer arriving later for a question already being answered is
+      // noise at best and a contradictory badge at worst.
+      return { outcome: { state: 'check-failed', error: 'A license check is already running on this device.' } }
+    }
+    this.deviceLicenseSequenceInFlight = true
+
+    try {
+      const anchor = await this.readLicenseAnchor(control.client)
+      if ('error' in anchor) return { outcome: { state: 'check-failed', error: anchor.error } }
+
+      const report = await resolveDeviceLicense(control.client, { ...request, anchor: anchor.anchor })
+      // The license FCs are device traffic like any other: without noting them the
+      // liveness poll can fall due mid-sequence and declare a healthy link lost.
+      this.deviceSession.noteTraffic()
+      return report
+    } catch (error) {
+      return { outcome: { state: 'check-failed', error: getErrorMessage(error) } }
+    } finally {
+      this.deviceLicenseSequenceInFlight = false
+    }
   }
 
   handleDebuggerSetVariable = async (

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -1,5 +1,9 @@
 import type { DiscoveredRuntimeDevice, RuntimeLogEntry } from '@root/middleware/shared/ports'
-import type { DeviceConnectionStatusPayload } from '@root/middleware/shared/ports/device-port'
+import type {
+  DeviceConnectionStatusPayload,
+  DeviceLicenseReport,
+  DeviceLicenseRequest,
+} from '@root/middleware/shared/ports/device-port'
 import type { ESIDevice, ESIRepositoryItemLight } from '@root/middleware/shared/ports/esi-types'
 import type {
   EtherCATRuntimeStatusResponse,
@@ -475,6 +479,15 @@ const rendererProcessBridge = {
   // Upload handoff: give up the link ONLY if it is the serial one holding `port`.
   deviceReleaseSerialPort: (port: string | null | undefined): Promise<{ released: boolean }> =>
     ipcRenderer.invoke('device:release-serial-port', port),
+
+  // VPP licensing over the HELD link. `read` is local-only (read + verify) and
+  // cheap; `refresh` may reach the network and write, which is why they are
+  // separate channels and neither is part of `device:connect`.
+  deviceReadLicense: (request: DeviceLicenseRequest): Promise<DeviceLicenseReport> =>
+    ipcRenderer.invoke('device:read-license', request),
+
+  deviceRefreshLicense: (request: DeviceLicenseRequest): Promise<DeviceLicenseReport> =>
+    ipcRenderer.invoke('device:refresh-license', request),
 
   // Diagnostic trace of the device connection (candidate attempts, poll verdicts,
   // which connection served each command), mirrored into the editor console so it

--- a/src/middleware/adapters/editor/__tests__/device-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/device-adapter.test.ts
@@ -32,6 +32,14 @@ beforeEach(() => {
     openRuntimeSession: jest.fn().mockResolvedValue({ success: true }),
     closeRuntimeSession: jest.fn().mockResolvedValue({ success: true }),
     deviceReleaseSerialPort: jest.fn().mockResolvedValue({ released: true }),
+    deviceReadLicense: jest.fn().mockResolvedValue({
+      deviceId: '659a3520540f803625ddc34081e893d3',
+      outcome: { state: 'licensed', how: 'already-stored' },
+    }),
+    deviceRefreshLicense: jest.fn().mockResolvedValue({
+      deviceId: '659a3520540f803625ddc34081e893d3',
+      outcome: { state: 'unlicensed', entitlementChecked: true },
+    }),
     onDeviceLinkLog: jest.fn().mockReturnValue(() => undefined),
     onDevicePlcState: jest.fn().mockReturnValue(() => undefined),
   } as unknown as typeof window.bridge
@@ -150,5 +158,28 @@ describe('createEditorDeviceAdapter', () => {
     const unsub = adapter.onPlcState?.(cb)
     expect(window.bridge.onDevicePlcState).toHaveBeenCalledWith(cb)
     expect(typeof unsub).toBe('function')
+  })
+
+  it('delegates readLicense to the local-only license channel', async () => {
+    const request = { packageId: 'com.openplc.espressif-licensed' }
+
+    await expect(adapter.readLicense?.(request)).resolves.toEqual({
+      deviceId: '659a3520540f803625ddc34081e893d3',
+      outcome: { state: 'licensed', how: 'already-stored' },
+    })
+    expect(window.bridge.deviceReadLicense).toHaveBeenCalledWith(request)
+    // The cheap channel must not be the one that reaches the network.
+    expect(window.bridge.deviceRefreshLicense).not.toHaveBeenCalled()
+  })
+
+  it('delegates refreshLicense to the recovering license channel', async () => {
+    const request = { packageId: 'com.openplc.espressif-licensed' }
+
+    await expect(adapter.refreshLicense?.(request)).resolves.toEqual({
+      deviceId: '659a3520540f803625ddc34081e893d3',
+      outcome: { state: 'unlicensed', entitlementChecked: true },
+    })
+    expect(window.bridge.deviceRefreshLicense).toHaveBeenCalledWith(request)
+    expect(window.bridge.deviceReadLicense).not.toHaveBeenCalled()
   })
 })

--- a/src/middleware/adapters/editor/__tests__/system-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/system-adapter.test.ts
@@ -69,3 +69,18 @@ describe('log', () => {
     expect(window.bridge.log).toHaveBeenCalledWith('error', 'error message')
   })
 })
+
+describe('getEdgeFrontendUrl', () => {
+  it('resolves an absolute Edge WEB app URL, distinct from the API host', () => {
+    // The `/buy` page lives on the web app, not the API. Deriving one host from
+    // the other by string surgery breaks the moment either moves, so this must be
+    // its own value — and it must be absolute, or `buildLicenseBuyUrl` falls back
+    // to a root-relative link that Electron cannot open.
+    const url = adapter.getEdgeFrontendUrl()
+
+    expect(url).toMatch(/^https?:\/\//)
+    expect(url).not.toContain('api.autonomylogic.com')
+    // No trailing slash: the URL builder appends `/buy` itself.
+    expect(url.endsWith('/')).toBe(false)
+  })
+})

--- a/src/middleware/adapters/editor/device-adapter.ts
+++ b/src/middleware/adapters/editor/device-adapter.ts
@@ -12,9 +12,17 @@
  *   hardware:refresh-available-boards           (invoke)
  *   hardware:refresh-communication-ports        (invoke)
  *   util:get-preview-image                      (invoke)
+ *   device:read-license                         (invoke)
+ *   device:refresh-license                      (invoke)
  */
 
-import type { DeviceConnectionStatusPayload, DeviceConnectResult, DevicePort } from '../../shared/ports/device-port'
+import type {
+  DeviceConnectionStatusPayload,
+  DeviceConnectResult,
+  DeviceLicenseReport,
+  DeviceLicenseRequest,
+  DevicePort,
+} from '../../shared/ports/device-port'
 import type { BoardInfo, CommunicationPort, DebugConnectionConfig } from '../../shared/ports/types'
 
 export function createEditorDeviceAdapter(): DevicePort {
@@ -61,6 +69,14 @@ export function createEditorDeviceAdapter(): DevicePort {
 
     disconnect(): Promise<{ success: boolean }> {
       return window.bridge.deviceDisconnect()
+    },
+
+    readLicense(request: DeviceLicenseRequest): Promise<DeviceLicenseReport> {
+      return window.bridge.deviceReadLicense(request)
+    },
+
+    refreshLicense(request: DeviceLicenseRequest): Promise<DeviceLicenseReport> {
+      return window.bridge.deviceRefreshLicense(request)
     },
 
     onLinkLog(callback: (message: string) => void): () => void {

--- a/src/middleware/adapters/editor/system-adapter.ts
+++ b/src/middleware/adapters/editor/system-adapter.ts
@@ -16,6 +16,25 @@
 import type { SystemPort } from '../../shared/ports/system-port'
 import type { SystemInfo } from '../../shared/ports/types'
 
+/**
+ * Edge web app host — where the license `/buy` page lives. Authoritative for
+ * shipped builds.
+ */
+const PRODUCTION_EDGE_WEB_URL = 'https://edge.autonomylogic.com'
+
+/**
+ * Build-time override, injected by webpack's `EnvironmentPlugin` (renderer dev +
+ * prod configs) exactly like `VPP_CATALOG_URL`. Electron renderer bundles have no
+ * live `process.env`, so this is evaluated when the bundle is BUILT: set it in the
+ * shell before `npm run dev` to aim the buy flow at a local Edge app.
+ *
+ *     OPENPLC_EDGE_WEB_URL=http://localhost:5173 npm run dev
+ *
+ * The release pipeline does not set it, and webpack's empty-string default is
+ * falsy, so shipped builds always point at production.
+ */
+const EDGE_WEB_URL = process.env.OPENPLC_EDGE_WEB_URL || PRODUCTION_EDGE_WEB_URL
+
 export function createEditorSystemAdapter(): SystemPort {
   return {
     getSystemInfo(): Promise<SystemInfo> {
@@ -36,6 +55,10 @@ export function createEditorSystemAdapter(): SystemPort {
 
     log(level: 'info' | 'error', message: string): void {
       window.bridge.log(level, message)
+    },
+
+    getEdgeFrontendUrl(): string {
+      return EDGE_WEB_URL
     },
   }
 }

--- a/src/middleware/shared/ports/device-port.ts
+++ b/src/middleware/shared/ports/device-port.ts
@@ -74,6 +74,72 @@ export interface DeviceConnectionStatusPayload {
   reason?: 'lost'
 }
 
+// ---------------------------------------------------------------------------
+// VPP licensing over the held link
+// ---------------------------------------------------------------------------
+
+/**
+ * What the licensing step concluded about a connected device.
+ *
+ * A discriminated union rather than a status string plus flags, so the three
+ * things the UI may assert stay three separate variants. In particular
+ * `unlicensed` (the backend says there is no purchase — demo is correct, offer to
+ * buy) and `checkFailed` (we could not find out) must never be rendered the same
+ * way: showing "Not licensed" for a rate-limited request tells someone who
+ * already paid to buy again.
+ *
+ * `licensed` asserts POSSESSION of a well-formed license bound to this device and
+ * this VPP — not that the closed license-core will run FULL. Only the core can say
+ * that, so the badge says "Licensed", never "Full mode".
+ */
+export type DeviceLicenseState =
+  /** A well-formed license bound to this device and this VPP is stored. */
+  | { state: 'licensed'; how: 'already-stored' | 'activated' }
+  /**
+   * The device does NOT hold a valid license.
+   *
+   * `entitlementChecked` says how far we got, and the UI must branch on it:
+   *   - `true`  — the backend was asked and reported no purchase for this device.
+   *               Demo mode is correct and BUYING is the fix. `backendReason`
+   *               carries the backend's own wording when it gave one.
+   *   - `false` — we only know the device is holding nothing usable; nobody has
+   *               asked whether a purchase exists. The fix to OFFER is "check for
+   *               a license" (a refresh), not "buy" — telling someone who already
+   *               paid to pay again is the worst outcome this union exists to
+   *               prevent.
+   */
+  | { state: 'unlicensed'; entitlementChecked: boolean; backendReason?: string }
+  /**
+   * The running firmware reports no licence storage.
+   *
+   * On a licensable board this is a FIRMWARE fault, not a hardware limitation:
+   * every licensable VPP targets hardware that persists a licence across a
+   * reboot, so a board answering this was built without its storage backend.
+   * The fix is always "rebuild and upload", never "buy a different board" —
+   * which is why this variant carries no detail to vary the message with.
+   */
+  | { state: 'unsupported' }
+  /** Possession could not be determined. Never render as "not licensed". */
+  | { state: 'check-failed'; error: string }
+
+/** Result of a licensing operation over the held link. */
+export interface DeviceLicenseReport {
+  outcome: DeviceLicenseState
+  /**
+   * The licensing identity, 32 lowercase hex chars. Derived main-side (it needs
+   * `node:crypto`), so the renderer cannot compute it and must be handed it: it
+   * feeds the license popover, the copy button, and the buy deep link. Absent only
+   * when there was no usable hardware anchor, which is itself a `checkFailed`.
+   */
+  deviceId?: string
+}
+
+/** Arguments both licensing calls take, resolved by `resolveLicensingTarget`. */
+export interface DeviceLicenseRequest {
+  /** Reverse-domain VPP package id (`package.id`). */
+  packageId: string
+}
+
 export interface DevicePort {
   /**
    * Get all available boards with their hardware specs and pin configurations.
@@ -158,6 +224,36 @@ export interface DevicePort {
 
   /** Close a held serial link. Editor: `device:disconnect`. */
   disconnect(): Promise<{ success: boolean }>
+
+  /**
+   * Ask the connected device what license it is holding RIGHT NOW: read FC 0x4A
+   * and verify the bytes. Never contacts the backend, so it is cheap and safe to
+   * call on a poll or a screen open.
+   *
+   * The verification is the point. A device answering `SUCCESS` does not mean the
+   * stored license is good — the targets disagree about what they check first —
+   * so a caller that trusted the status byte would show "Licensed" on a board
+   * running demo.
+   *
+   * Optional: only platforms that hold a device link implement it. Editor:
+   * `device:read-license`.
+   */
+  readLicense?(request: DeviceLicenseRequest): Promise<DeviceLicenseReport>
+
+  /**
+   * Run the FULL licensing flow over the held link: read, verify, and when the
+   * device holds nothing usable, ask the backend and write what it returns
+   * (re-reading to confirm).
+   *
+   * Separate from `readLicense` because this one can take seconds and reaches the
+   * network — a connect must not block on it, and it is also what the UI calls
+   * again after a purchase so a device gets its license without disconnecting or
+   * reflashing.
+   *
+   * Optional: only platforms that hold a device link implement it. Editor:
+   * `device:refresh-license`.
+   */
+  refreshLicense?(request: DeviceLicenseRequest): Promise<DeviceLicenseReport>
 
   /**
    * Subscribe to live serial-link status pushed by the main process (liveness

--- a/src/middleware/shared/ports/system-port.ts
+++ b/src/middleware/shared/ports/system-port.ts
@@ -51,4 +51,19 @@ export interface SystemPort {
    * Web: logs via console or remote logging service.
    */
   log(level: 'info' | 'error', message: string): void
+
+  /**
+   * Absolute base URL of the Autonomy Edge **web app** — the host that serves
+   * user-facing pages such as `/buy`. NOT the API host: those are different
+   * origins (`edge.autonomylogic.com` vs `api.autonomylogic.com`), and deriving
+   * one from the other by string surgery would break the moment either moves.
+   *
+   * A port and not a shared constant because each platform resolves it
+   * differently, and both need to be pointable at a local Edge instance for
+   * end-to-end testing — which a hardcoded production host in shared UI cannot be.
+   *
+   * Editor: build-time env override (`OPENPLC_EDGE_WEB_URL`) over the production
+   *         default. Web: its own env var (may be a same-origin prefix).
+   */
+  getEdgeFrontendUrl(): string
 }

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -779,6 +779,29 @@ export interface PackageManifest {
        * integration layer (hal.source).
        */
       precompiledLibrary?: string
+      /**
+       * On-device license-storage backend: source file(s) injected into the
+       * Baremetal sketch and recompiled against the editor's `license_blob.h`.
+       *
+       * PRESENCE is the signal — it is what resolves
+       * `TargetCapabilities.licenseStore` and what drives the backend into the
+       * build, so one declaration serves both and they cannot disagree. Absence
+       * means the board answers `LIC_UNSUPPORTED` and the licensing flow reports
+       * that instead of writing.
+       */
+      licenseStore?: string | string[]
+      /**
+       * Per-VPP signing key id (e.g. `espressif-licensed-2026`). Names which key
+       * the backend/KMS signs this VPP's licenses with and which public key the
+       * closed artifact embeds.
+       *
+       * INFORMATIONAL in the editor: the activation request sends only
+       * `{ deviceId, packageId }` and the backend resolves its own signing key
+       * from the package id. The real trust root is the public key compiled into
+       * the VPP, not this string — it is carried for the build side and for
+       * diagnosing "the board stored the blob and still runs demo".
+       */
+      licenseKeyId?: string
       compilerFlags?: {
         c_flags?: string[]
         cxx_flags?: string[]

--- a/src/middleware/shared/utils/licensing/__tests__/resolve-licensing-target.test.ts
+++ b/src/middleware/shared/utils/licensing/__tests__/resolve-licensing-target.test.ts
@@ -1,0 +1,93 @@
+import type { BoardInfo, VppMetadata } from '../../../ports/types'
+import { resolveLicensingTarget } from '../resolve-licensing-target'
+
+/** A minimally-valid BoardInfo; each test overrides only what it is about. */
+function board(overrides: Partial<BoardInfo> = {}): BoardInfo {
+  return {
+    compiler: 'arduino-cli',
+    core: 'esp32:esp32',
+    preview: '',
+    specs: {},
+    ...overrides,
+  }
+}
+
+/** VPP metadata for a package id; the rest is inert filler this unit ignores. */
+function vpp(packageId: string): VppMetadata {
+  return {
+    packageId,
+    vendor: 'Espressif',
+    deviceId: 'esp32-generic',
+    packagePath: '/packages/espressif',
+    screens: {},
+    moduleSystem: { enabled: false, maxSlots: 0, modules: [] },
+  }
+}
+
+const LICENSED_VPP = vpp('com.openplc.espressif-licensed')
+
+describe('resolveLicensingTarget', () => {
+  it('reports a licensable VPP with just its package id', () => {
+    const target = resolveLicensingTarget(board({ vpp: LICENSED_VPP, capabilities: { isLicensable: true } }))
+
+    // Deliberately only the package id. There is no "can this board store a
+    // licence" companion: every licensable VPP targets hardware that persists
+    // one, so the answer would be constant, and the DEVICE is what gets asked.
+    expect(target).toEqual({ licensable: true, packageId: 'com.openplc.espressif-licensed' })
+  })
+
+  it('is not licensable for a VPP that does not declare it', () => {
+    const target = resolveLicensingTarget(board({ vpp: vpp('com.openplc.espressif') }))
+
+    expect(target).toEqual({ licensable: false, reason: 'not-licensable' })
+  })
+
+  it('is not licensable for a plain non-VPP board', () => {
+    // The common case: every built-in hals.json board, and the reason this
+    // function has to be cheap — a connect here must carry no licensing traffic.
+    expect(resolveLicensingTarget(board())).toEqual({ licensable: false, reason: 'not-licensable' })
+  })
+
+  it('is not licensable for the simulator', () => {
+    expect(resolveLicensingTarget(board({ compiler: 'simulator' }))).toEqual({
+      licensable: false,
+      reason: 'not-licensable',
+    })
+  })
+
+  it('is not licensable for runtime v4', () => {
+    expect(resolveLicensingTarget(board({ compiler: 'openplc-compiler' }))).toEqual({
+      licensable: false,
+      reason: 'not-licensable',
+    })
+  })
+
+  it('never treats an explicit isLicensable:false as licensable, even on a VPP board', () => {
+    const target = resolveLicensingTarget(board({ vpp: LICENSED_VPP, capabilities: { isLicensable: false } }))
+
+    expect(target).toEqual({ licensable: false, reason: 'not-licensable' })
+  })
+
+  it('reports a broken manifest distinctly when isLicensable is set with no package id', () => {
+    // Distinct from `not-licensable` on purpose: this is a manifest someone has
+    // to fix, not a product that is simply free. Treating it as licensable would
+    // mean calling activate with nothing to identify the product, then telling the
+    // user to buy something the editor cannot name.
+    const target = resolveLicensingTarget(board({ capabilities: { isLicensable: true } }))
+
+    expect(target).toEqual({ licensable: false, reason: 'no-package-id' })
+  })
+
+  it('treats a blank package id as missing rather than as an id', () => {
+    const target = resolveLicensingTarget(
+      board({ vpp: { ...LICENSED_VPP, packageId: '   ' }, capabilities: { isLicensable: true } }),
+    )
+
+    expect(target).toEqual({ licensable: false, reason: 'no-package-id' })
+  })
+
+  it('handles an absent board without a null dance at the call site', () => {
+    expect(resolveLicensingTarget(null)).toEqual({ licensable: false, reason: 'not-licensable' })
+    expect(resolveLicensingTarget(undefined)).toEqual({ licensable: false, reason: 'not-licensable' })
+  })
+})

--- a/src/middleware/shared/utils/licensing/index.ts
+++ b/src/middleware/shared/utils/licensing/index.ts
@@ -1,0 +1,1 @@
+export { type LicensingSkipReason, type LicensingTarget, resolveLicensingTarget } from './resolve-licensing-target'

--- a/src/middleware/shared/utils/licensing/resolve-licensing-target.ts
+++ b/src/middleware/shared/utils/licensing/resolve-licensing-target.ts
@@ -1,0 +1,61 @@
+/**
+ * THE first node of the VPP licensing flow: does this board participate at all?
+ *
+ * Everything downstream — the extra Modbus round trips, the backend call, the
+ * badge, the demo prompt — hangs off this one answer. When it is "no", a connect
+ * is an ordinary connect: no license FCs, no HTTP, nothing on screen. That is
+ * the common case (every built-in board, plain Runtime v3/v4, Arduino, the
+ * Simulator), so it has to be the cheap, obvious path rather than a branch buried
+ * three layers into an activation routine.
+ *
+ * Pure function over the already-resolved capability block plus the board's VPP
+ * metadata — no IPC, no filesystem. Lives on the byte-identical shared surface
+ * because the renderer asks the same question the main process does: the badge
+ * must not appear on a board the flow will not run for.
+ */
+
+import type { BoardInfo } from '../../ports/types'
+import { resolveTargetCapabilities } from '../target-capabilities'
+
+/**
+ * Why the licensing flow will not run for a board. Kept as distinct reasons
+ * rather than a bare `false` because they are NOT interchangeable to a human:
+ * "this product is not sold licensed" is normal, while "declared licensable with
+ * no package id" is a broken manifest that someone has to fix.
+ */
+export type LicensingSkipReason = 'not-licensable' | 'no-package-id'
+
+export type LicensingTarget =
+  | {
+      licensable: true
+      /** Reverse-domain VPP package id (`package.id`) — the only VPP identifier
+       *  the activation wire accepts, and the one the purchase page resolves. */
+      packageId: string
+    }
+  | { licensable: false; reason: LicensingSkipReason }
+
+/**
+ * Decide whether the licensing flow applies to a board, and gather the two facts
+ * it needs if so.
+ *
+ * `boardInfo` is optional so callers can hand through a not-yet-resolved board
+ * without a null dance; absent board info is simply not licensable.
+ *
+ * A board whose manifest declares `isLicensable: true` but carries no
+ * `vpp.packageId` resolves to `no-package-id` rather than being treated as
+ * licensable. Proceeding without a package id would mean calling `/activate`
+ * with nothing to identify the product, or worse, deciding "no license" from a
+ * question that was never asked — and then telling the user to buy something the
+ * editor cannot name. Only a malformed or hand-edited manifest reaches this.
+ */
+export function resolveLicensingTarget(boardInfo: BoardInfo | null | undefined): LicensingTarget {
+  if (!boardInfo) return { licensable: false, reason: 'not-licensable' }
+
+  const capabilities = resolveTargetCapabilities(boardInfo)
+  if (!capabilities.isLicensable) return { licensable: false, reason: 'not-licensable' }
+
+  const packageId = boardInfo.vpp?.packageId?.trim()
+  if (!packageId) return { licensable: false, reason: 'no-package-id' }
+
+  return { licensable: true, packageId }
+}

--- a/src/middleware/shared/utils/target-capabilities/presets.ts
+++ b/src/middleware/shared/utils/target-capabilities/presets.ts
@@ -32,6 +32,11 @@ export const SIMULATOR_CAPABILITIES: TargetCapabilities = {
   isInProcessSimulator: true,
   plcStateControl: false,
   directUsbUpload: true,
+  // Licensing is never a property of a TARGET FAMILY: a VPP is what is
+  // sold, so only a VPP manifest can turn this on. Every preset leaves it
+  // off, and a board that does not declare it gets an ordinary connect
+  // with no licensing traffic at all.
+  isLicensable: false,
 }
 
 export const RUNTIME_V3_CAPABILITIES: TargetCapabilities = {
@@ -54,6 +59,11 @@ export const RUNTIME_V3_CAPABILITIES: TargetCapabilities = {
   // was this flag.
   plcStateControl: true,
   directUsbUpload: false,
+  // Licensing is never a property of a TARGET FAMILY: a VPP is what is
+  // sold, so only a VPP manifest can turn this on. Every preset leaves it
+  // off, and a board that does not declare it gets an ordinary connect
+  // with no licensing traffic at all.
+  isLicensable: false,
 }
 
 export const RUNTIME_V4_CAPABILITIES: TargetCapabilities = {
@@ -73,6 +83,11 @@ export const RUNTIME_V4_CAPABILITIES: TargetCapabilities = {
   isInProcessSimulator: false,
   plcStateControl: true,
   directUsbUpload: false,
+  // Licensing is never a property of a TARGET FAMILY: a VPP is what is
+  // sold, so only a VPP manifest can turn this on. Every preset leaves it
+  // off, and a board that does not declare it gets an ordinary connect
+  // with no licensing traffic at all.
+  isLicensable: false,
 }
 
 export const ARDUINO_CLI_CAPABILITIES: TargetCapabilities = {
@@ -93,4 +108,9 @@ export const ARDUINO_CLI_CAPABILITIES: TargetCapabilities = {
   isInProcessSimulator: false,
   plcStateControl: true,
   directUsbUpload: true,
+  // Licensing is never a property of a TARGET FAMILY: a VPP is what is
+  // sold, so only a VPP manifest can turn this on. Every preset leaves it
+  // off, and a board that does not declare it gets an ordinary connect
+  // with no licensing traffic at all.
+  isLicensable: false,
 }

--- a/src/middleware/shared/utils/target-capabilities/resolve.ts
+++ b/src/middleware/shared/utils/target-capabilities/resolve.ts
@@ -51,6 +51,7 @@ const EMPTY_CAPABILITIES: TargetCapabilities = {
   isInProcessSimulator: false,
   plcStateControl: false,
   directUsbUpload: false,
+  isLicensable: false,
 }
 
 /**
@@ -90,7 +91,8 @@ function inferFromCompiler(boardInfo: BoardInfoLike): TargetCapabilities {
  *   1. If `boardInfo.capabilities` is present, it's authoritative.
  *      Missing fields are filled in from the matching preset (compiler
  *      + vpp hint), so a manifest can declare only the overrides it
- *      cares about (e.g. SLM-RP4 just sets `vppIo: true`).
+ *      cares about (e.g. SLM-RP4 just sets `vppIo: true`; a licensed VPP
+ *      sets `isLicensable: true`).
  *   2. Otherwise, the preset matching the legacy `compiler` field.
  *   3. Otherwise, an empty (everything-disabled) block.
  *

--- a/src/middleware/shared/utils/target-capabilities/types.ts
+++ b/src/middleware/shared/utils/target-capabilities/types.ts
@@ -111,4 +111,30 @@ export interface TargetCapabilities {
    *  in-process Simulator. Runtime v3 / v4 require an established
    *  network connection. */
   directUsbUpload: boolean
+
+  /** The selected board's VPP is sold as a licensed product, so the
+   *  licensing flow runs for it.  Flows verbatim from the VPP manifest's
+   *  `device.capabilities.isLicensable`, exactly like `vppIo`.
+   *
+   *  This is THE gate on the whole flow, and the reason it is a
+   *  capability rather than an inference: when it is `false` a connect is
+   *  an ordinary connect — no anchor read beyond the usual
+   *  classification, no license FCs, no backend call. Every board that
+   *  does not declare it is `false`, which is every built-in hals.json
+   *  board, plain Runtime v3/v4, Linux, Arduino, and the Simulator.
+   *
+   *  There is deliberately NO companion "can this board store a licence"
+   *  capability. Every licensable VPP targets hardware that persists a
+   *  licence across a reboot — that is a product rule, not something a
+   *  manifest gets to vary — so the answer would be `true` wherever
+   *  `isLicensable` is true and irrelevant everywhere else. What the
+   *  build actually needs is the storage SOURCE, which travels as
+   *  `BoardBuildInfo.licenseStoreFiles`; a second derived boolean on top
+   *  of it bought one diagnostic sentence and one more way for two
+   *  representations of one fact to disagree.
+   *
+   *  A licensable board that answers `LIC_UNSUPPORTED` on the wire is
+   *  therefore a FIRMWARE fault (built without the backend), never a
+   *  hardware limitation — and the flow says exactly that. */
+  isLicensable: boolean
 }


### PR DESCRIPTION
## RTOP-193 — VPP licensing over the baremetal connection

Ports the device-licensing flow from `feat/always-on-debugger` onto `development`, and closes the editor side of the loop: a licensable board is checked on connect, recovered from the backend when it holds nothing usable, and told apart from a board nobody asked about.

**Companion PR (must be open for the sync check to pass):** Autonomy-Logic/openplc-web — same branch name, same base.

### Why this is not a cherry-pick

`development` had already evolved past `feat/always-on-debugger`: `DeviceChannelTransport` / `DeviceModbusTransport`, run/stop over FC 0x4b, and the held-session manager all postdate it. Cherry-picking would have reverted them. Everything here is **additive** over those abstractions.

### Verified on real hardware

Full flow exercised end-to-end against a NodeMCU (ESP8266) + a local `autonomy-edge` on `feat/vpp-tables`, with a real Paddle sandbox purchase through an ngrok tunnel:

| | evidence |
|---|---|
| `deriveDeviceId` matches silicon | anchor `00 b1 8c ed` → `659a3520540f803625ddc34081e893d3`, the same value as the golden test vector |
| FC 0x4A after a full erase | empty storage → the flow asked the backend |
| FC 0x49 + mandatory re-read | badge only says "Licensed" after reading back and re-verifying |
| size-aware serial framing | the 98-byte blob arrived intact |
| `license_store_esp8266.cpp` overrides the weak default | otherwise the board answers `LIC_UNSUPPORTED` |
| purchase path | new licence row with a **new signature**, not an idempotent rebuild |

### The distinctions this PR exists to protect

Three states, deliberately not two. `unlicensed` carries `entitlementChecked`:

- `true` — the backend was asked and reported no purchase → **offer to buy**
- `false` — the device holds nothing and nobody asked → **offer a re-check**
- `check-failed` — we could not find out → **never render as "not licensed"**

Collapsing any pair tells someone who already paid to pay again. The union is carried unchanged from the device to the badge, with no mapper at the IPC boundary — a hand-written mapper between two near-identical unions is exactly where that distinction gets lost.

`0x7E` from a read does **not** mean the stored licence is good: the two targets check different things before answering it. The bytes are verified (magic, crc32, `deviceId`, `productId`), and a blob that fails **falls through to recovery** — the only automatic repair path there is. `0x49` only stores bytes, so the flow re-reads and re-verifies before asserting possession.

### Two security properties

- **The hardware anchor is never handed to the gate.** An earlier design read `UniqueID` in the sketch and passed it in, which made the board's identity a claim the *open* firmware could rewrite. The closed license-core reads the silicon itself. FC 0x48 still *reports* the anchor so a purchase can be bound to the board — reporting an identity and asserting one are different things.
- **No weak fallback for `updateInput/OutputBuffers`.** Dropping the license-core from a licensable VPP fails to **link** rather than silently running unenforced I/O.

`debugWriteLicense` also closes a **network-reachable overread**: `len` came off the wire unchecked and Modbus TCP never cross-checked it against the frame size, so a 6-byte packet declaring `len = 0xFFFF` read ~64 KB past `mb_frame`.

### No dev mock signer

The ported client carried a dev-build-only signer that minted real device-bound blobs. It is deliberately absent: the local test path now runs the real backend against the real per-VPP key. Tests assert the **absence** — `OPLC_LICENSE_MOCK=licensed` must still reach the backend and honour its answer.

### Not verified

- **The demo gate.** The editor asserts *possession*, not execution. Nothing here proves the closed core runs FULL — that needs a board actuating outputs for >15 min without stopping.
- **The C-side golden vector.** `license-blob-c-parity.test.ts` reads `license_blob.h` as text and checks sizes, offsets, magic and CRC parameters against the TS side. It cannot catch compiler padding — the header's two packing directives plus `LIC_STATIC_ASSERT` make that a firmware build failure instead. A C host-test compiling the header and comparing bytes is the right follow-up; the repo has no C harness to hang one on.

### Pre-existing failures (not from this PR)

6 tests fail locally on Windows and fail identically on `development`: 4 in `board-info-resolver.test.ts` (the test helper's `path.resolve` adds a drive letter the assertions don't) and 2 in `stats-table.test.tsx` (pt-BR locale formats `1.234`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added VPP device licensing support, including activation, license storage, validation, and recovery.
  - Added license status indicators, recheck controls, device IDs, and purchase links for supported boards.
  - Added license read/write support for connected devices over supported communication channels.
  - Added configurable Edge web and API endpoints, including HTTP and HTTPS support.

- **Bug Fixes**
  - Improved handling of fragmented license responses and missing or invalid license data.
  - Compilation now continues safely when optional license backend files cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->