### PR TITLE
fix(iec-address): close the paths where address recompaction silently no-ops (DOPE-565)

### DIFF
--- a/docs/iec-address-registry.md
+++ b/docs/iec-address-registry.md
@@ -137,13 +137,26 @@ every producer active (`ALL_ADDRESS_PRODUCERS_ACTIVE`). Permissive is the safe
 direction — the worst case is compaction for a producer the eventual target
 turns out not to support, and selecting that target recalculates anyway.
 
-One producer is additionally forced active in its own **provisional** pool:
-`buildModbusProducerPool` always counts `modbus-tcp-remote`. Every other
-producer's editor is itself capability-gated, so "capability off" and "screen
-unreachable" coincide there; the Remote Devices branch is gated on the project
-TYPE instead, so a user can edit IO groups against a target that declares no
-remote I/O. Without the override, `nextFreeAddress` can't see the sibling
-groups and restarts each one at `%IW0`, persisting duplicates.
+**The consequence to be aware of:** a project authored while the target is
+unresolved allocates with every producer active, so once the package is
+installed and the target resolves, capabilities can shrink and the addresses
+**recompact on that first open**. For alias-bound variables that is
+transparent — it is the whole reason the registry exists. For a variable bound
+to a literal `%addr` the binding does not follow, and the amber
+orphan/collision glyph on the location cell is what surfaces it. That is
+acceptable, and strictly better than the previous symptom (stale addresses,
+reported as success), but it is not derivable from the invariant alone.
+
+Capability scoping is the **single authority** on which producers are active:
+no kind is ever forced on in a provisional pool. That holds because every
+producer's creation path is capability-gated in the UI, so "capability off"
+and "cannot author this producer" coincide. Remote devices reach that state
+through two predicates rather than one — the project type
+(`projectCaps.hasRemoteDevices`, false for libraries) and the target
+(`modbusTcpRemote || ethercat`, the same predicate the variable-location
+dropdown uses). Devices already configured stay **visible** on a target that
+can't host them, because the board-switch warning promises they are "disabled
+during compilation", not removed; only creating a new one is refused.
 
 ## 6. Aliases and variable binding
 

--- a/docs/iec-address-registry.md
+++ b/docs/iec-address-registry.md
@@ -109,6 +109,42 @@ to call on every mutation, on project load, and pre-compile.
 Determinism (stable order + stable channel order) guarantees reproducible
 results across sessions, so a re-open never gratuitously renumbers.
 
