### PR TITLE
fix: include C++ sources in program MD5

### DIFF
--- a/src/backend/shared/compile/__tests__/pipeline.test.ts
+++ b/src/backend/shared/compile/__tests__/pipeline.test.ts
@@ -12,6 +12,7 @@
  * emit-event payloads.
  */
 
+import { createHash } from 'node:crypto'
 import type { DevicePin } from '../../types/PLC/devices'
 import type { PLCProjectData } from '../../types/PLC/open-plc'
 import type {
@@ -1079,6 +1080,46 @@ describe('runCompilePipeline — failure propagation', () => {
 // ---------------------------------------------------------------------------
 
 describe('runCompilePipeline — side effects', () => {
+  it('keeps program.st as the MD5 input when the project has no C/C++ POUs', async () => {
+    const port = makePort()
+    const { emit } = captureEvents()
+
+    await runCompilePipeline(makeArgs(), port, emit)
+
+    expect(port.computeMd5).toHaveBeenCalledWith('PROGRAM main\nEND_PROGRAM')
+  })
+
+  it('changes the MD5 input when only a C/C++ POU body changes', async () => {
+    const port = makePort({
+      computeMd5: jest.fn((input: string) => Promise.resolve(createHash('md5').update(input).digest('hex'))),
+    })
+    const { emit } = captureEvents()
+    const projectWithCppCode = (code: string) =>
+      ({
+        ...projectDataFixture,
+        originalCppPous: [{ name: 'CppBlock', code, variables: [] }],
+      }) as unknown as PLCProjectData
+
+    const firstResult = await runCompilePipeline(
+      makeArgs({ projectData: projectWithCppCode('void setup() {}\nvoid loop() { int value = 1; }') }),
+      port,
+      emit,
+    )
+    const secondResult = await runCompilePipeline(
+      makeArgs({ projectData: projectWithCppCode('void setup() {}\nvoid loop() { int value = 2; }') }),
+      port,
+      emit,
+    )
+
+    const firstMd5Input = port.computeMd5.mock.calls[0][0]
+    const secondMd5Input = port.computeMd5.mock.calls[1][0]
+    expect(firstMd5Input).toContain('c_blocks_code.cpp:')
+    expect(firstMd5Input).toContain('int value = 1;')
+    expect(secondMd5Input).toContain('int value = 2;')
+    expect(secondMd5Input).not.toBe(firstMd5Input)
+    expect(secondResult.md5).not.toBe(firstResult.md5)
+  })
+
   it('calls cacheDebugData with the strucpp MD5 + debug-map.json content', async () => {
     const cacheDebugData = jest.fn()
     const port = makePort()

--- a/src/backend/shared/compile/pipeline.ts
+++ b/src/backend/shared/compile/pipeline.ts
@@ -271,9 +271,9 @@ export interface RunCompilePipelineResult {
    *  before compile.  Caller decides what to do with these bytes
    *  (editor: write to `Baremetal.ino.hex`; web: feed avr8js). */
   binary?: Uint8Array
-  /** MD5 of the strucpp-compiled `program.st`.  Echoed back so
-   *  callers can use it as a cache key (defines.h PROGRAM_MD5
-   *  refers to it). */
+  /** MD5 of the compiled program sources (`program.st` plus generated
+   *  C/C++ sidecars when present). Echoed back so callers can use it as
+   *  a cache key (`defines.h` `PROGRAM_MD5` refers to it). */
   md5?: string
   /** `true` when an upload step ran successfully (runtime v4 upload,
    *  arduino direct upload, or runtime v3 upload).  `false` when
@@ -466,16 +466,27 @@ async function runCompilePipelineInner(
   // ---------------------------------------------------------------------
   emit({ stage: 'strucpp', message: 'Compiling Structured Text to C++ with STruC++...', level: 'info' })
   const hasCBlocks = originalCppPous.length > 0
+  const cBlocks = buildCBlocksFromPous(originalCppPous as never)
   // `buildKnownPous` is typed against the port-shape `PLCPou`; cast
   // through `never` for the same reason described in Step 0.
   const knownPous = buildKnownPous(processedData.pous as never)
-  // MD5 of program.st — the runtime embeds this into defines.h via
-  // `generateDefinesContent` for stale-program detection.  Each
-  // platform's adapter implements `computeMd5` (editor: Node crypto;
-  // web: spark-md5) so the shared module doesn't carry a
-  // heavyweight hash dependency.  Both implementations produce
-  // byte-identical hex.
-  const md5 = await port.computeMd5(programSt)
+  // Hash every user-program source that reaches the compiler.  C/C++ POUs
+  // are extracted from the project before ST transpilation, so hashing only
+  // program.st would leave the digest unchanged when their bodies changed.
+  // Keep the historical input for projects without C/C++ POUs; for projects
+  // with sidecars, length-prefixed sections make the composite unambiguous.
+  const md5Input =
+    cBlocks.code === null
+      ? programSt
+      : [
+          `program.st:${programSt.length}\n${programSt}`,
+          `c_blocks.h:${cBlocks.header.length}\n${cBlocks.header}`,
+          `c_blocks_code.cpp:${cBlocks.code.length}\n${cBlocks.code}`,
+        ].join('\n')
+  // The runtime embeds this MD5 into defines.h for stale-program detection.
+  // Each platform's adapter implements `computeMd5` (editor: Node crypto;
+  // web: spark-md5), and both implementations produce byte-identical hex.
+  const md5 = await port.computeMd5(md5Input)
   const strucppResult = runProgramBuildPipeline({
     source: programSt,
     md5,
@@ -541,7 +552,6 @@ async function runCompilePipelineInner(
     }
 
     emit({ stage: 'runtime-v4-bundle', message: 'Composing Runtime v4 upload bundle...', level: 'info' })
-    const cBlocks = buildCBlocksFromPous(originalCppPous as never)
     const bundle = composeRuntimeV4Bundle({
       programSt,
       md5,
@@ -791,7 +801,6 @@ async function runCompilePipelineInner(
   // c_blocks header/code + defines.h + optional vpp_config.h).
   // Pure function.
   emit({ stage: 'firmware-bundle', message: 'Composing firmware bundle...', level: 'info' })
-  const cBlocks = buildCBlocksFromPous(originalCppPous as never)
   const firmwareFiles = composeFirmwareBundle({
     strucppFiles: strucppFilesMap,
     cBlocks,

--- a/src/backend/shared/compile/steps/generate-defines.ts
+++ b/src/backend/shared/compile/steps/generate-defines.ts
@@ -55,11 +55,10 @@ export interface GenerateDefinesInput {
    *  the canonical list — every change MUST match what the
    *  firmware's HAL headers `#ifdef`-gate on. */
   stProgramFileContent: string
-  /** MD5 hash of `program.st` bytes — embedded as `PROGRAM_MD5` so
-   *  the runtime can detect a stale upload (a v4 runtime reports
-   *  this back on `FC 0x45` and the debugger uses it to confirm
-   *  the layout it's reading matches the program it last
-   *  uploaded). */
+  /** MD5 hash of all compiled program sources — embedded as `PROGRAM_MD5`
+   *  so the runtime can detect a stale upload (a v4 runtime reports this
+   *  back on `FC 0x45` and the debugger uses it to confirm the layout it's
+   *  reading matches the program it last uploaded). */
   buildMD5Hash: string
   /** Runtime identifier from `hals.json` (`'simulator'` /
    *  `'arduino-cli'` / `'openplc-compiler'`).  Only `'simulator'`

--- a/src/middleware/shared/ports/compiler-platform-port.ts
+++ b/src/middleware/shared/ports/compiler-platform-port.ts
@@ -326,9 +326,9 @@ export interface CompilerPlatformPort {
   /** Compute the MD5 hex digest of an arbitrary string.  Editor:
    *  Node's `crypto.createHash('md5')`.  Web: `spark-md5` (already
    *  a web dep).  Both produce byte-identical output.  The pipeline
-   *  uses this to compute `program.st`'s MD5 — embedded in
-   *  `defines.h` as `PROGRAM_MD5` for the v4 runtime's stale-program
-   *  detection.  Kept in the port (rather than hardcoding either
+   *  uses this to compute the compiled program sources' MD5 — embedded
+   *  in `defines.h` as `PROGRAM_MD5` for the v4 runtime's stale-program
+   *  detection. Kept in the port (rather than hardcoding either
    *  library in shared code) so the shared module ships without a
    *  hash-impl dependency. */
   computeMd5(input: string): Promise<string>


### PR DESCRIPTION
## What changed

- Include the generated `c_blocks.h` and `c_blocks_code.cpp` sources in the program MD5 whenever the project contains C/C++ POUs.
- Use length-prefixed sections so the composite hash input is deterministic and unambiguous.
- Preserve the existing `MD5(program.st)` behavior for projects without C/C++ POUs.
- Reuse the same generated C-block artifacts for hashing and firmware/runtime bundle composition.
- Update the relevant API comments to describe the expanded hash scope.

## Why this is necessary

C/C++ POU bodies are extracted into the `originalCppPous` sidecar before Structured Text transpilation. The transpiler replaces each C/C++ body with an ST bridge, while the actual user-authored code is generated separately as `c_blocks_code.cpp`.

The pipeline previously calculated the MD5 from `program.st` only. As a result, changing only the C/C++ implementation while leaving the POU interface unchanged produced the same `program.st` and therefore the same MD5. The compiled program could change without the runtime/debugger digest reflecting that change, defeating stale-program detection.

Hashing the actual generated C/C++ sidecars together with `program.st` ensures every compiled user-program source contributes to the digest.

## Impact

- C/C++ implementation changes now produce a new `PROGRAM_MD5`.
- Runtime v4, simulator, and Arduino compilation paths use the same corrected digest.
- Projects containing no C/C++ POUs retain their previous digest and do not incur unnecessary cache invalidation.

## Validation

- Added a regression test that compiles two projects with identical ST output and different C/C++ bodies, then verifies that their MD5 values differ.
- Added coverage confirming ST-only projects still hash the raw `program.st` content.
- `npm test -- --runInBand --coverage=false src/backend/shared/compile/__tests__/pipeline.test.ts` — 54 tests passed.
- ESLint passed for all changed TypeScript files.
- Prettier check passed for all changed files.
- `git diff --check` passed.
