### PR TITLE
fix(variables): allow a comma in a declaration's type so inline multi-dimensional arrays parse

### DIFF
--- a/src/frontend/utils/PLC/__tests__/data-type-text-parser.test.ts
+++ b/src/frontend/utils/PLC/__tests__/data-type-text-parser.test.ts
@@ -176,6 +176,16 @@ describe('parseDataTypeFromText errors', () => {
     expect(parseDataTypeFromText(badFieldType).error).toMatch(/invalid structure field/)
   })
 
+  it('rejects a structure field whose ARRAY has a blank bound', () => {
+    // `parseArrayType` is shared with the variables text parser and declines a
+    // blank bound, so `buildFieldType` falls through to `identifierRegex`, which
+    // the bracketed type cannot satisfy.
+    const trailingComma = 'TYPE\n  P : STRUCT\n    m : ARRAY[0..1,] OF INT;\n  END_STRUCT;\nEND_TYPE\n'
+    expect(parseDataTypeFromText(trailingComma).error).toMatch(/invalid structure field/)
+    const doubledComma = 'TYPE\n  P : STRUCT\n    m : ARRAY[0..1,,0..2] OF INT;\n  END_STRUCT;\nEND_TYPE\n'
+    expect(parseDataTypeFromText(doubledComma).error).toMatch(/invalid structure field/)
+  })
+
   it('rejects invalid enumeration values', () => {
     expect(parseDataTypeFromText('TYPE\n  Color : (Red, 2bad);\nEND_TYPE\n').error).toMatch(/invalid enumeration value/)
   })

--- a/src/frontend/utils/__tests__/generate-iec-string-to-variables.test.ts
+++ b/src/frontend/utils/__tests__/generate-iec-string-to-variables.test.ts
@@ -160,6 +160,82 @@ describe('parseIecStringToVariables', () => {
     expect(result[0].documentation).toBe('buffer')
   })
 
