### PR TITLE
fix(modbus): make IO Group size edits visible and reject invalid lengths (DOPE-439)

### DIFF
--- a/src/frontend/components/_features/[workspace]/editor/device/remote-device/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/remote-device/index.tsx
@@ -9,6 +9,12 @@ import { PlusIcon } from '../../../../../../assets/icons/interface/Plus'
 import { useOpenPLCStore } from '../../../../../../store'
 import { cn } from '../../../../../../utils/cn'
 import { getErrorMessage } from '../../../../../../utils/get-error-message'
+import {
+  formatIOGroupAddressRange,
+  isSingleElementFunctionCode,
+  MAX_IO_GROUP_LENGTH_BY_FC,
+  validateIOGroupLength,
+} from '../../../../../../utils/modbus/io-group'
 import { GenericComboboxCell } from '../../../../../_atoms/generic-table-inputs/generic-combobox-cell'
 import { InputWithRef } from '../../../../../_atoms/input'
 import { Label } from '../../../../../_atoms/label'
@@ -171,7 +177,8 @@ const IOGroupModal = ({ isOpen, onClose, onSubmit, editingGroup }: IOGroupModalP
   const [errorHandling, setErrorHandling] = useState<'keep-last-value' | 'set-to-zero'>('keep-last-value')
 
   // FC 5 (Write Single Coil) and FC 6 (Write Single Register) are single-element operations
-  const isSingleElementOperation = functionCode === '5' || functionCode === '6'
+  const isSingleElementOperation = isSingleElementFunctionCode(functionCode)
+  const lengthValidation = validateIOGroupLength(functionCode, length)
 
   useEffect(() => {
     if (editingGroup) {
@@ -180,8 +187,7 @@ const IOGroupModal = ({ isOpen, onClose, onSubmit, editingGroup }: IOGroupModalP
       setCycleTime(editingGroup.cycleTime.toString())
       setOffset(editingGroup.offset)
       // For single-element operations, length is always 1
-      const isSingleElement = editingGroup.functionCode === '5' || editingGroup.functionCode === '6'
-      setLength(isSingleElement ? '1' : editingGroup.length.toString())
+      setLength(isSingleElementFunctionCode(editingGroup.functionCode) ? '1' : editingGroup.length.toString())
       setErrorHandling(editingGroup.errorHandling)
     } else {
       setName('')
@@ -201,13 +207,13 @@ const IOGroupModal = ({ isOpen, onClose, onSubmit, editingGroup }: IOGroupModalP
   }, [functionCode, isSingleElementOperation])
 
   const handleSubmit = () => {
-    if (!name.trim()) return
+    if (!name.trim() || !lengthValidation.ok) return
     onSubmit({
       name: name.trim(),
       functionCode,
       cycleTime: parseInt(cycleTime, 10) || 100,
       offset,
-      length: parseInt(length, 10) || 1,
+      length: lengthValidation.length,
       errorHandling,
     })
     setName('')
@@ -283,19 +289,44 @@ const IOGroupModal = ({ isOpen, onClose, onSubmit, editingGroup }: IOGroupModalP
               className={inputStyles}
             />
           </div>
-          <div className='flex items-center gap-2'>
-            <Label className='w-28 whitespace-nowrap text-xs text-neutral-950 dark:text-white'>Length</Label>
-            <InputWithRef
-              type='number'
-              value={length}
-              onChange={(e) => {
-                if (!isSingleElementOperation) setLength(e.target.value)
-              }}
-              placeholder='1'
-              min='1'
-              readOnly={isSingleElementOperation}
-              className={isSingleElementOperation ? `${inputStyles} cursor-not-allowed opacity-50` : inputStyles}
-            />
+          <div className='flex flex-col gap-1'>
+            <div className='flex items-center gap-2'>
+              <Label className='w-28 whitespace-nowrap text-xs text-neutral-950 dark:text-white'>Length</Label>
+              <InputWithRef
+                type='number'
+                value={length}
+                onChange={(e) => {
+                  if (!isSingleElementOperation) setLength(e.target.value)
+                }}
+                placeholder='1'
+                min='1'
+                max={MAX_IO_GROUP_LENGTH_BY_FC[functionCode]}
+                readOnly={isSingleElementOperation}
+                aria-describedby='io-group-length-hint'
+                aria-invalid={!lengthValidation.ok}
+                className={cn(
+                  inputStyles,
+                  isSingleElementOperation && 'cursor-not-allowed opacity-50',
+                  !lengthValidation.ok && 'border-red-500 focus:border-red-500 dark:border-red-500',
+                )}
+              />
+            </div>
+            {/* A permanently locked control deserves an always-visible reason,
+                so this is inline text rather than a hover tooltip (which would
+                also mean a Radix portal nested inside the modal's portal). */}
+            {(isSingleElementOperation || !lengthValidation.ok) && (
+              <p
+                id='io-group-length-hint'
+                className={cn(
+                  'pl-[7.5rem] font-caption text-xs',
+                  lengthValidation.ok ? 'text-neutral-500 dark:text-neutral-400' : 'text-red-500',
+                )}
+              >
+                {lengthValidation.ok
+                  ? 'FC 5 (Write Single Coil) and FC 6 (Write Single Register) address exactly one element, so length is fixed at 1. Use FC 15 or FC 16 to write multiple.'
+                  : lengthValidation.message}
+              </p>
+            )}
           </div>
           <div className='flex items-center gap-2'>
             <Label className='w-28 whitespace-nowrap text-xs text-neutral-950 dark:text-white'>Error Handling</Label>
@@ -333,7 +364,7 @@ const IOGroupModal = ({ isOpen, onClose, onSubmit, editingGroup }: IOGroupModalP
           </button>
           <button
             onClick={handleSubmit}
-            disabled={!name.trim()}
+            disabled={!name.trim() || !lengthValidation.ok}
             className='rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-medium-dark disabled:cursor-not-allowed disabled:opacity-50'
           >
             {editingGroup ? 'Save' : 'Create'}
@@ -356,7 +387,10 @@ type IOGroupRowProps = {
 const IOGroupRow = ({ ioGroup, isExpanded, onToggleExpand, onEdit, onDelete, onUpdateAlias }: IOGroupRowProps) => {
   const firstIOPoint = ioGroup.ioPoints?.[0]
   const groupType = firstIOPoint?.type || '-'
-  const groupAddress = firstIOPoint?.iecLocation || '-'
+  // The full span, not just the first point: this is what makes a size change
+  // — and the project-wide address recompaction it triggers — readable without
+  // expanding the group.
+  const groupAddress = formatIOGroupAddressRange(ioGroup.ioPoints ?? [])
   const groupOffset = ioGroup.offset
 
   return (
@@ -374,6 +408,7 @@ const IOGroupRow = ({ ioGroup, isExpanded, onToggleExpand, onEdit, onDelete, onU
         <td className='px-2 py-2 text-sm text-neutral-700 dark:text-neutral-300'>{groupType}</td>
         <td className='px-2 py-2 text-sm text-neutral-700 dark:text-neutral-300'>{groupAddress}</td>
         <td className='px-2 py-2 text-sm text-neutral-700 dark:text-neutral-300'>{groupOffset}</td>
+        <td className='px-2 py-2 text-sm text-neutral-700 dark:text-neutral-300'>{ioGroup.length}</td>
         <td className='px-2 py-2 text-sm text-neutral-700 dark:text-neutral-300'>
           {getFunctionCodeLabel(ioGroup.functionCode)}
         </td>
@@ -436,6 +471,8 @@ const IOPointRow = ({ ioPoint, offset, onUpdateAlias }: IOPointRowProps) => {
       <td className='px-2 py-1 text-xs text-neutral-600 dark:text-neutral-400'>{ioPoint.type}</td>
       <td className='px-2 py-1 text-xs text-neutral-600 dark:text-neutral-400'>{ioPoint.iecLocation}</td>
       <td className='px-2 py-1 text-xs text-neutral-600 dark:text-neutral-400'>{offset}</td>
+      {/* A single point has no length of its own — keeps the columns aligned. */}
+      <td className='px-2 py-1'></td>
       <td className='px-2 py-1 text-xs text-neutral-600 dark:text-neutral-400'>-</td>
       <td className='px-2 py-1'>
         <InputWithRef
@@ -964,19 +1001,22 @@ const RemoteDeviceEditor = () => {
             <thead className='sticky top-0 bg-neutral-100 dark:bg-neutral-900'>
               <tr>
                 <th className='w-8 px-2 py-2'></th>
-                <th className='w-[15%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                <th className='w-[14%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                   Name
                 </th>
-                <th className='w-[20%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                <th className='w-[18%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                   Type
                 </th>
-                <th className='w-[10%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                <th className='w-[15%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                   Address
                 </th>
-                <th className='w-[8%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                <th className='w-[7%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                   Offset
                 </th>
-                <th className='w-[20%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                <th className='w-[7%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
+                  Length
+                </th>
+                <th className='w-[17%] px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
                   Function Code
                 </th>
                 <th className='px-2 py-2 text-left text-xs font-medium text-neutral-700 dark:text-neutral-300'>
@@ -990,7 +1030,7 @@ const RemoteDeviceEditor = () => {
             <tbody>
               {ioGroups.length === 0 ? (
                 <tr>
-                  <td colSpan={8} className='px-4 py-8 text-center text-sm text-neutral-500 dark:text-neutral-400'>
+                  <td colSpan={9} className='px-4 py-8 text-center text-sm text-neutral-500 dark:text-neutral-400'>
                     No IO groups configured. Click the + button to add one.
                   </td>
                 </tr>

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -2791,6 +2791,14 @@ describe('createProjectSlice', () => {
       expect(points[0].iecLocation).toBe('%IW0')
       expect(points[1].iecLocation).toBe('%IW1')
     })
+
+    it('clamps a non-positive length on create', () => {
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', -2))
+      const group = store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups[0]
+      expect(group.ioPoints).toHaveLength(1)
+      expect(group.length).toBe(1)
+    })
   })
 
   describe('updateIOGroup', () => {
@@ -2871,6 +2879,43 @@ describe('createProjectSlice', () => {
       expect(points).toHaveLength(3)
       expect(points[0].alias).toBe('Temp') // survived the reshuffle
       expect(points[2].alias).toBe('') // freshly allocated slot
+    })
+
+    it('clamps a negative length to a single point, normalizing the stored field', () => {
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 4))
+      store.getState().projectActions.updateIOGroup('Dev1', 'g1', { length: -5 })
+      const group = store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups[0]
+      expect(group.ioPoints).toHaveLength(1)
+      // `length` is what reaches the runtime as `len` — it must be normalized too.
+      expect(group.length).toBe(1)
+    })
+
+    it('clamps a zero length to a single point', () => {
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 4))
+      store.getState().projectActions.updateIOGroup('Dev1', 'g1', { length: 0 })
+      const group = store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups[0]
+      expect(group.ioPoints).toHaveLength(1)
+      expect(group.length).toBe(1)
+    })
+
+    it('floors a fractional length', () => {
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 1))
+      store.getState().projectActions.updateIOGroup('Dev1', 'g1', { length: 3.7 })
+      const group = store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups[0]
+      expect(group.ioPoints).toHaveLength(3)
+      expect(group.length).toBe(3)
+    })
+
+    it('forces a single point when the function code becomes single-element (FC 5)', () => {
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 4)) // FC3 -> %IW
+      store.getState().projectActions.updateIOGroup('Dev1', 'g1', { functionCode: '5' }) // FC5 -> %QX, single
+      const group = store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups[0]
+      expect(group.length).toBe(1)
+      expect(group.ioPoints!.map((p) => p.iecLocation)).toEqual(['%QX0.0'])
     })
   })
 

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -37,6 +37,7 @@ import { parseIecStringToVariables } from '../../../utils/generate-iec-string-to
 import { generateIecVariablesToString } from '../../../utils/generate-iec-variables-to-string'
 import { isLegalIdentifier } from '../../../utils/keywords'
 import { DEFAULT_BUFFER_MAPPING } from '../../../utils/modbus/generate-modbus-slave-config'
+import { clampIOGroupLength } from '../../../utils/modbus/io-group'
 import { serializeDataTypeToText } from '../../../utils/PLC/data-type-serializer'
 import { parseDataTypeFromText } from '../../../utils/PLC/data-type-text-parser'
 import { getExtensionFromLanguage, getFolderFromPouType } from '../../../utils/PLC/pou-file-extensions'
@@ -1809,8 +1810,12 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
           if (!device?.modbusTcpConfig) return
 
           const pending = new Set<string>()
-          const ioPoints = generateIOPoints(group.functionCode, group.length, group.name, pool, pending)
-          device.modbusTcpConfig.ioGroups.push({ ...group, ioPoints })
+          // The UI validates and blocks; the store GUARANTEES the invariant,
+          // because a zero-point group emits a malformed runtime config
+          // (`len` is shipped verbatim by generate-modbus-master-config).
+          const length = clampIOGroupLength(group.functionCode, group.length)
+          const ioPoints = generateIOPoints(group.functionCode, length, group.name, pool, pending)
+          device.modbusTcpConfig.ioGroups.push({ ...group, length, ioPoints })
         }),
       )
       // Central recalculation is the authority for final addresses: it
@@ -1876,6 +1881,11 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
           if (!group) return
           const existingPoints = group.ioPoints ?? []
           Object.assign(group, updates)
+          // Normalize the PERSISTED field, not just the point count: `length`
+          // is what reaches the runtime as `len`. Two wins fall out — switching
+          // a group to FC 5/6 forces 1 even if the caller forgets, and a bad
+          // length loaded from an old project file self-heals on first edit.
+          group.length = clampIOGroupLength(group.functionCode, group.length)
           const pending = new Set<string>()
           group.ioPoints = generateIOPoints(group.functionCode, group.length, group.name, pool, pending, existingPoints)
         }),

--- a/src/frontend/utils/modbus/__tests__/io-group.test.ts
+++ b/src/frontend/utils/modbus/__tests__/io-group.test.ts
@@ -1,0 +1,115 @@
+import type { ModbusIOPoint } from '../../../../middleware/shared/ports/types'
+import {
+  clampIOGroupLength,
+  formatIOGroupAddressRange,
+  isSingleElementFunctionCode,
+  MAX_IO_GROUP_LENGTH_BY_FC,
+  validateIOGroupLength,
+} from '../io-group'
+
+const point = (iecLocation: string): ModbusIOPoint => ({
+  id: iecLocation,
+  name: iecLocation,
+  type: 'Analog Input (Input Registers)',
+  iecLocation,
+})
+
+describe('isSingleElementFunctionCode', () => {
+  it('is true only for FC 5 and FC 6', () => {
+    expect(isSingleElementFunctionCode('5')).toBe(true)
+    expect(isSingleElementFunctionCode('6')).toBe(true)
+    for (const fc of ['1', '2', '3', '4', '15', '16'] as const) {
+      expect(isSingleElementFunctionCode(fc)).toBe(false)
+    }
+  })
+})
+
+describe('clampIOGroupLength', () => {
+  it('raises non-positive lengths to a single point', () => {
+    expect(clampIOGroupLength('3', -5)).toBe(1)
+    expect(clampIOGroupLength('3', 0)).toBe(1)
+  })
+
+  it('floors fractional lengths', () => {
+    expect(clampIOGroupLength('3', 3.7)).toBe(3)
+  })
+
+  it('falls back to a single point for non-finite lengths', () => {
+    expect(clampIOGroupLength('3', NaN)).toBe(1)
+    expect(clampIOGroupLength('3', Infinity)).toBe(1)
+  })
+
+  it('forces a single point for single-element function codes', () => {
+    expect(clampIOGroupLength('5', 10)).toBe(1)
+    expect(clampIOGroupLength('6', 4)).toBe(1)
+  })
+
+  it('leaves an over-maximum length untouched', () => {
+    // Deliberate: applying the PDU maximum here would silently truncate a
+    // pre-existing group the moment the user edited only its name.
+    expect(clampIOGroupLength('3', 200)).toBe(200)
+  })
+
+  it('passes valid lengths through', () => {
+    expect(clampIOGroupLength('3', 4)).toBe(4)
+  })
+})
+
+describe('validateIOGroupLength', () => {
+  it('always accepts single-element function codes as length 1', () => {
+    expect(validateIOGroupLength('5', '10')).toEqual({ ok: true, length: 1 })
+    expect(validateIOGroupLength('6', '')).toEqual({ ok: true, length: 1 })
+  })
+
+  it('rejects an empty field', () => {
+    expect(validateIOGroupLength('3', '  ')).toEqual({ ok: false, message: 'Length is required.' })
+  })
+
+  it('rejects a non-numeric value', () => {
+    expect(validateIOGroupLength('3', 'abc')).toEqual({ ok: false, message: 'Length must be a number.' })
+  })
+
+  it('rejects a fractional value', () => {
+    expect(validateIOGroupLength('3', '3.5')).toEqual({ ok: false, message: 'Length must be a whole number.' })
+  })
+
+  it('rejects values below 1', () => {
+    expect(validateIOGroupLength('3', '0')).toEqual({ ok: false, message: 'Length must be at least 1.' })
+    expect(validateIOGroupLength('3', '-5')).toEqual({ ok: false, message: 'Length must be at least 1.' })
+  })
+
+  it('rejects values above the function code PDU limit, naming the code', () => {
+    expect(validateIOGroupLength('3', '126')).toEqual({
+      ok: false,
+      message: 'FC 3 addresses at most 125 elements per request.',
+    })
+    expect(validateIOGroupLength('16', '124')).toEqual({
+      ok: false,
+      message: 'FC 16 addresses at most 123 elements per request.',
+    })
+  })
+
+  it('accepts values at the limit', () => {
+    expect(validateIOGroupLength('3', '125')).toEqual({ ok: true, length: 125 })
+    expect(validateIOGroupLength('1', '2000')).toEqual({ ok: true, length: 2000 })
+    expect(validateIOGroupLength('15', ' 1968 ')).toEqual({ ok: true, length: 1968 })
+  })
+
+  it('exposes a maximum for every function code', () => {
+    expect(Object.keys(MAX_IO_GROUP_LENGTH_BY_FC).sort()).toEqual(['1', '15', '16', '2', '3', '4', '5', '6'])
+  })
+})
+
+describe('formatIOGroupAddressRange', () => {
+  it('renders a dash when the group has no points', () => {
+    expect(formatIOGroupAddressRange([])).toBe('-')
+  })
+
+  it('renders the single address when the group has one point', () => {
+    expect(formatIOGroupAddressRange([point('%IW0')])).toBe('%IW0')
+  })
+
+  it('renders first through last when the group has several points', () => {
+    expect(formatIOGroupAddressRange([point('%IW0'), point('%IW1'), point('%IW2'), point('%IW3')])).toBe('%IW0 – %IW3')
+  })
+})

--- a/src/frontend/utils/modbus/io-group.ts
+++ b/src/frontend/utils/modbus/io-group.ts
@@ -1,0 +1,82 @@
+import type { ModbusIOGroup, ModbusIOPoint } from '../../../middleware/shared/ports/types'
+
+type ModbusFunctionCode = ModbusIOGroup['functionCode']
+
+/**
+ * Maximum number of elements a single Modbus request can carry per function
+ * code, straight from the protocol's PDU limits. FC 5 and FC 6 address exactly
+ * one element by definition; the read codes are bounded by the 253-byte PDU.
+ *
+ * This is an INPUT rule (what the user may type), not a stored invariant — see
+ * `clampIOGroupLength`.
+ */
+export const MAX_IO_GROUP_LENGTH_BY_FC: Record<ModbusFunctionCode, number> = {
+  '1': 2000,
+  '2': 2000,
+  '3': 125,
+  '4': 125,
+  '5': 1,
+  '6': 1,
+  '15': 1968,
+  '16': 123,
+}
+
+/**
+ * FC 5 (Write Single Coil) and FC 6 (Write Single Register) write exactly one
+ * element, so a group using them always holds a single I/O point.
+ */
+export const isSingleElementFunctionCode = (functionCode: ModbusFunctionCode): boolean =>
+  functionCode === '5' || functionCode === '6'
+
+/**
+ * Normalizes a group's length to the invariant every writer must uphold: a
+ * positive integer, and exactly 1 for single-element function codes.
+ *
+ * FLOOR ONLY — deliberately does NOT apply `MAX_IO_GROUP_LENGTH_BY_FC`. Doing
+ * so would silently truncate a pre-existing group (say an FC 3 group of length
+ * 200) the moment the user edited only its name, i.e. data loss introduced by
+ * a bug fix. The maximum is enforced at the input, by `validateIOGroupLength`.
+ */
+export const clampIOGroupLength = (functionCode: ModbusFunctionCode, length: number): number => {
+  if (isSingleElementFunctionCode(functionCode)) return 1
+  if (!Number.isFinite(length)) return 1
+  const floored = Math.floor(length)
+  return floored < 1 ? 1 : floored
+}
+
+type IOGroupLengthValidation = { ok: true; length: number } | { ok: false; message: string }
+
+/**
+ * Validates the raw string a user typed into the Length field. Rejects
+ * non-integers, values below 1 and values above the function code's PDU limit,
+ * returning a message that names the code so the reason is actionable.
+ */
+export const validateIOGroupLength = (functionCode: ModbusFunctionCode, raw: string): IOGroupLengthValidation => {
+  if (isSingleElementFunctionCode(functionCode)) return { ok: true, length: 1 }
+
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return { ok: false, message: 'Length is required.' }
+
+  const parsed = Number(trimmed)
+  if (!Number.isFinite(parsed)) return { ok: false, message: 'Length must be a number.' }
+  if (!Number.isInteger(parsed)) return { ok: false, message: 'Length must be a whole number.' }
+  if (parsed < 1) return { ok: false, message: 'Length must be at least 1.' }
+
+  const max = MAX_IO_GROUP_LENGTH_BY_FC[functionCode]
+  if (parsed > max) return { ok: false, message: `FC ${functionCode} addresses at most ${max} elements per request.` }
+
+  return { ok: true, length: parsed }
+}
+
+/**
+ * Renders a group's occupied IEC address span for the collapsed table row.
+ * Showing the range (rather than just the first point's address) is what makes
+ * a size change — and the project-wide address recompaction that follows it —
+ * visible without expanding the group.
+ */
+export const formatIOGroupAddressRange = (points: ModbusIOPoint[]): string => {
+  if (points.length === 0) return '-'
+  const first = points[0].iecLocation
+  if (points.length === 1) return first
+  return `${first} – ${points[points.length - 1].iecLocation}`
+}


### PR DESCRIPTION
# Pull request info

## Description of the changes proposed

The ticket's literal root cause — `updateIOGroup` only `Object.assign`ing the
metadata and never regenerating `ioPoints` — was already fixed in `b81f7ee5a`
(v4.2.8). This PR closes the three remaining paths by which the ticket still
reproduced, none of which were in the store:

- **The resize was invisible.** The IO Group table had no Length column, and
  the Address cell showed only the *first* point's `iecLocation` — which does
  not move when the group grows. Testing the ticket on a collapsed row read as
  "nothing changed". Adds a **Length** column between Offset and Function Code,
  and turns Address into a span (`%IW0 – %IW3`), which also makes the
  project-wide address recompaction legible.
- **FC 5 / FC 6 locked Length at 1 with no explanation** — `readOnly` plus
  `opacity-50` and no help text. Correct Modbus semantics (Write Single Coil /
  Write Single Register address exactly one element), but the UI never said so.
  Adds an inline hint that explains the rule and points at FC 15 / FC 16.
- **A negative Length passed validation.** `parseInt(length, 10) || 1` does not
  catch `-5` (the `|| 1` only covers `0` and `NaN`), so the group ended up with
  **zero I/O points** and `len: -5` reached the generated Modbus master config.
  Adds input validation bounded by each function code's PDU limit (FC 3/4 = 125,
  FC 16 = 123, FC 1/2 = 2000, FC 15 = 1968), and a **floor-only clamp** as a
  store invariant on both `addIOGroup` and `updateIOGroup`.

New pure util `src/frontend/utils/modbus/io-group.ts` holds the rules
(`clampIOGroupLength`, `validateIOGroupLength`, `formatIOGroupAddressRange`,
`isSingleElementFunctionCode`), replacing the `functionCode === '5' || === '6'`
literal that was duplicated in the component.

### Decisions worth flagging in review

- **The clamp applies the floor only, never the per-FC maximum.** Enforcing the
  maximum in the store would silently truncate a pre-existing FC 3 group of
  length 200 the moment a user edited only its *name* — data loss introduced by
  a bug fix. The maximum is an input rule; a test pins this.
- **The store normalizes the persisted `length`, not just the point count**,
  because that field is what `generate-modbus-master-config.ts` ships to the
  runtime as `len`. Two things fall out for free: switching a group to FC 5/6
  forces `length: 1` even if a caller forgets, and a bad length loaded from an
  old project file self-heals on first edit.
- **`ModbusIOGroupSchema.length` is deliberately left as `z.number()`.** An
  `.int().min(1)` refinement fails `PLCRemoteDeviceSchema.safeParse`, and the
  load path responds by dropping the **whole remote device** with no
  diagnostic — trading a bad number for a vanished device. Normalization
  belongs in the store. A safe load-time coercion
  (`z.number().transform(...)`) is filed separately.
- **Inline hint instead of the `Tooltip` atom**: the field lives inside a Radix
  `Modal`, so a tooltip means a portal nested in a portal with `z-[999]`
  stacking to reason about — and a permanently locked control deserves an
  always-visible reason, not a hover-discoverable one.

### Out of scope (filed separately)

- Shrinking a group silently deletes the dropped slots' aliases, orphaning any
  variable bound to them. Orphaning is *deliberate* policy — see the
  `renameAlias` comment in `project/slice.ts` — so what's missing is a warning,
  not a data-model change.
- Deleting an IO group has no confirmation at all and destroys every alias in
  the group; strictly worse than the shrink case, and should reuse the same
  modal.
- `ModbusIOPoint.id` is `${groupName}_${i}`, so two same-named groups produce
  colliding ids (React keys, and the `sourceRef` used by the alias-uniqueness
  gate).
- DOPE-440 already covers address recalculation after gaps. This PR only makes
  visible what DOPE-440 fixes.

## Verification

Scoped runs only, Node v22:

    npx jest src/frontend/utils/modbus src/frontend/store/__tests__/project-slice.test.ts --no-coverage

- 341 tests green (editor, Jest) / 341 green (web, Vitest).
- New util: 100% statements, branches, functions and lines.
- `tsc --noEmit`, `npm run validate:arch`, eslint and prettier clean in both repos.
- `scripts/compare-surfaces.py`: `total_diffs: 0` across 1029 files.

Manual, in the running app: created an FC 3 group of length 4 (`%IW0 – %IW3`) plus
a second of length 2 (`%IW4 – %IW5`); grew the first to 6 → reads `%IW0 – %IW5`
with the sibling sliding to `%IW6 – %IW7`, aliases `t0`–`t3` intact and the two
new slots blank; `-5`, `0`, `3.5` and `126` each block Save with a reason;
switching to FC 5 snaps Length to 1 with the hint and yields `%QX0.0`; the
generated master config has `len >= 1` and never falls back to `%MW0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable length handling for Modbus I/O groups.
  - Group lengths are automatically normalized and limited according to the selected function code.
  - Group rows now display complete address ranges and point counts.
  - Added clearer alignment and a dedicated Length column in the I/O group table.

- **Bug Fixes**
  - Invalid, zero, negative, or fractional lengths are corrected automatically.
  - Single-element function codes now consistently create one point.
  - Group creation is disabled when the entered length is invalid, with validation feedback displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->