### PR TITLE
chore(strucpp): pin v0.6.3

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -1,6 +1,6 @@
 {
   "strucpp": {
-    "version": "v0.6.2",
+    "version": "v0.6.3",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }


### PR DESCRIPTION
Bumps the pinned STruC++ compiler from **v0.6.2** to **v0.6.3** in `binary-versions.json`.

```diff
-    "version": "v0.6.2",
+    "version": "v0.6.3",
```

`scripts/download-binaries.ts` resolves this to the release's npm-pack artifact, `strucpp-0.6.3.tgz`, which is published and reachable (verified HTTP 200 on the download URL). No other change is needed — the script derives the asset name from this field, and `electron-builder.json` references the extracted `strucpp/runtime/include` and `strucpp/libs` paths, which are version-agnostic.

## What v0.6.3 brings

**Structure & array initialization**
- `STRUCT` initializers in variable declarations
- Array repetition initializer `[N(value)]`
- 3D arrays, nested array initializers, function-block array invocation
- Validation of array initializer shape and subscript count
- Exact integer literal lowering (no precision loss into C++)
- Array-literal defaults preserved on `STRUCT` elements, strings escaped
- POU classes forward-declared ahead of user-defined types

**Debug table**
- One member-mangling rule applied everywhere a member is named, replacing divergent per-site logic
- Function-block parameters mangled at the invocation site
- `PROGRAM` constructor initializer list mangled
- Multi-dimensional arrays indexed with `operator()`

The debug-table mangling changes affect the debug map this repo generates and consumes for variable monitoring/forcing, so that path is worth a look during review.

Upstream release: [strucpp v0.6.3](https://github.com/Autonomy-Logic/STruCpp/releases/tag/v0.6.3) · [PR #214](https://github.com/Autonomy-Logic/STruCpp/pull/214) (2240 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `strucpp` binary to version `v0.6.3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->