### PR TITLE
feat(ladder): recover unusable rung geometry on load, and put GVLs in the LSP's scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,13 @@ resources/st-compiler/**.spec
 # arduino-cli stays committed since we don't own its releases
 resources/strucpp/
 resources/bin/**
+# Git will not re-include a file whose ancestor directory is excluded, and `bin/**` excludes
+# the platform/arch directories too — so the two exceptions below only bite once these are
+# re-included. Without them a NEWLY downloaded arduino-cli is invisible to git, and the six
+# committed ones survive only because they were already tracked when the rule landed.
+!resources/bin/
+!resources/bin/*/
+!resources/bin/*/*/
 !resources/bin/*/*/arduino-cli
 !resources/bin/*/*/arduino-cli.exe
 # A local build leaves xml2st, iec2c/iec2iec and .binary-metadata.json here, plus

--- a/.gitignore
+++ b/.gitignore
@@ -52,9 +52,19 @@ resources/st-compiler/**.spec
 # External tool binaries (downloaded by scripts/download-binaries.ts)
 # arduino-cli stays committed since we don't own its releases
 resources/strucpp/
+resources/bin/**
+!resources/bin/*/*/arduino-cli
+!resources/bin/*/*/arduino-cli.exe
+# A local build leaves xml2st, iec2c/iec2iec and .binary-metadata.json here, plus
+# timestamped .xml2st-backup-* copies. They are downloaded artefacts, not sources —
+# 123 MB of them were swept into a PR by a `git add -A` before this rule existed.
+resources/sources/MatIEC/
 
 # Playwright
 /test-results/
 playwright-report
 /blob-report/
 /playwright/.cache/
+
+# Claude Code session state (a running session's id and pid — never a project artefact)
+.claude/scheduled_tasks.lock

--- a/src/frontend/components/_features/[workspace]/global-variable-list/__tests__/view-toggle.test.tsx
+++ b/src/frontend/components/_features/[workspace]/global-variable-list/__tests__/view-toggle.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+// The declaration view pulls in Monaco, which cannot run in jsdom.
+vi.mock('@root/frontend/components/_organisms/variables-code-editor', () => ({
+  VariablesCodeEditor: ({ code }: { code: string }) => <div data-testid='variables-code-editor'>{code}</div>,
+}))
+
+import type { PLCGlobalVariableList } from '@root/middleware/shared/ports/types'
+import { useOpenPLCStore } from '@root/frontend/store'
+import { CreateEditorObjectFromTab } from '@root/frontend/store/slices/tabs/utils'
+
+import { GlobalVariableListEditor } from '../index'
+
+const member = (name: string, type = 'BOOL') => ({
+  name,
+  class: 'global' as const,
+  type: { definition: 'base-type' as const, value: type },
+  location: '',
+  documentation: '',
+})
+
+/**
+ * Seed the lists AND the editor model, the way opening the tab does.
+ *
+ * The model is where the view state lives, so a test that skips it is testing a component
+ * the app never renders.
+ */
+function seed(lists: PLCGlobalVariableList[], openList?: string) {
+  const model = openList
+    ? CreateEditorObjectFromTab({
+        name: openList,
+        path: `/data/global-variables/${openList}`,
+        elementType: { type: 'global-variable-list' },
+      })
+    : undefined
+  useOpenPLCStore.setState((state) => ({
+    ...state,
+    project: { ...state.project, data: { ...state.project.data, globalVariableLists: lists } },
+    editor: model ?? { type: 'available', meta: { name: 'available' } },
+    editors: model ? [model] : [],
+  }))
+}
+
+/** The name column of every DATA row — header rows carry `th`, not `td`. */
+const rowNames = () =>
+  screen
+    .queryAllByRole('row')
+    .filter((row) => row.querySelectorAll('td').length > 0)
+    .map((row) => row.querySelectorAll('td')[1]?.textContent?.trim())
+
+describe('GlobalVariableListEditor', () => {
+  beforeEach(() => seed([]))
+
+  it('opens on the table, with a row per member', () => {
+    seed([{ name: 'GVL', variables: [member('Output1'), member('Speed', 'INT')] }], 'GVL')
+    render(<GlobalVariableListEditor listName='GVL' />)
+
+    expect(screen.queryByTestId('variables-code-editor')).toBeNull()
+    expect(rowNames()).toEqual(['Output1', 'Speed'])
+  })
+
+  it('leaves out the columns a list cannot honour', () => {
+    // An address on a list member drives nothing (the STRUCT it compiles to discards `AT`),
+    // and nothing collects one into the debugger — so neither column is offered.
+    seed([{ name: 'GVL', variables: [member('Output1')] }], 'GVL')
+    render(<GlobalVariableListEditor listName='GVL' />)
+
+    const headers = screen.getAllByRole('columnheader').map((header) => header.textContent?.trim())
+    expect(headers).toEqual(['#', 'Name', 'Class', 'Type', 'Initial Value', 'Documentation'])
+  })
+
+  it('switches to the declaration and back', () => {
+    seed([{ name: 'GVL', variables: [member('Output1')] }], 'GVL')
+    render(<GlobalVariableListEditor listName='GVL' />)
+
+    fireEvent.click(screen.getByLabelText('Global variable list code visualization'))
+    expect(screen.getByTestId('variables-code-editor').textContent).toContain('Output1 : BOOL;')
+
+    fireEvent.click(screen.getByLabelText('Global variable list table visualization'))
+    expect(rowNames()).toEqual(['Output1'])
+  })
+
+  it('opens on the declaration when the saved text could not be parsed', () => {
+    // The editor lets a broken declaration be saved rather than losing what was typed, so a
+    // project can be RELOADED carrying one. Opening such a list on the table would show the
+    // last good parse — members the file no longer says — and hide the text that needs
+    // fixing. `variables` here is deliberately stale to make that visible if it regresses.
+    seed(
+      [
+        {
+          name: 'GVL',
+          variables: [member('Output1')],
+          text: 'VAR_GLOBAL\n  Output1 : BOOL\n  oops : ???\nEND_VAR\n',
+        },
+      ],
+      'GVL',
+    )
+    render(<GlobalVariableListEditor listName='GVL' />)
+
+    const view = screen.getByTestId('variables-code-editor')
+    expect(view.textContent).toContain('oops : ???')
+    expect(rowNames()).toEqual([])
+  })
+
+  it('keeps the user in the declaration while it does not parse', () => {
+    // The table is built from members the broken text has not produced, so the switch is
+    // refused — the same answer the POU variables and data type views give.
+    seed(
+      [
+        {
+          name: 'GVL',
+          variables: [member('Output1')],
+          text: 'VAR_GLOBAL\n  oops : ???\nEND_VAR\n',
+        },
+      ],
+      'GVL',
+    )
+    render(<GlobalVariableListEditor listName='GVL' />)
+
+    fireEvent.click(screen.getByLabelText('Global variable list table visualization'))
+    expect(screen.getByTestId('variables-code-editor')).toBeTruthy()
+    expect(rowNames()).toEqual([])
+  })
+
+  it('says so when the list is gone but its tab is still mounted', () => {
+    seed([])
+    render(<GlobalVariableListEditor listName='GVL' />)
+    expect(screen.getByText('This global variable list no longer exists.')).toBeTruthy()
+  })
+})

--- a/src/frontend/components/_features/[workspace]/global-variable-list/index.tsx
+++ b/src/frontend/components/_features/[workspace]/global-variable-list/index.tsx
@@ -1,8 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import type { PLCGlobalVariable } from '../../../../../middleware/shared/ports/types'
+import { CodeIcon } from '../../../../assets/icons/interface/CodeIcon'
+import { MinusIcon } from '../../../../assets/icons/interface/Minus'
+import { PlusIcon } from '../../../../assets/icons/interface/Plus'
+import { StickArrowIcon } from '../../../../assets/icons/interface/StickArrow'
+import { TableIcon } from '../../../../assets/icons/interface/TableIcon'
 import { useOpenPLCStore } from '../../../../store'
+import { cn } from '../../../../utils/cn'
 import { serializeGlobalVariableListToText } from '../../../../utils/PLC/global-variable-list-serializer'
 import { parseGlobalVariableListFromText } from '../../../../utils/PLC/global-variable-list-text-parser'
+import { InputWithRef } from '../../../_atoms/input'
+import TableActions from '../../../_atoms/table-actions'
+import { GlobalVariableListTable } from '../../../_molecules/global-variables-table'
 import { VariablesCodeEditor } from '../../../_organisms/variables-code-editor'
 import { toast } from '../../[app]/toast/use-toast'
 
@@ -10,25 +20,41 @@ type GlobalVariableListEditorProps = {
   listName: string
 }
 
+const ROWS_NOT_SELECTED = -1
+
 /**
  * The editor for one Global Variable List.
  *
- * A GVL is edited as its declaration — the `VAR_GLOBAL … END_VAR` block — which is how
- * CODESYS presents one, and what the user is qualifying against when they write
- * `GVL.Output1` elsewhere.
+ * Two views of the same members, switched by the icons in the header, the way a POU's
+ * variables and the Resource globals are:
  *
- * The text is the source of truth while the user types; it is parsed and committed to the
- * project on blur. A block that does not parse is NOT committed and the user is told why:
- * committing half of it would silently drop every declaration below the mistake, and
- * reverting the buffer would throw away what they just typed.
+ *   - the TABLE, which is the default and where each member is a row edited cell by cell.
+ *     It is the same table and the same cells the Resource globals use — a list member is a
+ *     variable in the same sense a resource global is — writing through the
+ *     `global-variable-list` scope on the shared variable actions.
+ *   - the DECLARATION, the `VAR_GLOBAL … END_VAR` block CODESYS shows and the on-disk
+ *     format, for editing many members at once or pasting one in.
  *
- * Every keystroke is ALSO mirrored into this list's editor model, and that is not
- * decoration. Blur is not the only way out of an editor: Ctrl+S with the caret still in
- * Monaco fires no blur at all, and closing the tab from its × unmounts without a
+ * Leaving the declaration requires it to parse. The text is the source of truth while the
+ * user types there; it is committed on blur, and a block that does not parse is NOT
+ * committed and the user is told why — committing half of it would silently drop every
+ * declaration below the mistake, and reverting the buffer would throw away what they just
+ * typed. A list whose declaration could not be read at all (`text` is set) opens in the
+ * declaration view, because that text is what has to be fixed and the table would show the
+ * last good parse instead of what the file says.
+ *
+ * Every keystroke in the declaration is ALSO mirrored into this list's editor model, and
+ * that is not decoration. Blur is not the only way out of an editor: Ctrl+S with the caret
+ * still in Monaco fires no blur at all, and closing the tab from its × unmounts without a
  * guaranteed one. The save path folds the mirrored buffer in itself
  * (`reconcileGlobalVariableListText`), so a save can no longer serialise the declarations
- * from before the user started typing. Same arrangement the data type code view uses, for
- * the same reason.
+ * from before the user started typing. Table edits need none of that: each one commits to
+ * the project as it happens.
+ *
+ * The name is shown, not edited. Renaming a list has to rewrite every `<list>.<member>`
+ * reference in the project, which the project tree's rename already does through
+ * `propagateGlobalVariableListRename`; a second entry point here would be a second chance
+ * to skip it.
  *
  * Reads its list by name rather than from the active editor, so every open list can stay
  * mounted at once without a background one writing over the foreground's model.
@@ -44,7 +70,13 @@ const GlobalVariableListEditor = ({ listName }: GlobalVariableListEditorProps) =
       data: { globalVariableLists },
     },
     editorActions: { updateModelStructureForName },
-    projectActions: { updateGlobalVariableList, updateGlobalVariableListQualifier },
+    projectActions: {
+      createVariable,
+      deleteVariable,
+      rearrangeVariables,
+      updateGlobalVariableList,
+      updateGlobalVariableListQualifier,
+    },
     sharedWorkspaceActions: { handleFileAndWorkspaceSavedState },
   } = useOpenPLCStore()
 
@@ -56,11 +88,33 @@ const GlobalVariableListEditor = ({ listName }: GlobalVariableListEditorProps) =
 
   // This list's own model, never the active `editor` — every open list is mounted.
   const model = editor.meta.name === listName ? editor : editors.find((e) => e.meta.name === listName)
-  const modelCode =
-    model?.type === 'plc-global-variable-list' && model.structure.display === 'code' ? model.structure.code : undefined
+  const structure = model?.type === 'plc-global-variable-list' ? model.structure : undefined
+  const modelCode = structure?.display === 'code' ? structure.code : undefined
+  const display = structure?.display === 'code' ? 'code' : 'table'
+  const selectedRow = structure?.display === 'table' ? parseInt(structure.selectedRow) : ROWS_NOT_SELECTED
 
   const [draft, setDraft] = useState(() => (typeof modelCode === 'string' ? modelCode : committedText))
   const lastMirroredRef = useRef(draft)
+
+  const members: PLCGlobalVariable[] = (list?.variables ?? []).map((variable) => ({ ...variable, class: 'global' }))
+
+  const setSelectedRow = useCallback(
+    (row: number) => {
+      // The action takes the row as a number and stores it as a string — see `applyStructureView`.
+      updateModelStructureForName(listName, { display: 'table', selectedRow: row })
+    },
+    [listName, updateModelStructureForName],
+  )
+
+  // A declaration that could not be read has to be shown as text, and the model is what
+  // says so — not a local override. `display === 'code'` is also the contract that makes
+  // `structure.code` the draft buffer a mid-edit save folds in, so forcing the view here
+  // without moving the model would leave that save serialising stale members.
+  useEffect(() => {
+    if (list?.text === undefined) return
+    if (structure?.display === 'code') return
+    updateModelStructureForName(listName, { display: 'code', code: list.text })
+  }, [list?.text, structure?.display, listName, updateModelStructureForName])
 
   // Follow the model when it changes underneath us — an import, an undo, a rename — but
   // never while the user has unsaved edits in the buffer, which would delete their typing.
@@ -77,12 +131,13 @@ const GlobalVariableListEditor = ({ listName }: GlobalVariableListEditorProps) =
   }, [modelCode])
 
   useEffect(() => {
+    if (display !== 'code') return
     lastMirroredRef.current = draft
     updateModelStructureForName(listName, { display: 'code', code: draft })
-  }, [draft, listName, updateModelStructureForName])
+  }, [draft, display, listName, updateModelStructureForName])
 
-  const commit = useCallback(() => {
-    if (!list || draft === committedText) return
+  const commit = useCallback((): boolean => {
+    if (!list || draft === committedText) return true
 
     const parsed = parseGlobalVariableListFromText(draft, listName)
     if (!parsed.globalVariableList) {
@@ -91,7 +146,7 @@ const GlobalVariableListEditor = ({ listName }: GlobalVariableListEditorProps) =
         description: parsed.error ?? 'Check the declaration and try again.',
         variant: 'fail',
       })
-      return
+      return false
     }
 
     updateGlobalVariableList(listName, parsed.globalVariableList.variables)
@@ -99,6 +154,7 @@ const GlobalVariableListEditor = ({ listName }: GlobalVariableListEditorProps) =
     // commit — otherwise editing the block silently drops a CONSTANT the user wrote.
     updateGlobalVariableListQualifier(listName, parsed.globalVariableList.qualifier)
     handleFileAndWorkspaceSavedState(listName)
+    return true
   }, [
     draft,
     committedText,
@@ -108,6 +164,132 @@ const GlobalVariableListEditor = ({ listName }: GlobalVariableListEditorProps) =
     updateGlobalVariableListQualifier,
     handleFileAndWorkspaceSavedState,
   ])
+
+  /**
+   * Whether the declaration can be left for the table.
+   *
+   * Typed text has to commit. Text that was never typed still has to PARSE: a list saved
+   * with a broken declaration comes back with that text on record, and `commit` treats an
+   * untouched buffer as nothing to do — which would wave the user through to a table built
+   * from the last good members, not from what the file says. Blur keeps using `commit`, so
+   * an untouched broken declaration does not toast on every focus change.
+   */
+  const canLeaveDeclaration = (): boolean => {
+    if (draft !== committedText) return commit()
+    if (list?.text === undefined) return true
+    toast({
+      title: 'The declaration could not be read',
+      description:
+        parseGlobalVariableListFromText(draft, listName).error ??
+        'Fix the declaration to edit these members as a table.',
+      variant: 'fail',
+    })
+    return false
+  }
+
+  const handleVisualizationTypeChange = (value: 'code' | 'table') => {
+    if (display === value) return
+    // A declaration that does not parse has no table to show — see above.
+    if (display === 'code' && !canLeaveDeclaration()) return
+    if (value === 'code') {
+      updateModelStructureForName(listName, { display: 'code', code: committedText })
+      setDraft(committedText)
+      return
+    }
+    setSelectedRow(ROWS_NOT_SELECTED)
+  }
+
+  const handleCreateVariable = () => {
+    if (display === 'code') return
+
+    // The first member has nothing to be modelled on; every later one is the selected row
+    // carried forward, which is what makes adding a run of similar members quick.
+    // `createVariableValidation` walks the name and any literal address to the next free
+    // one, so the copy cannot collide with its source.
+    if (members.length === 0) {
+      createVariable({
+        scope: 'global-variable-list',
+        associatedList: listName,
+        data: {
+          name: 'GlobalVar',
+          type: { definition: 'base-type', value: 'DINT' },
+          class: 'global',
+          location: '',
+          documentation: '',
+        },
+      })
+      setSelectedRow(0)
+      handleFileAndWorkspaceSavedState(listName)
+      return
+    }
+
+    const template = selectedRow === ROWS_NOT_SELECTED ? members[members.length - 1] : members[selectedRow]
+    const data = {
+      ...template,
+      // A manual literal address is carried forward and auto-incremented; an alias
+      // binding starts empty so two members never point at the same address.
+      location: template.location.startsWith('%') ? template.location : '',
+      documentation: '',
+    }
+
+    if (selectedRow === ROWS_NOT_SELECTED) {
+      createVariable({ scope: 'global-variable-list', associatedList: listName, data })
+      setSelectedRow(members.length)
+      handleFileAndWorkspaceSavedState(listName)
+      return
+    }
+
+    createVariable({
+      scope: 'global-variable-list',
+      associatedList: listName,
+      data,
+      rowToInsert: selectedRow + 1,
+    })
+    setSelectedRow(selectedRow + 1)
+    handleFileAndWorkspaceSavedState(listName)
+  }
+
+  const handleRemoveVariable = () => {
+    if (display === 'code' || selectedRow === ROWS_NOT_SELECTED) return
+    if (!members[selectedRow]) return
+
+    // No cascade to confirm, unlike a resource global: a POU reaches a member through the
+    // LIST (`<list>.<member>`), never through a `VAR_EXTERNAL` of the member itself.
+    const result = deleteVariable({
+      scope: 'global-variable-list',
+      associatedList: listName,
+      rowId: selectedRow,
+    })
+    if (!result.ok) {
+      toast({ title: result.title ?? 'Error', description: result.message, variant: 'fail' })
+      return
+    }
+
+    if (selectedRow === members.length - 1) setSelectedRow(selectedRow - 1)
+    handleFileAndWorkspaceSavedState(listName)
+  }
+
+  const handleRearrangeVariables = (offset: number) => {
+    if (display === 'code' || selectedRow === ROWS_NOT_SELECTED) return
+    const newIndex = selectedRow + offset
+    if (newIndex < 0 || newIndex > members.length - 1) return
+
+    rearrangeVariables({
+      scope: 'global-variable-list',
+      associatedList: listName,
+      rowId: selectedRow,
+      newIndex,
+    })
+    setSelectedRow(newIndex)
+    handleFileAndWorkspaceSavedState(listName)
+  }
+
+  const handleQualifierBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    const value = event.target.value.trim()
+    if (value === (list?.qualifier ?? '')) return
+    updateGlobalVariableListQualifier(listName, value === '' ? undefined : value)
+    handleFileAndWorkspaceSavedState(listName)
+  }
 
   // Deleting a list with its tab still open leaves this mounted for a frame. Say so,
   // rather than rendering a blank panel that reads as a broken editor.
