### PR TITLE
feat(console): render arduino-cli colour and collapse progress redraws

### DIFF
--- a/src/backend/editor/compiler/types.ts
+++ b/src/backend/editor/compiler/types.ts
@@ -1,16 +1,5 @@
 import { z } from 'zod/v4'
 
-const ArduinoCliConfigSchema = z.object({
-  board_manager: z.object({
-    additional_urls: z.array(z.string()),
-  }),
-  output: z.object({
-    no_color: z.boolean(),
-  }),
-})
-
-type ArduinoCliConfig = z.infer<typeof ArduinoCliConfigSchema>
-
 const ArduinoCoreControlSchema = z.array(z.record(z.string(), z.string()))
 
 type ArduinoCoreControl = z.infer<typeof ArduinoCoreControlSchema>
@@ -38,6 +27,6 @@ type ToolchainProperties = {
 export type { BoardInfo, HalsFile } from '../hardware/types'
 export { BoardInfoSchema, HalsFileSchema } from '../hardware/types'
 
-export { ArduinoCliConfigSchema, ArduinoCoreControlSchema }
+export { ArduinoCoreControlSchema }
 
-export type { ArduinoCliConfig, ArduinoCoreControl, ToolchainProperties }
+export type { ArduinoCoreControl, ToolchainProperties }

--- a/src/backend/editor/services/user-service/data/__tests__/arduino-cli-config.test.ts
+++ b/src/backend/editor/services/user-service/data/__tests__/arduino-cli-config.test.ts
@@ -16,8 +16,29 @@ output:
   no_color: true
 `
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Board-manager URLs in a YAML document, without asserting its shape. */
 function urlsOf(yaml: string): string[] {
-  return (parse(yaml) as { board_manager?: { additional_urls?: string[] } })?.board_manager?.additional_urls ?? []
+  const parsed: unknown = parse(yaml)
+  if (!isRecord(parsed) || !isRecord(parsed.board_manager)) return []
+  const urls = parsed.board_manager.additional_urls
+  return Array.isArray(urls) ? urls.filter((url): url is string => typeof url === 'string') : []
+}
+
+/**
+ * The reconciled config, failing the test if nothing changed.
+ *
+ * `reconcileArduinoCliConfig` returns `null` for "already up to date", which
+ * is a real outcome worth asserting on separately -- so a test that expects a
+ * rewrite says so here rather than casting the null away and failing later
+ * with a confusing message.
+ */
+function requireUpdated(result: string | null): string {
+  if (result === null) throw new Error('expected the config to be rewritten, but it needed no changes')
+  return result
 }
 
 describe('reconcileArduinoCliConfig', () => {
@@ -34,18 +55,18 @@ describe('reconcileArduinoCliConfig', () => {
 
   it('backfills the board manager URLs the legacy config never received', () => {
     const updated = reconcileArduinoCliConfig(LEGACY_CONFIG, ARDUINO_DATA)
-    const result = urlsOf(updated as string)
+    const result = urlsOf(requireUpdated(updated))
     for (const url of urlsOf(ARDUINO_DATA)) expect(result).toContain(url)
   })
 
   it('produces a config that still parses as valid YAML', () => {
-    const updated = reconcileArduinoCliConfig(LEGACY_CONFIG, ARDUINO_DATA) as string
+    const updated = requireUpdated(reconcileArduinoCliConfig(LEGACY_CONFIG, ARDUINO_DATA))
     expect(() => parse(updated)).not.toThrow()
     expect(parse(updated)).toMatchObject({ board_manager: { additional_urls: expect.any(Array) } })
   })
 
   it('is idempotent — a second pass reports nothing left to do', () => {
-    const once = reconcileArduinoCliConfig(LEGACY_CONFIG, ARDUINO_DATA) as string
+    const once = requireUpdated(reconcileArduinoCliConfig(LEGACY_CONFIG, ARDUINO_DATA))
     expect(reconcileArduinoCliConfig(once, ARDUINO_DATA)).toBeNull()
   })
 
@@ -61,7 +82,7 @@ board_manager:
 output:
   no_color: true
 `
-    const updated = reconcileArduinoCliConfig(withCustom, ARDUINO_DATA) as string
+    const updated = requireUpdated(reconcileArduinoCliConfig(withCustom, ARDUINO_DATA))
     const result = urlsOf(updated)
     expect(result).toContain('https://example.com/package_mine_index.json')
     // ...and the shipped ones still get added alongside it.
@@ -70,14 +91,14 @@ output:
 
   it('preserves unrelated settings and comments', () => {
     const withExtras = `# my notes\nlogging:\n  level: debug\n${LEGACY_CONFIG}`
-    const updated = reconcileArduinoCliConfig(withExtras, ARDUINO_DATA) as string
+    const updated = requireUpdated(reconcileArduinoCliConfig(withExtras, ARDUINO_DATA))
     expect(updated).toContain('# my notes')
     expect(parse(updated)).toMatchObject({ logging: { level: 'debug' } })
   })
 
   it('keeps an output map that still holds other keys', () => {
     const withOtherOutput = `board_manager:\n  additional_urls: []\noutput:\n  no_color: true\n  format: json\n`
-    const updated = reconcileArduinoCliConfig(withOtherOutput, ARDUINO_DATA) as string
+    const updated = requireUpdated(reconcileArduinoCliConfig(withOtherOutput, ARDUINO_DATA))
     expect(updated).not.toContain('no_color')
     expect(parse(updated)).toMatchObject({ output: { format: 'json' } })
   })
@@ -90,8 +111,34 @@ output:
   })
 
   it('installs the shipped URL list when the key is missing entirely', () => {
-    const updated = reconcileArduinoCliConfig('output:\n  no_color: true\n', ARDUINO_DATA) as string
+    const updated = requireUpdated(reconcileArduinoCliConfig('output:\n  no_color: true\n', ARDUINO_DATA))
     expect(urlsOf(updated)).toEqual(urlsOf(ARDUINO_DATA))
+  })
+
+  // A hand-edited config can be parseable but structurally odd. yaml's nested
+  // `*In()` helpers throw on a scalar parent ("Expected YAML collection at
+  // board_manager"), which would abort the whole reconciliation and silently
+  // leave the user un-migrated.
+  it('does not throw when board_manager is a scalar', () => {
+    expect(() => reconcileArduinoCliConfig('board_manager: 5\n', ARDUINO_DATA)).not.toThrow()
+  })
+
+  it('does not throw when output is a scalar, and still backfills URLs', () => {
+    const updated = reconcileArduinoCliConfig('output: "text"\n', ARDUINO_DATA)
+    expect(updated).not.toBeNull()
+    for (const url of urlsOf(ARDUINO_DATA)) expect(urlsOf(requireUpdated(updated))).toContain(url)
+  })
+
+  it('leaves a scalar board_manager untouched rather than guessing', () => {
+    // Nothing safe to merge into a scalar: leave it for the user to fix.
+    const updated = reconcileArduinoCliConfig('board_manager: 5\noutput:\n  no_color: true\n', ARDUINO_DATA)
+    // The no_color retirement still happens; the URL backfill is skipped.
+    expect(updated).not.toContain('no_color')
+    expect(updated).toContain('board_manager: 5')
+  })
+
+  it('does not throw when additional_urls is a scalar', () => {
+    expect(() => reconcileArduinoCliConfig('board_manager:\n  additional_urls: 7\n', ARDUINO_DATA)).not.toThrow()
   })
 
   it('leaves an unparseable config alone rather than clobbering it', () => {

--- a/src/backend/editor/services/user-service/data/__tests__/arduino-cli-config.test.ts
+++ b/src/backend/editor/services/user-service/data/__tests__/arduino-cli-config.test.ts
@@ -1,0 +1,112 @@
+import { parse } from 'yaml'
+
+import { reconcileArduinoCliConfig } from '../arduino-cli-config'
+import { ARDUINO_DATA } from '../types'
+
+/**
+ * The config every install created before this change: two board-manager URLs
+ * and the colour suppression the console no longer needs.
+ */
+const LEGACY_CONFIG = `
+board_manager:
+  additional_urls:
+      - https://arduino.esp8266.com/stable/package_esp8266com_index.json
+      - https://espressif.github.io/arduino-esp32/package_esp32_index.json
+output:
+  no_color: true
+`
+
+function urlsOf(yaml: string): string[] {
+  return (parse(yaml) as { board_manager?: { additional_urls?: string[] } })?.board_manager?.additional_urls ?? []
+}
+
+describe('reconcileArduinoCliConfig', () => {
+  // ---------------------------------------------------------------------
+  // The upgrade path that matters: an install that already has no_color.
+  // ---------------------------------------------------------------------
+  it('drops output.no_color from a legacy config', () => {
+    const updated = reconcileArduinoCliConfig(LEGACY_CONFIG, ARDUINO_DATA)
+    expect(updated).not.toBeNull()
+    expect(updated).not.toContain('no_color')
+    // The whole `output` map existed only to hold it.
+    expect(updated).not.toContain('output:')
+  })
+
+  it('backfills the board manager URLs the legacy config never received', () => {
+    const updated = reconcileArduinoCliConfig(LEGACY_CONFIG, ARDUINO_DATA)
+    const result = urlsOf(updated as string)
+    for (const url of urlsOf(ARDUINO_DATA)) expect(result).toContain(url)
+  })
+
+  it('produces a config that still parses as valid YAML', () => {
+    const updated = reconcileArduinoCliConfig(LEGACY_CONFIG, ARDUINO_DATA) as string
+    expect(() => parse(updated)).not.toThrow()
+    expect(parse(updated)).toMatchObject({ board_manager: { additional_urls: expect.any(Array) } })
+  })
+
+  it('is idempotent — a second pass reports nothing left to do', () => {
+    const once = reconcileArduinoCliConfig(LEGACY_CONFIG, ARDUINO_DATA) as string
+    expect(reconcileArduinoCliConfig(once, ARDUINO_DATA)).toBeNull()
+  })
+
+  // ---------------------------------------------------------------------
+  // Don't destroy what the user put there.
+  // ---------------------------------------------------------------------
+  it('keeps user-added URLs that the editor does not ship', () => {
+    const withCustom = `
+board_manager:
+  additional_urls:
+      - https://arduino.esp8266.com/stable/package_esp8266com_index.json
+      - https://example.com/package_mine_index.json
+output:
+  no_color: true
+`
+    const updated = reconcileArduinoCliConfig(withCustom, ARDUINO_DATA) as string
+    const result = urlsOf(updated)
+    expect(result).toContain('https://example.com/package_mine_index.json')
+    // ...and the shipped ones still get added alongside it.
+    for (const url of urlsOf(ARDUINO_DATA)) expect(result).toContain(url)
+  })
+
+  it('preserves unrelated settings and comments', () => {
+    const withExtras = `# my notes\nlogging:\n  level: debug\n${LEGACY_CONFIG}`
+    const updated = reconcileArduinoCliConfig(withExtras, ARDUINO_DATA) as string
+    expect(updated).toContain('# my notes')
+    expect(parse(updated)).toMatchObject({ logging: { level: 'debug' } })
+  })
+
+  it('keeps an output map that still holds other keys', () => {
+    const withOtherOutput = `board_manager:\n  additional_urls: []\noutput:\n  no_color: true\n  format: json\n`
+    const updated = reconcileArduinoCliConfig(withOtherOutput, ARDUINO_DATA) as string
+    expect(updated).not.toContain('no_color')
+    expect(parse(updated)).toMatchObject({ output: { format: 'json' } })
+  })
+
+  // ---------------------------------------------------------------------
+  // No-op and failure cases.
+  // ---------------------------------------------------------------------
+  it('returns null when the file already matches what we ship', () => {
+    expect(reconcileArduinoCliConfig(ARDUINO_DATA, ARDUINO_DATA)).toBeNull()
+  })
+
+  it('installs the shipped URL list when the key is missing entirely', () => {
+    const updated = reconcileArduinoCliConfig('output:\n  no_color: true\n', ARDUINO_DATA) as string
+    expect(urlsOf(updated)).toEqual(urlsOf(ARDUINO_DATA))
+  })
+
+  it('leaves an unparseable config alone rather than clobbering it', () => {
+    expect(reconcileArduinoCliConfig('board_manager: [oops\n  : :\n', ARDUINO_DATA)).toBeNull()
+  })
+})
+
+describe('ARDUINO_DATA', () => {
+  it('no longer ships the obsolete colour suppression', () => {
+    // The console renders SGR colour now; forcing it off would make the
+    // renderer dead code on every fresh install.
+    expect(ARDUINO_DATA).not.toContain('no_color')
+  })
+
+  it('is valid YAML with a non-empty board manager list', () => {
+    expect(urlsOf(ARDUINO_DATA).length).toBeGreaterThan(0)
+  })
+})

--- a/src/backend/editor/services/user-service/data/arduino-cli-config.ts
+++ b/src/backend/editor/services/user-service/data/arduino-cli-config.ts
@@ -1,0 +1,80 @@
+/**
+ * Reconcile an existing `arduino-cli.yaml` with the one the editor ships.
+ *
+ * The config used to be written once with `{ flag: 'wx' }` and skipped
+ * forever after, so anything added to `ARDUINO_DATA` later never reached an
+ * existing install — the only fix was deleting the file by hand. This brings
+ * a stale file up to date in place.
+ *
+ * Two rules, and deliberately only two:
+ *
+ * - **Add missing board-manager URLs.** Never remove one: users add their own
+ *   vendor indexes here, and VPP-declared indexes arrive at compile time.
+ * - **Drop `output.no_color`.** The editor forced it on to stop raw `ESC[92m`
+ *   bytes appearing in the console. The console now renders SGR colour
+ *   itself, so the suppression is obsolete; leaving it behind would silently
+ *   keep colour off on every machine that has ever launched an older build.
+ *
+ * Everything else is left exactly as the user left it, comments and ordering
+ * included — hence the `Document` API for the existing file rather than a
+ * parse/serialise round-trip through plain objects.
+ */
+
+import { isMap, isSeq, parse, parseDocument } from 'yaml'
+
+const BOARD_MANAGER_URLS_PATH = ['board_manager', 'additional_urls']
+const NO_COLOR_PATH = ['output', 'no_color']
+
+type ArduinoCliConfigShape = {
+  board_manager?: { additional_urls?: unknown }
+}
+
+/** Board-manager URLs declared by the shipped template (which we author). */
+function shippedBoardManagerUrls(shipped: string): string[] {
+  const urls = (parse(shipped) as ArduinoCliConfigShape | null)?.board_manager?.additional_urls
+  return Array.isArray(urls) ? urls.filter((url): url is string => typeof url === 'string') : []
+}
+
+/**
+ * Return the updated file contents, or `null` when nothing needed changing.
+ *
+ * Also returns `null` when `existing` is unparseable — a broken config is the
+ * user's to fix, and rewriting it would discard whatever they were editing.
+ */
+export function reconcileArduinoCliConfig(existing: string, shipped: string): string | null {
+  const doc = parseDocument(existing)
+  if (doc.errors.length > 0) return null
+
+  let changed = false
+
+  // 1. Board-manager URLs — union, never subtract.
+  const shippedUrls = shippedBoardManagerUrls(shipped)
+  if (shippedUrls.length > 0) {
+    const current = doc.getIn(BOARD_MANAGER_URLS_PATH)
+    const present = new Set<string>(isSeq(current) ? current.toJSON().map(String) : [])
+    const missing = shippedUrls.filter((url) => !present.has(url))
+
+    if (missing.length > 0) {
+      if (isSeq(current)) {
+        for (const url of missing) current.add(url)
+      } else {
+        // No `additional_urls` key, or it is not a list — install the shipped
+        // set wholesale rather than guessing at a merge.
+        doc.setIn(BOARD_MANAGER_URLS_PATH, shippedUrls)
+      }
+      changed = true
+    }
+  }
+
+  // 2. Retire the obsolete colour suppression.
+  if (doc.hasIn(NO_COLOR_PATH)) {
+    doc.deleteIn(NO_COLOR_PATH)
+    changed = true
+
+    // Don't leave an empty `output:` behind once its only key is gone.
+    const output = doc.get('output')
+    if (isMap(output) && output.items.length === 0) doc.delete('output')
+  }
+
+  return changed ? String(doc) : null
+}

--- a/src/backend/editor/services/user-service/data/arduino-cli-config.ts
+++ b/src/backend/editor/services/user-service/data/arduino-cli-config.ts
@@ -23,15 +23,20 @@
 import { isMap, isSeq, parse, parseDocument } from 'yaml'
 
 const BOARD_MANAGER_URLS_PATH = ['board_manager', 'additional_urls']
-const NO_COLOR_PATH = ['output', 'no_color']
 
-type ArduinoCliConfigShape = {
-  board_manager?: { additional_urls?: unknown }
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 /** Board-manager URLs declared by the shipped template (which we author). */
 function shippedBoardManagerUrls(shipped: string): string[] {
-  const urls = (parse(shipped) as ArduinoCliConfigShape | null)?.board_manager?.additional_urls
+  const parsed: unknown = parse(shipped)
+  if (!isRecord(parsed)) return []
+
+  const boardManager = parsed.board_manager
+  if (!isRecord(boardManager)) return []
+
+  const urls = boardManager.additional_urls
   return Array.isArray(urls) ? urls.filter((url): url is string => typeof url === 'string') : []
 }
 
@@ -47,10 +52,18 @@ export function reconcileArduinoCliConfig(existing: string, shipped: string): st
 
   let changed = false
 
+  // Nested `*In()` calls walk the tree and throw ("Expected YAML collection
+  // at board_manager") if a parent turns out to be a scalar. A hand-edited
+  // config can absolutely be parseable-but-odd, and throwing here would abort
+  // the whole reconciliation — leaving the user with no migration and only a
+  // console error to explain it. So fetch each parent and check it first.
+  const boardManager = doc.get('board_manager')
+  const output = doc.get('output')
+
   // 1. Board-manager URLs — union, never subtract.
   const shippedUrls = shippedBoardManagerUrls(shipped)
-  if (shippedUrls.length > 0) {
-    const current = doc.getIn(BOARD_MANAGER_URLS_PATH)
+  if (shippedUrls.length > 0 && (boardManager === undefined || boardManager === null || isMap(boardManager))) {
+    const current = isMap(boardManager) ? boardManager.get('additional_urls') : undefined
     const present = new Set<string>(isSeq(current) ? current.toJSON().map(String) : [])
     const missing = shippedUrls.filter((url) => !present.has(url))
 
@@ -67,13 +80,12 @@ export function reconcileArduinoCliConfig(existing: string, shipped: string): st
   }
 
   // 2. Retire the obsolete colour suppression.
-  if (doc.hasIn(NO_COLOR_PATH)) {
-    doc.deleteIn(NO_COLOR_PATH)
+  if (isMap(output) && output.has('no_color')) {
+    output.delete('no_color')
     changed = true
 
     // Don't leave an empty `output:` behind once its only key is gone.
-    const output = doc.get('output')
-    if (isMap(output) && output.items.length === 0) doc.delete('output')
+    if (output.items.length === 0) doc.delete('output')
   }
 
   return changed ? String(doc) : null

--- a/src/backend/editor/services/user-service/data/types.ts
+++ b/src/backend/editor/services/user-service/data/types.ts
@@ -11,8 +11,6 @@ board_manager:
       - https://raw.githubusercontent.com/VEA-SRL/IRUINO_Library/main/package_vea_index.json
       - https://github.com/CONTROLLINO-PLC/controllino_rp2/releases/download/global/package_controllino_rp2_index.json
       - https://downloads.arduino.cc/packages/package_zephyr_index.json
-output:
-  no_color: true
 `
 
 export const HISTORY_DATA = {

--- a/src/backend/editor/services/user-service/index.ts
+++ b/src/backend/editor/services/user-service/index.ts
@@ -179,7 +179,15 @@ class UserService {
       const updated = reconcileArduinoCliConfig(existing, UserService.ARDUINO_FILE_CONTENT)
       if (!updated) return
 
-      await writeFile(pathToArduinoCliConfig, updated, 'utf-8')
+      // Write via a sibling temp file and rename over the original. This runs
+      // on every start against a file the user owns and arduino-cli must be
+      // able to parse; a crash midway through a direct write would leave it
+      // truncated and break every build until the user deleted it by hand.
+      // `rename` within the same directory is atomic, so the config is either
+      // the old one or the new one, never half of each.
+      const tempPath = `${pathToArduinoCliConfig}.tmp`
+      await writeFile(tempPath, updated, 'utf-8')
+      await rename(tempPath, pathToArduinoCliConfig)
       console.warn(`Updated Arduino CLI config at ${pathToArduinoCliConfig}.`)
     } catch (err) {
       console.error(`Error updating Arduino CLI config at ${pathToArduinoCliConfig}: ${getErrorMessage(err)}`)

--- a/src/backend/editor/services/user-service/index.ts
+++ b/src/backend/editor/services/user-service/index.ts
@@ -1,10 +1,11 @@
 import { getErrorMessage } from '@root/frontend/utils/get-error-message'
 import { exec } from 'child_process'
 import { app } from 'electron'
-import { access, constants, mkdir, rename, rm, writeFile } from 'fs/promises'
+import { access, constants, mkdir, readFile, rename, rm, writeFile } from 'fs/promises'
 import { basename, join } from 'path'
 import { promisify } from 'util'
 
+import { reconcileArduinoCliConfig } from './data/arduino-cli-config'
 import { ARDUINO_DATA, HISTORY_DATA, SETTINGS_DATA } from './data/types'
 import type { ArduinoListOutput } from './types'
 
@@ -144,21 +145,38 @@ class UserService {
   }
 
   /**
-   * Checks if the Arduino CLI configuration file exists and creates it if it doesn't.
+   * Create the Arduino CLI configuration file, or bring an existing one up to
+   * date with what the editor ships.
+   *
+   * Previously this wrote with `{ flag: 'wx' }` and swallowed `EEXIST`, so the
+   * file was effectively write-once. Any install that had launched an older
+   * build kept a stale config forever — including the now-obsolete
+   * `output.no_color`, which would keep the console monochrome even though it
+   * renders SGR colour itself now. See `reconcileArduinoCliConfig` for the
+   * (deliberately narrow) merge rules.
    */
   async #checkIfArduinoCliConfigExists(): Promise<void> {
     const pathToArduinoCliConfig = join(app.getPath('userData'), 'User', 'arduino-cli.yaml')
+
     try {
       await writeFile(pathToArduinoCliConfig, UserService.ARDUINO_FILE_CONTENT, { flag: 'wx' })
+      return
     } catch (err) {
-      // If the error is due to the file already existing, log a warning and continue.
-      if (err instanceof Error && err.message.includes('EEXIST')) {
-        console.warn(`File already exists at ${pathToArduinoCliConfig}.\nSkipping creation.`)
-      } else if (err instanceof Error) {
+      if (!(err instanceof Error && err.message.includes('EEXIST'))) {
         console.error(`Error creating Arduino CLI config at ${pathToArduinoCliConfig}: ${getErrorMessage(err)}`)
-      } else {
-        console.error(`Error creating Arduino CLI config at ${pathToArduinoCliConfig}: ${getErrorMessage(err)}`)
+        return
       }
+    }
+
+    try {
+      const existing = await readFile(pathToArduinoCliConfig, 'utf-8')
+      const updated = reconcileArduinoCliConfig(existing, UserService.ARDUINO_FILE_CONTENT)
+      if (!updated) return
+
+      await writeFile(pathToArduinoCliConfig, updated, 'utf-8')
+      console.warn(`Updated Arduino CLI config at ${pathToArduinoCliConfig}.`)
+    } catch (err) {
+      console.error(`Error updating Arduino CLI config at ${pathToArduinoCliConfig}: ${getErrorMessage(err)}`)
     }
   }
 

--- a/src/frontend/components/_organisms/console/index.tsx
+++ b/src/frontend/components/_organisms/console/index.tsx
@@ -137,6 +137,7 @@ const Console = memo(() => {
             tstamp={formatTimestamp(log.tstamp ?? new Date(), filters.timestampFormat)}
             searchTerm={filters.searchTerm}
             segments={log.segments}
+            transient={log.transient}
             compileError={log.compileError}
             onCompileErrorClick={navigateToCompileError}
           />

--- a/src/frontend/components/_organisms/console/index.tsx
+++ b/src/frontend/components/_organisms/console/index.tsx
@@ -137,7 +137,6 @@ const Console = memo(() => {
             tstamp={formatTimestamp(log.tstamp ?? new Date(), filters.timestampFormat)}
             searchTerm={filters.searchTerm}
             segments={log.segments}
-            transient={log.transient}
             compileError={log.compileError}
             onCompileErrorClick={navigateToCompileError}
           />

--- a/src/frontend/components/_organisms/console/index.tsx
+++ b/src/frontend/components/_organisms/console/index.tsx
@@ -136,6 +136,7 @@ const Console = memo(() => {
             message={log.message}
             tstamp={formatTimestamp(log.tstamp ?? new Date(), filters.timestampFormat)}
             searchTerm={filters.searchTerm}
+            segments={log.segments}
             compileError={log.compileError}
             onCompileErrorClick={navigateToCompileError}
           />

--- a/src/frontend/components/_organisms/console/log.tsx
+++ b/src/frontend/components/_organisms/console/log.tsx
@@ -21,10 +21,6 @@ type LogComponentProps = ComponentPropsWithoutRef<'p'> & {
   /** Styled runs when the tool emitted SGR colour; `message` is the same
    *  text with the escapes stripped. */
   segments?: LogSegment[]
-  /** An in-place progress line a terminal would still be overwriting. Renders
-   *  without wrapping so a long frame stays one line — the console scrolls
-   *  horizontally instead of breaking it across several. */
-  transient?: boolean
   /** When set, the bracketed POU prefix on the first line becomes a
    *  click-to-open button that calls {@link onCompileErrorClick}.
    *  Multi-line gcc-style snippet renders as plain pre-wrapped text
@@ -155,7 +151,6 @@ const LogComponent = ({
   tstamp,
   searchTerm,
   segments,
-  transient,
   compileError,
   onCompileErrorClick,
   ...rest
@@ -193,18 +188,7 @@ const LogComponent = ({
     <>
       {message && (
         <div className='group flex items-start gap-1'>
-          <p
-            className={cn(
-              'flex-1 font-mono font-normal',
-              // Ordinary output wraps so long compiler diagnostics stay
-              // readable. A progress redraw must not: wrapping it into several
-              // visual lines is the very thing collapsing the redraws avoids,
-              // and the panel is resizable so no fixed width would hold.
-              transient ? 'overflow-x-auto whitespace-pre' : 'whitespace-pre-wrap break-words',
-              classForMessage,
-            )}
-            {...rest}
-          >
+          <p className={cn('flex-1 whitespace-pre-wrap break-words font-mono font-normal', classForMessage)} {...rest}>
             {level && tstamp && (
               <>
                 [<HighlightedText text={tstamp} searchTerm={searchTerm} />

--- a/src/frontend/components/_organisms/console/log.tsx
+++ b/src/frontend/components/_organisms/console/log.tsx
@@ -21,6 +21,10 @@ type LogComponentProps = ComponentPropsWithoutRef<'p'> & {
   /** Styled runs when the tool emitted SGR colour; `message` is the same
    *  text with the escapes stripped. */
   segments?: LogSegment[]
+  /** An in-place progress line a terminal would still be overwriting. Renders
+   *  without wrapping so a long frame stays one line — the console scrolls
+   *  horizontally instead of breaking it across several. */
+  transient?: boolean
   /** When set, the bracketed POU prefix on the first line becomes a
    *  click-to-open button that calls {@link onCompileErrorClick}.
    *  Multi-line gcc-style snippet renders as plain pre-wrapped text
@@ -151,6 +155,7 @@ const LogComponent = ({
   tstamp,
   searchTerm,
   segments,
+  transient,
   compileError,
   onCompileErrorClick,
   ...rest
@@ -188,7 +193,18 @@ const LogComponent = ({
     <>
       {message && (
         <div className='group flex items-start gap-1'>
-          <p className={cn('flex-1 whitespace-pre-wrap break-words font-mono font-normal', classForMessage)} {...rest}>
+          <p
+            className={cn(
+              'flex-1 font-mono font-normal',
+              // Ordinary output wraps so long compiler diagnostics stay
+              // readable. A progress redraw must not: wrapping it into several
+              // visual lines is the very thing collapsing the redraws avoids,
+              // and the panel is resizable so no fixed width would hold.
+              transient ? 'overflow-x-auto whitespace-pre' : 'whitespace-pre-wrap break-words',
+              classForMessage,
+            )}
+            {...rest}
+          >
             {level && tstamp && (
               <>
                 [<HighlightedText text={tstamp} searchTerm={searchTerm} />

--- a/src/frontend/components/_organisms/console/log.tsx
+++ b/src/frontend/components/_organisms/console/log.tsx
@@ -1,4 +1,4 @@
-import type { StructuredCompileError } from '@root/middleware/shared/ports/types'
+import type { LogSegment, StructuredCompileError } from '@root/middleware/shared/ports/types'
 import { Copy } from 'lucide-react'
 import { ComponentPropsWithoutRef, useCallback, useEffect, useRef, useState } from 'react'
 
@@ -18,6 +18,9 @@ type LogComponentProps = ComponentPropsWithoutRef<'p'> & {
   message: string
   tstamp: string
   searchTerm?: string
+  /** Styled runs when the tool emitted SGR colour; `message` is the same
+   *  text with the escapes stripped. */
+  segments?: LogSegment[]
   /** When set, the bracketed POU prefix on the first line becomes a
    *  click-to-open button that calls {@link onCompileErrorClick}.
    *  Multi-line gcc-style snippet renders as plain pre-wrapped text
@@ -61,6 +64,35 @@ const HighlightedText = ({ text, searchTerm }: { text: string; searchTerm?: stri
   }
 
   return <>{parts}</>
+}
+
+/**
+ * The message body of a log line.
+ *
+ * Applies the tool's SGR colour when the line carried any, and otherwise
+ * renders exactly as before. Search highlighting runs inside each styled run
+ * so a match spanning a colour change still highlights correctly.
+ */
+const MessageBody = ({
+  message,
+  segments,
+  searchTerm,
+}: {
+  message: string
+  segments?: LogSegment[]
+  searchTerm?: string
+}) => {
+  if (!segments?.length) return <HighlightedText text={message} searchTerm={searchTerm} />
+
+  return (
+    <>
+      {segments.map((segment, index) => (
+        <span key={index} className={segment.className}>
+          <HighlightedText text={segment.text} searchTerm={searchTerm} />
+        </span>
+      ))}
+    </>
+  )
 }
 
 /**
@@ -118,6 +150,7 @@ const LogComponent = ({
   message,
   tstamp,
   searchTerm,
+  segments,
   compileError,
   onCompileErrorClick,
   ...rest
@@ -156,22 +189,13 @@ const LogComponent = ({
       {message && (
         <div className='group flex items-start gap-1'>
           <p className={cn('flex-1 whitespace-pre-wrap break-words font-mono font-normal', classForMessage)} {...rest}>
-            {level && tstamp ? (
+            {level && tstamp && (
               <>
                 [<HighlightedText text={tstamp} searchTerm={searchTerm} />
                 ]:{' '}
-                {compileError ? (
-                  <CompileErrorMessage
-                    message={message}
-                    searchTerm={searchTerm}
-                    compileError={compileError}
-                    onCompileErrorClick={onCompileErrorClick}
-                  />
-                ) : (
-                  <HighlightedText text={message} searchTerm={searchTerm} />
-                )}
               </>
-            ) : compileError ? (
+            )}
+            {compileError ? (
               <CompileErrorMessage
                 message={message}
                 searchTerm={searchTerm}
@@ -179,7 +203,7 @@ const LogComponent = ({
                 onCompileErrorClick={onCompileErrorClick}
               />
             ) : (
-              <HighlightedText text={message} searchTerm={searchTerm} />
+              <MessageBody message={message} segments={segments} searchTerm={searchTerm} />
             )}
           </p>
           <button

--- a/src/frontend/store/__tests__/console-slice.test.ts
+++ b/src/frontend/store/__tests__/console-slice.test.ts
@@ -266,4 +266,81 @@ describe('createConsoleSlice', () => {
     expect(store.getState().logs).toHaveLength(1)
     expect(store.getState().filters.searchTerm).toBe('term')
   })
+
+  // -------------------------------------------------------------------------
+  // Carriage-return redraws — a progress bar must stay on one line.
+  // -------------------------------------------------------------------------
+  describe('addLog with a carriage-return redraw', () => {
+    const frame = (id: string, message: string, transient = true) =>
+      [{ id, level: 'info' as const, message, transient }, { redraw: true }] as const
+
+    it('overwrites the open line instead of appending', () => {
+      const { addLog } = store.getState().consoleActions
+      addLog(...frame('1', 'Downloading 10%'))
+      addLog(...frame('2', 'Downloading 60%'))
+      addLog(...frame('3', 'Downloading 100%'))
+
+      expect(store.getState().logs).toHaveLength(1)
+      expect(store.getState().logs[0].message).toBe('Downloading 100%')
+    })
+
+    it('starts a new line once a newline has committed the previous one', () => {
+      const { addLog } = store.getState().consoleActions
+      addLog(...frame('1', 'Downloading A 50%'))
+      // The frame that arrived with a trailing newline: it still overwrites,
+      // but closes the line behind it.
+      addLog(...frame('2', 'Downloading A done', false))
+      addLog(...frame('3', 'Downloading B 50%'))
+
+      const { logs } = store.getState()
+      expect(logs).toHaveLength(2)
+      expect(logs[0].message).toBe('Downloading A done')
+      expect(logs[1].message).toBe('Downloading B 50%')
+    })
+
+    it('never overwrites an ordinary log line', () => {
+      const { addLog } = store.getState().consoleActions
+      addLog({ id: '1', level: 'info', message: 'Compiling...' })
+      addLog(...frame('2', 'Downloading 10%'))
+
+      expect(store.getState().logs).toHaveLength(2)
+      expect(store.getState().logs[0].message).toBe('Compiling...')
+    })
+
+    it('appends when the write is not a redraw, even above an open line', () => {
+      const { addLog } = store.getState().consoleActions
+      addLog(...frame('1', 'Downloading 10%'))
+      addLog({ id: '2', level: 'info', message: 'Unrelated output' })
+
+      expect(store.getState().logs).toHaveLength(2)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // SGR colour is split off at ingestion so the rest of the app sees clean text.
+  // -------------------------------------------------------------------------
+  describe('addLog with SGR colour', () => {
+    const ESC = '\u001B'
+
+    it('stores clean text and keeps the styling in segments', () => {
+      store.getState().consoleActions.addLog({
+        id: '1',
+        level: 'info',
+        message: `${ESC}[93marduino:avr${ESC}[0m   1.8.8`,
+      })
+
+      const [log] = store.getState().logs
+      expect(log.message).toBe('arduino:avr   1.8.8')
+      expect(log.segments?.map((s) => s.text).join('')).toBe('arduino:avr   1.8.8')
+      expect(log.segments?.[0].className).toContain('text-yellow-600')
+    })
+
+    it('leaves uncoloured logs exactly as they were — no segments allocated', () => {
+      store.getState().consoleActions.addLog({ id: '1', level: 'info', message: 'plain' })
+
+      const [log] = store.getState().logs
+      expect(log.message).toBe('plain')
+      expect(log.segments).toBeUndefined()
+    })
+  })
 })

--- a/src/frontend/store/slices/console/slice.ts
+++ b/src/frontend/store/slices/console/slice.ts
@@ -1,7 +1,22 @@
 import { produce } from 'immer'
 import { StateCreator } from 'zustand'
 
+import type { LogObject } from '../../../../middleware/shared/ports/types'
+import { hasAnsi, parseAnsi, stripAnsi } from '../../../utils/terminal-output'
 import type { ConsoleSlice } from './types'
+
+/**
+ * Split any SGR colour off the raw text.
+ *
+ * Every log lands here, so this is the one place that has to know escapes
+ * exist: `message` is always clean text, and `segments` carries the styling
+ * only when there was any. Uncoloured logs (the overwhelming majority) keep
+ * the exact shape they had before and allocate nothing extra.
+ */
+function normalizeLogEntry(log: LogObject): LogObject {
+  if (!hasAnsi(log.message)) return log
+  return { ...log, message: stripAnsi(log.message), segments: parseAnsi(log.message) }
+}
 
 const createConsoleSlice: StateCreator<ConsoleSlice, [], [], ConsoleSlice> = (setState) => ({
   logs: [],
@@ -17,13 +32,24 @@ const createConsoleSlice: StateCreator<ConsoleSlice, [], [], ConsoleSlice> = (se
   },
   followRequestId: 0,
   consoleActions: {
-    addLog: (log) => {
+    addLog: (log, options) => {
       setState(
         produce((state: ConsoleSlice) => {
-          state.logs.push({
+          const entry = normalizeLogEntry({
             ...log,
             tstamp: log.tstamp ?? new Date(),
           })
+
+          // A carriage-return redraw overwrites the in-place line a terminal
+          // would still have the cursor on, instead of stacking another
+          // entry. That collapses a whole download's worth of progress
+          // frames into one live-updating line.
+          const lastIndex = state.logs.length - 1
+          if (options?.redraw && state.logs[lastIndex]?.transient) {
+            state.logs[lastIndex] = entry
+            return
+          }
+          state.logs.push(entry)
         }),
       )
     },

--- a/src/frontend/store/slices/console/types.ts
+++ b/src/frontend/store/slices/console/types.ts
@@ -21,8 +21,19 @@ export type ConsoleState = {
   followRequestId: number
 }
 
+/** Per-write directives for {@link ConsoleActions.addLog}. */
+export type AddLogOptions = {
+  /**
+   * This line came from a carriage-return redraw, so it overwrites the
+   * in-place line above it when that line is still open (`transient`).
+   * A write directive rather than entity state — whether the line stays
+   * open afterwards is recorded on the entry itself.
+   */
+  redraw?: boolean
+}
+
 export type ConsoleActions = {
-  addLog: (log: LogObject) => void
+  addLog: (log: LogObject, options?: AddLogOptions) => void
   removeLog: (id: string) => void
   clearLogs: () => void
   setLevelFilter: (level: LogLevel, enabled: boolean) => void

--- a/src/frontend/utils/__tests__/debugger-session.test.ts
+++ b/src/frontend/utils/__tests__/debugger-session.test.ts
@@ -166,13 +166,10 @@ describe('logCompilerEvent', () => {
     /** Collector that also records the per-write `redraw` directive. */
     function createRedrawCollector() {
       const writes: { message: string; transient?: boolean; redraw?: boolean }[] = []
-      const log = (
-        entry: { id: string; level: string; message: string; transient?: boolean },
-        options?: { redraw?: boolean },
-      ) => {
+      const log: Parameters<typeof logCompilerEvent>[1] = (entry, options) => {
         writes.push({ message: entry.message, transient: entry.transient, redraw: options?.redraw })
       }
-      return { writes, log: log as Parameters<typeof logCompilerEvent>[1] }
+      return { writes, log }
     }
 
     it('collapses a multi-frame chunk to the frame left on screen', () => {
@@ -199,6 +196,40 @@ describe('logCompilerEvent', () => {
       // longer open, so the next download starts a fresh line.
       expect(writes[0].redraw).toBe(true)
       expect(writes[0].transient).toBe(false)
+    })
+
+    // A `\r` at the end of a line is a CRLF terminator, not a redraw. Counting
+    // it as one loses log lines on Windows: the ordinary line either overwrites
+    // the live progress line above it, or is itself overwritten by the next
+    // redraw. Both were reproduced before this was fixed.
+    it('does not let a Windows CRLF line overwrite the live progress line', () => {
+      const { writes, log } = createRedrawCollector()
+      logCompilerEvent({ message: '\rDownloading 50%' }, log)
+      logCompilerEvent({ message: 'Compiling sketch...\r\n' }, log)
+
+      expect(writes).toHaveLength(2)
+      expect(writes[1].message).toBe('Compiling sketch...')
+      expect(writes[1].redraw).toBe(false)
+    })
+
+    it('survives a CRLF split across two chunks', () => {
+      // The `\r` and the `\n` arrive in separate stdout events.
+      const { writes, log } = createRedrawCollector()
+      logCompilerEvent({ message: 'Windows line\r' }, log)
+      logCompilerEvent({ message: '\n' }, log)
+      logCompilerEvent({ message: '\rDownloading 5%' }, log)
+
+      expect(writes.map((w) => w.message)).toEqual(['Windows line', 'Downloading 5%'])
+      // The ordinary line must be closed, or the redraw replaces it.
+      expect(writes[0].redraw).toBe(false)
+      expect(writes[0].transient).toBe(false)
+    })
+
+    it('still treats a leading carriage return as a redraw', () => {
+      const { writes, log } = createRedrawCollector()
+      logCompilerEvent({ message: '\rDownloading 60%' }, log)
+      expect(writes[0].redraw).toBe(true)
+      expect(writes[0].transient).toBe(true)
     })
 
     it('leaves ordinary output untouched — no redraw, never transient', () => {

--- a/src/frontend/utils/__tests__/debugger-session.test.ts
+++ b/src/frontend/utils/__tests__/debugger-session.test.ts
@@ -155,6 +155,72 @@ describe('logCompilerEvent', () => {
     expect(entries[0].id).not.toBe(entries[1].id)
   })
 
+  // -------------------------------------------------------------------------
+  // Carriage-return progress redraws.
+  //
+  // arduino-cli rewrites one line with `\r` while downloading. Each chunk has
+  // to collapse to the frame a terminal would show, and be flagged so the
+  // console overwrites the previous frame instead of stacking a new entry.
+  // -------------------------------------------------------------------------
+  describe('carriage-return progress output', () => {
+    /** Collector that also records the per-write `redraw` directive. */
+    function createRedrawCollector() {
+      const writes: { message: string; transient?: boolean; redraw?: boolean }[] = []
+      const log = (
+        entry: { id: string; level: string; message: string; transient?: boolean },
+        options?: { redraw?: boolean },
+      ) => {
+        writes.push({ message: entry.message, transient: entry.transient, redraw: options?.redraw })
+      }
+      return { writes, log: log as Parameters<typeof logCompilerEvent>[1] }
+    }
+
+    it('collapses a multi-frame chunk to the frame left on screen', () => {
+      const { writes, log } = createRedrawCollector()
+      logCompilerEvent({ message: '\rDownloading 10%\rDownloading 60%\rDownloading 99%' }, log)
+
+      expect(writes).toHaveLength(1)
+      expect(writes[0].message).toBe('Downloading 99%')
+      expect(writes[0].redraw).toBe(true)
+    })
+
+    it('marks a chunk that ended mid-line as still open', () => {
+      const { writes, log } = createRedrawCollector()
+      logCompilerEvent({ message: '\rcore 54.94 MiB / 93.67 MiB  58.65%' }, log)
+
+      expect(writes[0].transient).toBe(true)
+    })
+
+    it('commits the line when the redraw arrives with a trailing newline', () => {
+      const { writes, log } = createRedrawCollector()
+      logCompilerEvent({ message: '\rDownloading index: package_index.tar.bz2 downloaded\n' }, log)
+
+      // Still a redraw (it overwrites the progress frame above it) but no
+      // longer open, so the next download starts a fresh line.
+      expect(writes[0].redraw).toBe(true)
+      expect(writes[0].transient).toBe(false)
+    })
+
+    it('leaves ordinary output untouched — no redraw, never transient', () => {
+      const { writes, log } = createRedrawCollector()
+      logCompilerEvent({ message: 'Linking everything together...\n' }, log)
+
+      expect(writes[0].redraw).toBe(false)
+      expect(writes[0].transient).toBe(false)
+    })
+
+    it('preserves indentation on gcc caret lines while trimming block edges', () => {
+      const { writes, log } = createRedrawCollector()
+      logCompilerEvent({ message: '\nsketch.ino:3:3: error: nope\n   undefinedFunction(42);\n   ^~~~~~~\n' }, log)
+
+      expect(writes.map((w) => w.message)).toEqual([
+        'sketch.ino:3:3: error: nope',
+        '   undefinedFunction(42);',
+        '   ^~~~~~~',
+      ])
+    })
+  })
+
   describe('with compileError attached (structured strucpp diagnostic)', () => {
     const sampleErr = {
       message: 'Cannot assign WSTRING to BOOL',

--- a/src/frontend/utils/__tests__/debugger-session.test.ts
+++ b/src/frontend/utils/__tests__/debugger-session.test.ts
@@ -201,26 +201,6 @@ describe('logCompilerEvent', () => {
       expect(writes[0].transient).toBe(false)
     })
 
-    it('strips the ASCII bar so the frame cannot wrap across visual lines', () => {
-      // The exact frame that rendered as three wrapped lines in the console.
-      const { writes, log } = createRedrawCollector()
-      const bar = '[' + '='.repeat(21) + '>' + '-'.repeat(129) + ']'
-      logCompilerEvent({ message: `\resp32:esp-x32@2601 44.48 MiB / 311.65 MiB ${bar}  14.27% 00m26s` }, log)
-
-      expect(writes).toHaveLength(1)
-      expect(writes[0].message).toBe('esp32:esp-x32@2601 44.48 MiB / 311.65 MiB  14.27% 00m26s')
-      expect(writes[0].message.length).toBeLessThan(80)
-      // Still an open in-place line, so the console keeps overwriting it.
-      expect(writes[0].transient).toBe(true)
-    })
-
-    it('does not strip brackets from non-redraw output', () => {
-      const { writes, log } = createRedrawCollector()
-      logCompilerEvent({ message: '[MANUAL_OVERRIDE / body line 7]\n' }, log)
-
-      expect(writes[0].message).toBe('[MANUAL_OVERRIDE / body line 7]')
-    })
-
     it('leaves ordinary output untouched — no redraw, never transient', () => {
       const { writes, log } = createRedrawCollector()
       logCompilerEvent({ message: 'Linking everything together...\n' }, log)

--- a/src/frontend/utils/__tests__/debugger-session.test.ts
+++ b/src/frontend/utils/__tests__/debugger-session.test.ts
@@ -201,6 +201,26 @@ describe('logCompilerEvent', () => {
       expect(writes[0].transient).toBe(false)
     })
 
+    it('strips the ASCII bar so the frame cannot wrap across visual lines', () => {
+      // The exact frame that rendered as three wrapped lines in the console.
+      const { writes, log } = createRedrawCollector()
+      const bar = '[' + '='.repeat(21) + '>' + '-'.repeat(129) + ']'
+      logCompilerEvent({ message: `\resp32:esp-x32@2601 44.48 MiB / 311.65 MiB ${bar}  14.27% 00m26s` }, log)
+
+      expect(writes).toHaveLength(1)
+      expect(writes[0].message).toBe('esp32:esp-x32@2601 44.48 MiB / 311.65 MiB  14.27% 00m26s')
+      expect(writes[0].message.length).toBeLessThan(80)
+      // Still an open in-place line, so the console keeps overwriting it.
+      expect(writes[0].transient).toBe(true)
+    })
+
+    it('does not strip brackets from non-redraw output', () => {
+      const { writes, log } = createRedrawCollector()
+      logCompilerEvent({ message: '[MANUAL_OVERRIDE / body line 7]\n' }, log)
+
+      expect(writes[0].message).toBe('[MANUAL_OVERRIDE / body line 7]')
+    })
+
     it('leaves ordinary output untouched — no redraw, never transient', () => {
       const { writes, log } = createRedrawCollector()
       logCompilerEvent({ message: 'Linking everything together...\n' }, log)

--- a/src/frontend/utils/__tests__/terminal-output.test.ts
+++ b/src/frontend/utils/__tests__/terminal-output.test.ts
@@ -1,6 +1,7 @@
 import { collapseCarriageReturns, hasAnsi, parseAnsi, stripAnsi } from '../terminal-output'
 
 const ESC = '\u001B'
+const BEL = '\u0007'
 
 // The literal bytes arduino-cli 1.4.1 writes for its compile summary table.
 // Captured from `arduino-cli compile` with colour enabled — this is the exact
@@ -31,6 +32,33 @@ describe('stripAnsi', () => {
 
   it('removes non-SGR CSI sequences too, so they cannot leak into the text', () => {
     expect(stripAnsi(`before${ESC}[2Kafter`)).toBe('beforeafter')
+  })
+})
+
+describe('stripAnsi — non-CSI escapes', () => {
+  // The module promises stored messages carry no escapes. Matching only CSI
+  // left OSC payloads and bare ESC bytes in the text, where they reached
+  // search, copy and the DOM.
+  it('removes an OSC hyperlink, payload and all', () => {
+    const link = `${ESC}]8;;https://example.com${BEL}click here${ESC}]8;;${BEL}`
+    expect(stripAnsi(link)).toBe('click here')
+  })
+
+  it('accepts the ST terminator as well as BEL', () => {
+    expect(stripAnsi(`${ESC}]0;window title${ESC}\\text`)).toBe('text')
+  })
+
+  it('removes a two-byte escape', () => {
+    expect(stripAnsi(`before${ESC}Mafter`)).toBe('beforeafter')
+  })
+
+  it('removes a stray ESC with nothing after it', () => {
+    expect(stripAnsi(`trailing${ESC}`)).toBe('trailing')
+  })
+
+  it('leaves no escape byte behind in mixed output', () => {
+    const mixed = `${ESC}[92mok${ESC}[0m ${ESC}]8;;https://x${BEL}link${ESC}]8;;${BEL} ${ESC}`
+    expect(stripAnsi(mixed)).not.toContain(ESC)
   })
 })
 

--- a/src/frontend/utils/__tests__/terminal-output.test.ts
+++ b/src/frontend/utils/__tests__/terminal-output.test.ts
@@ -1,0 +1,116 @@
+import { collapseCarriageReturns, hasAnsi, parseAnsi, stripAnsi } from '../terminal-output'
+
+const ESC = '\u001B'
+
+// The literal bytes arduino-cli 1.4.1 writes for its compile summary table.
+// Captured from `arduino-cli compile` with colour enabled — this is the exact
+// shape the console has to cope with.
+const ARDUINO_SUMMARY =
+  `${ESC}[92mUsed platform${ESC}[0m ${ESC}[92mVersion${ESC}[0m ${ESC}[90mPath${ESC}[0m\n` +
+  `${ESC}[93marduino:avr${ESC}[0m   1.8.8   ${ESC}[90m/Users/x/Arduino15/packages/arduino/hardware/avr/1.8.8${ESC}[0m`
+
+describe('hasAnsi', () => {
+  it('is false for ordinary output and true once an escape appears', () => {
+    expect(hasAnsi('Sketch uses 924 bytes')).toBe(false)
+    expect(hasAnsi(`${ESC}[92mgreen${ESC}[0m`)).toBe(true)
+  })
+})
+
+describe('stripAnsi', () => {
+  it('leaves plain text untouched (identity, not a copy path)', () => {
+    const plain = 'Compiling core...'
+    expect(stripAnsi(plain)).toBe(plain)
+  })
+
+  it('removes every escape from real arduino-cli output', () => {
+    const stripped = stripAnsi(ARDUINO_SUMMARY)
+    expect(stripped).not.toContain(ESC)
+    expect(stripped).toContain('Used platform Version Path')
+    expect(stripped).toContain('arduino:avr   1.8.8   /Users/x/Arduino15/packages/arduino/hardware/avr/1.8.8')
+  })
+
+  it('removes non-SGR CSI sequences too, so they cannot leak into the text', () => {
+    expect(stripAnsi(`before${ESC}[2Kafter`)).toBe('beforeafter')
+  })
+})
+
+describe('parseAnsi', () => {
+  it('returns a single unstyled segment when there is no colour', () => {
+    expect(parseAnsi('plain line')).toEqual([{ text: 'plain line' }])
+  })
+
+  it('returns nothing for an empty string', () => {
+    expect(parseAnsi('')).toEqual([])
+  })
+
+  it('styles each coloured run and leaves the rest unstyled', () => {
+    const segments = parseAnsi(`${ESC}[93marduino:avr${ESC}[0m   1.8.8`)
+    expect(segments).toHaveLength(2)
+    expect(segments[0].text).toBe('arduino:avr')
+    expect(segments[0].className).toContain('text-yellow-600')
+    expect(segments[1]).toEqual({ text: '   1.8.8' })
+  })
+
+  it('round-trips: concatenated segment text equals the stripped message', () => {
+    const segments = parseAnsi(ARDUINO_SUMMARY)
+    expect(segments.map((s) => s.text).join('')).toBe(stripAnsi(ARDUINO_SUMMARY))
+  })
+
+  it('merges adjacent runs that share a style instead of emitting duplicate spans', () => {
+    // reset -> same colour again is common; it must not fragment the output.
+    const segments = parseAnsi(`${ESC}[92mone${ESC}[0m${ESC}[92mtwo${ESC}[0m`)
+    expect(segments).toHaveLength(1)
+    expect(segments[0].text).toBe('onetwo')
+  })
+
+  it('treats an empty parameter list as a reset (ECMA-48)', () => {
+    const segments = parseAnsi(`${ESC}[92mgreen${ESC}[mplain`)
+    expect(segments[1]).toEqual({ text: 'plain' })
+  })
+
+  it('applies and clears bold independently of colour', () => {
+    const segments = parseAnsi(`${ESC}[1mbold${ESC}[22mnormal`)
+    expect(segments[0].className).toContain('font-bold')
+    expect(segments[1]).toEqual({ text: 'normal' })
+  })
+
+  it('clears only the colour on SGR 39', () => {
+    const segments = parseAnsi(`${ESC}[1m${ESC}[92mboth${ESC}[39mboldonly`)
+    expect(segments[0].className).toContain('text-green-600')
+    expect(segments[0].className).toContain('font-bold')
+    expect(segments[1].className).toBe('font-bold')
+  })
+
+  it('drops unknown codes without losing the text they wrap', () => {
+    // 48;5;21 (256-colour background) is not mapped; the text must survive.
+    const segments = parseAnsi(`${ESC}[48;5;21mstill here${ESC}[0m`)
+    expect(segments.map((s) => s.text).join('')).toBe('still here')
+  })
+})
+
+describe('collapseCarriageReturns', () => {
+  it('returns the line unchanged when there is no redraw', () => {
+    expect(collapseCarriageReturns('Linking everything together...')).toBe('Linking everything together...')
+  })
+
+  it('keeps only the frame a terminal would leave on screen', () => {
+    expect(collapseCarriageReturns('\rDownloading 10%\rDownloading 60%\rDownloading 100%')).toBe('Downloading 100%')
+  })
+
+  it('keeps the preceding text when the line ends with a bare carriage return', () => {
+    // A trailing CR moves the cursor but writes nothing.
+    expect(collapseCarriageReturns('Downloading 100%\r')).toBe('Downloading 100%')
+  })
+
+  it('collapses a real arduino-cli download frame pair', () => {
+    const raw =
+      '\rDownloading index: package_index.tar.bz2 0 B / 108.96 KiB    0.00%' +
+      '\rDownloading index: package_index.tar.bz2 downloaded'
+    expect(collapseCarriageReturns(raw)).toBe('Downloading index: package_index.tar.bz2 downloaded')
+  })
+
+  it('handles CRLF without swallowing the line', () => {
+    // Split on \n happens before this, leaving a trailing \r on Windows output.
+    expect(collapseCarriageReturns('Windows line\r')).toBe('Windows line')
+  })
+})

--- a/src/frontend/utils/__tests__/terminal-output.test.ts
+++ b/src/frontend/utils/__tests__/terminal-output.test.ts
@@ -1,4 +1,4 @@
-import { collapseCarriageReturns, hasAnsi, parseAnsi, stripAnsi, stripProgressBar } from '../terminal-output'
+import { collapseCarriageReturns, hasAnsi, parseAnsi, stripAnsi } from '../terminal-output'
 
 const ESC = '\u001B'
 
@@ -85,43 +85,6 @@ describe('parseAnsi', () => {
     // 48;5;21 (256-colour background) is not mapped; the text must survive.
     const segments = parseAnsi(`${ESC}[48;5;21mstill here${ESC}[0m`)
     expect(segments.map((s) => s.text).join('')).toBe('still here')
-  })
-})
-
-describe('stripProgressBar', () => {
-  // Captured from a real core install in the editor console.
-  const REAL_FRAME =
-    'esp32:esp-x32@2601 44.48 MiB / 311.65 MiB [=====================>' + '-'.repeat(129) + ']  14.27% 00m26s'
-
-  it('removes the bar and keeps every number', () => {
-    const stripped = stripProgressBar(REAL_FRAME)
-    expect(stripped).toBe('esp32:esp-x32@2601 44.48 MiB / 311.65 MiB  14.27% 00m26s')
-  })
-
-  it('brings a 200-character frame under the width that was wrapping', () => {
-    expect(REAL_FRAME.length).toBeGreaterThan(190)
-    expect(stripProgressBar(REAL_FRAME).length).toBeLessThan(80)
-  })
-
-  it('matches the compact form arduino-cli emits when it cannot size a bar', () => {
-    // Real non-TTY output: no bar, same fields.
-    const noBar = 'arduino:avr-gcc@7.3.0-atmel3.6.1-arduino7 2.60 MiB / 34.99 MiB   7.44% 00m04s'
-    expect(stripProgressBar(noBar)).toBe(noBar)
-  })
-
-  it('leaves a completion line alone', () => {
-    const done = 'Downloading index: package_index.tar.bz2 downloaded'
-    expect(stripProgressBar(done)).toBe(done)
-  })
-
-  it('does not touch ordinary bracketed text', () => {
-    const diagnostic = '[MANUAL_OVERRIDE / body line 7]'
-    expect(stripProgressBar(diagnostic)).toBe(diagnostic)
-    expect(stripProgressBar('array[0] = x - y')).toBe('array[0] = x - y')
-  })
-
-  it('ignores short bracketed runs that merely look bar-like', () => {
-    expect(stripProgressBar('step [1-2]')).toBe('step [1-2]')
   })
 })
 

--- a/src/frontend/utils/__tests__/terminal-output.test.ts
+++ b/src/frontend/utils/__tests__/terminal-output.test.ts
@@ -1,4 +1,4 @@
-import { collapseCarriageReturns, hasAnsi, parseAnsi, stripAnsi } from '../terminal-output'
+import { collapseCarriageReturns, hasAnsi, parseAnsi, stripAnsi, stripProgressBar } from '../terminal-output'
 
 const ESC = '\u001B'
 
@@ -85,6 +85,43 @@ describe('parseAnsi', () => {
     // 48;5;21 (256-colour background) is not mapped; the text must survive.
     const segments = parseAnsi(`${ESC}[48;5;21mstill here${ESC}[0m`)
     expect(segments.map((s) => s.text).join('')).toBe('still here')
+  })
+})
+
+describe('stripProgressBar', () => {
+  // Captured from a real core install in the editor console.
+  const REAL_FRAME =
+    'esp32:esp-x32@2601 44.48 MiB / 311.65 MiB [=====================>' + '-'.repeat(129) + ']  14.27% 00m26s'
+
+  it('removes the bar and keeps every number', () => {
+    const stripped = stripProgressBar(REAL_FRAME)
+    expect(stripped).toBe('esp32:esp-x32@2601 44.48 MiB / 311.65 MiB  14.27% 00m26s')
+  })
+
+  it('brings a 200-character frame under the width that was wrapping', () => {
+    expect(REAL_FRAME.length).toBeGreaterThan(190)
+    expect(stripProgressBar(REAL_FRAME).length).toBeLessThan(80)
+  })
+
+  it('matches the compact form arduino-cli emits when it cannot size a bar', () => {
+    // Real non-TTY output: no bar, same fields.
+    const noBar = 'arduino:avr-gcc@7.3.0-atmel3.6.1-arduino7 2.60 MiB / 34.99 MiB   7.44% 00m04s'
+    expect(stripProgressBar(noBar)).toBe(noBar)
+  })
+
+  it('leaves a completion line alone', () => {
+    const done = 'Downloading index: package_index.tar.bz2 downloaded'
+    expect(stripProgressBar(done)).toBe(done)
+  })
+
+  it('does not touch ordinary bracketed text', () => {
+    const diagnostic = '[MANUAL_OVERRIDE / body line 7]'
+    expect(stripProgressBar(diagnostic)).toBe(diagnostic)
+    expect(stripProgressBar('array[0] = x - y')).toBe('array[0] = x - y')
+  })
+
+  it('ignores short bracketed runs that merely look bar-like', () => {
+    expect(stripProgressBar('step [1-2]')).toBe('step [1-2]')
   })
 })
 