+  // ---- multi-dimensional arrays declared inline ----
+  //
+  // The type group used to exclude the comma, so a 2D/3D array could only be
+  // declared by naming an ARRAY data type first; written inline it failed the
+  // whole POU with "invalid or unsupported characters".
+
+  it('parses a 2D ARRAY declared inline', () => {
+    const input = 'VAR\n  m : ARRAY[0..1, 0..2] OF INT;\nEND_VAR'
+    const result = parseIecStringToVariables(input)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].type.definition).toBe('array')
+    expect(result[0].type.value).toBe('ARRAY[0..1, 0..2] OF INT')
+    expect(result[0].type.data).toEqual({
+      baseType: { definition: 'base-type', value: 'INT' },
+      dimensions: [{ dimension: '0..1' }, { dimension: '0..2' }],
+    })
+  })
+
+  it('parses a 3D ARRAY declared inline', () => {
+    const input = 'VAR\n  c : ARRAY[0..1, 0..1, 0..1] OF INT;\nEND_VAR'
+    const result = parseIecStringToVariables(input)
+
+    expect(result[0].type.data).toEqual({
+      baseType: { definition: 'base-type', value: 'INT' },
+      dimensions: [{ dimension: '0..1' }, { dimension: '0..1' }, { dimension: '0..1' }],
+    })
+  })
+
+  it('parses a multi-dimensional ARRAY with no space after the comma', () => {
+    const input = 'VAR\n  m : ARRAY[0..1,0..1] OF INT;\nEND_VAR'
+    const result = parseIecStringToVariables(input)
+
+    expect(result[0].type.data?.dimensions).toEqual([{ dimension: '0..1' }, { dimension: '0..1' }])
+  })
+
+  it('parses a multi-dimensional ARRAY of a user-defined type', () => {
+    const input = 'VAR\n  grid : ARRAY[0..1, 0..1] OF Point;\nEND_VAR'
+    const result = parseIecStringToVariables(input)
+
+    expect(result[0].type.data).toEqual({
+      baseType: { definition: 'user-data-type', value: 'Point' },
+      dimensions: [{ dimension: '0..1' }, { dimension: '0..1' }],
+    })
+  })
+
+  it('keeps the initial value when a multi-dimensional ARRAY has one', () => {
+    const input = 'VAR\n  m : ARRAY[0..1, 0..2] OF INT := [[1,2,3],[4,5,6]];\nEND_VAR'
+    const result = parseIecStringToVariables(input)
+
+    expect(result[0].type.value).toBe('ARRAY[0..1, 0..2] OF INT')
+    expect(result[0].initialValue).toBe('[[1,2,3],[4,5,6]]')
+  })
+
+  it('parses a multi-dimensional ARRAY in the alternate located format', () => {
+    const input = 'VAR_GLOBAL\n  m AT %MW0 : ARRAY[0..1, 0..1] OF INT;\nEND_VAR'
+    const result = parseIecStringToVariables(input)
+
+    expect(result[0].location).toBe('%MW0')
+    expect(result[0].type.data?.dimensions).toHaveLength(2)
+  })
+
+  it('still rejects a multi-name declaration', () => {
+    // Allowing the comma in the type must not make `a, b : INT;` parse — the
+    // name group is a single identifier followed by the colon.
+    const input = 'VAR\n  a, b : INT;\nEND_VAR'
+    expect(() => parseIecStringToVariables(input)).toThrow(/Syntax error on line 2/)
+  })
+
+  it('no longer blames a comma for an unrelated syntax error', () => {
+    // A comma is legal now, so the guessed reason must fall through instead of
+    // reporting "invalid or unsupported characters".
+    const input = 'VAR\n  m ARRAY[0..1, 0..1] OF INT;\nEND_VAR'
+    expect(() => parseIecStringToVariables(input)).toThrow(/missing colon/)
+  })
+
   // ---- alternate format (line 115) ----
 
   it('parses the alternate format: name AT location : type', () => {

--- a/src/frontend/utils/__tests__/generate-iec-string-to-variables.test.ts
+++ b/src/frontend/utils/__tests__/generate-iec-string-to-variables.test.ts
@@ -236,6 +236,72 @@ describe('parseIecStringToVariables', () => {
     expect(() => parseIecStringToVariables(input)).toThrow(/missing colon/)
   })
 
+  it('parses a multi-dimensional ARRAY whose bounds are symbolic', () => {
+    // Bounds are only checked for blankness, not for an `a..b` shape — IEC
+    // allows a constant expression, and rejecting one here would be a
+    // regression.
+    const input = 'VAR\n  m : ARRAY[1..MAX, 0..1] OF INT;\nEND_VAR'
+    const result = parseIecStringToVariables(input)
+
+    expect(result[0].type.data?.dimensions).toEqual([{ dimension: '1..MAX' }, { dimension: '0..1' }])
+  })
+
+  // ---- the comma is confined to well-formed ARRAY bounds ----
+  //
+  // Widening the type group must not let a comma through anywhere else: an
+  // empty bound or a comma in a non-array type used to throw, and silently
+  // accepting either persists a broken type into the project (see
+  // `getTypeAsText` / `getArrayTotalElements` / the array modal, none of which
+  // validate).
+
+  it.each([
+    ['a trailing comma in the bounds', 'm : ARRAY[0..1,] OF INT;'],
+    ['a trailing comma and a space in the bounds', 'm : ARRAY[0..1, ] OF INT;'],
+    ['only commas in the bounds', 'm : ARRAY[,] OF INT;'],
+    ['a doubled comma in the bounds', 'm : ARRAY[0..1,,0..2] OF INT;'],
+    ['a leading comma in the bounds', 'm : ARRAY[,0..2] OF INT;'],
+  ])('rejects an ARRAY with %s', (_label, declaration) => {
+    const input = `VAR\n  ${declaration}\nEND_VAR`
+    expect(() => parseIecStringToVariables(input)).toThrow(
+      /Syntax error on line 2.*A comma is only allowed between inline ARRAY bounds/s,
+    )
+  })
+
+  it.each([
+    ['two type names', 'x : INT, DINT;'],
+    ['a trailing comma', 'x : INT,;'],
+    ['a comma in a user-defined type', 'x : MyStruct, Point;'],
+  ])('rejects a non-array type with %s', (_label, declaration) => {
+    const input = `VAR\n  ${declaration}\nEND_VAR`
+    expect(() => parseIecStringToVariables(input)).toThrow(
+      /Syntax error on line 2.*A comma is only allowed between inline ARRAY bounds/s,
+    )
+  })
+
+  it('rejects a malformed ARRAY in the alternate located format too', () => {
+    const input = 'VAR_GLOBAL\n  m AT %MW0 : ARRAY[0..1,] OF INT;\nEND_VAR'
+    expect(() => parseIecStringToVariables(input)).toThrow(/A comma is only allowed between inline ARRAY bounds/)
+  })
+
+  it('still accepts a comma-free non-array type the guard must not touch', () => {
+    // The guard keys on the comma alone, so bracketed non-array types such as a
+    // sized STRING keep parsing exactly as before.
+    const input = 'VAR\n  s : STRING[10];\nEND_VAR'
+    const result = parseIecStringToVariables(input)
+
+    expect(result[0].type).toEqual({ definition: 'user-data-type', value: 'STRING[10]' })
+  })
+
+  it('still accepts a comma inside an initial value', () => {
+    // The comma guard inspects the type only — initial-value lists have always
+    // been allowed to contain commas.
+    const input = 'VAR\n  arr : ARRAY[0..2] OF INT := [1,2,3];\nEND_VAR'
+    const result = parseIecStringToVariables(input)
+
+    expect(result[0].type.definition).toBe('array')
+    expect(result[0].initialValue).toBe('[1,2,3]')
+  })
+
   // ---- alternate format (line 115) ----
 
   it('parses the alternate format: name AT location : type', () => {

--- a/src/frontend/utils/__tests__/generate-iec-variables-to-string.test.ts
+++ b/src/frontend/utils/__tests__/generate-iec-variables-to-string.test.ts
@@ -1,4 +1,5 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import { parseIecStringToVariables } from '../generate-iec-string-to-variables'
 import { generateIecVariablesToString, getIecVariableLineMap } from '../generate-iec-variables-to-string'
 
 const makeVariable = (overrides: Partial<PLCVariable> & Pick<PLCVariable, 'name'>): PLCVariable => ({
@@ -211,5 +212,27 @@ describe('getIecVariableLineMap', () => {
   it('uses column 5 (4-space indent + 1-indexed Monaco) for every variable name', () => {
     const map = getIecVariableLineMap([makeVariable({ name: 'OnlyOne', class: 'input' })])
     expect(map.get('OnlyOne')?.column).toBe(5)
+  })
+
+  // The variables table and the code view are two views of the same data, so
+  // text -> variables -> text has to be byte-stable. Multi-dimensional array
+  // types are the interesting case: the parser splits the bounds into
+  // `dimensions` but keeps the full type string in `type.value`, which is what
+  // this serializer emits.
+  it('round-trips inline multi-dimensional array declarations unchanged', () => {
+    const input = [
+      '  VAR',
+      '    m : ARRAY[0..1, 0..2] OF INT := [[1,2,3],[4,5,6]];',
+      '    c : ARRAY[0..1, 0..1, 0..1] OF INT := [1,2,3,4,5,6,7,8];',
+      '    g : ARRAY[0..1, 0..1] OF Point;',
+      '  END_VAR',
+    ].join('\n')
+
+    const vars = parseIecStringToVariables(input)
+    expect(vars).toHaveLength(3)
+
+    const out = generateIecVariablesToString(vars)
+    expect(out).toBe(input)
+    expect(parseIecStringToVariables(out)).toEqual(vars)
   })
 })

--- a/src/frontend/utils/generate-iec-string-to-variables.ts
+++ b/src/frontend/utils/generate-iec-string-to-variables.ts
@@ -27,22 +27,37 @@ export const DISALLOWED_LOCATION_CLASSES: ReadonlyArray<PLCVariable['class']> = 
   'temp',
 ]
 
+// The type group accepts a comma so a multi-dimensional array can be declared
+// inline: `m : ARRAY[0..1, 0..2] OF INT;`.  `parseArrayType` below has always
+// split multi-dimensional bounds, and the data-type text parser
+// (`PLC/data-type-text-parser.ts`) already allows the comma — without it here,
+// the only way to declare a 2D/3D array was to name an ARRAY data type first,
+// and writing it inline failed the whole POU with "invalid or unsupported
+// characters".
+//
+// The group stays lazy and is bounded by the following `AT` / `:=` / `;`, and a
+// comma is never valid between a declaration's name and its type, so this can't
+// swallow anything it didn't before.  Note this does NOT enable multi-name
+// declarations (`a, b : INT;`) — `name` is a single `\w+` followed by `:`.
+
 // Primary format: name : type AT location := initialValue ; (* documentation *)
 const lineRegex =
   // eslint-disable-next-line no-useless-escape
-  /^\s*(?<name>\w+)\s*:\s*(?<type>[\w\s\[\]\.]+?)(?:\s+AT\s+(?<location>[\w\d\._%]+))?\s*(?::=\s*(?<initialValue>[^;]+?))?\s*;\s*(?:\(\*\s*(?<documentation>.*?)\s*\*\))?$/
+  /^\s*(?<name>\w+)\s*:\s*(?<type>[\w\s\[\],\.]+?)(?:\s+AT\s+(?<location>[\w\d\._%]+))?\s*(?::=\s*(?<initialValue>[^;]+?))?\s*;\s*(?:\(\*\s*(?<documentation>.*?)\s*\*\))?$/
 
 // Alternate format: name AT location : type := initialValue ; (* documentation *)
 // This format is used by some IEC 61131-3 tools and older versions of OpenPLC Editor
 const alternateLineRegex =
   // eslint-disable-next-line no-useless-escape
-  /^\s*(?<name>\w+)\s+AT\s+(?<location>[\w\d\._%]+)\s*:\s*(?<type>[\w\s\[\]\.]+?)\s*(?::=\s*(?<initialValue>[^;]+?))?\s*;\s*(?:\(\*\s*(?<documentation>.*?)\s*\*\))?$/
+  /^\s*(?<name>\w+)\s+AT\s+(?<location>[\w\d\._%]+)\s*:\s*(?<type>[\w\s\[\],\.]+?)\s*(?::=\s*(?<initialValue>[^;]+?))?\s*;\s*(?:\(\*\s*(?<documentation>.*?)\s*\*\))?$/
 
 const guessErrorReason = (line: string): string => {
   if (!line.includes(';')) return 'missing semicolon (;) at the end of the declaration'
   if (!line.includes(':')) return 'missing colon (:) between name and type'
+  // Comma is legal — multi-dimensional array bounds and comma-separated initial
+  // values both use it — so it must not be reported as an unsupported character.
   // eslint-disable-next-line no-useless-escape
-  if (/[^A-Za-z0-9_\s:;=%()/*\-.\[\]]/.test(line)) return 'invalid or unsupported characters'
+  if (/[^A-Za-z0-9_\s:;=%()/*\-.,\[\]]/.test(line)) return 'invalid or unsupported characters'
   return 'unrecognized declaration format'
 }
 

--- a/src/frontend/utils/generate-iec-string-to-variables.ts
+++ b/src/frontend/utils/generate-iec-string-to-variables.ts
@@ -35,10 +35,16 @@ export const DISALLOWED_LOCATION_CLASSES: ReadonlyArray<PLCVariable['class']> = 
 // and writing it inline failed the whole POU with "invalid or unsupported
 // characters".
 //
-// The group stays lazy and is bounded by the following `AT` / `:=` / `;`, and a
-// comma is never valid between a declaration's name and its type, so this can't
-// swallow anything it didn't before.  Note this does NOT enable multi-name
-// declarations (`a, b : INT;`) — `name` is a single `\w+` followed by `:`.
+// The group stays lazy and is bounded by the following `AT` / `:=` / `;`.  Note
+// this does NOT enable multi-name declarations (`a, b : INT;`) — `name` is a
+// single `\w+` followed by `:`.
+//
+// Widening the character class is not by itself a guarantee of well-formedness:
+// the regex will happily match a comma inside a NON-array type, so
+// `parseIecStringToVariables` rejects any type that still contains a comma after
+// `parseArrayType` has declined it, and `parseArrayType` declines blank bounds.
+// Both guards are below; between them, a comma reaches the store only as part of
+// a well-formed multi-dimensional ARRAY.
 
 // Primary format: name : type AT location := initialValue ; (* documentation *)
 const lineRegex =
@@ -83,6 +89,20 @@ export const parseArrayType = (typeStr: string): PLCVariable['type'] | null => {
 
   // Parse dimensions (can be comma-separated for multi-dimensional arrays)
   const dimensionParts = dimensionsStr.split(',').map((d) => d.trim())
+
+  // A blank bound (`ARRAY[0..1,] OF INT`, `ARRAY[,] OF INT`,
+  // `ARRAY[0..1,,0..2] OF INT`) is not an array — reject it rather than
+  // recording an empty dimension.  An empty dimension survives every
+  // downstream consumer silently: `getTypeAsText` re-emits the trailing comma
+  // into the generated ST, `getArrayTotalElements` collapses to 0 elements, and
+  // the array modal drops the blank entry on save, quietly turning a 2D array
+  // into a 1D one.  The GUI already refuses a blank bound (`arrayValidation`);
+  // this brings the text path in line.
+  //
+  // Only *blank* is rejected: bounds may legitimately be symbolic
+  // (`ARRAY[1..MAX] OF INT`), so this is deliberately not a `a..b` range check.
+  if (dimensionParts.some((dimensionRange) => dimensionRange === '')) return null
+
   const dimensions = dimensionParts.map((dimensionRange) => ({ dimension: dimensionRange }))
 
   // Determine the base type definition
@@ -178,6 +198,19 @@ export const parseIecStringToVariables = (
         debug: false,
       })
       return
+    }
+
+    // The type group admits a comma only so that inline multi-dimensional
+    // ARRAY bounds parse.  Anything else that reached here with a comma is
+    // malformed — `x : INT, DINT;`, `x : INT,;`, or an ARRAY with a blank bound
+    // — and must be rejected instead of becoming a user data type named
+    // "INT, DINT", which is persisted, shown in the type cell, and emitted
+    // verbatim into the generated ST.  Mirrors the guard `buildFieldType` in
+    // `PLC/data-type-text-parser.ts` applies to structure fields.
+    if (parsedType.includes(',')) {
+      throw new Error(
+        `Syntax error on line ${lineNumber}: "${line}". A comma is only allowed between inline ARRAY bounds (e.g. "ARRAY[0..1, 0..2] OF INT"), and no bound may be empty.`,
+      )
     }
 
     const baseCheck = baseTypeSchema.safeParse(parsedType.toUpperCase())


### PR DESCRIPTION
`m : ARRAY[0..1, 0..2] OF INT;` written in a POU's variables text failed the **whole POU**, not just that line:

```
POU "PLC_PRG" (pous/programs/PLC_PRG.st) could not be fully parsed:
Syntax error on line 50: "m : ARRAY[0..1, 0..1] OF INT;".
Possible cause: invalid or unsupported characters.
```

The type capture group in `generate-iec-string-to-variables.ts` excluded the comma, so no line matched — and `guessErrorReason`, whose allowed-character set also omitted the comma, then blamed "invalid or unsupported characters". The only way to declare a 2D/3D array was to define a named ARRAY data type first and reference that.

## Why the change is this small

Nothing downstream needed touching:

- `parseArrayType` has always split comma-separated bounds into multiple `dimensions`
- the reverse serializer emits `type.value`, which holds the full type string, so `text → variables → text` is byte-stable
- the **data-type** text parser (`PLC/data-type-text-parser.ts`) already allowed the comma — this brings the variable parser in line with a sibling that got it right

## Scope is bounded by two explicit guards

~~The type group stays lazy and is still bounded by the following `AT` / `:=` / `;`, and a comma is never valid between a declaration's name and its type.~~ **That reasoning was wrong** — it only covered the *name* side. @marconetsf pointed out that the widened class also admits a comma inside a **non-array** type, and admits malformed bound lists, with nothing downstream validating either. Both are now rejected explicitly (second commit):

- `parseArrayType` returns `null` for a blank bound, so `ARRAY[0..1,] OF INT`, `ARRAY[,] OF INT` and `ARRAY[0..1,,0..2] OF INT` no longer become empty `dimensions` entries. Only *blank* is rejected — symbolic bounds (`ARRAY[1..MAX] OF INT`) stay valid, since IEC allows a constant expression there.
- `parseIecStringToVariables` throws when the type still contains a comma after `parseArrayType` has declined it, so `x : INT, DINT;` no longer becomes a user data type named `INT, DINT`. This mirrors the intent of `buildFieldType` in `PLC/data-type-text-parser.ts`, but keys on the comma rather than importing its `identifierRegex` — that would also have rejected `s : STRING[10];`, which this parser accepts today.

Between the two, a comma reaches the store only as part of a well-formed multi-dimensional ARRAY. What *is* bounded by construction: this does **not** start accepting multi-name declarations (`a, b : INT;`) — the name group is a single identifier that must be followed by the colon — and a test pins that.

## Tests

**26 new** (13 in the first commit, 13 in the review follow-up).

First commit — inline 2D and 3D; with and without a space after the comma; of a base type and of a user-defined type; with an initial value; in the alternate located (`name AT loc : type`) format. Plus the negative cases: multi-name still rejected, and an unrelated syntax error no longer misreported as a bad character. And a round-trip test in the serializer's own file, since the variables table and the code view are two views of the same data.

Follow-up commit — the five malformed bound-list shapes and the three comma-bearing non-array types, the same in the alternate located format, plus the positives that must not regress (symbolic bounds, `STRING[10]`, a comma inside an initial value), and one in `data-type-text-parser.test.ts` since `parseArrayType` is shared and the blank-bound guard tightens structure fields there too.

`src/frontend`: **4065 passing** (179 files).

## Notes for the reviewer

- The same fix is in openplc-web (autonomy-logic/openplc-web) — the two copies of this parser are byte-identical, and so are the two commits.
- Multi-dimensional array **initializers** (`[[1,2,3],[4,5,6]]`, 3D arrays) are a separate strucpp change: Autonomy-Logic/STruCpp#205. This PR is what lets those types be *declared* inline; the two are independent but complementary.
- Not touched: the variables-table type picker. This fixes the code-view path; whether the dropdown can construct a multi-dimensional array is a separate question.

Validated end-to-end on a real project through parse → transpile → strucpp → g++ → run, including inline 2D/3D arrays of base types, of a STRUCT, and of a function block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for inline multidimensional IEC `ARRAY` declarations, including varied spacing, symbolic bounds, custom element types, initial values, and located variables.
  * Preserved multidimensional array declarations during parsing and serialization.
  * Improved validation and error messages for malformed array bounds, invalid comma usage, and unsupported multi-name declarations.
  * Continued accepting valid comma-free types and comma-containing initial values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