@@ -128,14 +310,128 @@ const GlobalVariableListEditor = ({ listName }: GlobalVariableListEditorProps) =
     <div
       aria-label={`Global variable list ${listName}`}
       className='flex h-full w-full flex-1 flex-col gap-2 overflow-hidden'
-      onBlur={commit}
+      onBlur={() => {
+        if (display === 'code') commit()
+      }}
     >
-      <VariablesCodeEditor
-        code={draft}
-        onCodeChange={setDraft}
-        shouldUseDarkMode={shouldUseDarkMode}
-        modelUri={`inmemory://global-variable-list/${listName}.gvl`}
-      />
+      <div
+        aria-label='Global variable list metadata container'
+        className='flex w-full shrink-0 items-center gap-4 rounded-md bg-neutral-50 p-2 shadow-md dark:border dark:border-neutral-800 dark:bg-neutral-1000'
+      >
+        <div className='flex items-center gap-2'>
+          <span className='font-caption text-xs font-medium text-neutral-950 dark:text-white'>Name:</span>
+          <span
+            aria-label='Global variable list name'
+            className='font-caption text-xs text-neutral-850 dark:text-neutral-100'
+          >
+            {listName}
+          </span>
+        </div>
+        <div className='flex items-center gap-2'>
+          <label
+            htmlFor={`gvl-qualifier-${listName}`}
+            className='font-caption text-xs font-medium text-neutral-950 dark:text-white'
+          >
+            Qualifier:
+          </label>
+          {/* The header qualifier (`VAR_GLOBAL CONSTANT`) appears nowhere in the table, and
+              it round-trips to CODESYS, so the table view has to be able to show and set it. */}
+          <InputWithRef
+            id={`gvl-qualifier-${listName}`}
+            aria-label='Global variable list qualifier'
+            key={list.qualifier ?? ''}
+            defaultValue={list.qualifier ?? ''}
+            onBlur={handleQualifierBlur}
+            placeholder='None'
+            className='h-6 w-40 rounded-md border border-neutral-400 bg-white p-1 font-caption text-xs text-neutral-850 outline-none focus:border-brand dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100'
+          />
+        </div>
+
+        {display === 'table' && (
+          <div
+            aria-label='Global variable list table actions container'
+            className='ml-auto flex h-full w-28 items-center justify-evenly *:rounded-md *:p-1'
+          >
+            <TableActions
+              actions={[
+                {
+                  ariaLabel: 'Add table row button',
+                  onClick: handleCreateVariable,
+                  icon: <PlusIcon className='!stroke-brand' />,
+                  id: 'add-variable-button',
+                },
+                {
+                  ariaLabel: 'Remove table row button',
+                  onClick: handleRemoveVariable,
+                  disabled: selectedRow === ROWS_NOT_SELECTED,
+                  icon: <MinusIcon />,
+                  id: 'remove-variable-button',
+                },
+                {
+                  ariaLabel: 'Move table row up button',
+                  onClick: () => handleRearrangeVariables(-1),
+                  disabled: selectedRow === ROWS_NOT_SELECTED || selectedRow === 0,
+                  icon: <StickArrowIcon direction='up' className='stroke-[#0464FB]' />,
+                  id: 'move-variable-up-button',
+                },
+                {
+                  ariaLabel: 'Move table row down button',
+                  onClick: () => handleRearrangeVariables(1),
+                  disabled: selectedRow === ROWS_NOT_SELECTED || selectedRow === members.length - 1,
+                  icon: <StickArrowIcon direction='down' className='stroke-[#0464FB]' />,
+                  id: 'move-variable-down-button',
+                },
+              ]}
+            />
+          </div>
+        )}
+
+        <div
+          aria-label='Global variable list visualization switch container'
+          className={cn('flex h-fit w-fit items-center justify-center rounded-md', {
+            'ml-auto': display === 'code',
+          })}
+        >
+          <TableIcon
+            aria-label='Global variable list table visualization'
+            onClick={() => handleVisualizationTypeChange('table')}
+            size='md'
+            currentVisible={display === 'table'}
+            className={cn(
+              display === 'table' ? 'fill-brand' : 'fill-neutral-100 dark:fill-neutral-900',
+              'rounded-l-md transition-colors ease-in-out hover:cursor-pointer',
+            )}
+          />
+          <CodeIcon
+            aria-label='Global variable list code visualization'
+            onClick={() => handleVisualizationTypeChange('code')}
+            size='md'
+            currentVisible={display === 'code'}
+            className={cn(
+              display === 'code' ? 'fill-brand' : 'fill-neutral-100 dark:fill-neutral-900',
+              'rounded-r-md transition-colors ease-in-out hover:cursor-pointer',
+            )}
+          />
+        </div>
+      </div>
+
+      <div aria-label='Global variable list content container' className='flex h-full w-full flex-col overflow-hidden'>
+        {display === 'table' ? (
+          <GlobalVariableListTable
+            listName={listName}
+            tableData={members}
+            selectedRow={selectedRow}
+            handleRowClick={(row) => setSelectedRow(parseInt(row.id))}
+          />
+        ) : (
+          <VariablesCodeEditor
+            code={draft}
+            onCodeChange={setDraft}
+            shouldUseDarkMode={shouldUseDarkMode}
+            modelUri={`inmemory://global-variable-list/${listName}.gvl`}
+          />
+        )}
+      </div>
     </div>
   )
 }

--- a/src/frontend/components/_molecules/global-variables-table/editable-cell.tsx
+++ b/src/frontend/components/_molecules/global-variables-table/editable-cell.tsx
@@ -32,8 +32,26 @@ declare module '@tanstack/react-table' {
   }
 }
 