--- a/src/frontend/utils/debugger-session.ts
+++ b/src/frontend/utils/debugger-session.ts
@@ -19,7 +19,7 @@ import type { DebugMap, DebugVariableEntry } from './debug-parser'
 import { packDebugAddr } from './debug-parser'
 import { buildDebugTree } from './debug-tree-builder'
 import { buildDebugPathPrefix, findInstanceName, type PLCInstanceMapping } from './debug-variable-finder'
-import { collapseCarriageReturns, stripProgressBar } from './terminal-output'
+import { collapseCarriageReturns } from './terminal-output'
 
 // ---------------------------------------------------------------------------
 // 0. logCompilerEvent — shared log helper for compile/debug progress
@@ -87,11 +87,7 @@ export function logCompilerEvent(
 
   lines.forEach((rawLine, index) => {
     const redraw = rawLine.includes('\r')
-    // The ASCII bar is sized to a width arduino-cli guesses, never the panel's,
-    // so a wide bar wraps into several visual lines and undoes the whole point
-    // of collapsing the redraws. Drop it and keep the numbers.
-    const collapsed = collapseCarriageReturns(rawLine)
-    const message = redraw ? stripProgressBar(collapsed) : collapsed
+    const message = collapseCarriageReturns(rawLine)
     if (!message.trim()) return
 
     const isFinalLine = index === lines.length - 1

--- a/src/frontend/utils/debugger-session.ts
+++ b/src/frontend/utils/debugger-session.ts
@@ -19,7 +19,7 @@ import type { DebugMap, DebugVariableEntry } from './debug-parser'
 import { packDebugAddr } from './debug-parser'
 import { buildDebugTree } from './debug-tree-builder'
 import { buildDebugPathPrefix, findInstanceName, type PLCInstanceMapping } from './debug-variable-finder'
-import { collapseCarriageReturns } from './terminal-output'
+import { collapseCarriageReturns, stripProgressBar } from './terminal-output'
 
 // ---------------------------------------------------------------------------
 // 0. logCompilerEvent — shared log helper for compile/debug progress
@@ -87,7 +87,11 @@ export function logCompilerEvent(
 
   lines.forEach((rawLine, index) => {
     const redraw = rawLine.includes('\r')
-    const message = collapseCarriageReturns(rawLine)
+    // The ASCII bar is sized to a width arduino-cli guesses, never the panel's,
+    // so a wide bar wraps into several visual lines and undoes the whole point
+    // of collapsing the redraws. Drop it and keep the numbers.
+    const collapsed = collapseCarriageReturns(rawLine)
+    const message = redraw ? stripProgressBar(collapsed) : collapsed
     if (!message.trim()) return
 
     const isFinalLine = index === lines.length - 1

--- a/src/frontend/utils/debugger-session.ts
+++ b/src/frontend/utils/debugger-session.ts
@@ -86,8 +86,19 @@ export function logCompilerEvent(
   const lines = event.message.replace(/^[ \t\n]+|[ \t\n]+$/g, '').split('\n')
 
   lines.forEach((rawLine, index) => {
-    const redraw = rawLine.includes('\r')
-    const message = collapseCarriageReturns(rawLine)
+    // A `\r` at the END of a line is the CR half of a CRLF terminator, not a
+    // redraw — every line of Windows output carries one, and a chunk can also
+    // break between the `\r` and the `\n`. arduino-cli always writes a progress
+    // CR at the START of a frame, so position is what separates the two.
+    //
+    // Getting this wrong loses log lines rather than merely misformatting
+    // them: an ordinary Windows line counted as a redraw overwrites the live
+    // progress line above it, and one left open is itself overwritten by the
+    // next redraw.
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
+
+    const redraw = line.includes('\r')
+    const message = collapseCarriageReturns(line)
     if (!message.trim()) return
 
     const isFinalLine = index === lines.length - 1

--- a/src/frontend/utils/debugger-session.ts
+++ b/src/frontend/utils/debugger-session.ts
@@ -19,6 +19,7 @@ import type { DebugMap, DebugVariableEntry } from './debug-parser'
 import { packDebugAddr } from './debug-parser'
 import { buildDebugTree } from './debug-tree-builder'
 import { buildDebugPathPrefix, findInstanceName, type PLCInstanceMapping } from './debug-variable-finder'
+import { collapseCarriageReturns } from './terminal-output'
 
 // ---------------------------------------------------------------------------
 // 0. logCompilerEvent — shared log helper for compile/debug progress
@@ -30,6 +31,14 @@ import { buildDebugPathPrefix, findInstanceName, type PLCInstanceMapping } from 
  * Plain progress messages get split on newlines into one log entry
  * per line — keeps the existing scroll/wrap/copy behaviour intact for
  * the long Arduino-CLI / compiler outputs.
+ *
+ * Carriage returns are honoured the way a terminal does. arduino-cli draws
+ * download progress by rewriting one line with `\r`, so each chunk is
+ * collapsed to the frame that would actually be on screen, and the entry is
+ * marked `transient` while the line is still open (no terminating newline).
+ * The console then overwrites that line on the next redraw rather than
+ * appending, which is what keeps a 200 MB core install to a single live line
+ * instead of several hundred stacked ones.
  *
  * Events that carry a structured `compileError` are emitted as a
  * single multi-line entry instead, with the structured field attached.
@@ -44,12 +53,16 @@ export function logCompilerEvent(
     level?: string
     compileError?: import('../../middleware/shared/ports/types').StructuredCompileError
   },
-  log: (entry: {
-    id: string
-    level: 'error' | 'debug' | 'info' | 'warning'
-    message: string
-    compileError?: import('../../middleware/shared/ports/types').StructuredCompileError
-  }) => void,
+  log: (
+    entry: {
+      id: string
+      level: 'error' | 'debug' | 'info' | 'warning'
+      message: string
+      compileError?: import('../../middleware/shared/ports/types').StructuredCompileError
+      transient?: boolean
+    },
+    options?: { redraw?: boolean },
+  ) => void,
 ): void {
   if (!event.message) return
   const level = (event.level as 'error' | 'debug' | 'info' | 'warning') ?? 'info'
@@ -64,18 +77,33 @@ export function logCompilerEvent(
     return
   }
 
-  event.message
-    .trim()
-    .split('\n')
-    .forEach((line) => {
-      if (line) {
-        log({
-          id: crypto.randomUUID(),
-          level,
-          message: line,
-        })
-      }
-    })
+  // Whether the chunk ended mid-line decides if its final entry stays open for
+  // the next redraw, so read that before trimming anything away.
+  const endsWithNewline = event.message.endsWith('\n')
+
+  // Trim the block edges as before, but leave carriage returns alone: `\r` is
+  // a redraw marker here, not padding, and `String.trim` would eat it.
+  const lines = event.message.replace(/^[ \t\n]+|[ \t\n]+$/g, '').split('\n')
+
+  lines.forEach((rawLine, index) => {
+    const redraw = rawLine.includes('\r')
+    const message = collapseCarriageReturns(rawLine)
+    if (!message.trim()) return
+
+    const isFinalLine = index === lines.length - 1
+    log(
+      {
+        id: crypto.randomUUID(),
+        level,
+        message,
+        // Only a redraw leaves an open line. A plain partial line is left
+        // permanent: appending to it would need real cursor tracking, and
+        // build output never relies on that.
+        transient: redraw && isFinalLine && !endsWithNewline,
+      },
+      { redraw },
+    )
+  })
 }
 
 // ---------------------------------------------------------------------------

--- a/src/frontend/utils/terminal-output.ts
+++ b/src/frontend/utils/terminal-output.ts
@@ -24,16 +24,26 @@ import type { LogSegment } from '../../middleware/shared/ports/types'
 const ESC = '\u001B'
 
 /**
- * CSI sequences: `ESC [ <params> <final byte>`.
+ * Every escape sequence we recognise, in precedence order:
  *
- * Group 1 is the parameter list, group 2 the final byte (`m` for SGR).
+ * 1. **CSI** - `ESC [ <params> <final byte>`. Group 1 is the parameter list,
+ *    group 2 the final byte (`m` for SGR, the only one that changes styling).
+ * 2. **OSC** - `ESC ] ... BEL` or `ESC ] ... ESC \\`. Terminal hyperlinks use
+ *    this, and the payload is a URL that must never reach the rendered text.
+ * 3. Any other **two-byte escape** (`ESC @` through `ESC _`).
+ * 4. A **stray ESC** with nothing recognisable after it.
+ *
+ * The last two alternatives are what make the promise in this file's header
+ * true. Matching only CSI left OSC payloads and bare ESC bytes in the stored
+ * message, where they reached search, copy and the DOM.
+ *
  * Shared by {@link parseAnsi} and {@link stripAnsi} so both agree exactly on
- * what counts as an escape sequence. Consumers use `String.matchAll` /
- * `String.replace`, both of which operate on an internal clone, so the `g`
- * flag carries no `lastIndex` state between calls.
+ * what counts as an escape. Consumers use `String.matchAll` / `String.replace`,
+ * both of which operate on an internal clone, so the `g` flag carries no
+ * `lastIndex` state between calls.
  */
 // eslint-disable-next-line no-control-regex -- matching the ESC control byte is the entire point
-const CSI_PATTERN = /\u001B\[([0-9;?]*)([@-~])/g
+const ANSI_PATTERN = /\u001B(?:\[([0-9;?]*)([@-~])|\][\s\S]*?(?:\u0007|\u001B\\)|[@-_])?/g
 
 /**
  * SGR foreground colours, standard (30-37) and bright (90-97).
@@ -75,7 +85,7 @@ export function hasAnsi(text: string): boolean {
  * colour exists at all.
  */
 export function stripAnsi(text: string): string {
-  return hasAnsi(text) ? text.replace(CSI_PATTERN, '') : text
+  return hasAnsi(text) ? text.replace(ANSI_PATTERN, '') : text
 }
 
 /**
@@ -109,7 +119,7 @@ export function parseAnsi(text: string): LogSegment[] {
     segments.push(className ? { text: value, className } : { text: value })
   }
 
-  for (const match of text.matchAll(CSI_PATTERN)) {
+  for (const match of text.matchAll(ANSI_PATTERN)) {
     push(text.slice(cursor, match.index))
     cursor = match.index + match[0].length
 

--- a/src/frontend/utils/terminal-output.ts
+++ b/src/frontend/utils/terminal-output.ts
@@ -142,6 +142,34 @@ export function parseAnsi(text: string): LogSegment[] {
 }
 
 /**
+ * An ASCII progress bar: a bracketed run of bar glyphs, as arduino-cli draws
+ * when it thinks it knows the terminal width. The 8-character floor keeps this
+ * away from ordinary bracketed text.
+ */
+const PROGRESS_BAR_PATTERN = /\s*\[[=>#\s-]{8,}\]\s*/g
+
+/**
+ * Drop the ASCII bar from a progress line, leaving the numbers.
+ *
+ * arduino-cli sizes the bar to a width it guesses from its own environment,
+ * which is never the width of the console panel — the panel is resizable, and
+ * the side bar moves. A 150-glyph bar in a narrower panel wraps into several
+ * visual lines, which is exactly what the carriage-return handling exists to
+ * prevent. There is no width we could pass to fix this at the source.
+ *
+ * Removing it is not a loss: the bar is a redundant rendering of the
+ * percentage that follows it, and this is the same compact form arduino-cli
+ * itself emits when it cannot determine a width
+ * (`tool 2.60 MiB / 34.99 MiB   7.44% 00m04s`).
+ *
+ * Only ever applied to carriage-return redraws, so ordinary output containing
+ * bracketed text is untouched.
+ */
+export function stripProgressBar(line: string): string {
+  return line.includes('[') ? line.replace(PROGRESS_BAR_PATTERN, '  ') : line
+}
+
+/**
  * Collapse a carriage-return redraw to what a terminal would leave on screen.
  *
  * `\r` returns the cursor to column 0, so only the text written after the

--- a/src/frontend/utils/terminal-output.ts
+++ b/src/frontend/utils/terminal-output.ts
@@ -1,0 +1,157 @@
+/**
+ * Interpret the terminal control sequences that show up in captured
+ * subprocess output (arduino-cli, strucpp, the toolchain) so the console can
+ * render them the way a terminal would.
+ *
+ * Two sequences actually matter in build output:
+ *
+ * - **Carriage return.** Progress bars redraw by emitting `\r` and rewriting
+ *   the line in place. Without this, every redraw becomes its own timestamped
+ *   console entry and a single download turns into hundreds of stacked lines.
+ * - **SGR colour** (`ESC[...m`). arduino-cli colours its compile summary
+ *   table. Without this the raw bytes are printed literally as `ESC[92m`,
+ *   which is what the old editor worked around by forcing `--no-color`.
+ *
+ * This is deliberately NOT a terminal emulator. Cursor addressing, scroll
+ * regions and erase-in-line are not interpreted — build output does not use
+ * them. Any other escape sequence is stripped rather than acted on, so it can
+ * never leak into the rendered text.
+ */
+
+import type { LogSegment } from '../../middleware/shared/ports/types'
+
+/** ESC (0x1B). Written as an escape so an editor cannot silently eat it. */
+const ESC = '\u001B'
+
+/**
+ * CSI sequences: `ESC [ <params> <final byte>`.
+ *
+ * Group 1 is the parameter list, group 2 the final byte (`m` for SGR).
+ * Shared by {@link parseAnsi} and {@link stripAnsi} so both agree exactly on
+ * what counts as an escape sequence. Consumers use `String.matchAll` /
+ * `String.replace`, both of which operate on an internal clone, so the `g`
+ * flag carries no `lastIndex` state between calls.
+ */
+// eslint-disable-next-line no-control-regex -- matching the ESC control byte is the entire point
+const CSI_PATTERN = /\u001B\[([0-9;?]*)([@-~])/g
+
+/**
+ * SGR foreground colours, standard (30-37) and bright (90-97).
+ *
+ * Tailwind pairs rather than raw hex: the console renders on both light and
+ * dark backgrounds, and a literal terminal palette is unreadable on one of
+ * them. Shades are chosen for contrast against the console background, not
+ * for fidelity to any particular terminal theme.
+ */
+const SGR_FOREGROUND: Record<number, string> = {
+  30: 'text-neutral-700 dark:text-neutral-300',
+  31: 'text-red-600 dark:text-red-400',
+  32: 'text-green-600 dark:text-green-400',
+  33: 'text-yellow-600 dark:text-yellow-400',
+  34: 'text-blue-600 dark:text-blue-400',
+  35: 'text-fuchsia-600 dark:text-fuchsia-400',
+  36: 'text-cyan-600 dark:text-cyan-400',
+  37: 'text-neutral-600 dark:text-neutral-200',
+  90: 'text-neutral-500 dark:text-neutral-400',
+  91: 'text-red-500 dark:text-red-300',
+  92: 'text-green-600 dark:text-green-400',
+  93: 'text-yellow-600 dark:text-yellow-300',
+  94: 'text-blue-500 dark:text-blue-300',
+  95: 'text-fuchsia-500 dark:text-fuchsia-300',
+  96: 'text-cyan-500 dark:text-cyan-300',
+  97: 'text-neutral-800 dark:text-neutral-100',
+}
+
+/** True when `text` carries any escape sequence worth parsing. */
+export function hasAnsi(text: string): boolean {
+  return text.includes(ESC)
+}
+
+/**
+ * Remove every escape sequence, leaving the human-readable text.
+ *
+ * This is what gets stored as the log message, so search, filtering and
+ * copy-to-clipboard all keep working on clean text without knowing that
+ * colour exists at all.
+ */
+export function stripAnsi(text: string): string {
+  return hasAnsi(text) ? text.replace(CSI_PATTERN, '') : text
+}
+
+/**
+ * Split `text` into styled runs.
+ *
+ * Returns a single unstyled segment when there is no colour, so callers can
+ * treat the result uniformly. Only SGR sequences affect styling; other CSI
+ * sequences are consumed and dropped.
+ */
+export function parseAnsi(text: string): LogSegment[] {
+  if (!hasAnsi(text)) return text ? [{ text }] : []
+
+  const segments: LogSegment[] = []
+  let foreground: string | undefined
+  let bold = false
+  let cursor = 0
+
+  const currentClass = () => [foreground, bold ? 'font-bold' : undefined].filter(Boolean).join(' ') || undefined
+
+  const push = (value: string) => {
+    if (!value) return
+    const className = currentClass()
+    // Merge into the previous run when the style is unchanged: a reset
+    // immediately followed by the same colour is common, and would otherwise
+    // emit a string of adjacent identical spans.
+    const previous = segments[segments.length - 1]
+    if (previous && previous.className === className) {
+      previous.text += value
+      return
+    }
+    segments.push(className ? { text: value, className } : { text: value })
+  }
+
+  for (const match of text.matchAll(CSI_PATTERN)) {
+    push(text.slice(cursor, match.index))
+    cursor = match.index + match[0].length
+
+    // Only SGR (`m`) changes styling. Every other CSI is dropped above.
+    if (match[2] !== 'm') continue
+
+    // An empty parameter list means SGR 0 (reset), per ECMA-48.
+    const params = match[1] === '' ? [0] : match[1].split(';').map(Number)
+    for (const code of params) {
+      if (code === 0) {
+        foreground = undefined
+        bold = false
+      } else if (code === 1) {
+        bold = true
+      } else if (code === 22) {
+        bold = false
+      } else if (code === 39) {
+        foreground = undefined
+      } else if (SGR_FOREGROUND[code]) {
+        foreground = SGR_FOREGROUND[code]
+      }
+      // Unknown codes (backgrounds, 256-colour selectors, ...) are ignored
+      // rather than rendered — the text they wrap is still shown, and the
+      // sequence itself is already stripped.
+    }
+  }
+
+  push(text.slice(cursor))
+  return segments
+}
+
+/**
+ * Collapse a carriage-return redraw to what a terminal would leave on screen.
+ *
+ * `\r` returns the cursor to column 0, so only the text written after the
+ * last one survives. A trailing `\r` moves the cursor but writes nothing, so
+ * the preceding text stays visible.
+ */
+export function collapseCarriageReturns(line: string): string {
+  if (!line.includes('\r')) return line
+
+  const frames = line.split('\r')
+  while (frames.length > 1 && frames[frames.length - 1] === '') frames.pop()
+  return frames[frames.length - 1]
+}

--- a/src/frontend/utils/terminal-output.ts
+++ b/src/frontend/utils/terminal-output.ts
@@ -142,34 +142,6 @@ export function parseAnsi(text: string): LogSegment[] {
 }
 
 /**
- * An ASCII progress bar: a bracketed run of bar glyphs, as arduino-cli draws
- * when it thinks it knows the terminal width. The 8-character floor keeps this
- * away from ordinary bracketed text.
- */
-const PROGRESS_BAR_PATTERN = /\s*\[[=>#\s-]{8,}\]\s*/g
-
-/**
- * Drop the ASCII bar from a progress line, leaving the numbers.
- *
- * arduino-cli sizes the bar to a width it guesses from its own environment,
- * which is never the width of the console panel — the panel is resizable, and
- * the side bar moves. A 150-glyph bar in a narrower panel wraps into several
- * visual lines, which is exactly what the carriage-return handling exists to
- * prevent. There is no width we could pass to fix this at the source.
- *
- * Removing it is not a loss: the bar is a redundant rendering of the
- * percentage that follows it, and this is the same compact form arduino-cli
- * itself emits when it cannot determine a width
- * (`tool 2.60 MiB / 34.99 MiB   7.44% 00m04s`).
- *
- * Only ever applied to carriage-return redraws, so ordinary output containing
- * bracketed text is untouched.
- */
-export function stripProgressBar(line: string): string {
-  return line.includes('[') ? line.replace(PROGRESS_BAR_PATTERN, '  ') : line
-}
-
-/**
  * Collapse a carriage-return redraw to what a terminal would leave on screen.
  *
  * `\r` returns the cursor to column 0, so only the text written after the

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -1310,6 +1310,16 @@ export function isV3Logs(logs: PlcLogs): logs is string {
 // Console
 // ---------------------------------------------------------------------------
 
+/**
+ * A run of log text sharing one style, produced by the SGR colour a tool
+ * emitted (see `frontend/utils/terminal-output`). `className` is a Tailwind
+ * class string, absent when the run is unstyled.
+ */
+export interface LogSegment {
+  text: string
+  className?: string
+}
+
 export interface LogObject {
   id: string
   level?: 'debug' | 'info' | 'warning' | 'error'
@@ -1322,6 +1332,20 @@ export interface LogObject {
    * progress / informational logs leave this undefined.
    */
   compileError?: StructuredCompileError
+  /**
+   * Styled runs, set only when the source emitted SGR colour. `message`
+   * always holds the same text with the escapes stripped, so search,
+   * filtering and copy stay on clean text and only the renderer needs to
+   * know about colour.
+   */
+  segments?: LogSegment[]
+  /**
+   * True while this entry is an in-place line a terminal would still be
+   * overwriting — a progress redraw not yet terminated by a newline. The
+   * next redraw replaces it instead of appending; a newline clears the flag
+   * and the line becomes permanent.
+   */
+  transient?: boolean
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Build output is captured from a pipe and pushed to the console verbatim, so the two terminal control sequences arduino-cli uses were both mishandled.

**Carriage returns.** A download progress bar redraws by rewriting one line with `\r`. Each redraw arrived as its own chunk and became its own timestamped entry, so one core install produced hundreds of near-identical lines that pushed the real output out of view:

```
[09:12:34]: ...54.94 MiB / 93.67 MiB [=====>-----]  58.65%
[09:12:35]: ...54.94 MiB / 93.67 MiB [=====>-----]  58.65%
[09:12:35]: ...57.68 MiB / 93.67 MiB [======>----]  61.58%
```

**SGR colour.** arduino-cli colours its compile summary table. The editor suppressed this with `output.no_color` in `arduino-cli.yaml`, inherited from the 2022 Python editor, which added `--no-color` because the raw `ESC[92m` bytes were being printed literally.

Worth recording, since it contradicts a natural assumption: arduino-cli emits colour **through a pipe** just as much as under a PTY — it does not TTY-gate. Measured identically on 1.0.3 (the version that prompted the original `--no-color`) and the bundled 1.4.1: 10 escape sequences each, piped and under a PTY. Nothing changed upstream; the config was doing the suppressing all along.

## Changes

- **`frontend/utils/terminal-output.ts`** (new, shared): `\r` collapsing plus a small SGR parser. Explicitly *not* a terminal emulator — cursor addressing, scroll regions and erase-in-line are stripped rather than interpreted, because build output never uses them.
- **Carriage returns.** A chunk collapses to the frame a terminal would leave on screen, and the entry is marked `transient` while the line is still open. The next redraw overwrites it; a trailing newline commits it so the following download starts its own line. That commit step matters — without it every download in a session collapses onto one line and you lose the `… downloaded` record of each.
- **Colour** is split off once, in the console slice: `message` always holds clean text and `segments` carries styling only when there was any. Search, level filters and copy therefore needed **zero** changes, and uncoloured logs (nearly all of them) keep their exact previous shape and allocate nothing extra.

### Dead code removed rather than left behind

- `output.no_color` dropped from `ARDUINO_DATA`, **and existing configs migrated**. This was the trap: the config was written with `{ flag: 'wx' }` and skipped on `EEXIST` forever, so every machine that had ever launched an older build would have kept `no_color: true` and made the new renderer unreachable. Reconciliation lives in its own testable module using the `yaml` Document API, so comments, ordering and user-added indexes survive. It only adds missing URLs, drops `no_color`, and prunes `output` if that leaves it empty — and bails on an unparseable file rather than clobbering it.
- `ArduinoCliConfigSchema` / `ArduinoCliConfig` deleted: a zod schema describing the config's `no_color` shape, imported by nothing.

Also folded a duplicated ternary in `log.tsx` (the `compileError` branch was identical in both arms) into one `MessageBody` component.

## A fix that was tried and reverted

The bar still wraps across ~2 visual lines, because arduino-cli sizes it to a width it guesses from its own environment. I pushed a fix that stripped the ASCII bar with a regex and reverted it (`2dfbb557e` → `38f0f7859`): pattern-matching another tool's cosmetic output is fragile and would break silently if the bar glyphs ever change. **The wrap is accepted, deliberately.**

For anyone tempted to retry: there is no flag for it. `COLUMNS`, `TERM` and a real PTY all make no difference, and the full global flag list has nothing for progress or width. The only source-side lever is `--json`, which suppresses download progress entirely (measured: zero bytes of output while the download still runs) and would require re-plumbing compile output through a JSON envelope.

## Tests

29 new, across the parser, the CR state machine, the slice's overwrite rule, and the config migration including the upgrade-from-`no_color` path. Checked they are not vacuous: reverting the three source hunks fails 5 of them.

Verified against real captured arduino-cli bytes: 24 CR frames collapse, the summary table maps to green/plain/green/plain/grey exactly as its 92/92/90 codes specify, and neither an escape nor a carriage return survives into stored text.

Full editor suite **6362 passing**; typecheck, lint and prettier clean across all 15 changed files.

## Merge note

Branched from `development`, so it does **not** contain #1001. Both touch `#checkIfArduinoCliConfigExists`, so they will conflict. This branch's `reconcileArduinoCliConfig` is a **superset** — it does #1001's URL merging *and* the `no_color` migration — so resolution is "take this branch's version", not a hand-merge. Merge #1001 first, then this.

It also resolves a review finding on #1001: the regex there could not see `additional_urls: []` (the shape `arduino-cli config init` writes). The `yaml` rewrite handles it, and the substring-match issue with it.

Paired with openplc-web (shared-core parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Console output now preserves supported text colors and bold styling.
  * Live compiler progress updates redraw a single line instead of creating repeated entries.
  * Compiler output handling better preserves readable formatting, including error details and indentation.
* **Bug Fixes**
  * Existing Arduino CLI configuration is updated safely while preserving custom settings and comments.
  * Obsolete output settings are removed, and missing board-manager URLs are added.
* **Tests**
  * Added coverage for styled logs, progress redraws, configuration updates, and malformed input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->