+### 5.1 Capability scoping vs. unresolved targets
+
+Allocation is scoped to the consumer kinds the active target supports
+(`allocateAddresses`'s `activeKinds`). Deactivating a kind is deliberate and
+load-bearing: switching to a board without VPP frees the VPP space, and the
+still-active producers compact into it on the next recalculation.
+
+The invariant that makes that safe:
+
+> **An unknown target is permissive for allocation and empty for feature
+> gating.**
+
+`resolveTargetCapabilities(undefined)` answers `EMPTY_CAPABILITIES`, which is
+correct for gating — never offer an affordance the target can't back. Feeding
+that same answer to the allocator is not: an empty `activeKinds` set is
+indistinguishable from "this target supports nothing", so **every** consumer
+is filtered out, `assignments` comes back empty, and the write-back leaves the
+stale addresses in place while reporting success. A board id fails to resolve
+whenever the VPP package isn't installed, the project was authored elsewhere,
+or the catalogue hasn't loaded yet — all ordinary situations.
+
+So the store distinguishes the two cases (`allocationCapabilities` /
+`activeKindsForAllocation` in the project slice): a target that **answered** is
+honoured exactly as declared; a target that **didn't resolve** allocates with
+every producer active (`ALL_ADDRESS_PRODUCERS_ACTIVE`). Permissive is the safe
+direction — the worst case is compaction for a producer the eventual target
+turns out not to support, and selecting that target recalculates anyway.
+
+One producer is additionally forced active in its own **provisional** pool:
+`buildModbusProducerPool` always counts `modbus-tcp-remote`. Every other
+producer's editor is itself capability-gated, so "capability off" and "screen
+unreachable" coincide there; the Remote Devices branch is gated on the project
+TYPE instead, so a user can edit IO groups against a target that declares no
+remote I/O. Without the override, `nextFreeAddress` can't see the sibling
+groups and restarts each one at `%IW0`, persisting duplicates.
+
 ## 6. Aliases and variable binding
 
 - **Aliases live only in the registry**, attached to channels. Uniqueness
@@ -228,7 +264,15 @@ Shipped on `feat/central-iec-address-registry` (editor + web, byte-identical):
   Invoked from every producer mutation and on target switch.
 - **Pins** participate as **fixed constraints** — hardware addresses are never
   reallocated; their aliases persist per-board and flow through the same
-  registry uniqueness gate. Nothing to route.
+  registry uniqueness gate. But a pin edit MOVES those constraints, so
+  `createNewPin` / `removePin` / `updatePin` drive the central recalculation
+  whenever the pin address signature changes (alias-only and pin-number-only
+  edits skip it). Without that, `removePin` slid the freed slot to the end of
+  the pin block and left it stranded, and `createNewPin` could mint an address
+  already held by a VPP or Modbus channel — an unreported two-producer
+  collision.
+- **Unresolved targets** allocate permissively rather than as if the target
+  supported nothing — see §5.1.
 - **Aliases** resolve to concrete IEC addresses **in the editor** (each
   variable's `location` is kept resolved); the compiler/runtime are untouched.
 

--- a/src/frontend/components/_features/[workspace]/create-element/index.tsx
+++ b/src/frontend/components/_features/[workspace]/create-element/index.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 
 import { projectCapabilities } from '../../../../../middleware/shared/ports/types'
 import { PlusIcon } from '../../../../assets/icons/interface/Plus'
+import { useTargetCapabilities } from '../../../../hooks/use-target-capabilities'
 import { useOpenPLCStore } from '../../../../store'
 import { cn } from '../../../../utils/cn'
 import { ElementCard } from './element-card'
@@ -25,6 +26,12 @@ const CreatePLCElement = () => {
   // gating happens here so a future new POU type doesn't have to be
   // wired up in two places.
   const projectCaps = projectCapabilities({ type: projectType })
+  // Remote devices are additionally gated on the TARGET: a board that hosts
+  // neither Modbus remote I/O nor EtherCAT cannot drive one, and creating it
+  // anyway yields I/O points no variable can reference (the location dropdown
+  // hides them behind this same predicate). Unlike the tree branch, which
+  // keeps already-configured devices visible, creation is refused outright.
+  const targetCaps = useTargetCapabilities()
   const CreatePLCElementTypes: CreatePLCElementType[] = (
     ['function', 'function-block', 'program', 'data-type', 'server', 'remote-device'] as const
   ).filter((target) => {
@@ -34,7 +41,7 @@ const CreatePLCElement = () => {
       case 'server':
         return projectCaps.hasServers
       case 'remote-device':
-        return projectCaps.hasRemoteDevices
+        return projectCaps.hasRemoteDevices && (targetCaps.modbusTcpRemote || targetCaps.ethercat)
       default:
         // function / function-block / data-type — always available.
         return true

--- a/src/frontend/components/_organisms/explorer/project.tsx
+++ b/src/frontend/components/_organisms/explorer/project.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { projectCapabilities } from '../../../../middleware/shared/ports/types'
 import { useCapabilities, useProject } from '../../../../middleware/shared/providers'
 import { FolderIcon } from '../../../assets/icons/interface/Folder'
+import { useTargetCapabilities } from '../../../hooks/use-target-capabilities'
 import { useOpenPLCStore } from '../../../store'
 import type { TabsProps } from '../../../store/slices/tabs'
 import { CreateEditorObjectFromTab, LIBRARY_MANIFEST_TAB_NAME } from '../../../store/slices/tabs/utils'
@@ -69,6 +70,14 @@ const Project = () => {
   // Servers / Remote-Devices / VPP screens are program-level
   // affordances that don't apply to a `.stlib` build.
   const projectCaps = projectCapabilities({ type: projectType })
+
+  // Remote devices are also gated on the TARGET, not just the project type:
+  // a board that hosts neither Modbus remote I/O nor EtherCAT cannot drive
+  // them at all (the v3 build ships a single `program.st` and no remote-I/O
+  // config), and the variable-location dropdown already hides their points
+  // behind this exact predicate.
+  const targetCaps = useTargetCapabilities()
+  const canHostRemoteIo = targetCaps.modbusTcpRemote || targetCaps.ethercat
 
   // Get VPP vendor screens from the currently selected board
   const deviceBoard = useOpenPLCStore((s) => s.deviceDefinitions.configuration.deviceBoard)
@@ -451,8 +460,13 @@ const Project = () => {
             </ProjectTreeBranch>
           )}
 
-          {/* Project Remote Devices tree branch — hidden for libraries. */}
-          {projectCaps.hasRemoteDevices && (
+          {/* Project Remote Devices tree branch — hidden for libraries, and on
+              a target that can host neither Modbus remote I/O nor EtherCAT.
+              Devices already configured stay visible on such a target: the
+              board-switch warning promises they are "disabled during
+              compilation", not removed, so hiding saved data would contradict
+              what the user just accepted. */}
+          {projectCaps.hasRemoteDevices && (canHostRemoteIo || (remoteDevices?.length ?? 0) > 0) && (
             <ProjectTreeBranch branchTarget='remote-device'>
               {[...(remoteDevices || [])]
                 .sort((a, b) => a.name.localeCompare(b.name))

--- a/src/frontend/store/__tests__/device-slice.test.ts
+++ b/src/frontend/store/__tests__/device-slice.test.ts
@@ -1712,4 +1712,160 @@ describe('createDeviceSlice', () => {
       expect(store.getState().deviceDefinitions.configuration.deviceBoard).toBe('Custom')
     })
   })
+
+  // -------------------------------------------------------------------------
+  // Pin edits drive the central IEC recalculation (DOPE-440)
+  // -------------------------------------------------------------------------
+
+  describe('pin edits recompact the other address producers (DOPE-440)', () => {
+    /** A board that hosts BOTH fixed pins and Modbus remote I/O — the only
+     *  configuration where the two producers share an address space. */
+    function seedPinAndModbusBoard(store: ReturnType<typeof makeStore>) {
+      store.getState().deviceActions.setAvailableOptions({
+        availableBoards: new Map<string, BoardInfo>([
+          [
+            'GPIO Runtime v4',
+            {
+              compiler: 'openplc-compiler',
+              core: 'rt-v4',
+              preview: '',
+              specs: {},
+              capabilities: {
+                pinMapping: true,
+                vppIo: false,
+                modbusTcpRemote: true,
+                ethercat: false,
+                modbusTcpServer: true,
+                opcuaServer: true,
+                s7Server: true,
+                debuggerTransports: ['websocket'],
+                pythonFunctionBlocks: true,
+                arduinoApiCompletions: false,
+                hasRuntimeStats: true,
+                isInProcessSimulator: false,
+                directUsbUpload: false,
+              },
+            },
+          ],
+        ]),
+      })
+      store.getState().deviceActions.setDeviceBoard('GPIO Runtime v4')
+    }
+
+    /** Three digital-input pins occupying %IX0.0–%IX0.2, plus a two-point
+     *  Modbus FC1 group that allocates immediately after them. */
+    function seedPinsAndGroup(store: ReturnType<typeof makeStore>) {
+      seedPinAndModbusBoard(store)
+      store.getState().deviceActions.setDeviceDefinitions({
+        pinMapping: [
+          makePin({ pin: 'D0', pinType: 'digitalInput', address: '%IX0.0' }),
+          makePin({ pin: 'D1', pinType: 'digitalInput', address: '%IX0.1' }),
+          makePin({ pin: 'D2', pinType: 'digitalInput', address: '%IX0.2' }),
+        ],
+      })
+      const project = store.getState().project
+      store.getState().projectActions.setProject({
+        ...project,
+        data: {
+          ...project.data,
+          remoteDevices: [
+            {
+              name: 'Dev1',
+              protocol: 'modbus-tcp',
+              modbusTcpConfig: { host: '127.0.0.1', port: 502, slaveId: 1, timeout: 1000, ioGroups: [] },
+            },
+          ],
+        },
+      })
+      store.getState().projectActions.addIOGroup('Dev1', {
+        id: 'g1',
+        name: 'group-g1',
+        functionCode: '1',
+        cycleTime: 100,
+        offset: '0',
+        length: 2,
+        errorHandling: 'keep-last-value',
+        ioPoints: [],
+      })
+    }
+
+    const modbusAddresses = (store: ReturnType<typeof makeStore>) =>
+      store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups[0].ioPoints!.map((p) => p.iecLocation)
+
+    /** Count store writes from here on. The actions are frozen by Immer so
+     *  `recalculateIecAddresses` can't be spied on directly — but it always
+     *  issues its own `setState`, so a pin edit that recalculates writes twice
+     *  and one that skips it writes once. */
+    function countWrites(store: ReturnType<typeof makeStore>) {
+      let writes = 0
+      store.subscribe(() => {
+        writes += 1
+      })
+      return () => writes
+    }
+
+    it('removePin lets the Modbus group reclaim the freed pin slot', () => {
+      const store = makeStore()
+      seedPinsAndGroup(store)
+      expect(modbusAddresses(store)).toEqual(['%IX0.3', '%IX0.4'])
+
+      store.getState().deviceActions.selectPinTableRow(1)
+      store.getState().deviceActions.removePin()
+
+      // The pin block shrank to %IX0.0–%IX0.1; the group used to stay put at
+      // %IX0.3/.4, leaving %IX0.2 stranded.
+      expect(activePins(store.getState()).map((p) => p.address)).toEqual(['%IX0.0', '%IX0.1'])
+      expect(modbusAddresses(store)).toEqual(['%IX0.2', '%IX0.3'])
+    })
+
+    it('createNewPin pushes the Modbus group off the slot it just claimed', () => {
+      const store = makeStore()
+      seedPinsAndGroup(store)
+
+      // `createNewPin` mints highest+1 = %IX0.3, checking only OTHER PINS for a
+      // collision — so it lands squarely on the group's first point.
+      store.getState().deviceActions.selectPinTableRow(2)
+      store.getState().deviceActions.createNewPin()
+
+      expect(activePins(store.getState()).map((p) => p.address)).toContain('%IX0.3')
+      // Pins are fixed hardware and stay pinned, so the group moves instead.
+      expect(modbusAddresses(store)).toEqual(['%IX0.4', '%IX0.5'])
+    })
+
+    it('updatePin recalculates when a pin type change rewrites addresses', () => {
+      const store = makeStore()
+      seedPinsAndGroup(store)
+      store.getState().deviceActions.selectPinTableRow(0)
+
+      const writes = countWrites(store)
+      store.getState().deviceActions.updatePin({ pinType: 'digitalOutput' })
+
+      expect(writes()).toBe(2)
+      // %IX0.0 moved to the output space and the remaining inputs slid down,
+      // so the group follows into the freed slot.
+      expect(modbusAddresses(store)).toEqual(['%IX0.2', '%IX0.3'])
+    })
+
+    it('updatePin does not recalculate for an alias-only edit', () => {
+      const store = makeStore()
+      seedPinsAndGroup(store)
+      store.getState().deviceActions.selectPinTableRow(0)
+
+      const writes = countWrites(store)
+      store.getState().deviceActions.updatePin({ alias: 'Start' })
+
+      expect(writes()).toBe(1)
+    })
+
+    it('updatePin does not recalculate for a pin-number-only edit', () => {
+      const store = makeStore()
+      seedPinsAndGroup(store)
+      store.getState().deviceActions.selectPinTableRow(0)
+
+      const writes = countWrites(store)
+      store.getState().deviceActions.updatePin({ pin: 'D9' })
+
+      expect(writes()).toBe(1)
+    })
+  })
 })

--- a/src/frontend/store/__tests__/device-slice.test.ts
+++ b/src/frontend/store/__tests__/device-slice.test.ts
@@ -1789,13 +1789,20 @@ describe('createDeviceSlice', () => {
       })
     }
 
-    const modbusAddresses = (store: ReturnType<typeof makeStore>) =>
-      store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups[0].ioPoints!.map((p) => p.iecLocation)
+    /** The seeded group's IEC addresses. Throws rather than asserting non-null
+     *  so a broken fixture names itself instead of failing as an unrelated
+     *  expectation. */
+    function modbusAddresses(store: ReturnType<typeof makeStore>): string[] {
+      const points = store.getState().project.data.remoteDevices?.[0]?.modbusTcpConfig?.ioGroups[0]?.ioPoints
+      if (!points) throw new Error('fixture: expected a remote device with one IO group holding points')
+      return points.map((point) => point.iecLocation)
+    }
 
     /** Count store writes from here on. The actions are frozen by Immer so
-     *  `recalculateIecAddresses` can't be spied on directly — but it always
-     *  issues its own `setState`, so a pin edit that recalculates writes twice
-     *  and one that skips it writes once. */
+     *  `recalculateIecAddresses` can't be spied on directly, and a skipped
+     *  recalculation has no other observable — it changes no address. Only the
+     *  negative cases assert on this; where addresses move, they are the
+     *  stronger assertion. */
     function countWrites(store: ReturnType<typeof makeStore>) {
       let writes = 0
       store.subscribe(() => {
@@ -1837,10 +1844,8 @@ describe('createDeviceSlice', () => {
       seedPinsAndGroup(store)
       store.getState().deviceActions.selectPinTableRow(0)
 
-      const writes = countWrites(store)
       store.getState().deviceActions.updatePin({ pinType: 'digitalOutput' })
 
-      expect(writes()).toBe(2)
       // %IX0.0 moved to the output space and the remaining inputs slid down,
       // so the group follows into the freed slot.
       expect(modbusAddresses(store)).toEqual(['%IX0.2', '%IX0.3'])

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -358,6 +358,48 @@ function seedVppBoard(store: ReturnType<typeof makeStore>) {
   store.getState().deviceActions.setDeviceBoard('VPP Board')
 }
 
+/** Seed a Runtime v3 target: a target that RESOLVED and genuinely declares no
+ *  remote I/O. Distinct from an unresolved board — allocation must keep
+ *  honouring the declaration here (DOPE-440). */
+function seedRuntimeV3Board(store: ReturnType<typeof makeStore>) {
+  store.getState().deviceActions.setAvailableOptions({
+    availableBoards: new Map<string, BoardInfo>([
+      [
+        'OpenPLC Runtime v3',
+        {
+          compiler: 'openplc-compiler',
+          core: 'rt-v3',
+          preview: '',
+          specs: {},
+          capabilities: {
+            pinMapping: false,
+            vppIo: false,
+            modbusTcpRemote: false,
+            ethercat: false,
+            modbusTcpServer: false,
+            opcuaServer: false,
+            s7Server: false,
+            debuggerTransports: ['modbus-tcp'],
+            pythonFunctionBlocks: true,
+            arduinoApiCompletions: false,
+            hasRuntimeStats: false,
+            isInProcessSimulator: false,
+            directUsbUpload: false,
+          },
+        },
+      ],
+    ]),
+  })
+  store.getState().deviceActions.setDeviceBoard('OpenPLC Runtime v3')
+}
+
+/** Point the project at a board id that is NOT in `availableBoards` — a VPP
+ *  board whose package isn't installed, or a project authored elsewhere.
+ *  `resolveTargetCapabilities(undefined)` answers EMPTY_CAPABILITIES there. */
+function selectUnresolvedBoard(store: ReturnType<typeof makeStore>) {
+  store.getState().deviceActions.setDeviceBoard('Uninstalled VPP Board')
+}
+
 // ===========================================================================
 // Tests
 // ===========================================================================
@@ -2904,6 +2946,113 @@ describe('createProjectSlice', () => {
       expect(groups).toHaveLength(1)
       // g2 slides down into the freed slots — no gap left behind.
       expect(groups[0].ioPoints!.map((p) => p.iecLocation)).toEqual(['%IW0', '%IW1'])
+    })
+  })
+
+  describe('allocation against an unresolved or incapable target (DOPE-440)', () => {
+    /** A device whose group already carries addresses — the shape a project
+     *  file has on load, before any edit. */
+    function seedDeviceAt(name: string, addresses: string[]) {
+      seedRemoteDevice(store, {
+        ...makeRemoteDevice(name),
+        modbusTcpConfig: {
+          host: '127.0.0.1',
+          port: 502,
+          slaveId: 1,
+          timeout: 1000,
+          ioGroups: [
+            {
+              ...makeIOGroup('g1', '3', addresses.length),
+              ioPoints: addresses.map((iecLocation, i) => ({
+                id: `group-g1_${i}`,
+                name: `group-g1_${i}`,
+                type: 'Analog Input (Holding Register)',
+                iecLocation,
+                alias: '',
+              })),
+            },
+          ],
+        },
+      })
+    }
+
+    const addressesOf = (deviceIndex = 0) =>
+      store
+        .getState()
+        .project.data.remoteDevices![deviceIndex].modbusTcpConfig!.ioGroups.flatMap((g) =>
+          g.ioPoints!.map((p) => p.iecLocation),
+        )
+
+    it('recompacts after a delete even when the board id does not resolve', () => {
+      seedRuntimeV4Board(store)
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 2)) // %IW0,1
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g2', '3', 2)) // %IW2,3
+      // The VPP package goes missing, or the project is opened on another
+      // machine: the board id no longer resolves to a BoardInfo.
+      selectUnresolvedBoard(store)
+
+      store.getState().projectActions.deleteIOGroup('Dev1', 'g1')
+
+      // Used to keep %IW2,3 — every consumer was filtered out of allocation,
+      // so the recompaction wrote nothing and reported success.
+      expect(addressesOf()).toEqual(['%IW0', '%IW1'])
+    })
+
+    it('does not mint duplicate addresses when the board id does not resolve', () => {
+      selectUnresolvedBoard(store)
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 2))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g2', '3', 2))
+
+      // Both groups used to restart at %IW0 — the pool couldn't see the sibling.
+      expect(addressesOf()).toEqual(['%IW0', '%IW1', '%IW2', '%IW3'])
+    })
+
+    it('does not mint duplicate addresses on a target that declares no remote I/O', () => {
+      // Runtime v3 RESOLVED and said `modbusTcpRemote: false`, so the central
+      // recalculation rightly leaves these addresses alone. That makes the
+      // provisional pool the only thing standing between the two groups.
+      seedRuntimeV3Board(store)
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 2))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g2', '3', 2))
+
+      const addresses = addressesOf()
+      expect(new Set(addresses).size).toBe(addresses.length)
+    })
+
+    it('still honours a resolved target that declares no remote I/O', () => {
+      // The other half of the invariant, and the guard against "simplifying"
+      // the fix into dropping capability scoping altogether: a board that
+      // ANSWERED keeps its declaration, so the inactive kind is not reallocated.
+      seedRuntimeV3Board(store)
+      seedDeviceAt('Dev1', ['%IW4', '%IW5'])
+
+      store.getState().projectActions.recalculateIecAddresses()
+
+      expect(addressesOf()).toEqual(['%IW4', '%IW5'])
+    })
+
+    it('compacts the same gap once the target is merely unresolved', () => {
+      selectUnresolvedBoard(store)
+      seedDeviceAt('Dev1', ['%IW4', '%IW5'])
+
+      store.getState().projectActions.recalculateIecAddresses()
+
+      expect(addressesOf()).toEqual(['%IW0', '%IW1'])
+    })
+
+    it('keeps the alias-uniqueness gate working when the board id does not resolve', () => {
+      selectUnresolvedBoard(store)
+      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
+      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 2))
+      store.getState().projectActions.updateIOPointAlias('Dev1', 'g1', 'group-g1_0', 'Temp')
+
+      const result = store.getState().projectActions.updateIOPointAlias('Dev1', 'g1', 'group-g1_1', 'Temp')
+
+      expect(result.ok).toBe(false)
+      expect(result.title).toBe('Alias already in use')
     })
   })
 

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -292,7 +292,11 @@ function locVar(name: string, location: string, cls: PLCVariable['class'] = 'loc
  *  Modbus claims. Producer-edit actions (addIOGroup, updateIOGroup …)
  *  rely on `caps.modbusTcpRemote = true` to count sibling groups when
  *  allocating addresses. */
-function seedRuntimeV4Board(store: ReturnType<typeof makeStore>) {
+/** Land the board catalogue WITHOUT selecting a board — the project-load moment
+ *  where discovery finishes and target capabilities become resolvable. Split out
+ *  of `seedRuntimeV4Board` so a test can land the catalogue while the project's
+ *  own board stays unresolved. */
+function landBoardCatalogue(store: ReturnType<typeof makeStore>) {
   store.getState().deviceActions.setAvailableOptions({
     availableBoards: new Map<string, BoardInfo>([
       [
@@ -321,6 +325,10 @@ function seedRuntimeV4Board(store: ReturnType<typeof makeStore>) {
       ],
     ]),
   })
+}
+
+function seedRuntimeV4Board(store: ReturnType<typeof makeStore>) {
+  landBoardCatalogue(store)
   store.getState().deviceActions.setDeviceBoard('OpenPLC Runtime v4')
 }
 
@@ -3080,14 +3088,33 @@ describe('createProjectSlice', () => {
       expect(addressesOf()).toEqual(['%IW0', '%IW1'])
     })
 
-    it('warns once when the board is missing from a populated catalogue', () => {
-      // Resolving first clears the once-per-board dedupe, so this test does not
-      // depend on what ran before it.
-      seedRuntimeV4Board(store)
+    it('stays quiet when the target resolves', () => {
       const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
       try {
-        selectUnresolvedBoard(store) // setDeviceBoard recalculates
-        store.getState().projectActions.recalculateIecAddresses() // deduped
+        seedRuntimeV4Board(store)
+        store.getState().projectActions.recalculateIecAddresses()
+
+        expect(warn).not.toHaveBeenCalled()
+      } finally {
+        warn.mockRestore()
+      }
+    })
+
+    it('stays quiet while the board catalogue is still loading, then reports once it lands', () => {
+      // The two halves are ONE behaviour and have to be asserted together. An
+      // empty catalogue is an ordinary startup state, not a missing package —
+      // but discovery finishing is precisely when the situation becomes
+      // actionable, so whatever suppresses the load-time warning must not also
+      // suppress the one after it. Asserting only the quiet half lets that
+      // through: it is how a module-scoped "warn once" latch, armed during
+      // load, silently swallowed the report forever.
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+      try {
+        selectUnresolvedBoard(store) // recalculates against an empty catalogue
+        expect(warn).not.toHaveBeenCalled()
+
+        landBoardCatalogue(store) // discovery finishes; this board isn't in it
+        store.getState().projectActions.recalculateIecAddresses()
 
         expect(warn).toHaveBeenCalledTimes(1)
         expect(warn.mock.calls[0][0]).toContain('Uninstalled VPP Board')
@@ -3096,13 +3123,17 @@ describe('createProjectSlice', () => {
       }
     })
 
-    it('stays quiet while the board catalogue is still loading', () => {
-      // An empty catalogue is an ordinary startup state, not a missing package.
+    it('reports every recalculation against an unresolved target', () => {
+      // Not deduplicated by design — see `warnIfTargetUnresolved`. Each
+      // recalculation is a user-initiated mutation, and a latch that outlives
+      // the store silences the next project on the same board.
+      seedRuntimeV4Board(store)
       const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
       try {
+        selectUnresolvedBoard(store) // setDeviceBoard recalculates
         store.getState().projectActions.recalculateIecAddresses()
 
-        expect(warn).not.toHaveBeenCalled()
+        expect(warn).toHaveBeenCalledTimes(2)
       } finally {
         warn.mockRestore()
       }

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -2976,12 +2976,11 @@ describe('createProjectSlice', () => {
       })
     }
 
-    const addressesOf = (deviceIndex = 0) =>
-      store
-        .getState()
-        .project.data.remoteDevices![deviceIndex].modbusTcpConfig!.ioGroups.flatMap((g) =>
-          g.ioPoints!.map((p) => p.iecLocation),
-        )
+    /** Every IEC address the first remote device's groups currently hold. */
+    function addressesOf(): string[] {
+      const groups = store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups
+      return groups.flatMap((g) => g.ioPoints!.map((p) => p.iecLocation))
+    }
 
     it('recompacts after a delete even when the board id does not resolve', () => {
       seedRuntimeV4Board(store)

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -2976,10 +2976,16 @@ describe('createProjectSlice', () => {
       })
     }
 
-    /** Every IEC address the first remote device's groups currently hold. */
+    /** Every IEC address the first remote device's groups currently hold.
+     *  Throws rather than asserting non-null so a broken fixture names itself
+     *  instead of failing as an unrelated expectation. */
     function addressesOf(): string[] {
-      const groups = store.getState().project.data.remoteDevices![0].modbusTcpConfig!.ioGroups
-      return groups.flatMap((g) => g.ioPoints!.map((p) => p.iecLocation))
+      const groups = store.getState().project.data.remoteDevices?.[0]?.modbusTcpConfig?.ioGroups
+      if (!groups) throw new Error('fixture: expected a remote device with a modbusTcpConfig')
+      return groups.flatMap((group) => {
+        if (!group.ioPoints) throw new Error(`fixture: group "${group.id}" has no ioPoints`)
+        return group.ioPoints.map((point) => point.iecLocation)
+      })
     }
 
     it('recompacts after a delete even when the board id does not resolve', () => {
@@ -3008,19 +3014,6 @@ describe('createProjectSlice', () => {
       expect(addressesOf()).toEqual(['%IW0', '%IW1', '%IW2', '%IW3'])
     })
 
-    it('does not mint duplicate addresses on a target that declares no remote I/O', () => {
-      // Runtime v3 RESOLVED and said `modbusTcpRemote: false`, so the central
-      // recalculation rightly leaves these addresses alone. That makes the
-      // provisional pool the only thing standing between the two groups.
-      seedRuntimeV3Board(store)
-      seedRemoteDevice(store, makeRemoteDevice('Dev1'))
-      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g1', '3', 2))
-      store.getState().projectActions.addIOGroup('Dev1', makeIOGroup('g2', '3', 2))
-
-      const addresses = addressesOf()
-      expect(new Set(addresses).size).toBe(addresses.length)
-    })
-
     it('still honours a resolved target that declares no remote I/O', () => {
       // The other half of the invariant, and the guard against "simplifying"
       // the fix into dropping capability scoping altogether: a board that
@@ -3040,6 +3033,34 @@ describe('createProjectSlice', () => {
       store.getState().projectActions.recalculateIecAddresses()
 
       expect(addressesOf()).toEqual(['%IW0', '%IW1'])
+    })
+
+    it('warns once when the board is missing from a populated catalogue', () => {
+      // Resolving first clears the once-per-board dedupe, so this test does not
+      // depend on what ran before it.
+      seedRuntimeV4Board(store)
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+      try {
+        selectUnresolvedBoard(store) // setDeviceBoard recalculates
+        store.getState().projectActions.recalculateIecAddresses() // deduped
+
+        expect(warn).toHaveBeenCalledTimes(1)
+        expect(warn.mock.calls[0][0]).toContain('Uninstalled VPP Board')
+      } finally {
+        warn.mockRestore()
+      }
+    })
+
+    it('stays quiet while the board catalogue is still loading', () => {
+      // An empty catalogue is an ordinary startup state, not a missing package.
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+      try {
+        store.getState().projectActions.recalculateIecAddresses()
+
+        expect(warn).not.toHaveBeenCalled()
+      } finally {
+        warn.mockRestore()
+      }
     })
 
     it('keeps the alias-uniqueness gate working when the board id does not resolve', () => {

--- a/src/frontend/store/slices/device/slice.ts
+++ b/src/frontend/store/slices/device/slice.ts
@@ -31,6 +31,40 @@ function getActivePinsDraft(draft: DeviceSlice): DevicePin[] {
   return draft.deviceDefinitions.pinMapping.pinsByBoard[board]
 }
 
+/**
+ * The only pin state the central IEC recalculation depends on: which addresses
+ * the pin block occupies, in order.
+ *
+ * Pins are the one producer the registry keeps PINNED — they're fixed hardware,
+ * so VPP / Modbus / EtherCAT allocate around them. Every pin add / remove /
+ * retype therefore moves the constraints the other producers were packed
+ * against, and nothing recompacted them: `removePin` decrements the trailing
+ * pins of its own type, so the freed slot slides to the END of the pin block
+ * and whatever allocated after it never moves up; `createNewPin` mints
+ * `highest + 1`, which on a board with pin mapping AND VPP/Modbus can land on
+ * top of a channel already sitting there — a two-producer collision with no
+ * conflict report, because nothing recalculated.
+ */
+function pinAddressSignature(state: DeviceSliceRoot): string {
+  const board = state.deviceDefinitions.configuration.deviceBoard
+  return (state.deviceDefinitions.pinMapping.pinsByBoard[board] ?? []).map((pin) => pin.address).join(',')
+}
+
+/**
+ * Recompact the other producers around the new pin layout, but only when the
+ * pin addresses actually moved since `before`. Mirrors `setDeviceBoard`, the
+ * other place where a constraint change drives the central recalculation.
+ *
+ * Comparing rather than recalculating unconditionally keeps alias-only and
+ * pin-number-only edits free, and covers `updatePin`'s pinType branch (which
+ * rewrites addresses) without special-casing it.
+ */
+function recalcIfPinAddressesMoved(getState: () => DeviceSliceRoot, before: string): void {
+  if (pinAddressSignature(getState()) !== before) {
+    getState().projectActions.recalculateIecAddresses()
+  }
+}
+
 const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (setState, getState) => ({
   deviceAvailableOptions: {
     availableBoards: new Map(),
@@ -169,6 +203,7 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
     },
 
     createNewPin: (): void => {
+      const pinsBefore = pinAddressSignature(getState())
       setState(
         produce((draft: DeviceSlice) => {
           draft.deviceUpdated.updated = true
@@ -217,8 +252,10 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
           pinMapping.currentSelectedPinTableRow = indexOfHighestPinAddress + 1
         }),
       )
+      recalcIfPinAddressesMoved(getState, pinsBefore)
     },
     removePin: (): void => {
+      const pinsBefore = pinAddressSignature(getState())
       setState(
         produce((draft: DeviceSlice) => {
           draft.deviceUpdated.updated = true
@@ -251,6 +288,7 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
           pinMapping.currentSelectedPinTableRow = selectedRow
         }),
       )
+      recalcIfPinAddressesMoved(getState, pinsBefore)
     },
     updatePin: (updatedData): PinUpdateResponse => {
       const returnMessage: PinUpdateResponse = {
@@ -259,6 +297,7 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
         message: '',
         data: { pin: '', pinType: '', address: '', alias: '' },
       }
+      const pinsBefore = pinAddressSignature(getState())
       setState(
         produce((draft: DeviceSlice) => {
           draft.deviceUpdated.updated = true
@@ -376,6 +415,7 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
           }
         }),
       )
+      recalcIfPinAddressesMoved(getState, pinsBefore)
       return returnMessage
     },
     setDeviceBoard: (deviceBoard): void => {

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -265,7 +265,7 @@ type VppMappingEntry = {
 function readVppEntries(live: ProjectSliceRoot): VppMappingEntry[] {
   return (
     (
-      live.deviceDefinitions?.configuration?.vendorScreenData?.['io-mapping'] as
+      live.deviceDefinitions.configuration.vendorScreenData?.['io-mapping'] as
         | { entries?: VppMappingEntry[] }
         | undefined
     )?.entries ?? []
@@ -290,7 +290,7 @@ function activeKindsFromCapabilities(caps: TargetCapabilities): Set<string> {
  *  resolve — a VPP board whose package isn't installed, a project authored on
  *  another machine, or the catalogue not having loaded yet. */
 function resolveBoardInfo(live: ProjectSliceRoot): BoardInfoLike | undefined {
-  return live.deviceAvailableOptions?.availableBoards?.get(live.deviceDefinitions?.configuration?.deviceBoard ?? '')
+  return live.deviceAvailableOptions.availableBoards.get(live.deviceDefinitions.configuration.deviceBoard ?? '')
 }
 
 /**
@@ -306,6 +306,40 @@ function resolveBoardInfo(live: ProjectSliceRoot): BoardInfoLike | undefined {
 function allocationCapabilities(live: ProjectSliceRoot): AddressProducerCapabilities {
   const boardInfo = resolveBoardInfo(live)
   return boardInfo ? resolveTargetCapabilities(boardInfo) : ALL_ADDRESS_PRODUCERS_ACTIVE
+}
+
+/** Board most recently reported as unresolved, so a project that never
+ *  resolves warns once instead of on every edit. */
+let lastUnresolvedBoardWarned: string | null = null
+
+/**
+ * Allocating against an unresolved target is a legitimate fallback but an
+ * invisible one, and this class of bug survived months precisely because it
+ * was silent.
+ *
+ * Only reported once the catalogue has actually loaded: an EMPTY
+ * `availableBoards` means board discovery hasn't finished, which is an
+ * ordinary startup state where permissive allocation is simply correct. A
+ * board missing from a POPULATED catalogue is the actionable case — the VPP
+ * package isn't installed, or the project came from another machine. Warn once
+ * per board so a project that never resolves doesn't drown the console.
+ *
+ * Called from `recalculateIecAddresses` only, never from the memoized
+ * alias-index path, which is hot.
+ */
+function warnOnceIfTargetUnresolved(live: ProjectSliceRoot): void {
+  const board = live.deviceDefinitions.configuration.deviceBoard
+  if (resolveBoardInfo(live)) {
+    lastUnresolvedBoardWarned = null
+    return
+  }
+  if (live.deviceAvailableOptions.availableBoards.size === 0) return
+  if (lastUnresolvedBoardWarned === board) return
+  lastUnresolvedBoardWarned = board
+  console.warn(
+    `[iec-address] Target "${board}" did not resolve — allocating with every producer active. ` +
+      'Addresses may recompact once the target resolves (e.g. after installing its VPP package).',
+  )
 }
 
 /**
@@ -328,14 +362,11 @@ function activeKindsForAllocation(live: ProjectSliceRoot): Set<string> | undefin
  * resized group must not land on. The final addresses come from
  * `recalculateIecAddresses`; this only seeds the point structure.
  *
- * `modbus-tcp-remote` is forced active regardless of the target. Every other
- * producer's editor is itself capability-gated (pin mapping, the VPP layouts
- * and EtherCAT only render when their flag is on), so "capability off" and
- * "screen unreachable" coincide there. Remote devices are the outlier: the
- * explorer branch is gated on the project TYPE, not on the target, so the user
- * can edit IO groups against a Runtime v3 or unresolved board — and with the
- * kind filtered out of the pool, `nextFreeAddress` cannot see the sibling
- * groups and restarts every one of them at `%IW0`, persisting duplicates.
+ * Capability scoping stays the single authority on which producers are active
+ * — no kind is forced on here. `allocationCapabilities` already turns Modbus
+ * on for an unresolved target, and on a target that resolved and declared no
+ * remote I/O the creation paths are gated in the UI, so a group can't be
+ * seeded against a target the allocator won't manage afterwards.
  *
  * `clearGroup` drops one group's own points from the pool so a resize can
  * reuse the addresses it is about to give up.
@@ -344,7 +375,7 @@ function buildModbusProducerPool(
   live: ProjectSliceRoot,
   clearGroup?: { deviceName: string; groupId: string },
 ): AddressPool {
-  const board = live.deviceDefinitions?.configuration?.deviceBoard ?? ''
+  const board = live.deviceDefinitions.configuration.deviceBoard
   const remoteDevices = clearGroup
     ? live.project.data.remoteDevices?.map((d) =>
         d.name !== clearGroup.deviceName || !d.modbusTcpConfig
@@ -363,11 +394,11 @@ function buildModbusProducerPool(
 
   return buildAddressPool(
     {
-      pinMapping: { pins: live.deviceDefinitions?.pinMapping?.pinsByBoard[board] ?? [] },
+      pinMapping: { pins: live.deviceDefinitions.pinMapping.pinsByBoard[board] ?? [] },
       vendorIoMapping: { entries: readVppEntries(live) },
       remoteDevices,
     },
-    { ...allocationCapabilities(live), modbusTcpRemote: true },
+    allocationCapabilities(live),
   )
 }
 
@@ -1815,6 +1846,7 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       // compile time. Only a producer *rename* touches variables — via
       // `renameAlias`, called by the alias editors.
       const live = getState()
+      warnOnceIfTargetUnresolved(live)
       const registry = buildIecRegistry(live)
       const index = indexRegistry(registry)
 

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -309,34 +309,33 @@ function allocationCapabilities(live: ProjectSliceRoot): AddressProducerCapabili
   return boardInfo ? resolveTargetCapabilities(boardInfo) : ALL_ADDRESS_PRODUCERS_ACTIVE
 }
 
-/** Board most recently reported as unresolved, so a project that never
- *  resolves warns once instead of on every edit. */
-let lastUnresolvedBoardWarned: string | null = null
-
 /**
  * Allocating against an unresolved target is a legitimate fallback but an
  * invisible one, and this class of bug survived months precisely because it
  * was silent.
  *
- * Only reported once the catalogue has actually loaded: an EMPTY
- * `availableBoards` means board discovery hasn't finished, which is an
- * ordinary startup state where permissive allocation is simply correct. A
- * board missing from a POPULATED catalogue is the actionable case — the VPP
- * package isn't installed, or the project came from another machine. Warn once
- * per board so a project that never resolves doesn't drown the console.
+ * Reported only once the catalogue has actually loaded. An EMPTY
+ * `availableBoards` means board discovery hasn't finished — an ordinary
+ * startup state where permissive allocation is simply correct, and where the
+ * board may yet resolve. A board missing from a POPULATED catalogue is the
+ * actionable case: the VPP package isn't installed, or the project came from
+ * another machine.
+ *
+ * Deliberately NOT deduplicated. An earlier version latched the last reported
+ * board in module scope to keep a never-resolving project from repeating
+ * itself. That bought almost nothing — the empty-catalogue guard is what
+ * removes the noise — and cost real correctness: module state outlives the
+ * store, so a second project on the same unresolved board went silent, and
+ * test outcomes depended on execution order. One line per recalculation, all
+ * of them user-initiated mutations, is the honest signal.
  *
  * Called from `recalculateIecAddresses` only, never from the memoized
  * alias-index path, which is hot.
  */
-function warnOnceIfTargetUnresolved(live: ProjectSliceRoot): void {
+function warnIfTargetUnresolved(live: ProjectSliceRoot): void {
   const board = live.deviceDefinitions.configuration.deviceBoard
-  if (resolveBoardInfo(live)) {
-    lastUnresolvedBoardWarned = null
-    return
-  }
+  if (resolveBoardInfo(live)) return
   if (live.deviceAvailableOptions.availableBoards.size === 0) return
-  if (lastUnresolvedBoardWarned === board) return
-  lastUnresolvedBoardWarned = board
   console.warn(
     `[iec-address] Target "${board}" did not resolve — allocating with every producer active. ` +
       'Addresses may recompact once the target resolves (e.g. after installing its VPP package).',
@@ -1847,7 +1846,7 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       // compile time. Only a producer *rename* touches variables — via
       // `renameAlias`, called by the alias editors.
       const live = getState()
-      warnOnceIfTargetUnresolved(live)
+      warnIfTargetUnresolved(live)
       const registry = buildIecRegistry(live)
       const index = indexRegistry(registry)
 

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -12,6 +12,7 @@ import type {
   S7CommServerSettings,
 } from '../../../../middleware/shared/ports/types'
 import {
+  type AddressPool,
   buildAddressPool,
   buildAliasRegistry,
   describeSource,
@@ -30,8 +31,15 @@ import {
   restoreAliasesFromMemory,
   unpinAllocatableChannels,
 } from '../../../../middleware/shared/utils/iec-address/registry'
-import type { TargetCapabilities } from '../../../../middleware/shared/utils/target-capabilities'
-import { resolveTargetCapabilities } from '../../../../middleware/shared/utils/target-capabilities'
+import type {
+  AddressProducerCapabilities,
+  BoardInfoLike,
+  TargetCapabilities,
+} from '../../../../middleware/shared/utils/target-capabilities'
+import {
+  ALL_ADDRESS_PRODUCERS_ACTIVE,
+  resolveTargetCapabilities,
+} from '../../../../middleware/shared/utils/target-capabilities'
 import { renameDataTypeInDataType, renameDataTypeInVariableType } from '../../../utils/data-type-references'
 import { parseIecStringToVariables } from '../../../utils/generate-iec-string-to-variables'
 import { generateIecVariablesToString } from '../../../utils/generate-iec-variables-to-string'
@@ -257,7 +265,7 @@ type VppMappingEntry = {
 function readVppEntries(live: ProjectSliceRoot): VppMappingEntry[] {
   return (
     (
-      live.deviceDefinitions.configuration.vendorScreenData?.['io-mapping'] as
+      live.deviceDefinitions?.configuration?.vendorScreenData?.['io-mapping'] as
         | { entries?: VppMappingEntry[] }
         | undefined
     )?.entries ?? []
@@ -278,6 +286,91 @@ function activeKindsFromCapabilities(caps: TargetCapabilities): Set<string> {
   return kinds
 }
 
+/** The active target's BoardInfo, or `undefined` when the board id doesn't
+ *  resolve — a VPP board whose package isn't installed, a project authored on
+ *  another machine, or the catalogue not having loaded yet. */
+function resolveBoardInfo(live: ProjectSliceRoot): BoardInfoLike | undefined {
+  return live.deviceAvailableOptions?.availableBoards?.get(live.deviceDefinitions?.configuration?.deviceBoard ?? '')
+}
+
+/**
+ * Capabilities for ADDRESS ALLOCATION. Never use for UI / feature gating.
+ *
+ * A target that answered is honoured exactly as declared. A target that did
+ * NOT resolve is permissive instead of empty: `resolveTargetCapabilities`
+ * returns `EMPTY_CAPABILITIES` for an unknown board, which is the safe answer
+ * for gating and the wrong one here — it reads as "this target supports no
+ * producers", so every consumer drops out of allocation and the recompaction
+ * silently keeps whatever stale addresses each point already had (DOPE-440).
+ */
+function allocationCapabilities(live: ProjectSliceRoot): AddressProducerCapabilities {
+  const boardInfo = resolveBoardInfo(live)
+  return boardInfo ? resolveTargetCapabilities(boardInfo) : ALL_ADDRESS_PRODUCERS_ACTIVE
+}
+
+/**
+ * Consumer kinds to scope allocation to, or `undefined` for "every kind" —
+ * exactly how `allocateAddresses` reads a missing `activeKinds`.
+ *
+ * Only an UNRESOLVED target gets `undefined`. A resolved board that declares
+ * `modbusTcpRemote: false` must still deactivate that kind, so its space frees
+ * up and the still-active producers compact into it — that's the deliberate
+ * target-switch behaviour documented on `activeKindsFromCapabilities`, and the
+ * empty Set an unresolved board used to produce is indistinguishable from it.
+ */
+function activeKindsForAllocation(live: ProjectSliceRoot): Set<string> | undefined {
+  const boardInfo = resolveBoardInfo(live)
+  return boardInfo ? activeKindsFromCapabilities(resolveTargetCapabilities(boardInfo)) : undefined
+}
+
+/**
+ * Provisional address pool for a Modbus IO-group edit — the claims a new or
+ * resized group must not land on. The final addresses come from
+ * `recalculateIecAddresses`; this only seeds the point structure.
+ *
+ * `modbus-tcp-remote` is forced active regardless of the target. Every other
+ * producer's editor is itself capability-gated (pin mapping, the VPP layouts
+ * and EtherCAT only render when their flag is on), so "capability off" and
+ * "screen unreachable" coincide there. Remote devices are the outlier: the
+ * explorer branch is gated on the project TYPE, not on the target, so the user
+ * can edit IO groups against a Runtime v3 or unresolved board — and with the
+ * kind filtered out of the pool, `nextFreeAddress` cannot see the sibling
+ * groups and restarts every one of them at `%IW0`, persisting duplicates.
+ *
+ * `clearGroup` drops one group's own points from the pool so a resize can
+ * reuse the addresses it is about to give up.
+ */
+function buildModbusProducerPool(
+  live: ProjectSliceRoot,
+  clearGroup?: { deviceName: string; groupId: string },
+): AddressPool {
+  const board = live.deviceDefinitions?.configuration?.deviceBoard ?? ''
+  const remoteDevices = clearGroup
+    ? live.project.data.remoteDevices?.map((d) =>
+        d.name !== clearGroup.deviceName || !d.modbusTcpConfig
+          ? d
+          : {
+              ...d,
+              modbusTcpConfig: {
+                ...d.modbusTcpConfig,
+                ioGroups: d.modbusTcpConfig.ioGroups.map((g) =>
+                  g.id === clearGroup.groupId ? { ...g, ioPoints: [] } : g,
+                ),
+              },
+            },
+      )
+    : live.project.data.remoteDevices
+
+  return buildAddressPool(
+    {
+      pinMapping: { pins: live.deviceDefinitions?.pinMapping?.pinsByBoard[board] ?? [] },
+      vendorIoMapping: { entries: readVppEntries(live) },
+      remoteDevices,
+    },
+    { ...allocationCapabilities(live), modbusTcpRemote: true },
+  )
+}
+
 /**
  * Build the capability-scoped registry from live producer state: derive
  * consumers (pins/VPP/Modbus/EtherCAT), restore any aliases held in the
@@ -287,15 +380,15 @@ function activeKindsFromCapabilities(caps: TargetCapabilities): Set<string> {
  */
 function buildIecRegistry(live: ProjectSliceRoot): IecAddressRegistry {
   const board = live.deviceDefinitions.configuration.deviceBoard
-  const boardInfo = live.deviceAvailableOptions.availableBoards.get(board ?? '')
   const seeded = migrateToRegistry({
     pinMapping: { pins: live.deviceDefinitions.pinMapping.pinsByBoard[board] ?? [] },
     vendorIoMapping: { entries: readVppEntries(live) },
     remoteDevices: live.project.data.remoteDevices,
   })
   const restored = restoreAliasesFromMemory(seeded, live.iecAliasMemory ?? {})
-  const activeKinds = activeKindsFromCapabilities(resolveTargetCapabilities(boardInfo))
-  return recalculateRegistry(unpinAllocatableChannels(restored, ALLOCATED_KINDS), { activeKinds }).registry
+  const activeKinds = activeKindsForAllocation(live)
+  const unpinned = unpinAllocatableChannels(restored, ALLOCATED_KINDS)
+  return recalculateRegistry(unpinned, activeKinds ? { activeKinds } : {}).registry
 }
 
 /**
@@ -1779,29 +1872,8 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       // Read producer state from the live store before entering produce
       // so the pool reflects every active source (pin-mapping, VPP,
       // every Modbus / EtherCAT remote device — including this one's
-      // existing groups, which must not be reclaimed) under the
-      // current target's capabilities.
-      const live = getState()
-      const boardInfo = live.deviceAvailableOptions.availableBoards.get(
-        live.deviceDefinitions.configuration.deviceBoard ?? '',
-      )
-      const ioMapping =
-        (
-          live.deviceDefinitions.configuration.vendorScreenData?.['io-mapping'] as
-            | { entries?: Array<{ iecAddress: string; alias?: string; slot: number; channelName: string }> }
-            | undefined
-        )?.entries ?? []
-
-      const pool = buildAddressPool(
-        {
-          pinMapping: {
-            pins: live.deviceDefinitions.pinMapping.pinsByBoard[live.deviceDefinitions.configuration.deviceBoard] ?? [],
-          },
-          vendorIoMapping: { entries: ioMapping },
-          remoteDevices: live.project.data.remoteDevices,
-        },
-        resolveTargetCapabilities(boardInfo),
-      )
+      // existing groups, which must not be reclaimed).
+      const pool = buildModbusProducerPool(getState())
 
       setState(
         produce((slice: ProjectSlice) => {
@@ -1831,42 +1903,7 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       // group's current points (all other Modbus groups, pin-mapping, VPP
       // and EtherCAT claims are still honoured). Existing aliases are
       // carried over positionally.
-      const live = getState()
-      const boardInfo = live.deviceAvailableOptions.availableBoards.get(
-        live.deviceDefinitions.configuration.deviceBoard ?? '',
-      )
-      const ioMapping =
-        (
-          live.deviceDefinitions.configuration.vendorScreenData?.['io-mapping'] as
-            | { entries?: Array<{ iecAddress: string; alias?: string; slot: number; channelName: string }> }
-            | undefined
-        )?.entries ?? []
-
-      // Clone remoteDevices with the edited group's points cleared so its
-      // own addresses are free for re-allocation without disturbing the
-      // rest of the project.
-      const remoteDevicesForPool = live.project.data.remoteDevices?.map((d) =>
-        d.name !== deviceName || !d.modbusTcpConfig
-          ? d
-          : {
-              ...d,
-              modbusTcpConfig: {
-                ...d.modbusTcpConfig,
-                ioGroups: d.modbusTcpConfig.ioGroups.map((g) => (g.id === groupId ? { ...g, ioPoints: [] } : g)),
-              },
-            },
-      )
-
-      const pool = buildAddressPool(
-        {
-          pinMapping: {
-            pins: live.deviceDefinitions.pinMapping.pinsByBoard[live.deviceDefinitions.configuration.deviceBoard] ?? [],
-          },
-          vendorIoMapping: { entries: ioMapping },
-          remoteDevices: remoteDevicesForPool,
-        },
-        resolveTargetCapabilities(boardInfo),
-      )
+      const pool = buildModbusProducerPool(getState(), { deviceName, groupId })
 
       setState(
         produce((slice: ProjectSlice) => {
@@ -1903,29 +1940,7 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       // rationale.
       const live = getState()
       const sourceRef = { kind: 'modbus-tcp-remote' as const, ref: `${deviceName}:${pointId}` }
-      const boardInfo = live.deviceAvailableOptions?.availableBoards?.get(
-        live.deviceDefinitions?.configuration?.deviceBoard ?? '',
-      )
-      const ioMapping =
-        (
-          live.deviceDefinitions?.configuration?.vendorScreenData?.['io-mapping'] as
-            | { entries?: Array<{ iecAddress: string; alias?: string; slot: number; channelName: string }> }
-            | undefined
-        )?.entries ?? []
-      const pool = buildAddressPool(
-        {
-          pinMapping: {
-            pins:
-              live.deviceDefinitions?.pinMapping?.pinsByBoard[
-                live.deviceDefinitions?.configuration?.deviceBoard ?? ''
-              ] ?? [],
-          },
-          vendorIoMapping: { entries: ioMapping },
-          remoteDevices: live.project.data.remoteDevices,
-        },
-        resolveTargetCapabilities(boardInfo),
-      )
-      const registry = buildAliasRegistry(pool)
+      const registry = buildAliasRegistry(buildModbusProducerPool(live))
       const validation = validateAliasEdit(registry, alias, sourceRef)
       if (!validation.ok) {
         return {

--- a/src/middleware/shared/utils/iec-address/address-pool.ts
+++ b/src/middleware/shared/utils/iec-address/address-pool.ts
@@ -39,7 +39,7 @@
  * re-run the address-sync flow (Phase 4) to reassign the losers.
  */
 
-import type { TargetCapabilities } from '../target-capabilities'
+import type { AddressProducerCapabilities } from '../target-capabilities'
 
 /** Which kind of source attached this claim. */
 export type SourceKind = 'pin-mapping' | 'vpp-io' | 'modbus-tcp-remote' | 'ethercat'
@@ -184,7 +184,11 @@ function compareClaimedAddress(a: ClaimedAddress, b: ClaimedAddress): number {
 
 export function buildAddressPool(
   inputs: PoolInputs,
-  caps: TargetCapabilities,
+  /* Only the four producer flags are read. Narrower than
+   * `TargetCapabilities` on purpose: "which producers are active" can also be
+   * answered by something that is not a target — see
+   * `ALL_ADDRESS_PRODUCERS_ACTIVE`, the answer for an unresolved board. */
+  caps: AddressProducerCapabilities,
   options: BuildPoolOptions = {},
 ): AddressPool {
   const byAddress = new Map<string, ClaimedAddress>()

--- a/src/middleware/shared/utils/target-capabilities/index.ts
+++ b/src/middleware/shared/utils/target-capabilities/index.ts
@@ -1,8 +1,9 @@
 export {
+  ALL_ADDRESS_PRODUCERS_ACTIVE,
   ARDUINO_CLI_CAPABILITIES,
   RUNTIME_V3_CAPABILITIES,
   RUNTIME_V4_CAPABILITIES,
   SIMULATOR_CAPABILITIES,
 } from './presets'
 export { type BoardInfoLike, resolveTargetCapabilities } from './resolve'
-export type { DebuggerTransport, TargetCapabilities } from './types'
+export type { AddressProducerCapabilities, DebuggerTransport, TargetCapabilities } from './types'

--- a/src/middleware/shared/utils/target-capabilities/presets.ts
+++ b/src/middleware/shared/utils/target-capabilities/presets.ts
@@ -10,7 +10,30 @@
  * updated yet.
  */
 
-import type { TargetCapabilities } from './types'
+import type { AddressProducerCapabilities, TargetCapabilities } from './types'
+
+/**
+ * Every address producer active. NOT a target preset — no board reports this,
+ * and it must never reach a UI / feature gate.
+ *
+ * This is the allocation-time answer to a board id that did not resolve: a VPP
+ * board whose package isn't installed, a project authored on another machine,
+ * or the catalogue not having loaded yet. `resolveTargetCapabilities`
+ * answers `EMPTY_CAPABILITIES` there, which is right for gating (never offer
+ * an affordance the target can't back) and wrong for allocation, where it
+ * reads as "this target supports no producers" and freezes every address in
+ * place — the recompaction after a delete silently keeps the stale addresses.
+ *
+ * Permissive is the safe direction here: the worst case is that addresses get
+ * compacted for a producer the eventual target turns out not to support, and
+ * selecting that target recalculates anyway (`setDeviceBoard`).
+ */
+export const ALL_ADDRESS_PRODUCERS_ACTIVE: AddressProducerCapabilities = {
+  pinMapping: true,
+  vppIo: true,
+  modbusTcpRemote: true,
+  ethercat: true,
+}
 
 export const SIMULATOR_CAPABILITIES: TargetCapabilities = {
   pinMapping: false,

--- a/src/middleware/shared/utils/target-capabilities/types.ts
+++ b/src/middleware/shared/utils/target-capabilities/types.ts
@@ -138,3 +138,16 @@ export interface TargetCapabilities {
    *  hardware limitation — and the flow says exactly that. */
   isLicensable: boolean
 }
+
+/**
+ * The four flags that decide which producers claim IEC addresses.
+ *
+ * Address-space code reads nothing else, so it takes this narrower type and a
+ * full `TargetCapabilities` is assignable to it. The point of the narrowing is
+ * that "which producers are active" can also be answered by something that is
+ * NOT a target — see `ALL_ADDRESS_PRODUCERS_ACTIVE`.
+ */
+export type AddressProducerCapabilities = Pick<
+  TargetCapabilities,
+  'pinMapping' | 'vppIo' | 'modbusTcpRemote' | 'ethercat'
+>


### PR DESCRIPTION
# Pull request info

## Description of the changes proposed

**The scenario named in the ticket was already fixed.** The central registry work
(Phases 3–6, July) made `deleteIOGroup` call `recalculateIecAddresses()`, and the test
`recompacts the surviving groups into the freed slots (bug #4)` has passed ever since.
The ticket predates that work and was never re-verified. What remained are the paths
where the recompaction **silently no-ops**, plus the ticket's own "May also affect other
plugins" clause — which turns out to be literally true for pin mapping.

- **An unresolved target is not a target without capabilities.** `resolveTargetCapabilities(undefined)`
  answers `EMPTY_CAPABILITIES`; feeding that to the allocator filters out *every* consumer,
  so `assignments` comes back empty and the write-back leaves the stale addresses in place
  while reporting success. A board id fails to resolve whenever the VPP package isn't
  installed, the project was authored elsewhere, or the catalogue hasn't loaded yet. A board
  that **answered** is now honoured exactly as declared (the deliberate kind-deactivation on
  target switch is untouched); a board that **did not resolve** allocates with every producer
  active.
- **Duplicate addresses were being persisted.** The provisional pool had the same conflation,
  so on a Runtime v3 or unresolved target every new group restarted at `%IW0`.
  `modbus-tcp-remote` is now always counted in its own pool. This also collapses the three
  duplicated ~25-line pool preambles into one helper.
- **Pin mapping never recompacted.** `removePin` slides the freed slot to the end of the pin
  block; `createNewPin` can mint an address already held by a VPP or Modbus channel, with no
  conflict report. All three pin actions now compare the pin address signature and recalculate
  only when it moves, so alias-only and pin-number-only edits stay free.
- Docs: new §5.1 in `docs/iec-address-registry.md` capturing the invariant
  *"unknown target ⇒ permissive for allocation, empty for feature gating"*.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote-device creation and navigation now reflect the selected target’s supported capabilities.
  * Address allocation adapts to target capabilities, including unresolved targets and target changes.
  * Existing remote devices remain accessible when the current target no longer supports them.

* **Bug Fixes**
  * IEC addresses recalculate after relevant pin changes, preventing stranded or duplicate addresses.
  * Improved address reuse, alias uniqueness, and warning behavior during target and device updates.

* **Documentation**
  * Added guidance on capability-based allocation, target switching, producer visibility, and address recalculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->