-type IEditableCellProps = CellContext<PLCGlobalVariable, unknown> & { editable?: boolean }
-const EditableNameCell = ({ getValue, row: { index }, column: { id }, table, editable = true }: IEditableCellProps) => {
+type IEditableCellProps = CellContext<PLCGlobalVariable, unknown> & {
+  editable?: boolean
+  /**
+   * Skip the rename impact analysis and the propagation that follows it.
+   *
+   * A Global Variable List's member is reached as `<list>.<member>`, never as a bare
+   * identifier, so searching POUs for the bare name finds unrelated locals and would
+   * rewrite them. The list's own name is what POUs reference, and renaming THAT is
+   * `propagateGlobalVariableListRename`'s job.
+   */
+  skipReferenceImpact?: boolean
+}
+const EditableNameCell = ({
+  getValue,
+  row: { index },
+  column: { id },
+  table,
+  editable = true,
+  skipReferenceImpact = false,
+}: IEditableCellProps) => {
   const initialValue = getValue<string>()
   const { toast } = useToast()
 
@@ -77,15 +95,9 @@ const EditableNameCell = ({ getValue, row: { index }, column: { id }, table, edi
       return
     }
 
-    const impact = findAllReferencesToVariable(
-      oldName,
-      currentVariable.type,
-      'Resource',
-      pous,
-      ladderFlows,
-      fbdFlows,
-      'global',
-    )
+    const impact: ReferenceImpactAnalysis = skipReferenceImpact
+      ? { totalReferences: 0, byPou: new Map(), byEditorType: new Map(), references: [] }
+      : findAllReferencesToVariable(oldName, currentVariable.type, 'Resource', pous, ladderFlows, fbdFlows, 'global')
 
     let shouldPropagate = true
     if (impact.totalReferences > 0) {

--- a/src/frontend/components/_molecules/global-variables-table/index.tsx
+++ b/src/frontend/components/_molecules/global-variables-table/index.tsx
@@ -14,7 +14,30 @@ import { SelectableDebugCell, SelectableTypeCell } from './selectable-cell'
 
 const columnHelper = createColumnHelper<PLCGlobalVariable>()
 
-const columns = [
+/**
+ * The columns, built per table rather than shared as one constant.
+ *
+ * Two tables use these: the Resource globals and a Global Variable List's members. They
+ * differ in exactly two ways, so those are the options — everything else, including every
+ * cell, is the same code in both, which is the point of building them here.
+ *
+ * `includeDebug` is off for a list: nothing collects a list member into the debugger's
+ * variable set, so the toggle would render a watch that never happens.
+ *
+ * `includeLocation` is off for a list for the same reason — an address on a list member does
+ * not drive anything. The compiler shape a list becomes is a STRUCT, and `AT %QX0.0` on a
+ * struct member is accepted and then silently discarded, producing no located mapping, so
+ * the serializers deliberately omit it (see `global-variable-list-serializer`). An address a
+ * project arrives with is still kept on the member and still written back on export to
+ * CODESYS; what is withheld is the editing affordance for a binding openplc cannot honour.
+ *
+ * `skipReferenceImpact` is on for a list: see the prop's note on the name cell.
+ */
+const buildColumns = ({
+  includeDebug = true,
+  includeLocation = true,
+  skipReferenceImpact = false,
+}: { includeDebug?: boolean; includeLocation?: boolean; skipReferenceImpact?: boolean } = {}) => [
   columnHelper.display({
     id: 'rowNumber',
     header: '#',
@@ -30,7 +53,7 @@ const columns = [
     size: 300,
     minSize: 150,
     maxSize: 300,
-    cell: EditableNameCell,
+    cell: (props) => <EditableNameCell {...props} skipReferenceImpact={skipReferenceImpact} />,
   }),
   columnHelper.accessor('class', {
     header: 'Class',
@@ -45,11 +68,15 @@ const columns = [
     maxSize: 300,
     cell: SelectableTypeCell,
   }),
-  columnHelper.accessor('location', {
-    header: 'Location',
-    enableResizing: true,
-    cell: EditableLocationCell,
-  }),
+  ...(includeLocation
+    ? [
+        columnHelper.accessor('location', {
+          header: 'Location',
+          enableResizing: true,
+          cell: EditableLocationCell,
+        }),
+      ]
+    : []),
   columnHelper.accessor('initialValue', {
     header: 'Initial Value',
     enableResizing: true,
@@ -63,8 +90,24 @@ const columns = [
     maxSize: 468,
     cell: EditableDocumentationCell,
   }),
-  columnHelper.accessor('debug', { header: 'Debug', size: 64, minSize: 64, maxSize: 64, cell: SelectableDebugCell }),
+  ...(includeDebug
+    ? [
+        columnHelper.accessor('debug', {
+          header: 'Debug',
+          size: 64,
+          minSize: 64,
+          maxSize: 64,
+          cell: SelectableDebugCell,
+        }),
+      ]
+    : []),
 ]
+
+/** The Resource globals table's columns, which never change. */
+const resourceColumns = buildColumns()
+
+/** A list's columns: no address, no debugger watch, no bare-name reference rewriting. */
+const listColumns = buildColumns({ includeDebug: false, includeLocation: false, skipReferenceImpact: true })
 
 type PLCVariablesTableProps = {
   tableData: PLCGlobalVariable[]
@@ -85,7 +128,7 @@ const GlobalVariablesTable = ({ tableData, selectedRow, handleRowClick }: PLCVar
 
   return (
     <GenericTable<PLCGlobalVariable>
-      columns={columns}
+      columns={resourceColumns}
       tableData={tableData}
       selectedRow={selectedRow}
       handleRowClick={handleRowClick}
@@ -102,4 +145,45 @@ const GlobalVariablesTable = ({ tableData, selectedRow, handleRowClick }: PLCVar
   )
 }
 
-export { GlobalVariablesTable }
+/**
+ * A Global Variable List's members, as a table.
+ *
+ * Same table and same cells as the Resource globals above — a member is a variable in the
+ * same sense a resource global is — with the writes going to the list instead, through the
+ * `global-variable-list` scope on the shared variable actions.
+ */
+const GlobalVariableListTable = ({
+  listName,
+  tableData,
+  selectedRow,
+  handleRowClick,
+}: PLCVariablesTableProps & { listName: string }) => {
+  const {
+    projectActions: { updateVariable },
+    sharedWorkspaceActions: { handleFileAndWorkspaceSavedState },
+  } = useOpenPLCStore()
+
+  return (
+    <GenericTable<PLCGlobalVariable>
+      columns={listColumns}
+      tableData={tableData}
+      selectedRow={selectedRow}
+      handleRowClick={handleRowClick}
+      updateData={(rowIndex, columnId, value) => {
+        const result = updateVariable({
+          scope: 'global-variable-list',
+          associatedList: listName,
+          rowId: rowIndex,
+          data: { [columnId]: value },
+        })
+        if (result.ok) {
+          handleFileAndWorkspaceSavedState(listName)
+        }
+        return result
+      }}
+      tableContext='Variables'
+    />
+  )
+}
+
+export { GlobalVariableListTable, GlobalVariablesTable }

--- a/src/frontend/services/st-lsp/__tests__/goto-definition-redirect.test.ts
+++ b/src/frontend/services/st-lsp/__tests__/goto-definition-redirect.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import type { PLCDataType, PLCPou } from '../../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCGlobalVariableList, PLCPou } from '../../../../middleware/shared/ports/types'
 import { openPLCStoreBase } from '../../../store'
 import * as featureFlags from '../../../utils/feature-flags'
 import { setBodyLineOffset } from '../../lsp-shared/body-offsets'
@@ -348,5 +348,105 @@ describe('redirectDefinitionToStore', () => {
         range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } },
       }),
     ).toBe(false)
+  })
+})
+
+describe('redirectDefinitionToStore — global variable lists', () => {
+  const lists: PLCGlobalVariableList[] = [
+    {
+      name: 'GVL',
+      variables: [
+        {
+          name: 'Output1',
+          class: 'global',
+          type: { definition: 'base-type', value: 'BOOL' },
+          location: '',
+          documentation: '',
+        },
+        {
+          name: 'Output2',
+          class: 'global',
+          type: { definition: 'base-type', value: 'BOOL' },
+          location: '',
+          documentation: '',
+        },
+      ],
+    },
+    {
+      name: 'MyGlobalList',
+      variables: [
+        {
+          name: 'MotorSpeed',
+          class: 'global',
+          type: { definition: 'base-type', value: 'INT' },
+          location: '',
+          documentation: '',
+        },
+      ],
+    },
+  ]
+
+  const setLists = (globalVariableLists: PLCGlobalVariableList[]) => {
+    openPLCStoreBase.setState((s) => ({
+      ...s,
+      project: {
+        ...s.project,
+        data: { ...s.project.data, pous: [], dataTypes: [], remoteDevices: [], globalVariableLists },
+      },
+      editor: { type: 'available', meta: { name: 'available' } },
+      editors: [],
+      tabs: [],
+      selectedTab: null,
+    }))
+  }
+
+  const at = (line: number) => ({
+    uri: 'inmemory://globals/__lists__.st',
+    range: { start: { line, character: 2 }, end: { line, character: 8 } },
+  })
+
+  beforeEach(() => setLists(lists))
+
+  /**
+   * The synthesized document, for reference — the lines the LSP points at:
+   *
+   *   0  TYPE
+   *   1  GVL_TYPE : STRUCT
+   *   2    Output1 : BOOL;
+   *   3    Output2 : BOOL;
+   *   4  END_STRUCT;
+   *   5  MyGlobalList_TYPE : STRUCT
+   *   6    MotorSpeed : INT;
+   *   7  END_STRUCT;
+   *   8  END_TYPE
+   *   9  VAR_GLOBAL
+   *  10    GVL : GVL_TYPE;
+   *  11    MyGlobalList : MyGlobalList_TYPE;
+   *  12  END_VAR
+   */
+  it('opens the owning list from a member line', () => {
+    // A member line carries no list name: the mapping walks back to its STRUCT header.
+    expect(redirectDefinitionToStore(at(2))).toBe(true)
+    expect(openPLCStoreBase.getState().selectedTab).toBe('GVL')
+  })
+
+  it('opens the second list from ITS member line, not the first', () => {
+    expect(redirectDefinitionToStore(at(6))).toBe(true)
+    expect(openPLCStoreBase.getState().selectedTab).toBe('MyGlobalList')
+  })
+
+  it('opens the list from its instance line', () => {
+    expect(redirectDefinitionToStore(at(11))).toBe(true)
+    expect(openPLCStoreBase.getState().selectedTab).toBe('MyGlobalList')
+  })
+
+  it('returns false when the project has no lists, so Monaco can fall back', () => {
+    setLists([])
+    expect(redirectDefinitionToStore(at(2))).toBe(false)
+  })
+
+  it('returns false for a line above any list, rather than guessing', () => {
+    // Line 0 is `TYPE` — no struct header above it to attribute the position to.
+    expect(redirectDefinitionToStore(at(0))).toBe(false)
   })
 })

--- a/src/frontend/services/st-lsp/__tests__/goto-definition-redirect.test.ts
+++ b/src/frontend/services/st-lsp/__tests__/goto-definition-redirect.test.ts
@@ -425,7 +425,7 @@ describe('redirectDefinitionToStore — global variable lists', () => {
    *  12  END_VAR
    */
   it('opens the owning list from a member line', () => {
-    // A member line carries no list name: the mapping walks back to its STRUCT header.
+    // A member line carries no list name; ownership comes from where the line sits.
     expect(redirectDefinitionToStore(at(2))).toBe(true)
     expect(openPLCStoreBase.getState().selectedTab).toBe('GVL')
   })
@@ -446,7 +446,79 @@ describe('redirectDefinitionToStore — global variable lists', () => {
   })
 
   it('returns false for a line above any list, rather than guessing', () => {
-    // Line 0 is `TYPE` — no struct header above it to attribute the position to.
+    // Line 0 is `TYPE` — a frame line, owned by no list.
     expect(redirectDefinitionToStore(at(0))).toBe(false)
+  })
+
+  it('opens the list from its STRUCT header', () => {
+    expect(redirectDefinitionToStore(at(5))).toBe(true)
+    expect(openPLCStoreBase.getState().selectedTab).toBe('MyGlobalList')
+  })
+
+  it.each([
+    ['END_STRUCT; of the first list', 4],
+    ['END_TYPE', 8],
+    ['VAR_GLOBAL', 9],
+    ['END_VAR', 12],
+    ['a line past the end of the document', 99],
+  ])('returns false on %s rather than the nearest list', (_label, line) => {
+    expect(redirectDefinitionToStore(at(line))).toBe(false)
+  })
+
+  it('opens the list a member is declared IN, even when the member is named after another list', () => {
+    // Same shape as an instance line, and the name of a real list: resolving by name would
+    // open `MyGlobalList` instead of the list this member actually belongs to.
+    setLists([
+      {
+        name: 'GVL',
+        variables: [
+          {
+            name: 'MyGlobalList',
+            class: 'global',
+            type: { definition: 'base-type', value: 'BOOL' },
+            location: '',
+            documentation: '',
+          },
+        ],
+      },
+      {
+        name: 'MyGlobalList',
+        variables: [
+          {
+            name: 'MotorSpeed',
+            class: 'global',
+            type: { definition: 'base-type', value: 'INT' },
+            location: '',
+            documentation: '',
+          },
+        ],
+      },
+    ])
+    // 0 TYPE / 1 GVL_TYPE : STRUCT / 2   MyGlobalList : BOOL;
+    expect(redirectDefinitionToStore(at(2))).toBe(true)
+    expect(openPLCStoreBase.getState().selectedTab).toBe('GVL')
+  })
+
+  it('skips a memberless list, which contributes no lines to the document', () => {
+    // An empty STRUCT is not a legal type, so the serializers omit such a list entirely —
+    // the line map has to omit it too or every line after it is attributed to the wrong list.
+    setLists([
+      { name: 'Empty', variables: [] },
+      {
+        name: 'Real',
+        variables: [
+          {
+            name: 'Flag',
+            class: 'global',
+            type: { definition: 'base-type', value: 'BOOL' },
+            location: '',
+            documentation: '',
+          },
+        ],
+      },
+    ])
+    // 0 TYPE / 1 Real_TYPE : STRUCT / 2   Flag : BOOL;
+    expect(redirectDefinitionToStore(at(2))).toBe(true)
+    expect(openPLCStoreBase.getState().selectedTab).toBe('Real')
   })
 })

--- a/src/frontend/services/st-lsp/__tests__/project-sync.test.ts
+++ b/src/frontend/services/st-lsp/__tests__/project-sync.test.ts
@@ -145,6 +145,145 @@ function setProjectPous(pous: PLCPou[]) {
 beforeEach(() => {
   // Clear any leftover POUs from prior tests.
   setProjectPous([])
+  // And any leftover lists: one left in the store adds its synthesized document to every
+  // later test's didOpen/didChange/didClose counts.
+  openPLCStoreBase.setState((state) => ({
+    ...state,
+    project: { ...state.project, data: { ...state.project.data, globalVariableLists: [] } },
+  }))
+})
+
+describe('attachProjectSync — global variable lists', () => {
+  const seedList = () => {
+    openPLCStoreBase.setState((state) => ({
+      ...state,
+      project: {
+        ...state.project,
+        data: {
+          ...state.project.data,
+          pous: [],
+          globalVariableLists: [
+            {
+              name: 'GVL',
+              variables: [
+                {
+                  name: 'Output1',
+                  class: 'global' as const,
+                  type: { definition: 'base-type' as const, value: 'BOOL' },
+                  location: '',
+                  documentation: '',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    }))
+  }
+
+  const listDocCalls = (mock: jest.Mock) =>
+    mock.mock.calls.filter(([uri]: [string]) => uri === 'inmemory://globals/__lists__.st')
+
+  it('opens the synthesized document with the lists already in the store', () => {
+    seedList()
+    const service = makeStubService()
+    const handle = attachProjectSync(service)
+
+    const [, text] = listDocCalls(service.openDocument)[0]
+    expect(text).toContain('GVL_TYPE : STRUCT')
+    expect(text).toContain('Output1 : BOOL;')
+    expect(text).toContain('GVL : GVL_TYPE;')
+    handle.dispose()
+  })
+
+  it('refreshes the document when a member is edited through the table', () => {
+    // The table writes one cell at a time through the shared variable action; the LSP has to
+    // hear about it, or the editor keeps completing `GVL.` against the members as they were.
+    seedList()
+    const service = makeStubService()
+    const handle = attachProjectSync(service)
+    service.changeDocument.mockClear()
+
+    openPLCStoreBase.getState().projectActions.updateVariable({
+      scope: 'global-variable-list',
+      associatedList: 'GVL',
+      rowId: 0,
+      data: { name: 'MotorEnable' },
+    })
+
+    const calls = listDocCalls(service.changeDocument)
+    expect(calls.length).toBeGreaterThan(0)
+    expect(calls[calls.length - 1][1]).toContain('MotorEnable : BOOL;')
+    handle.dispose()
+  })
+
+  it('re-publishes a POU that references the list, so it is analysed against the new members', () => {
+    // The POU's own text does not change when a member is renamed — it only ever names the
+    // list — so without this the worker answers `GVL.` from the analysis it already had.
+    seedList()
+    setProjectPous([makeStPou('Uses', 'localCopy := GVL.Output1;'), makeStPou('Ignores', 'x := 1;')])
+    const service = makeStubService()
+    const handle = attachProjectSync(service)
+    service.changeDocument.mockClear()
+
+    openPLCStoreBase.getState().projectActions.updateVariable({
+      scope: 'global-variable-list',
+      associatedList: 'GVL',
+      rowId: 0,
+      data: { name: 'MotorEnable' },
+    })
+
+    const uris = service.changeDocument.mock.calls.map(([uri]: [string]) => uri)
+    expect(uris).toContain('inmemory://pou/Uses.st')
+    // And only that one: re-publishing every document per edited cell is analysis work
+    // nothing asked for.
+    expect(uris).not.toContain('inmemory://pou/Ignores.st')
+    handle.dispose()
+  })
+
+  it('does not re-publish consumers when the edit leaves the declaration identical', () => {
+    // Member documentation is not part of the declaration, so an edit to it moves the store
+    // without giving the worker anything to re-analyse.
+    seedList()
+    setProjectPous([makeStPou('Uses', 'localCopy := GVL.Output1;')])
+    const service = makeStubService()
+    const handle = attachProjectSync(service)
+    service.changeDocument.mockClear()
+
+    openPLCStoreBase.getState().projectActions.updateVariable({
+      scope: 'global-variable-list',
+      associatedList: 'GVL',
+      rowId: 0,
+      data: { documentation: 'now documented' },
+    })
+
+    expect(service.changeDocument).not.toHaveBeenCalled()
+    handle.dispose()
+  })
+
+  it('refreshes the document when a member is added through the table', () => {
+    seedList()
+    const service = makeStubService()
+    const handle = attachProjectSync(service)
+    service.changeDocument.mockClear()
+
+    openPLCStoreBase.getState().projectActions.createVariable({
+      scope: 'global-variable-list',
+      associatedList: 'GVL',
+      data: {
+        name: 'Extra',
+        class: 'global',
+        type: { definition: 'base-type', value: 'INT' },
+        location: '',
+        documentation: '',
+      },
+    })
+
+    const calls = listDocCalls(service.changeDocument)
+    expect(calls.length).toBeGreaterThan(0)
+    expect(calls[calls.length - 1][1]).toContain('Extra : INT;')
+    handle.dispose()
+  })
 })
 
 describe('attachProjectSync', () => {

--- a/src/frontend/services/st-lsp/goto-definition-redirect.ts
+++ b/src/frontend/services/st-lsp/goto-definition-redirect.ts
@@ -35,17 +35,13 @@
 
 import type { Location, LocationLink } from 'vscode-languageserver-protocol'
 
-import type { PLCDataType } from '../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCGlobalVariableList } from '../../../middleware/shared/ports/types'
 import { sanitizeAxisName, softMotionAxisNames } from '../../../middleware/shared/utils/ethercat'
 import { openPLCStoreBase } from '../../store'
 import { CreateEditorObjectFromTab } from '../../store/slices/tabs/utils'
 import { isDataTypeFilesEnabled } from '../../utils/feature-flags'
 import { dataTypeLineSpans } from '../../utils/PLC/data-type-serializer'
-import {
-  globalVariableListTypeName,
-  serializeGlobalVariableListInstances,
-  serializeGlobalVariableListsToTypes,
-} from '../../utils/PLC/global-variable-list-serializer'
+import { serializeGlobalVariableListsToTypes } from '../../utils/PLC/global-variable-list-serializer'
 import { getBodyLineOffset } from '../lsp-shared/body-offsets'
 import { normaliseLocation, routeToPou, routeToPouBody, routeToPouPreamble } from '../lsp-shared/definition-redirect'
 import {
@@ -246,39 +242,37 @@ function openGlobalVariableListEditor(name: string): boolean {
 }
 
 /**
- * Which list a line of the synthesized Global-Variable-Lists document belongs to.
+ * Which list owns each line of the synthesized Global-Variable-Lists document.
  *
- * The document is rebuilt here with the SAME serializers that produced it, rather than by
- * counting lines against an assumed layout: the two cannot drift, and adding a list or a
- * member cannot silently shift the mapping.
+ * Ownership is POSITIONAL, and derived from the same serializers that produce the document —
+ * each list's own block is re-serialized to learn how many lines it takes — so the map cannot
+ * drift from the text, and adding a list or a member cannot silently shift it.
  *
- * A member line (`Output1 : BOOL;`) carries no list name, so the search walks BACKWARDS to the
- * nearest `<name>_TYPE : STRUCT` header, which is the struct the member sits in. An instance
- * line (`GVL : GVL_TYPE;`) names its list directly — it is only accepted when the name really
- * is a list's, since a member line has the same shape.
+ * Positional is also the only correct reading. A member line (`Output1 : BOOL;`) and an
+ * instance line (`GVL : GVL_TYPE;`) are the same shape, so resolving by name would send a
+ * definition on a member that happens to be called `MyGlobalList` to the list of that name
+ * instead of to the list the member is declared in. The frame lines — `TYPE`, `END_STRUCT;`,
+ * `END_TYPE`, `VAR_GLOBAL`, `END_VAR` — belong to no list and map to `undefined`, so a
+ * position on one is reported as unresolved rather than as the nearest list.
  */
-function globalVariableListAtLine(lineLsp: number): string | undefined {
-  const lists = openPLCStoreBase.getState().project.data.globalVariableLists ?? []
-  if (lists.length === 0) return undefined
+function globalVariableListLineOwners(lists: PLCGlobalVariableList[]): (string | undefined)[] {
+  const withMembers = lists.filter((list) => list.variables.length > 0)
+  if (withMembers.length === 0) return []
 
-  const doc = `${serializeGlobalVariableListsToTypes(lists)}${serializeGlobalVariableListInstances(lists)}`.split('\n')
-
-  for (let line = Math.min(lineLsp, doc.length - 1); line >= 0; line--) {
-    const text = doc[line] ?? ''
-
-    const struct = /^\s*(\w+)\s*:\s*STRUCT\s*$/i.exec(text)
-    if (struct) {
-      const typeName = struct[1]
-      return lists.find((list) => globalVariableListTypeName(list.name) === typeName)?.name
-    }
-
-    const declaration = /^\s*(\w+)\s*:\s*\w+;\s*$/.exec(text)
-    const named = declaration
-      ? lists.find((list) => list.name.toLowerCase() === declaration[1].toLowerCase())
-      : undefined
-    if (named) return named.name
+  const owners: (string | undefined)[] = [undefined] // TYPE
+  for (const list of withMembers) {
+    // `TYPE`, the block, `END_STRUCT;`, `END_TYPE`, `''` — keep the block and its END_STRUCT.
+    const block = serializeGlobalVariableListsToTypes([list]).split('\n').slice(1, -2)
+    block.forEach((_line, index) => owners.push(index === block.length - 1 ? undefined : list.name))
   }
-  return undefined
+  owners.push(undefined) // END_TYPE
+
+  owners.push(undefined) // VAR_GLOBAL
+  // One instance line per list, in this order — the serializer filters the same way.
+  for (const list of withMembers) owners.push(list.name)
+  owners.push(undefined) // END_VAR
+
+  return owners
 }
 
 /**
@@ -289,7 +283,8 @@ function globalVariableListAtLine(lineLsp: number): string | undefined {
  * the same trap the data-types branch documents.
  */
 function redirectGlobalVariableList(lineLsp: number): boolean {
-  const name = globalVariableListAtLine(lineLsp)
+  const lists = openPLCStoreBase.getState().project.data.globalVariableLists ?? []
+  const name = globalVariableListLineOwners(lists)[lineLsp]
   if (!name) return false
   return openGlobalVariableListEditor(name)
 }

--- a/src/frontend/services/st-lsp/goto-definition-redirect.ts
+++ b/src/frontend/services/st-lsp/goto-definition-redirect.ts
@@ -41,11 +41,17 @@ import { openPLCStoreBase } from '../../store'
 import { CreateEditorObjectFromTab } from '../../store/slices/tabs/utils'
 import { isDataTypeFilesEnabled } from '../../utils/feature-flags'
 import { dataTypeLineSpans } from '../../utils/PLC/data-type-serializer'
+import {
+  globalVariableListTypeName,
+  serializeGlobalVariableListInstances,
+  serializeGlobalVariableListsToTypes,
+} from '../../utils/PLC/global-variable-list-serializer'
 import { getBodyLineOffset } from '../lsp-shared/body-offsets'
 import { normaliseLocation, routeToPou, routeToPouBody, routeToPouPreamble } from '../lsp-shared/definition-redirect'
 import {
   DATA_TYPES_URI,
   DT_VIEW_FRAME_LINE_COUNT,
+  GLOBAL_VARIABLE_LISTS_URI,
   parsePouUri,
   RESOURCE_GLOBALS_URI,
   SOFTMOTION_GLOBALS_URI,
@@ -212,6 +218,82 @@ function openResourceEditor(): boolean {
   return true
 }
 
+/**
+ * Open a Global Variable List's editor, mirroring the project-tree click path.
+ */
+function openGlobalVariableListEditor(name: string): boolean {
+  const tabProps: Parameters<typeof CreateEditorObjectFromTab>[0] = {
+    name,
+    path: `/data/global-variables/${name}`,
+    elementType: { type: 'global-variable-list' },
+  }
+  const {
+    editorActions: { setEditor, addModel, getEditorFromEditors },
+    tabsActions: { updateTabs, setSelectedTab },
+  } = openPLCStoreBase.getState()
+  updateTabs(tabProps)
+  const existing = getEditorFromEditors(name)
+  if (existing) {
+    addModel(existing)
+    setEditor(existing)
+  } else {
+    const model = CreateEditorObjectFromTab(tabProps)
+    addModel(model)
+    setEditor(model)
+  }
+  setSelectedTab(name)
+  return true
+}
+
+/**
+ * Which list a line of the synthesized Global-Variable-Lists document belongs to.
+ *
+ * The document is rebuilt here with the SAME serializers that produced it, rather than by
+ * counting lines against an assumed layout: the two cannot drift, and adding a list or a
+ * member cannot silently shift the mapping.
+ *
+ * A member line (`Output1 : BOOL;`) carries no list name, so the search walks BACKWARDS to the
+ * nearest `<name>_TYPE : STRUCT` header, which is the struct the member sits in. An instance
+ * line (`GVL : GVL_TYPE;`) names its list directly — it is only accepted when the name really
+ * is a list's, since a member line has the same shape.
+ */
+function globalVariableListAtLine(lineLsp: number): string | undefined {
+  const lists = openPLCStoreBase.getState().project.data.globalVariableLists ?? []
+  if (lists.length === 0) return undefined
+
+  const doc = `${serializeGlobalVariableListsToTypes(lists)}${serializeGlobalVariableListInstances(lists)}`.split('\n')
+
+  for (let line = Math.min(lineLsp, doc.length - 1); line >= 0; line--) {
+    const text = doc[line] ?? ''
+
+    const struct = /^\s*(\w+)\s*:\s*STRUCT\s*$/i.exec(text)
+    if (struct) {
+      const typeName = struct[1]
+      return lists.find((list) => globalVariableListTypeName(list.name) === typeName)?.name
+    }
+
+    const declaration = /^\s*(\w+)\s*:\s*\w+;\s*$/.exec(text)
+    const named = declaration
+      ? lists.find((list) => list.name.toLowerCase() === declaration[1].toLowerCase())
+      : undefined
+    if (named) return named.name
+  }
+  return undefined
+}
+
+/**
+ * Global-Variable-Lists doc → open the list's own editor rather than the synthesised
+ * (non-editable) STRUCT and instance declarations.
+ *
+ * Monaco has no editor host for that URI, so without this the redirect dead-ends silently —
+ * the same trap the data-types branch documents.
+ */
+function redirectGlobalVariableList(lineLsp: number): boolean {
+  const name = globalVariableListAtLine(lineLsp)
+  if (!name) return false
+  return openGlobalVariableListEditor(name)
+}
+
 export function redirectDefinitionToStore(loc: Location | LocationLink): boolean {
   const target = normaliseLocation(loc)
 
@@ -225,6 +307,11 @@ export function redirectDefinitionToStore(loc: Location | LocationLink): boolean
   // than the synthesised (non-editable) global declaration.
   if (target.uri === SOFTMOTION_GLOBALS_URI) {
     return redirectSoftMotionAxis(target.lineLsp)
+  }
+
+  // Global-Variable-Lists doc → open the list's editor.
+  if (target.uri === GLOBAL_VARIABLE_LISTS_URI) {
+    return redirectGlobalVariableList(target.lineLsp)
   }
 
   // Datatypes URI → open the matching data-type editor tab.  The LSP

--- a/src/frontend/services/st-lsp/project-sync.ts
+++ b/src/frontend/services/st-lsp/project-sync.ts
@@ -25,15 +25,26 @@
  * `refreshStlibs()` on the service.
  */
 
-import type { PLCDataType, PLCPou, PLCRemoteDevice, PLCVariable } from '../../../middleware/shared/ports/types'
+import type {
+  PLCDataType,
+  PLCGlobalVariableList,
+  PLCPou,
+  PLCRemoteDevice,
+  PLCVariable,
+} from '../../../middleware/shared/ports/types'
 import { serializeSoftMotionAxisGlobalsToST } from '../../../middleware/shared/utils/ethercat'
 import { openPLCStoreBase } from '../../store'
 import { serializeDataTypesToST } from '../../utils/PLC/data-type-serializer'
+import {
+  serializeGlobalVariableListInstances,
+  serializeGlobalVariableListsToTypes,
+} from '../../utils/PLC/global-variable-list-serializer'
 import { serializePouSignatureToSTWithBodyOffset } from '../../utils/PLC/pou-signature-serializer'
 import { serializeResourceGlobalsToST } from '../../utils/PLC/resource-globals-serializer'
 import { deleteBodyLineOffset, setBodyLineOffset } from '../lsp-shared/body-offsets'
 import {
   DATA_TYPES_URI,
+  GLOBAL_VARIABLE_LISTS_URI,
   pouUri,
   RESOURCE_GLOBALS_URI,
   SOFTMOTION_GLOBALS_URI,
@@ -134,6 +145,28 @@ export function attachProjectSync(service: StLspService): ProjectSyncHandle {
   // A `VAR_GLOBAL <axis> : AXIS_REF_SM3` per recognized CiA 402 drive, so editor
   // code that names an axis resolves it (AXIS_REF_SM3 comes from the bundled
   // stlib the LSP already ingests).
+  /**
+   * Global Variable Lists, as the compiler sees them: a STRUCT type per list and one global
+   * instance of each, built by the SAME serializers the transpiler uses. Sharing those is the
+   * point — the language server's picture of a GVL cannot drift from the one that compiles,
+   * so `GVL.Output1` completing in the editor means it will also compile.
+   *
+   * This is what puts a GVL in scope AT ALL. A POU never declares one — historically an
+   * OpenPLC global reached a POU through a `VAR_EXTERNAL` the user wrote, and a list has no
+   * such declaration anywhere — so without this document strucpp has never heard the name and
+   * every consumer fails identically: no completion in ST, none in the graphical editors, and
+   * a typed-in `GVL.Output2` resolves to nothing and is drawn as an unknown symbol.
+   */
+  function reconcileGlobalVariableLists(lists: PLCGlobalVariableList[] | undefined): void {
+    const all = lists ?? []
+    // Both serializers already return '' for a list with no members, and each ends in a
+    // newline, so `END_TYPE` and `VAR_GLOBAL` never run together.
+    reconcileSyntheticDoc(
+      GLOBAL_VARIABLE_LISTS_URI,
+      `${serializeGlobalVariableListsToTypes(all)}${serializeGlobalVariableListInstances(all)}`,
+    )
+  }
+
   function reconcileSoftMotionGlobals(remoteDevices: PLCRemoteDevice[] | undefined): void {
     reconcileSyntheticDoc(SOFTMOTION_GLOBALS_URI, serializeSoftMotionAxisGlobalsToST({ remoteDevices } as never))
   }
@@ -151,6 +184,7 @@ export function attachProjectSync(service: StLspService): ProjectSyncHandle {
     seenUris.add(DATA_TYPES_URI)
     seenUris.add(RESOURCE_GLOBALS_URI)
     seenUris.add(SOFTMOTION_GLOBALS_URI)
+    seenUris.add(GLOBAL_VARIABLE_LISTS_URI)
 
     for (const pou of pous) {
       seenNames.add(pou.name)
@@ -233,6 +267,13 @@ export function attachProjectSync(service: StLspService): ProjectSyncHandle {
     (state) => state.project.data.remoteDevices,
     (remoteDevices) => reconcileSoftMotionGlobals(remoteDevices),
   )
+  // Global Variable Lists change on their own too — creating one, renaming it, or editing a
+  // member has to refresh the synthesized document, or the editor keeps completing against
+  // the list as it was.
+  const unsubscribeGlobalVariableLists = openPLCStoreBase.subscribe(
+    (state) => state.project.data.globalVariableLists,
+    (lists) => reconcileGlobalVariableLists(lists),
+  )
   // Every document that declares variables is serialized against the alias →
   // address index, so a producer-only change must re-emit them.  Renaming an
   // alias already cascades into `project.data.pous` (via `renameAlias`) and
@@ -257,6 +298,7 @@ export function attachProjectSync(service: StLspService): ProjectSyncHandle {
   reconcileDataTypes(openPLCStoreBase.getState().project.data.dataTypes)
   reconcileResourceGlobals(openPLCStoreBase.getState().project.data.configurations.resource.globalVariables)
   reconcileSoftMotionGlobals(openPLCStoreBase.getState().project.data.remoteDevices)
+  reconcileGlobalVariableLists(openPLCStoreBase.getState().project.data.globalVariableLists)
   reconcile(openPLCStoreBase.getState().project.data.pous)
 
   return {
@@ -265,6 +307,7 @@ export function attachProjectSync(service: StLspService): ProjectSyncHandle {
       reconcileDataTypes(openPLCStoreBase.getState().project.data.dataTypes)
       reconcileResourceGlobals(openPLCStoreBase.getState().project.data.configurations.resource.globalVariables)
       reconcileSoftMotionGlobals(openPLCStoreBase.getState().project.data.remoteDevices)
+      reconcileGlobalVariableLists(openPLCStoreBase.getState().project.data.globalVariableLists)
       reconcile(openPLCStoreBase.getState().project.data.pous)
     },
     forceResync() {
@@ -285,6 +328,7 @@ export function attachProjectSync(service: StLspService): ProjectSyncHandle {
       unsubscribeDataTypes()
       unsubscribeResourceGlobals()
       unsubscribeRemoteDevices()
+      unsubscribeGlobalVariableLists()
       unsubscribeAliasIndex()
       // Close every doc we'd opened so the worker stays consistent
       // if the service is restarted in the same session.

--- a/src/frontend/services/st-lsp/project-sync.ts
+++ b/src/frontend/services/st-lsp/project-sync.ts
@@ -36,6 +36,8 @@ import { serializeSoftMotionAxisGlobalsToST } from '../../../middleware/shared/u
 import { openPLCStoreBase } from '../../store'
 import { serializeDataTypesToST } from '../../utils/PLC/data-type-serializer'
 import {
+  globalVariableListIsReferencedIn,
+  referenceSearchText,
   serializeGlobalVariableListInstances,
   serializeGlobalVariableListsToTypes,
 } from '../../utils/PLC/global-variable-list-serializer'
@@ -111,23 +113,25 @@ export function attachProjectSync(service: StLspService): ProjectSyncHandle {
   // globals, softmotion axes …) against the worker: open on first non-empty
   // text, didChange on a text change, didClose when it becomes empty. Centralised
   // so every synthesized doc shares one diff engine instead of copy-pasting it.
-  function reconcileSyntheticDoc(uri: string, nextText: string): void {
-    if (disposed) return
+  function reconcileSyntheticDoc(uri: string, nextText: string): boolean {
+    if (disposed) return false
     const previousText = snapshot.contentByUri.get(uri)
     if (nextText.length === 0) {
-      if (previousText !== undefined) {
-        service.closeDocument(uri)
-        snapshot.contentByUri.delete(uri)
-      }
-      return
+      if (previousText === undefined) return false
+      service.closeDocument(uri)
+      snapshot.contentByUri.delete(uri)
+      return true
     }
     if (previousText === undefined) {
       service.openDocument(uri, nextText)
     } else if (previousText !== nextText) {
       snapshot.version += 1
       service.changeDocument(uri, nextText, snapshot.version)
+    } else {
+      return false
     }
     snapshot.contentByUri.set(uri, nextText)
+    return true
   }
 
   // The whole `TYPE … END_TYPE` block, so any POU that references a user data
@@ -157,14 +161,44 @@ export function attachProjectSync(service: StLspService): ProjectSyncHandle {
    * every consumer fails identically: no completion in ST, none in the graphical editors, and
    * a typed-in `GVL.Output2` resolves to nothing and is drawn as an unknown symbol.
    */
-  function reconcileGlobalVariableLists(lists: PLCGlobalVariableList[] | undefined): void {
+  function reconcileGlobalVariableLists(lists: PLCGlobalVariableList[] | undefined): boolean {
     const all = lists ?? []
     // Both serializers already return '' for a list with no members, and each ends in a
     // newline, so `END_TYPE` and `VAR_GLOBAL` never run together.
-    reconcileSyntheticDoc(
+    return reconcileSyntheticDoc(
       GLOBAL_VARIABLE_LISTS_URI,
       `${serializeGlobalVariableListsToTypes(all)}${serializeGlobalVariableListInstances(all)}`,
     )
+  }
+
+  /**
+   * Re-publish the POU documents that reach into a list.
+   *
+   * Changing the synthesized document does not change one character of any POU: a POU only
+   * ever names the list (`GVL : GVL_TYPE;`), never its members. The worker analyses per
+   * document and answers from that analysis, so with the declaration alone re-sent, a POU
+   * keeps the scope it was last analysed against — `GVL.` then completes against the members
+   * as they were one edit ago, whichever view made the edit. Re-sending the POU with a bumped
+   * version is the trigger; the text is deliberately unchanged.
+   *
+   * Only the POUs that reference a list are re-sent. Re-publishing every document on every
+   * edited cell is analysis work nothing asked for, and `referenceSearchText` is the same
+   * scan the `VAR_EXTERNAL` projection already runs per POU.
+   */
+  function republishGlobalVariableListConsumers(lists: PLCGlobalVariableList[] | undefined): void {
+    if (disposed) return
+    const declared = (lists ?? []).filter((list) => list.variables.length > 0)
+    if (declared.length === 0) return
+
+    for (const pou of openPLCStoreBase.getState().project.data.pous) {
+      const searchText = referenceSearchText(pou)
+      if (!declared.some((list) => globalVariableListIsReferencedIn(list.name, searchText))) continue
+      const uri = snapshot.uriByName.get(pou.name)
+      const text = uri === undefined ? undefined : snapshot.contentByUri.get(uri)
+      if (uri === undefined || text === undefined) continue
+      snapshot.version += 1
+      service.changeDocument(uri, text, snapshot.version)
+    }
   }
 
   function reconcileSoftMotionGlobals(remoteDevices: PLCRemoteDevice[] | undefined): void {
@@ -272,7 +306,11 @@ export function attachProjectSync(service: StLspService): ProjectSyncHandle {
   // the list as it was.
   const unsubscribeGlobalVariableLists = openPLCStoreBase.subscribe(
     (state) => state.project.data.globalVariableLists,
-    (lists) => reconcileGlobalVariableLists(lists),
+    (lists) => {
+      // A documentation-only edit moves the store without moving the document — nothing to
+      // re-analyse then.
+      if (reconcileGlobalVariableLists(lists)) republishGlobalVariableListConsumers(lists)
+    },
   )
   // Every document that declares variables is serialized against the alias →
   // address index, so a producer-only change must re-emit them.  Renaming an

--- a/src/frontend/services/st-lsp/types.ts
+++ b/src/frontend/services/st-lsp/types.ts
@@ -64,6 +64,20 @@ export const SOFTMOTION_GLOBALS_URI = 'inmemory://softmotion/__axes__.st'
  */
 export const RESOURCE_GLOBALS_URI = 'inmemory://globals/__resource__.st'
 
+/**
+ * URI for the synthesized Global-Variable-List document — one STRUCT type per list plus a
+ * global instance of each, which is exactly what the compiler generates for them.
+ *
+ * Emitted as a **bare top-level `VAR_GLOBAL` block**, the same way the SoftMotion axes are:
+ * strucpp puts top-level globals in the ambient scope, so `GVL.Output1` resolves from any POU
+ * without a `VAR_EXTERNAL` — and the user's own documents stay byte-for-byte what they wrote.
+ * (The compiler needs those externals because it puts the instances inside a CONFIGURATION;
+ * here they are ambient, so it does not.)
+ *
+ * Single fixed URI per session; the lists are project-global.
+ */
+export const GLOBAL_VARIABLE_LISTS_URI = 'inmemory://globals/__lists__.st'
+
 /** Public service the rest of the renderer talks to. */
 export interface StLspService {
   /**

--- a/src/frontend/store/__tests__/ladder-slice.test.ts
+++ b/src/frontend/store/__tests__/ladder-slice.test.ts
@@ -2,7 +2,7 @@ import type { Edge, Node } from '@xyflow/react'
 import { produce } from 'immer'
 import { createStore } from 'zustand/vanilla'
 
-import { createLadderFlowSlice, needsPositionRecovery } from '../slices/ladder/slice'
+import { createLadderFlowSlice, elementsSurvived, needsPositionRecovery } from '../slices/ladder/slice'
 import type { LadderFlowSlice, LadderFlowType, RungLadderState } from '../slices/ladder/types'
 
 function makeStore() {
@@ -243,6 +243,25 @@ describe('createLadderFlowSlice', () => {
       ).not.toThrow()
     })
 
+    it('falls back to default bounds when the file carries a non-array in their place', () => {
+      // `?? []` covers null and undefined only; an object here made the destructuring throw,
+      // and the rung then kept the geometry recovery was meant to replace.
+      const rung = {
+        ...makeRung({
+          nodes: [
+            makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
+            makeNode({ id: 'c1', type: 'contact', position: { x: 0, y: 0 } }),
+          ],
+        }),
+        defaultBounds: {} as unknown as number[],
+      }
+
+      expect(() =>
+        store.getState().ladderFlowActions.addLadderFlow({ name: 'e', updated: false, rungs: [rung] }),
+      ).not.toThrow()
+      expect(store.getState().ladderFlows[0].rungs[0].nodes.map((n) => n.id)).toContain('c1')
+    })
+
     it('falls back to default bounds when the rung carries none it can use', () => {
       const rung = {
         ...makeRung({
@@ -257,6 +276,41 @@ describe('createLadderFlowSlice', () => {
       expect(() =>
         store.getState().ladderFlowActions.addLadderFlow({ name: 'e', updated: false, rungs: [rung] }),
       ).not.toThrow()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // elementsSurvived
+  // -------------------------------------------------------------------------
+  describe('elementsSurvived', () => {
+    const node = (id: string, type: string): Node => makeNode({ id, type })
+
+    it('accepts a layout that moved every element', () => {
+      const before = [node('c1', 'contact'), node('b1', 'block')]
+      expect(elementsSurvived(before, [node('b1', 'block'), node('c1', 'contact')])).toBe(true)
+    })
+
+    it('accepts variable boxes rebuilt under new ids, which the layout does on every block', () => {
+      // `updateVariableBlockPosition` discards the incoming boxes and builds its own, so one
+      // can legitimately become two — or none.
+      const before = [node('b1', 'block'), node('variable_nwl_0_3', 'variable')]
+      const after = [node('b1', 'block'), node('VARIABLE_1', 'variable'), node('VARIABLE_2', 'variable')]
+      expect(elementsSurvived(before, after)).toBe(true)
+    })
+
+    it('rejects an empty result, which would delete the rung', () => {
+      expect(elementsSurvived([node('c1', 'contact')], [])).toBe(false)
+    })
+
+    it('rejects a missing element even when the count is unchanged', () => {
+      const before = [node('c1', 'contact'), node('c2', 'contact')]
+      expect(elementsSurvived(before, [node('c1', 'contact'), node('c3', 'contact')])).toBe(false)
+    })
+
+    it('rejects an element that came back as a different type under its own id', () => {
+      // Same id is not the same element: a contact returned as anything else has been
+      // replaced, not moved, and the rung's incoming geometry is the safer answer.
+      expect(elementsSurvived([node('c1', 'contact')], [node('c1', 'coil')])).toBe(false)
     })
   })
 

--- a/src/frontend/store/__tests__/ladder-slice.test.ts
+++ b/src/frontend/store/__tests__/ladder-slice.test.ts
@@ -2,7 +2,7 @@ import type { Edge, Node } from '@xyflow/react'
 import { produce } from 'immer'
 import { createStore } from 'zustand/vanilla'
 
-import { createLadderFlowSlice } from '../slices/ladder/slice'
+import { createLadderFlowSlice, needsPositionRecovery } from '../slices/ladder/slice'
 import type { LadderFlowSlice, LadderFlowType, RungLadderState } from '../slices/ladder/types'
 
 function makeStore() {
@@ -26,13 +26,23 @@ const defaultRailData = {
   outputConnector: { id: 'rail-out', glbPosition: { x: 0, y: 50 } },
 }
 
+/**
+ * Distinct default positions, one step apart along the rung.
+ *
+ * The origin is not a neutral default: an element at `{0,0}`, or two sharing any point, is how
+ * this editor recognises geometry it cannot use, and loading such a rung rebuilds it
+ * (`needsPositionRecovery`). A fixture that means nothing by its coordinates should not be
+ * saying that.
+ */
+let nextNodeX = 68
+
 function makeNode(overrides?: Partial<Node>): Node {
   const type = overrides?.type ?? 'block'
   const baseData = type === 'powerRail' ? defaultRailData : defaultBlockData
   return {
     id: overrides?.id ?? 'node-1',
     type,
-    position: overrides?.position ?? { x: 0, y: 0 },
+    position: overrides?.position ?? { x: (nextNodeX += 114), y: 38 },
     data: overrides?.data ? { ...baseData, ...overrides.data } : baseData,
     draggable: overrides?.draggable ?? true,
     selectable: overrides?.selectable ?? true,
@@ -94,6 +104,160 @@ describe('createLadderFlowSlice', () => {
   // -------------------------------------------------------------------------
   it('should have correct initial state', () => {
     expect(store.getState().ladderFlows).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // Geometry recovery on load
+  // -------------------------------------------------------------------------
+  describe('needsPositionRecovery', () => {
+    const rungOf = (...positions: (Node['position'] | undefined)[]) =>
+      makeRung({
+        nodes: [
+          makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
+          ...positions.map((position, i) =>
+            position
+              ? makeNode({ id: `c${i}`, type: 'contact', position })
+              : ({ ...makeNode({ id: `c${i}`, type: 'contact' }), position: undefined } as unknown as Node),
+          ),
+          makeNode({ id: 'right-rail-rung-1', type: 'powerRail' }),
+        ],
+      })
+
+    it('leaves a rung whose elements are laid out', () => {
+      expect(needsPositionRecovery(rungOf({ x: 68, y: 38 }, { x: 182, y: 38 }))).toBe(false)
+    })
+
+    it('leaves a rung of rails only', () => {
+      expect(needsPositionRecovery(makeRung())).toBe(false)
+    })
+
+    it('leaves a rung whose nodes carry no position at all', () => {
+      // Not a damaged diagram — one assembled programmatically. Re-laying it out would rewrite
+      // nodes whose author is still holding them.
+      expect(needsPositionRecovery(rungOf(undefined, undefined))).toBe(false)
+    })
+
+    it('rebuilds a rung whose single element sits at the origin', () => {
+      // Conclusive on its own: the rails live at x=0 and the layout never puts an element
+      // there, so a lone coil at {0,0} would otherwise draw on top of the left rail — and a
+      // one-element rung has no duplicate point to give it away.
+      expect(needsPositionRecovery(rungOf({ x: 0, y: 0 }))).toBe(true)
+    })
+
+    it('rebuilds a rung whose elements share a point', () => {
+      expect(needsPositionRecovery(rungOf({ x: 120, y: 38 }, { x: 120, y: 38 }))).toBe(true)
+    })
+
+    it('treats negative zero as the same point', () => {
+      // `-0` and `0` are one point but stringify differently, and `JSON.parse` preserves `-0`.
+      expect(needsPositionRecovery(rungOf({ x: 120, y: -0 }, { x: 120, y: 0 }))).toBe(true)
+    })
+
+    it('rebuilds a rung whose coordinates are not finite', () => {
+      expect(needsPositionRecovery(rungOf({ x: Number.NaN, y: 38 }, { x: 182, y: 38 }))).toBe(true)
+    })
+
+    it('ignores the rails when judging a rung', () => {
+      // Both rails sit at the same point in `makeNode`'s defaults; only elements count.
+      expect(needsPositionRecovery(rungOf({ x: 68, y: 38 }))).toBe(false)
+    })
+  })
+
+  describe('addLadderFlow geometry recovery', () => {
+    it('leaves a laid-out rung untouched, and does not dirty the flow', () => {
+      const rung = makeRung({
+        nodes: [
+          makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
+          makeNode({ id: 'c1', type: 'contact', position: { x: 68, y: 38 } }),
+          makeNode({ id: 'c2', type: 'contact', position: { x: 182, y: 38 } }),
+        ],
+      })
+      store.getState().ladderFlowActions.addLadderFlow({ name: 'e', updated: false, rungs: [rung] })
+
+      const nodes = store.getState().ladderFlows[0].rungs[0].nodes
+      expect(nodes.find((n) => n.id === 'c1')?.position).toEqual({ x: 68, y: 38 })
+      expect(nodes.find((n) => n.id === 'c2')?.position).toEqual({ x: 182, y: 38 })
+      // Nothing was rebuilt, so there is nothing to persist: a load the user did not edit must
+      // not come back dirty.
+      expect(store.getState().ladderFlows[0].updated).toBe(false)
+    })
+
+    it('loads a rung the layout cannot walk, keeping what it arrived with', () => {
+      // A contact with no handle data is a shape the layout throws on. Opening a project must
+      // not fail because one rung could not be rebuilt.
+      const bare = {
+        id: 'c1',
+        type: 'contact',
+        position: { x: 0, y: 0 },
+        data: { variant: 'default' },
+      } as unknown as Node
+      const rung = makeRung({
+        nodes: [makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }), bare],
+        edges: [makeEdge({ id: 'e1', source: 'left-rail-rung-1', target: 'c1' })],
+      })
+
+      expect(() =>
+        store.getState().ladderFlowActions.addLadderFlow({ name: 'e', updated: false, rungs: [rung] }),
+      ).not.toThrow()
+      expect(store.getState().ladderFlows[0].rungs[0].nodes.find((n) => n.id === 'c1')?.position).toEqual({
+        x: 0,
+        y: 0,
+      })
+      // Nothing was rebuilt, so the flow stays clean.
+      expect(store.getState().ladderFlows[0].updated).toBe(false)
+    })
+
+    it('never loses an element to a layout that returns fewer nodes', () => {
+      // The layout can come back short — empty, for an unwired rung — and accepting that would
+      // delete part of the diagram on open. Moving an element is recovery; losing one is not.
+      const rung = makeRung({
+        nodes: [
+          makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
+          makeNode({ id: 'c1', type: 'contact', position: { x: 0, y: 0 } }),
+          makeNode({ id: 'c2', type: 'contact', position: { x: 0, y: 0 } }),
+        ],
+      })
+      store.getState().ladderFlowActions.addLadderFlow({ name: 'e', updated: false, rungs: [rung] })
+
+      const ids = store.getState().ladderFlows[0].rungs[0].nodes.map((n) => n.id)
+      expect(ids).toEqual(['left-rail-rung-1', 'c1', 'c2'])
+    })
+
+    it('loads a rung whose block variant is incomplete', () => {
+      // `getBlockSize` reads every pin's name and class; project-file data is not validated by
+      // any assertion, and sizing must not be a precondition for opening the project.
+      const rung = makeRung({
+        nodes: [
+          makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
+          makeNode({
+            id: 'b1',
+            type: 'block',
+            position: { x: 0, y: 0 },
+            data: { variant: { name: 'AND', variables: [null] } } as unknown as Record<string, unknown>,
+          }),
+        ],
+      })
+
+      expect(() =>
+        store.getState().ladderFlowActions.addLadderFlow({ name: 'e', updated: false, rungs: [rung] }),
+      ).not.toThrow()
+    })
+
+    it('falls back to default bounds when the rung carries none it can use', () => {
+      const rung = {
+        ...makeRung({
+          nodes: [
+            makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
+            makeNode({ id: 'c1', type: 'contact', position: { x: 0, y: 0 } }),
+          ],
+        }),
+        defaultBounds: [] as unknown as number[],
+      }
+
+      expect(() =>
+        store.getState().ladderFlowActions.addLadderFlow({ name: 'e', updated: false, rungs: [rung] }),
+      ).not.toThrow()
+    })
   })
 
   // -------------------------------------------------------------------------

--- a/src/frontend/store/__tests__/ladder-slice.test.ts
+++ b/src/frontend/store/__tests__/ladder-slice.test.ts
@@ -110,6 +110,17 @@ describe('createLadderFlowSlice', () => {
   // Geometry recovery on load
   // -------------------------------------------------------------------------
   describe('needsPositionRecovery', () => {
+    /**
+     * A node with no position at all — planted through `Reflect.set` rather than cast in.
+     * The editor never writes one; a converter or an imported file can, which is what these
+     * fixtures are for, so the value the type forbids is set deliberately instead of the type
+     * being talked out of it.
+     */
+    const withoutPosition = (node: Node): Node => {
+      Reflect.set(node, 'position', undefined)
+      return node
+    }
+
     const rungOf = (...positions: (Node['position'] | undefined)[]) =>
       makeRung({
         nodes: [
@@ -117,7 +128,7 @@ describe('createLadderFlowSlice', () => {
           ...positions.map((position, i) =>
             position
               ? makeNode({ id: `c${i}`, type: 'contact', position })
-              : ({ ...makeNode({ id: `c${i}`, type: 'contact' }), position: undefined } as unknown as Node),
+              : withoutPosition(makeNode({ id: `c${i}`, type: 'contact' })),
           ),
           makeNode({ id: 'right-rail-rung-1', type: 'powerRail' }),
         ],
@@ -185,12 +196,8 @@ describe('createLadderFlowSlice', () => {
     it('loads a rung the layout cannot walk, keeping what it arrived with', () => {
       // A contact with no handle data is a shape the layout throws on. Opening a project must
       // not fail because one rung could not be rebuilt.
-      const bare = {
-        id: 'c1',
-        type: 'contact',
-        position: { x: 0, y: 0 },
-        data: { variant: 'default' },
-      } as unknown as Node
+      const bare = makeNode({ id: 'c1', type: 'contact', position: { x: 0, y: 0 } })
+      Reflect.set(bare, 'data', { variant: 'default' })
       const rung = makeRung({
         nodes: [makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }), bare],
         edges: [makeEdge({ id: 'e1', source: 'left-rail-rung-1', target: 'c1' })],
@@ -223,19 +230,18 @@ describe('createLadderFlowSlice', () => {
       expect(ids).toEqual(['left-rail-rung-1', 'c1', 'c2'])
     })
 
+    /** A block whose variant carries a pin entry that is not a pin — file data, not editor data. */
+    const incompleteBlock = (): Node => {
+      const node = makeNode({ id: 'b1', type: 'block', position: { x: 0, y: 0 } })
+      Reflect.set(node, 'data', { variant: { name: 'AND', variables: [null] } })
+      return node
+    }
+
     it('loads a rung whose block variant is incomplete', () => {
       // `getBlockSize` reads every pin's name and class; project-file data is not validated by
       // any assertion, and sizing must not be a precondition for opening the project.
       const rung = makeRung({
-        nodes: [
-          makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
-          makeNode({
-            id: 'b1',
-            type: 'block',
-            position: { x: 0, y: 0 },
-            data: { variant: { name: 'AND', variables: [null] } } as unknown as Record<string, unknown>,
-          }),
-        ],
+        nodes: [makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }), incompleteBlock()],
       })
 
       expect(() =>
@@ -246,15 +252,15 @@ describe('createLadderFlowSlice', () => {
     it('falls back to default bounds when the file carries a non-array in their place', () => {
       // `?? []` covers null and undefined only; an object here made the destructuring throw,
       // and the rung then kept the geometry recovery was meant to replace.
-      const rung = {
-        ...makeRung({
-          nodes: [
-            makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
-            makeNode({ id: 'c1', type: 'contact', position: { x: 0, y: 0 } }),
-          ],
-        }),
-        defaultBounds: {} as unknown as number[],
-      }
+      const rung = makeRung({
+        nodes: [
+          makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
+          makeNode({ id: 'c1', type: 'contact', position: { x: 0, y: 0 } }),
+        ],
+      })
+      // Planted through `Reflect.set` rather than cast in: the value is one the type forbids
+      // and a project file can still carry, which is the whole point of the fixture.
+      Reflect.set(rung, 'defaultBounds', {})
 
       expect(() =>
         store.getState().ladderFlowActions.addLadderFlow({ name: 'e', updated: false, rungs: [rung] }),
@@ -263,15 +269,13 @@ describe('createLadderFlowSlice', () => {
     })
 
     it('falls back to default bounds when the rung carries none it can use', () => {
-      const rung = {
-        ...makeRung({
-          nodes: [
-            makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
-            makeNode({ id: 'c1', type: 'contact', position: { x: 0, y: 0 } }),
-          ],
-        }),
-        defaultBounds: [] as unknown as number[],
-      }
+      const rung = makeRung({
+        nodes: [
+          makeNode({ id: 'left-rail-rung-1', type: 'powerRail' }),
+          makeNode({ id: 'c1', type: 'contact', position: { x: 0, y: 0 } }),
+        ],
+      })
+      Reflect.set(rung, 'defaultBounds', [])
 
       expect(() =>
         store.getState().ladderFlowActions.addLadderFlow({ name: 'e', updated: false, rungs: [rung] }),

--- a/src/frontend/store/__tests__/ladder-slice.test.ts
+++ b/src/frontend/store/__tests__/ladder-slice.test.ts
@@ -214,6 +214,50 @@ describe('createLadderFlowSlice', () => {
       expect(store.getState().ladderFlows[0].updated).toBe(false)
     })
 
+    it('recovers a wired rung: sizes its block, moves its elements, and marks the flow dirty', () => {
+      // The happy path, which the cases around it only approach: a rung whose elements are all
+      // at the origin but which the layout CAN walk — rails, a block between them, edges
+      // linking the three. Everything recovery is for happens here and nowhere else in this
+      // file: the block is sized from its variant, the layout moves what it was given, and the
+      // flow is marked dirty so the rebuilt coordinates reach disk on the next save.
+      const rung = makeRung({
+        nodes: [
+          makeNode({ id: 'left-rail-rung-1', type: 'powerRail', position: { x: 0, y: 0 } }),
+          makeNode({
+            id: 'b1',
+            type: 'block',
+            position: { x: 0, y: 0 },
+            data: {
+              variant: {
+                name: 'AND',
+                variables: [
+                  { name: 'IN1', class: 'input' },
+                  { name: 'IN2', class: 'input' },
+                  { name: 'OUT', class: 'output' },
+                ],
+              },
+            },
+          }),
+          makeNode({ id: 'right-rail-rung-1', type: 'powerRail', position: { x: 0, y: 0 } }),
+        ],
+        edges: [
+          makeEdge({ id: 'e1', source: 'left-rail-rung-1', target: 'b1' }),
+          makeEdge({ id: 'e2', source: 'b1', target: 'right-rail-rung-1' }),
+        ],
+      })
+
+      store.getState().ladderFlowActions.addLadderFlow({ name: 'e', updated: false, rungs: [rung] })
+
+      const flow = store.getState().ladderFlows[0]
+      const block = flow.rungs[0].nodes.find((node) => node.id === 'b1')
+      expect(block).toBeTruthy()
+      expect(block?.position).not.toEqual({ x: 0, y: 0 })
+      // Width comes from the variant, not from the layout — a rung recovered without this step
+      // is laid out around a block of zero width.
+      expect(block?.width).toBeGreaterThan(0)
+      expect(flow.updated).toBe(true)
+    })
+
     it('never loses an element to a layout that returns fewer nodes', () => {
       // The layout can come back short — empty, for an unwired rung — and accepting that would
       // delete part of the diagram on open. Moving an element is recovery; losing one is not.
@@ -315,6 +359,37 @@ describe('createLadderFlowSlice', () => {
       // Same id is not the same element: a contact returned as anything else has been
       // replaced, not moved, and the rung's incoming geometry is the safer answer.
       expect(elementsSurvived([node('c1', 'contact')], [node('c1', 'coil')])).toBe(false)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // setHandleBranches
+  // -------------------------------------------------------------------------
+  describe('setHandleBranches', () => {
+    const branch = { blockId: 'b1', handleId: 'R', direction: 'input' as const, nodeIds: ['c1', 'c2'] }
+
+    it('stores the rung branches and marks the flow dirty', () => {
+      seedFlowWithRung(store, 'editor-1')
+      store.getState().ladderFlowActions.setHandleBranches({
+        handleBranches: [branch],
+        editorName: 'editor-1',
+        rungId: 'rung-1',
+      })
+
+      const flow = store.getState().ladderFlows[0]
+      expect(flow.rungs[0].handleBranches).toEqual([branch])
+      expect(flow.updated).toBe(true)
+    })
+
+    it('is a no-op for an unknown flow or rung', () => {
+      seedFlowWithRung(store, 'editor-1')
+      const actions = store.getState().ladderFlowActions
+      actions.setHandleBranches({ handleBranches: [branch], editorName: 'nope', rungId: 'rung-1' })
+      actions.setHandleBranches({ handleBranches: [branch], editorName: 'editor-1', rungId: 'nope' })
+
+      // `addLadderFlow` derives the branches on load, so an untouched rung carries an empty
+      // list rather than nothing at all.
+      expect(store.getState().ladderFlows[0].rungs[0].handleBranches).toEqual([])
     })
   })
 

--- a/src/frontend/store/slices/ladder/slice.ts
+++ b/src/frontend/store/slices/ladder/slice.ts
@@ -65,22 +65,39 @@ import { deriveHandleBranches } from '../../../components/_molecules/graphical-e
 import { LadderFlowSlice, LadderFlowState } from './types'
 import { duplicateLadderRung } from './utils'
 
+/**
+ * Whether a value carries everything `getBlockSize` reads off a variant.
+ *
+ * A block node is not required to carry a complete variant — a placeholder dropped on the
+ * canvas, or a fixture, may have neither name nor pins. Sizing is an improvement on such a
+ * node, never a precondition for loading it, so anything incomplete is left exactly as it is.
+ * The entries are checked and not just the array, because `getBlockSize` reads every one's
+ * `name` and `class`.
+ *
+ * A guard rather than an assertion: this runs against project-file data, which is whatever
+ * the file said, and `as` would only silence the compiler about that.
+ */
+const isSizableVariant = (value: unknown): value is BlockVariant => {
+  if (typeof value !== 'object' || value === null) return false
+  const { name, variables } = value as { name?: unknown; variables?: unknown }
+  return (
+    typeof name === 'string' &&
+    Array.isArray(variables) &&
+    variables.every(
+      (entry): boolean =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        typeof (entry as { name?: unknown }).name === 'string' &&
+        typeof (entry as { class?: unknown }).class === 'string',
+    )
+  )
+}
+
 /** Give a block node the size the editor computes for its variant; leave anything else be. */
 const sizeBlockNode = (node: Node): Node => {
   if (node.type !== 'block') return node
-  const variant = (node.data as { variant?: BlockVariant }).variant
-  // A block node is not required to carry a complete variant — a placeholder dropped on the
-  // canvas, or a fixture, may have neither name nor pins. Sizing is an improvement on such a
-  // node, never a precondition for loading it, so anything incomplete is left exactly as it
-  // is. `getBlockSize` reads every entry's `name` and `class`, so the entries are checked too
-  // and not just the array: this runs against project-file data, which no type assertion
-  // validates.
-  if (
-    typeof variant?.name !== 'string' ||
-    !Array.isArray(variant.variables) ||
-    !variant.variables.every((v) => typeof v?.name === 'string' && typeof v?.class === 'string')
-  )
-    return node
+  const variant: unknown = node.data?.variant
+  if (!isSizableVariant(variant)) return node
   const { width, height } = getBlockSize(variant, { x: 0, y: 0 })
   return {
     ...node,
@@ -97,7 +114,9 @@ const sizeBlockNode = (node: Node): Node => {
  * negative extent, which is not a shape it is written against.
  */
 const rungBounds = (rung: RungLadderState): [number, number] => {
-  const [width, height] = rung.defaultBounds ?? []
+  // `?? []` would only cover null/undefined; an object in the file makes the destructuring
+  // throw, which costs the rung its recovery.
+  const [width, height] = Array.isArray(rung.defaultBounds) ? rung.defaultBounds : []
   return [
     Number.isFinite(width) && width > 0 ? width : DEFAULT_RUNG_BOUNDS[0],
     Number.isFinite(height) && height > 0 ? height : DEFAULT_RUNG_BOUNDS[1],
@@ -111,11 +130,12 @@ const rungBounds = (rung: RungLadderState): [number, number] => {
  * `connectedVariables`, and `updateVariableBlockPosition` rebuilds them with fresh ids rather
  * than moving them — a rung that arrives with one can legitimately come back with two, or with
  * none. Counting nodes therefore says nothing, while every contact, coil, block and parallel
- * marker must survive by id.
+ * marker must survive as itself: same id AND same type, so a contact that came back as some
+ * other kind of node counts as lost rather than as moved.
  */
-const elementsSurvived = (before: Node[], after: Node[]): boolean => {
-  const present = new Set(after.map((node) => node.id))
-  return before.every((node) => node.type === 'variable' || present.has(node.id))
+export const elementsSurvived = (before: Node[], after: Node[]): boolean => {
+  const present = new Set(after.map((node) => `${node.type}\u0000${node.id}`))
+  return before.every((node) => node.type === 'variable' || present.has(`${node.type}\u0000${node.id}`))
 }
 
 /** Whether the layout actually moved anything, comparing node for node by id. */

--- a/src/frontend/store/slices/ladder/slice.ts
+++ b/src/frontend/store/slices/ladder/slice.ts
@@ -1,17 +1,121 @@
+/**
+ * Whether a rung's coordinates are unusable and have to be rebuilt.
+ *
+ * Ladder is a rigid matrix — every element sits on the rung's power line at a step the layout
+ * computes — so a rung is either laid out or it is broken; there is no "arranged differently
+ * but fine". That makes the damage detectable rather than guessed at. Three signals, none of
+ * them things this editor writes:
+ *
+ *   - a `position` that IS there but holds non-finite numbers, which cannot be drawn;
+ *   - an element at the ORIGIN. The rails live at x=0 and the layout never puts an element
+ *     there, so one element at `{0,0}` is already conclusive — a rung holding a single coil
+ *     would otherwise go undetected and draw on top of the left rail; and
+ *   - two elements sharing one point, which is what a writer that computes no geometry emits
+ *     for a rung of several elements, and what a partial parse leaves behind.
+ *
+ * A node with NO `position` at all is deliberately not a signal. That is not a damaged
+ * diagram, it is one assembled programmatically — a fixture, a test, a caller building a rung
+ * by hand — and re-laying those out would rewrite nodes their author is still holding.
+ *
+ * Anything else is left exactly as the file has it. A diagram someone arranged by hand is not
+ * this editor's to rearrange on open.
+ */
+// Exported for its own tests: the predicate decides whether a project's geometry is thrown
+// away and rebuilt, and every branch of it is a judgement about data this editor did not write.
+export const needsPositionRecovery = (rung: RungLadderState): boolean => {
+  // Rails are placed by the rung itself, not by the element layout, so they never make a rung
+  // look broken and never rescue one that is.
+  const elements = rung.nodes.filter((node) => node.type !== 'powerRail')
+  if (elements.length === 0) return false
+
+  const seen = new Set<string>()
+  for (const node of elements) {
+    if (!node.position) continue
+    const { x, y } = node.position
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return true
+    if (x === 0 && y === 0) return true
+    // `+ 0` normalises negative zero: `-0` and `0` are the same point but stringify
+    // differently, so without it two elements on top of each other slip through whenever one
+    // axis arrives as `-0` — which `JSON.parse` preserves.
+    const point = `${x + 0},${y + 0}`
+    if (seen.has(point)) return true
+    seen.add(point)
+  }
+  return false
+}
+
+import type { Node } from '@xyflow/react'
 import { addEdge, applyEdgeChanges, applyNodeChanges } from '@xyflow/react'
 import { produce } from 'immer'
 import { StateCreator } from 'zustand'
 
-import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import type { PLCVariable, RungLadderState } from '../../../../middleware/shared/ports/types'
 import {
   defaultCustomNodesStyles,
   nodesBuilder,
 } from '../../../components/_atoms/graphical-editor/ladder/node-builders'
-import type { LadderBlockConnectedVariables } from '../../../components/_atoms/graphical-editor/ladder/utils/types'
+import type {
+  BlockVariant,
+  LadderBlockConnectedVariables,
+} from '../../../components/_atoms/graphical-editor/ladder/utils/types'
+import { getBlockSize } from '../../../components/_atoms/graphical-editor/ladder/utils/utils'
 import { removeElements } from '../../../components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements'
+import { updateDiagramElementsPosition } from '../../../components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/diagram'
 import { deriveHandleBranches } from '../../../components/_molecules/graphical-editor/ladder/rung/ladder-utils/elements/handle-branch'
 import { LadderFlowSlice, LadderFlowState } from './types'
 import { duplicateLadderRung } from './utils'
+
+/** Give a block node the size the editor computes for its variant; leave anything else be. */
+const sizeBlockNode = (node: Node): Node => {
+  if (node.type !== 'block') return node
+  const variant = (node.data as { variant?: BlockVariant }).variant
+  // A block node is not required to carry a complete variant — a placeholder dropped on the
+  // canvas, or a fixture, may have neither name nor pins. Sizing is an improvement on such a
+  // node, never a precondition for loading it, so anything incomplete is left exactly as it
+  // is. `getBlockSize` reads every entry's `name` and `class`, so the entries are checked too
+  // and not just the array: this runs against project-file data, which no type assertion
+  // validates.
+  if (
+    typeof variant?.name !== 'string' ||
+    !Array.isArray(variant.variables) ||
+    !variant.variables.every((v) => typeof v?.name === 'string' && typeof v?.class === 'string')
+  )
+    return node
+  const { width, height } = getBlockSize(variant, { x: 0, y: 0 })
+  return {
+    ...node,
+    width,
+    height,
+    measured: { width, height },
+  }
+}
+
+/**
+ * The rung's bounds, or the default when the file's are unusable.
+ *
+ * A short or malformed `defaultBounds` would otherwise reach the layout as `undefined` or a
+ * negative extent, which is not a shape it is written against.
+ */
+const rungBounds = (rung: RungLadderState): [number, number] => {
+  const [width, height] = rung.defaultBounds ?? []
+  return [
+    Number.isFinite(width) && width > 0 ? width : DEFAULT_RUNG_BOUNDS[0],
+    Number.isFinite(height) && height > 0 ? height : DEFAULT_RUNG_BOUNDS[1],
+  ]
+}
+
+/** Whether the layout actually moved anything, comparing node for node by id. */
+const positionsChanged = (before: Node[], after: Node[]): boolean => {
+  const priorById = new Map(before.map((node) => [node.id, node.position]))
+  return after.some((node) => {
+    const prior = priorById.get(node.id)
+    if (!prior) return true
+    return prior.x !== node.position.x || prior.y !== node.position.y
+  })
+}
+
+/** Bounds a rung falls back to when the file does not carry usable ones. */
+const DEFAULT_RUNG_BOUNDS: [number, number] = [300, 100]
 
 export const createLadderFlowSlice: StateCreator<LadderFlowSlice, [], [], LadderFlowSlice> = (setState) => ({
   ladderFlows: [],
@@ -74,9 +178,66 @@ export const createLadderFlowSlice: StateCreator<LadderFlowSlice, [], [], Ladder
             handleBranches: deriveHandleBranches(rung),
           }))
 
-          // Reset updated to false on load — the flow is being loaded from a saved project.
-          // Only mark as updated if legacy data was migrated so the next save writes the new format.
-          const newFlow = { ...flow, rungs: rungsWithBranches, updated: needsMigration }
+          // Rebuild the geometry of any rung whose coordinates cannot be used, and ONLY
+          // those.
+          //
+          // Where a ladder element sits is derived from the graph — element order, which pins
+          // carry branches, how tall a block must be to fit them — by
+          // `updateDiagramElementsPosition` and the passes it runs. Those rules live here and
+          // change as the editor grows, so anything writing a .ld from outside (the CODESYS
+          // converter, a PLCopen import) can emit the graph and leave geometry alone: this
+          // recovers it.
+          //
+          // Running it on every load instead would re-lay-out projects that are already
+          // correct, moving elements on open for no reason the user asked for. So it is a
+          // recovery path, gated on `needsPositionRecovery`, not a load step.
+          let recovered = false
+          const laidOutRungs = rungsWithBranches.map((rung) => {
+            if (!needsPositionRecovery(rung)) return rung
+            try {
+              // Sizing is INSIDE the try. A block whose variant is incomplete would otherwise
+              // throw here and take the project load with it — and this path exists precisely
+              // to cope with a rung whose contents cannot be trusted.
+              //
+              // `updateDiagramElementsPosition` spaces a block's pin rows and grows it to fit
+              // its branches, but block WIDTH comes from the variant and is otherwise only
+              // computed when one is created or edited, so a rung recovered without this lays
+              // out around blocks of zero width.
+              const sized = { ...rung, nodes: rung.nodes.map(sizeBlockNode) }
+              const { nodes, edges } = updateDiagramElementsPosition(sized, rungBounds(sized))
+
+              // Recovery may MOVE an element; it may never lose one. The layout can return a
+              // shorter node set for a rung it did not understand — on a skeletal or unwired
+              // rung it can come back empty — and accepting that deletes part of the user's
+              // diagram on open, silently. Anything but a node-for-node result is a failure.
+              if (nodes.length !== sized.nodes.length) return rung
+
+              // The layout hands the ORIGINAL geometry straight back when it cannot walk the
+              // rung (`diagram/index.ts`, the `previousLinkedNodes` early return) — no throw,
+              // nothing rebuilt. Treating that as a recovery marks the flow dirty on its
+              // behalf: the user is prompted to save a project they never edited, the save
+              // writes the same unusable coordinates back, and the next open recovers again.
+              if (!positionsChanged(rung.nodes, nodes)) return rung
+
+              recovered = true
+              return { ...sized, nodes, edges }
+            } catch {
+              // Best-effort by definition: a rung the layout cannot walk keeps the geometry it
+              // arrived with, and `recovered` is left alone — one rung failing must not erase
+              // another rung's success, which is what marks the flow dirty so the rebuilt
+              // coordinates reach disk.
+              return rung
+            }
+          })
+
+          // A recovered rung marks the flow dirty for the same reason a migrated one does: the
+          // file still holds the unusable coordinates until the next save writes the rebuilt
+          // ones, and recovering again on every open is work nobody needs.
+          const newFlow = {
+            ...flow,
+            rungs: laidOutRungs,
+            updated: needsMigration || recovered,
+          }
 
           if (flowIndex === -1) {
             ladderFlows.push(newFlow)

--- a/src/frontend/store/slices/ladder/slice.ts
+++ b/src/frontend/store/slices/ladder/slice.ts
@@ -104,6 +104,20 @@ const rungBounds = (rung: RungLadderState): [number, number] => {
   ]
 }
 
+/**
+ * Whether every element the rung came in with is still there.
+ *
+ * Variable boxes are exempt, and not as a convenience: they are DERIVED from a block's
+ * `connectedVariables`, and `updateVariableBlockPosition` rebuilds them with fresh ids rather
+ * than moving them — a rung that arrives with one can legitimately come back with two, or with
+ * none. Counting nodes therefore says nothing, while every contact, coil, block and parallel
+ * marker must survive by id.
+ */
+const elementsSurvived = (before: Node[], after: Node[]): boolean => {
+  const present = new Set(after.map((node) => node.id))
+  return before.every((node) => node.type === 'variable' || present.has(node.id))
+}
+
 /** Whether the layout actually moved anything, comparing node for node by id. */
 const positionsChanged = (before: Node[], after: Node[]): boolean => {
   const priorById = new Map(before.map((node) => [node.id, node.position]))
@@ -207,10 +221,10 @@ export const createLadderFlowSlice: StateCreator<LadderFlowSlice, [], [], Ladder
               const { nodes, edges } = updateDiagramElementsPosition(sized, rungBounds(sized))
 
               // Recovery may MOVE an element; it may never lose one. The layout can return a
-              // shorter node set for a rung it did not understand — on a skeletal or unwired
-              // rung it can come back empty — and accepting that deletes part of the user's
-              // diagram on open, silently. Anything but a node-for-node result is a failure.
-              if (nodes.length !== sized.nodes.length) return rung
+              // set that has dropped elements for a rung it did not understand — on a skeletal
+              // or unwired rung it comes back empty — and accepting that deletes part of the
+              // user's diagram on open, silently.
+              if (!elementsSurvived(sized.nodes, nodes)) return rung
 
               // The layout hands the ORIGINAL geometry straight back when it cannot walk the
               // rung (`diagram/index.ts`, the `previousLinkedNodes` early return) — no throw,

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -52,7 +52,7 @@ import { renameGlobalVariableListInPou } from '../../../utils/PLC/global-variabl
 import { serializeGlobalVariableListToText } from '../../../utils/PLC/global-variable-list-serializer'
 import { parseGlobalVariableListFromText } from '../../../utils/PLC/global-variable-list-text-parser'
 import { getExtensionFromLanguage, getFolderFromPouType } from '../../../utils/PLC/pou-file-extensions'
-import type { ProjectResponse, ProjectSlice, ProjectSliceRoot } from './types'
+import type { ProjectResponse, ProjectSlice, ProjectSliceRoot, VariableScope } from './types'
 import { getVariableBasedOnRowIdOrVariableId } from './utils'
 import { createVariableValidation, updateVariableValidation } from './validation/variables'
 
@@ -687,6 +687,41 @@ const regenerateDatatypeText = (name: string, getState: ProjectGetState): void =
 // the variables from before the user started typing — the buffer had no way in, because
 // nothing but a blur committed it.
 
+/**
+ * The variables array a scoped action works on.
+ *
+ * Every variable action resolved this the same way inline, which is how the three scopes
+ * drifted: a Global Variable List's members are variables like a POU's locals and the
+ * resource globals are, so they belong on the same actions rather than on a parallel set.
+ *
+ * `local` without a POU falls through to the resource globals, which is what the inline
+ * ternaries did and what their callers rely on.
+ */
+const scopedVariables = (
+  data: ProjectSlice['project']['data'],
+  scope: VariableScope,
+  associatedPou?: string,
+  associatedList?: string,
+): PLCVariable[] | undefined => {
+  if (scope === 'local' && associatedPou) return data.pous.find((p) => p.name === associatedPou)?.interface?.variables
+  if (scope === 'global-variable-list')
+    return (data.globalVariableLists ?? []).find((l) => nameMatches(l.name, associatedList ?? ''))?.variables
+  return data.configurations.resource.globalVariables
+}
+
+/**
+ * Drop a list's preserved declaration text after its members change.
+ *
+ * `text` is the verbatim declaration kept when it could not be parsed, and it is what the
+ * editor SHOWS while it is set. Editing a member through the table means the declaration
+ * reads again, so leaving the old text would keep showing the broken version the user just
+ * fixed — the same reason `updateGlobalVariableList` drops it.
+ */
+const clearGlobalVariableListText = (data: ProjectSlice['project']['data'], listName?: string): void => {
+  const list = (data.globalVariableLists ?? []).find((l) => nameMatches(l.name, listName ?? ''))
+  if (list) delete list.text
+}
+
 const findGlobalVariableListEditorCode = (name: string, getState: ProjectGetState): string | undefined => {
   const state = getState()
   const editorModel = state.editor.meta.name === name ? state.editor : state.editors.find((e) => e.meta.name === name)
@@ -998,10 +1033,7 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       // variable as a template, so the validator walks the location forward
       // to the next free slot to avoid duplicate-address compile errors
       // (forum thread "openplc-420-teething-bugs", v4.2.0).
-      const sourceVariables =
-        scope === 'local' && associatedPou
-          ? (getState().project.data.pous.find((p) => p.name === associatedPou)?.interface?.variables ?? [])
-          : getState().project.data.configurations.resource.globalVariables
+      const sourceVariables = scopedVariables(getState().project.data, scope, associatedPou, dto.associatedList) ?? []
       const validated = createVariableValidation(sourceVariables, data)
       // Single-field location model: `location` is the binding itself — an
       // alias name OR a literal `%addr`. It is stored verbatim (no
@@ -1012,17 +1044,10 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       let response: ProjectResponse = { ok: true }
       setState(
         produce((slice: ProjectSlice) => {
-          // Resolve the target variables array (local POU or global)
-          let variables: PLCVariable[] | undefined
-          if (scope === 'local' && associatedPou) {
-            const pou = slice.project.data.pous.find((p) => p.name === associatedPou)
-            if (!pou?.interface) {
-              response = fail('POU not found')
-              return
-            }
-            variables = pou.interface.variables
-          } else {
-            variables = slice.project.data.configurations.resource.globalVariables
+          const variables = scopedVariables(slice.project.data, scope, associatedPou, dto.associatedList)
+          if (!variables) {
+            response = fail(scope === 'global-variable-list' ? 'Global variable list not found' : 'POU not found')
+            return
           }
 
           // Insert or append
@@ -1036,6 +1061,7 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
           } else {
             variables.push(data)
           }
+          if (scope === 'global-variable-list') clearGlobalVariableListText(slice.project.data, dto.associatedList)
           response.data = data
         }),
       )
@@ -1059,7 +1085,7 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       )
       return ok()
     },
-    updateVariable: ({ scope, associatedPou, rowId, variableId, data: updates }) => {
+    updateVariable: ({ scope, associatedPou, associatedList, rowId, variableId, data: updates }) => {
       if (scope === 'local') {
         const reconcile = reconcileVariablesText(associatedPou, getState, setState)
         if (!reconcile.ok) return reconcile
@@ -1073,17 +1099,10 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       // address; alias→address resolution happens at compile time.
       setState(
         produce((slice: ProjectSlice) => {
-          // Resolve the target variables array (local POU or global)
-          let variables: PLCVariable[] | undefined
-          if (scope === 'local' && associatedPou) {
-            const pou = slice.project.data.pous.find((p) => p.name === associatedPou)
-            if (!pou?.interface) {
-              response = fail('POU not found')
-              return
-            }
-            variables = pou.interface.variables
-          } else {
-            variables = slice.project.data.configurations.resource.globalVariables
+          const variables = scopedVariables(slice.project.data, scope, associatedPou, associatedList)
+          if (!variables) {
+            response = fail(scope === 'global-variable-list' ? 'Global variable list not found' : 'POU not found')
+            return
           }
 
           const found = getVariableBasedOnRowIdOrVariableId(variables, rowId, variableId)
@@ -1105,10 +1124,14 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
           }
           response.data = variables[found.index]
 
+          if (scope === 'global-variable-list') clearGlobalVariableListText(slice.project.data, associatedList)
+
           // A shared global's watch flag belongs to the global, not to any one
           // reference — keep the global's definition and every VAR_EXTERNAL to it
-          // in sync so the debug icon toggles everywhere at once.
-          if (updates.debug !== undefined) {
+          // in sync so the debug icon toggles everywhere at once. A list member is
+          // reached as `<list>.<member>` and never through a VAR_EXTERNAL of its own,
+          // so there is nothing to keep in sync for one.
+          if (updates.debug !== undefined && scope !== 'global-variable-list') {
             const target = variables[found.index]
             if (scope === 'global' || target.class === 'external') {
               syncGlobalDebugFlag(slice, target.name, updates.debug)
@@ -1119,17 +1142,14 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       if (scope === 'local' && response.ok) regenerateVariablesText(associatedPou, getState)
       return response
     },
-    getVariable: ({ scope, associatedPou, rowId, variableId }) => {
-      const variables =
-        scope === 'local' && associatedPou
-          ? getState().project.data.pous.find((p) => p.name === associatedPou)?.interface?.variables
-          : getState().project.data.configurations.resource.globalVariables
+    getVariable: ({ scope, associatedPou, associatedList, rowId, variableId }) => {
+      const variables = scopedVariables(getState().project.data, scope, associatedPou, associatedList)
       if (!variables) return undefined
 
       const found = getVariableBasedOnRowIdOrVariableId(variables, rowId, variableId)
       return found?.variable
     },
-    deleteVariable: ({ scope, associatedPou, rowId, variableId, variableName, force }) => {
+    deleteVariable: ({ scope, associatedPou, associatedList, rowId, variableId, variableName, force }) => {
       if (scope === 'local') {
         const reconcile = reconcileVariablesText(associatedPou, getState, setState)
         if (!reconcile.ok) return reconcile
@@ -1173,10 +1193,7 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       let response: ProjectResponse = { ok: true }
       setState(
         produce((slice: ProjectSlice) => {
-          const variables =
-            scope === 'local' && associatedPou
-              ? slice.project.data.pous.find((p) => p.name === associatedPou)?.interface?.variables
-              : slice.project.data.configurations.resource.globalVariables
+          const variables = scopedVariables(slice.project.data, scope, associatedPou, associatedList)
           if (!variables) {
             response = fail('Variable container not found')
             return
@@ -1197,6 +1214,8 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
             }
             variables.splice(found.index, 1)
           }
+
+          if (scope === 'global-variable-list') clearGlobalVariableListText(slice.project.data, associatedList)
 
           // Cascade: remove the matching VAR_EXTERNAL from every referencing POU.
           if (cascade) {
@@ -1219,19 +1238,17 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       }
       return response
     },
-    rearrangeVariables: ({ scope, associatedPou, rowId, variableId, newIndex }) => {
+    rearrangeVariables: ({ scope, associatedPou, associatedList, rowId, variableId, newIndex }) => {
       setState(
         produce((slice: ProjectSlice) => {
-          const variables =
-            scope === 'local' && associatedPou
-              ? slice.project.data.pous.find((p) => p.name === associatedPou)?.interface?.variables
-              : slice.project.data.configurations.resource.globalVariables
+          const variables = scopedVariables(slice.project.data, scope, associatedPou, associatedList)
           if (!variables) return
 
           const found = getVariableBasedOnRowIdOrVariableId(variables, rowId, variableId)
           if (!found) return
           const [item] = variables.splice(found.index, 1)
           variables.splice(newIndex, 0, item)
+          if (scope === 'global-variable-list') clearGlobalVariableListText(slice.project.data, associatedList)
         }),
       )
     },

--- a/src/frontend/store/slices/project/types.ts
+++ b/src/frontend/store/slices/project/types.ts
@@ -31,9 +31,21 @@ import type {
 // DTOs
 // ---------------------------------------------------------------------------
 
+/**
+ * Which set of variables an action works on.
+ *
+ * A Global Variable List's members are variables in the same sense a POU's locals and the
+ * resource globals are: same fields, same validation, same table in the UI. They are a third
+ * scope on the existing actions rather than a parallel set of list-specific ones, so the
+ * declaration editor and the table view cannot drift apart.
+ */
+export type VariableScope = 'global' | 'local' | 'global-variable-list'
+
 export type VariableDTO = {
-  scope: 'global' | 'local'
+  scope: VariableScope
   associatedPou?: string
+  /** Required for `global-variable-list` scope: which list's members to work on. */
+  associatedList?: string
   data: PLCVariable
 }
 
@@ -120,21 +132,24 @@ export type ProjectActions = {
   setPouVariables: (args: { pouName: string; variables: PLCVariable[] }) => ProjectResponse
   setGlobalVariables: (args: { variables: PLCVariable[] }) => ProjectResponse
   updateVariable: (args: {
-    scope: 'global' | 'local'
+    scope: VariableScope
     associatedPou?: string
+    associatedList?: string
     rowId?: number
     variableId?: string
     data: Partial<PLCVariable>
   }) => ProjectResponse
   getVariable: (args: {
-    scope: 'global' | 'local'
+    scope: VariableScope
     associatedPou?: string
+    associatedList?: string
     rowId?: number
     variableId?: string
   }) => PLCVariable | undefined
   deleteVariable: (args: {
-    scope: 'global' | 'local'
+    scope: VariableScope
     associatedPou?: string
+    associatedList?: string
     rowId?: number
     variableId?: string
     variableName?: string
@@ -148,8 +163,9 @@ export type ProjectActions = {
     force?: boolean
   }) => ProjectResponse
   rearrangeVariables: (args: {
-    scope: 'global' | 'local'
+    scope: VariableScope
     associatedPou?: string
+    associatedList?: string
     rowId?: number
     variableId?: string
     newIndex: number

--- a/src/frontend/store/slices/tabs/utils.ts
+++ b/src/frontend/store/slices/tabs/utils.ts
@@ -154,17 +154,22 @@ const CreateDiffViewerEditor = (name: string, filePath: string): EditorModel => 
 })
 
 /**
- * A Global Variable List opens on its declaration, the only view it has — which is
- * also how CODESYS presents one.
+ * A Global Variable List opens on its members, as a table — the same view a POU's
+ * variables and the resource globals open on, and the one most edits want.
  *
- * `display: 'code'` is what makes `structure.code` the list's draft buffer, so a save
- * landing mid-edit can fold it in (`reconcileGlobalVariableListText`). Opening on
- * `'table'` would leave that buffer permanently undefined and the reconcile a no-op.
+ * The declaration view is the other half, and it is where `structure.code` becomes the
+ * list's draft buffer so a save landing mid-edit can fold it in
+ * (`reconcileGlobalVariableListText`). That buffer is undefined in table mode, which is
+ * correct rather than a gap: a table edit commits to the project as it happens, so there
+ * is no unsaved text for a save to fold, and both `reconcileGlobalVariableListText` and
+ * `regenerateGlobalVariableListText` return early unless the display is `'code'`. The
+ * editor moves the model to `'code'` itself when a list arrives with a declaration that
+ * could not be parsed, so that buffer exists whenever there is text only it can hold.
  */
 const CreateGlobalVariableListEditor = (name: string): EditorModel => ({
   type: 'plc-global-variable-list',
   meta: { name },
-  structure: { display: 'code' },
+  structure: { display: 'table', selectedRow: '-1', description: '' },
 })
 
 const CreateEditorObjectFromTab = (tab: TabsProps): EditorModel => {


### PR DESCRIPTION
## What

Two independent fixes a CODESYS-converted project surfaced. Both apply to any project.

### Ladder geometry is recovered when it cannot be used

Where a ladder element sits is **derived** from the graph — element order, which pins carry branches, how tall a block must be to fit them — by `updateDiagramElementsPosition` and the passes it runs. Those rules live here and change as the editor grows, so anything writing a `.ld` from outside had to reimplement them and stay in step forever. The CODESYS converter did, and produced diagrams with labels on top of each other.

Now such a writer emits the graph and leaves geometry alone. `addLadderFlow` rebuilds a rung whose coordinates cannot be used — and only that rung.

`needsPositionRecovery` looks for the two things this editor never writes:
- a `position` holding non-finite numbers, and
- two elements sharing one point (what a writer that computes no geometry emits, and what a partial parse leaves behind).

A node with **no** `position` is deliberately not a signal: that is a rung assembled programmatically, not a damaged one. A diagram someone arranged by hand is not the editor's to rearrange on open.

Blocks are sized first — the layout spaces pin rows and grows a block to fit its branches, but block *width* comes from the variant and is otherwise only computed on create/edit. Recovery is best-effort: a rung the layout cannot walk keeps what it arrived with, because opening a project must not fail on one rung.

### Global Variable Lists are in scope for autocomplete and validation

They were in no scope at all. The language-server sync told strucpp about data types, resource globals and SoftMotion axes, but never about the lists — so `GVL` was a name it had never heard, and every consumer failed identically: no completion in ST, none in Ladder or FBD (both drive the same LSP through `scoped-query`), and a typed-in `GVL.Output2` resolved to nothing and drew as an unknown symbol.

Historically an OpenPLC global reached a POU through a `VAR_EXTERNAL` the user wrote, which is why this never bit before — a list member has no such declaration anywhere.

The synthesized document is built by the **same serializers the transpiler uses**, so the language server's picture of a list cannot drift from the one that compiles. It is emitted as a bare top-level `VAR_GLOBAL` block, the way the SoftMotion axes are: strucpp puts top-level globals in the ambient scope, so a POU resolves the list without a `VAR_EXTERNAL` and the user's documents stay byte-for-byte what they wrote.

## Verified

- `GVL.` completes in a ladder variable box, and so does a list named `MyGlobalList` — members of the wrong type filtered out by the box's expected type
- a converted project carrying **no geometry** lays out identically to the same diagram drawn by hand: block 210x340, pin contacts at (68,118)/(68,198), rail branch handles at 100/180
- full suite: 6598 passing; the 2 failing suites (`device-types`, `use-device-connect`) fail identically on a clean tree

## Notes

Mirrored byte-for-byte to openplc-web (`feat/ladder-layout-on-load`). Ladder-slice fixtures gained distinct positions — they stacked every node at the origin, which is now read as damage.

Pairs with the converter change in autonomy-edge#365 / autonomy-node#100: a `.ld` written by that converter cannot be laid out by an editor without this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global variable lists now synchronize reliably with language services, including shared type information and global instance declarations.
  * Global variable data is initialized, refreshed when changed, and cleaned up appropriately.
  * Go-to-definition from global variable references now opens the corresponding editable variable list.

* **Bug Fixes**
  * Improved ladder-flow loading by recovering invalid, duplicated, or malformed rung geometry.
  * Preserved valid ladder content when recovery encounters layout errors, missing data, or node changes.
  * Updated flows are correctly marked after geometry recovery or migration.
  * Improved navigation for empty and memberless global variable lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->