### PR TITLE
chore(shared): mirror the Edge session surface from openplc-web [EDGE-602]

### DIFF
--- a/src/frontend/components/_atoms/autonomy-logo/index.tsx
+++ b/src/frontend/components/_atoms/autonomy-logo/index.tsx
@@ -1,0 +1,19 @@
+/**
+ * The Autonomy `<>` mark, as Edge's sign-in screen shows it.
+ *
+ * Copied path-for-path from `@autonomy-edge/assets`, which belongs to another
+ * repository this project cannot import. The mark is what tells a user at a glance
+ * which account the form is asking for, so it has to be the same one.
+ */
+const AutonomyLogo = ({ className }: { className?: string }) => (
+  // Explicit width/height, not just a viewBox: with no intrinsic size the mark
+  // collapses to nothing inside a flex container, which is how it vanished.
+  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 124 86' width={58} height={40} aria-hidden className={className}>
+    <path
+      className='fill-current'
+      d='M41.892 0 0 43l41.892 43 9.216-9.653-25.56-25.985c-1.877-1.907-4.389-2.974-7.003-2.974H11.73v-8.776h6.815c2.614 0 5.126-1.067 7.002-2.974L51.108 9.653zM82.108 0 124 43 82.108 86l-9.216-9.653 25.56-25.985c1.877-1.907 4.389-2.974 7.003-2.974h6.815v-8.776h-6.815c-2.614 0-5.126-1.067-7.002-2.974L72.892 9.653z'
+    />
+  </svg>
+)
+
+export { AutonomyLogo }

--- a/src/frontend/components/_atoms/edge-avatar/index.tsx
+++ b/src/frontend/components/_atoms/edge-avatar/index.tsx
@@ -23,8 +23,12 @@ interface EdgeAvatarProps {
 const EdgeAvatar = ({ name, imageSrc, customInitials, initialsColor, className }: EdgeAvatarProps) => {
   // A profileImage URL can 404 (deleted upload, expired link). Falling back to
   // initials keeps a broken-image icon out of the title bar.
-  const [imageFailed, setImageFailed] = useState(false)
-  const showImage = Boolean(imageSrc) && !imageFailed
+  //
+  // The failed URL is remembered, not a boolean: a user who replaces their photo
+  // arrives here with a different `imageSrc`, and a flag would keep showing
+  // initials for a URL that was never actually tried.
+  const [failedSrc, setFailedSrc] = useState<string | null>(null)
+  const showImage = Boolean(imageSrc) && imageSrc !== failedSrc
 
   return (
     <span
@@ -42,7 +46,7 @@ const EdgeAvatar = ({ name, imageSrc, customInitials, initialsColor, className }
           src={imageSrc ?? undefined}
           alt={name}
           className='size-full object-cover'
-          onError={() => setImageFailed(true)}
+          onError={() => setFailedSrc(imageSrc ?? null)}
         />
       ) : (
         <span

--- a/src/frontend/components/_atoms/edge-avatar/index.tsx
+++ b/src/frontend/components/_atoms/edge-avatar/index.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+
+import { cn } from '../../../utils/cn'
+import { resolveInitials } from './resolve-initials'
+
+/**
+ * The signed-in user's picture, mirroring how Edge renders it.
+ *
+ * Reimplemented rather than imported: the Edge avatar lives in
+ * `@autonomy-edge/design-system`, which is a package of a different repository
+ * that this project does not depend on. The behaviour is what has to match —
+ * photo when there is one, otherwise initials over the colour the account picked
+ * — so the same user looks the same in both apps.
+ */
+interface EdgeAvatarProps {
+  name: string
+  imageSrc?: string | null
+  customInitials?: string | null
+  initialsColor?: string | null
+  className?: string
+}
+
+const EdgeAvatar = ({ name, imageSrc, customInitials, initialsColor, className }: EdgeAvatarProps) => {
+  // A profileImage URL can 404 (deleted upload, expired link). Falling back to
+  // initials keeps a broken-image icon out of the title bar.
+  const [imageFailed, setImageFailed] = useState(false)
+  const showImage = Boolean(imageSrc) && !imageFailed
+
+  return (
+    <span
+      // `cn`, not string concatenation: a caller passing `size-10` has to actually
+      // override the `size-7` here, and with plain concatenation both survive and
+      // CSS declaration order decides — which is not the caller's intent.
+      className={cn(
+        'relative flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-full',
+        className,
+      )}
+      style={initialsColor && !showImage ? { backgroundColor: initialsColor } : undefined}
+    >
+      {showImage ? (
+        <img
+          src={imageSrc ?? undefined}
+          alt={name}
+          className='size-full object-cover'
+          onError={() => setImageFailed(true)}
+        />
+      ) : (
+        <span
+          aria-hidden
+          className={`text-[11px] font-medium ${
+            initialsColor ? 'text-white' : 'bg-neutral-300 text-neutral-700 dark:bg-neutral-700 dark:text-neutral-200'
+          } flex size-full items-center justify-center`}
+        >
+          {resolveInitials(name, customInitials)}
+        </span>
+      )}
+    </span>
+  )
+}
+
+export { EdgeAvatar }

--- a/src/frontend/components/_atoms/edge-avatar/resolve-initials.ts
+++ b/src/frontend/components/_atoms/edge-avatar/resolve-initials.ts
@@ -1,0 +1,29 @@
+/**
+ * Up to two initials from the display name.
+ *
+ * `customInitials` wins when the account set them: a user who chose "AL" should
+ * not see something else derived from a name they may have typed differently.
+ *
+ * Separate module so the avatar file exports only its component — Fast Refresh
+ * stops working on files that mix components with other exports.
+ */
+export function resolveInitials(name: string, customInitials?: string | null): string {
+  if (customInitials?.trim()) {
+    return customInitials.trim().slice(0, 2).toUpperCase()
+  }
+
+  const parts = name
+    .trim()
+    .split(/\s+/)
+    .filter((part) => part.length > 0)
+
+  if (parts.length === 0) {
+    return '?'
+  }
+
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase()
+  }
+
+  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
+}

--- a/src/frontend/components/_atoms/edge-avatar/resolve-initials.ts
+++ b/src/frontend/components/_atoms/edge-avatar/resolve-initials.ts
@@ -9,7 +9,7 @@
  */
 export function resolveInitials(name: string, customInitials?: string | null): string {
   if (customInitials?.trim()) {
-    return customInitials.trim().slice(0, 2).toUpperCase()
+    return firstCodePoints(customInitials.trim(), 2).toUpperCase()
   }
 
   const parts = name
@@ -22,8 +22,23 @@ export function resolveInitials(name: string, customInitials?: string | null): s
   }
 
   if (parts.length === 1) {
-    return parts[0].slice(0, 2).toUpperCase()
+    return firstCodePoints(parts[0], 2).toUpperCase()
   }
 
-  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
+  return `${firstCodePoints(parts[0], 1)}${firstCodePoints(parts[parts.length - 1], 1)}`.toUpperCase()
+}
+
+/**
+ * The first `count` code points of a string.
+ *
+ * `slice(0, 2)` and `[0]` count UTF-16 code units, which cut through the middle of a
+ * surrogate pair: a name starting with an emoji or any astral-plane character
+ * rendered half a pair, which draws as a replacement glyph. `Array.from` iterates
+ * code points, so such a character survives whole.
+ *
+ * Code points, not grapheme clusters — a flag or a ZWJ sequence is still more than
+ * one of these, which is not worth an `Intl.Segmenter` for a two-character avatar.
+ */
+function firstCodePoints(value: string, count: number): string {
+  return Array.from(value).slice(0, count).join('')
 }

--- a/src/frontend/components/_atoms/provider-icons/index.tsx
+++ b/src/frontend/components/_atoms/provider-icons/index.tsx
@@ -1,0 +1,62 @@
+import type { EdgeOAuthProviderId } from '../../../../middleware/shared/ports/edge-account-port'
+
+/**
+ * Brand marks for the sign-in providers.
+ *
+ * Copied path-for-path from Edge's `@autonomy-edge/assets` rather than redrawn:
+ * that package belongs to another repository this project does not depend on, and
+ * the point is for the two sign-in screens to be indistinguishable. Monochrome for
+ * the same reason — Edge renders them tinted to the foreground colour, not in
+ * brand colours.
+ */
+const GoogleMark = () => (
+  <svg xmlns='http://www.w3.org/2000/svg' width={18} height={18} fill='none' aria-hidden>
+    <g className='fill-current' clipPath='url(#editor_google_svg__a)'>
+      <path d='M17.405 9.198c0-.583-.047-1.169-.148-1.742H9.172v3.3h4.63a3.97 3.97 0 0 1-1.714 2.605v2.142h2.763c1.621-1.493 2.554-3.697 2.554-6.305' />
+      <path d='M9.171 17.573c2.312 0 4.262-.76 5.682-2.07l-2.762-2.141c-.768.522-1.76.819-2.916.819-2.237 0-4.133-1.51-4.813-3.537h-2.85v2.207a8.57 8.57 0 0 0 7.66 4.722' />
+      <path d='M4.36 10.643a5.13 5.13 0 0 1 0-3.282V5.153H1.512a8.58 8.58 0 0 0 0 7.698z' />
+      <path d='M9.171 3.821a4.66 4.66 0 0 1 3.289 1.285l2.447-2.447A8.24 8.24 0 0 0 9.17.43a8.57 8.57 0 0 0-7.66 4.725L4.36 7.36c.677-2.031 2.576-3.54 4.812-3.54' />
+    </g>
+    <defs>
+      <clipPath id='editor_google_svg__a'>
+        <path fill='#fff' d='M.429.429h17.143v17.143H.429z' />
+      </clipPath>
+    </defs>
+  </svg>
+)
+
+const MicrosoftMark = () => (
+  <svg xmlns='http://www.w3.org/2000/svg' width={18} height={18} fill='none' aria-hidden>
+    <path
+      className='fill-current'
+      d='M9.328 0H0v8.988h9.328zM20 0h-9.327v8.988H20zM9.328 10.264H0V20h9.328zm10.672 0h-9.327V20H20z'
+    />
+  </svg>
+)
+
+const AppleMark = () => (
+  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width={20} height={20} fill='none' aria-hidden>
+    <g className='fill-current' clipPath='url(#editor_apple_svg__a)'>
+      <path d='M16.773.012c-.051-.057-1.889.023-3.488 1.758-1.599 1.734-1.353 3.723-1.317 3.774s2.28.13 3.713-1.887C17.113 1.64 16.824.071 16.773.012m4.97 17.6c-.071-.144-3.487-1.851-3.169-5.133s2.513-4.184 2.547-4.281c.035-.098-.895-1.185-1.88-1.736a5.55 5.55 0 0 0-2.345-.651c-.162-.004-.725-.142-1.881.174-.762.209-2.48.884-2.952.91-.474.028-1.884-.782-3.4-.997-.971-.187-2 .197-2.737.492-.735.294-2.133 1.131-3.11 3.356-.979 2.223-.467 5.745-.101 6.84s.937 2.886 1.91 4.194c.863 1.476 2.01 2.5 2.488 2.848s1.828.579 2.764.1c.753-.462 2.112-.727 2.65-.708.535.02 1.59.232 2.672.809.857.296 1.667.172 2.478-.157.812-.332 1.986-1.589 3.357-4.137q.78-1.778.71-1.924' />
+    </g>
+    <defs>
+      <clipPath id='editor_apple_svg__a'>
+        <path fill='#fff' d='M0 0h24v24H0z' />
+      </clipPath>
+    </defs>
+  </svg>
+)
+
+const MARKS = {
+  google: GoogleMark,
+  microsoft: MicrosoftMark,
+  apple: AppleMark,
+} as const
+
+const ProviderIcon = ({ provider }: { provider: EdgeOAuthProviderId }) => {
+  const Mark = MARKS[provider]
+
+  return <Mark />
+}
+
+export { ProviderIcon }

--- a/src/frontend/components/_atoms/provider-icons/index.tsx
+++ b/src/frontend/components/_atoms/provider-icons/index.tsx
@@ -25,8 +25,16 @@ const GoogleMark = () => (
   </svg>
 )
 
+/**
+ * `viewBox` is required here, unlike Google's mark above.
+ *
+ * This path is drawn on a 0–20 grid (`M20 0`, `V20`), so without a viewBox the user
+ * units map 1:1 to px and everything past 18 is simply cut off — the right-hand and
+ * bottom squares of the four-square logo rendered clipped, and the mark sat
+ * asymmetrically beside Google's, whose path already fits inside 18×18.
+ */
 const MicrosoftMark = () => (
-  <svg xmlns='http://www.w3.org/2000/svg' width={18} height={18} fill='none' aria-hidden>
+  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' width={18} height={18} fill='none' aria-hidden>
     <path
       className='fill-current'
       d='M9.328 0H0v8.988h9.328zM20 0h-9.327v8.988H20zM9.328 10.264H0V20h9.328zm10.672 0h-9.327V20H20z'

--- a/src/frontend/components/_organisms/edge-account-menu/index.tsx
+++ b/src/frontend/components/_organisms/edge-account-menu/index.tsx
@@ -1,0 +1,152 @@
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import { LayoutDashboard, LogOut, Settings, User } from 'lucide-react'
+
+import type { EdgeUser } from '../../../../middleware/shared/ports/edge-account-port'
+import { EdgeAvatar } from '../../_atoms/edge-avatar'
+
+/**
+ * The signed-in user's menu, built to Edge's user-dropdown pattern: a tinted
+ * header card identifying the account, then sections of icon-and-label items
+ * separated by rules, with Sign out last.
+ *
+ * Same pattern, not the same code: Edge's version lives in a design system this
+ * repo cannot import, so the treatment is rebuilt from the palette available here
+ * in place of Edge's `primary`/`muted` tokens.
+ *
+ * Signing out ends the ONE session both apps share, so Edge goes too. That is the
+ * point of this menu existing in the editor at all.
+ *
+ * Deliberately fewer items than Edge's. Context switching, Admin, Forum, What's
+ * new and the theme toggle are either Edge-only concerns or features this app does
+ * not have; inventing entries to pad out the shape would give the user dead ends.
+ */
+interface EdgeAccountMenuProps {
+  user: EdgeUser
+  /**
+   * e.g. `Pro Plan`. Omitted from the card when null rather than replaced with a
+   * guess, which is how Edge handles an account with no active subscription.
+   */
+  planCaption?: string | null
+  onSignOut: () => void
+  /**
+   * Origin of the Edge SPA. Passed in rather than read from the environment: this
+   * component lives in a surface the desktop editor mirrors, where no such
+   * environment exists.
+   */
+  edgeBaseUrl: string
+  /**
+   * Which way the menu opens. Defaults to `right` because this lives in the
+   * activity bar, a ~48px strip — a menu dropping straight down would be clipped
+   * by the window edge on short viewports.
+   */
+  side?: 'right' | 'bottom'
+}
+
+const ITEM_CLASSES =
+  'flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 outline-none hover:bg-neutral-100 dark:hover:bg-neutral-800'
+const ICON_CLASSES = 'h-4 w-4 shrink-0 text-neutral-500 dark:text-neutral-400'
+const LABEL_CLASSES = 'text-sm text-neutral-900 dark:text-neutral-100'
+
+const EdgeAccountMenu = ({ user, planCaption, onSignOut, edgeBaseUrl, side = 'right' }: EdgeAccountMenuProps) => {
+  const edgeBase = edgeBaseUrl
+  // Same destinations Edge's own dropdown navigates to. `/profile` rather than
+  // `/{username}`: the latter is the public profile page, not the account one the
+  // menu item means. `/dashboard` redirects itself to `/{slug}/dashboard`.
+  const dashboardUrl = new URL('/dashboard', edgeBase).toString()
+  const profileUrl = new URL('/profile', edgeBase).toString()
+  const settingsUrl = new URL('/profile/settings', edgeBase).toString()
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type='button'
+          aria-label={`Account: ${user.name}`}
+          className='cursor-pointer rounded-full outline-none ring-offset-1 focus-visible:ring-2 focus-visible:ring-brand'
+        >
+          <EdgeAvatar
+            name={user.name}
+            imageSrc={user.profileImage}
+            customInitials={user.customInitials}
+            initialsColor={user.initialsColor}
+          />
+        </button>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          side={side}
+          align='end'
+          sideOffset={12}
+          className='z-50 w-72 rounded-lg border border-neutral-200 bg-white p-1.5 shadow-lg dark:border-neutral-800 dark:bg-neutral-900'
+        >
+          {/* Header card. The tint marks the account as this menu's subject rather
+              than one of its actions, the same way Edge treats it. Uses the palette
+              blue with an opacity modifier — the idiom the activity bar already
+              uses for its own highlights — rather than `brand/5`, because `brand`
+              resolves to a `var()` holding a hex and Tailwind 3 cannot reliably
+              apply an opacity modifier to that. */}
+          <div className='flex items-center gap-3 rounded-md border border-blue-500/20 bg-blue-500/5 px-3 py-2.5'>
+            <EdgeAvatar
+              className='size-10'
+              name={user.name}
+              imageSrc={user.profileImage}
+              customInitials={user.customInitials}
+              initialsColor={user.initialsColor}
+            />
+            {/* min-w-0 so the name and username truncate as one block instead of
+                widening the menu. */}
+            <div className='min-w-0 flex-1'>
+              <div className='truncate text-sm font-semibold text-neutral-900 dark:text-neutral-100'>
+                {user.name}
+                <span className='ml-1 text-xs font-normal text-neutral-500 dark:text-neutral-400'>
+                  ({user.username})
+                </span>
+              </div>
+              {planCaption && (
+                <div className='truncate text-[11px] text-neutral-500 dark:text-neutral-400'>{planCaption}</div>
+              )}
+            </div>
+          </div>
+
+          <DropdownMenu.Separator className='my-1.5 h-px bg-neutral-200 dark:bg-neutral-800' />
+
+          {/* Account destinations. All live on Edge, so all open there. */}
+          <div className='py-0.5'>
+            <DropdownMenu.Item asChild>
+              <a href={dashboardUrl} target='_blank' rel='noreferrer' className={ITEM_CLASSES}>
+                <LayoutDashboard className={ICON_CLASSES} />
+                <span className={LABEL_CLASSES}>Dashboard</span>
+              </a>
+            </DropdownMenu.Item>
+            <DropdownMenu.Item asChild>
+              <a href={profileUrl} target='_blank' rel='noreferrer' className={ITEM_CLASSES}>
+                <User className={ICON_CLASSES} />
+                <span className={LABEL_CLASSES}>Profile</span>
+              </a>
+            </DropdownMenu.Item>
+            <DropdownMenu.Item asChild>
+              <a href={settingsUrl} target='_blank' rel='noreferrer' className={ITEM_CLASSES}>
+                <Settings className={ICON_CLASSES} />
+                <span className={LABEL_CLASSES}>Settings</span>
+              </a>
+            </DropdownMenu.Item>
+          </div>
+
+          <DropdownMenu.Separator className='my-1.5 h-px bg-neutral-200 dark:bg-neutral-800' />
+
+          <div className='py-0.5'>
+            {/* Neutral, not red: Edge treats signing out as an ordinary item, and a
+                red row here would read as destructive when nothing is lost by it. */}
+            <DropdownMenu.Item onSelect={onSignOut} className={ITEM_CLASSES}>
+              <LogOut className={ICON_CLASSES} />
+              <span className={LABEL_CLASSES}>Sign out</span>
+            </DropdownMenu.Item>
+          </div>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}
+
+export { EdgeAccountMenu }

--- a/src/frontend/components/_organisms/edge-sign-in-modal/index.tsx
+++ b/src/frontend/components/_organisms/edge-sign-in-modal/index.tsx
@@ -1,0 +1,325 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Eye, EyeOff, Mail } from 'lucide-react'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import type { EdgeAccountPort } from '../../../../middleware/shared/ports/edge-account-port'
+import { AutonomyLogo } from '../../_atoms/autonomy-logo'
+import { ProviderIcon } from '../../_atoms/provider-icons'
+import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'
+
+/**
+ * Sign in to Autonomy Edge from inside the editor.
+ *
+ * A copy of Edge's own sign-in screen, down to the mark, the headings and the
+ * strings: same account, same credentials, so a screen that looked different would
+ * read as a less trustworthy login. Text is taken verbatim from Edge's `auth.json`
+ * locale file rather than paraphrased.
+ *
+ * The one deliberate difference is density. Edge lays this out down a full page;
+ * here it has to fit a dialog without scrolling, so the vertical rhythm is
+ * compressed — no gap is decorative, and the provider row is three across.
+ *
+ * NOT the same thing as `RuntimeLoginModal`, which authenticates against a PLC
+ * runtime device. The subtitle names the account for exactly that reason.
+ *
+ * Provider buttons are links, not handlers: the consent screen has to render as a
+ * top-level navigation, and a provider refuses to be framed or fetched.
+ */
+const signInSchema = z.object({
+  email: z.string().min(1, 'Enter your email').email('Enter a valid email'),
+  password: z.string().min(1, 'Enter your password'),
+})
+
+type SignInValues = z.infer<typeof signInSchema>
+
+interface EdgeSignInModalProps {
+  open: boolean
+  onSignedIn: () => void
+  /**
+   * The platform's Edge account port: signing in, the provider list and where
+   * Edge's own pages live. Passed in rather than imported — this component lives
+   * in a surface the desktop editor mirrors, and reaching into the web adapter
+   * would compile that build against an API it does not speak.
+   */
+  account: EdgeAccountPort
+  /**
+   * Why the user is being asked to sign in. Each of these is a different person
+   * with a different question, and one greeting cannot answer all of them:
+   *
+   *  - `expired`: they were editing and the session died under them. "Welcome to
+   *    OpenPLC Editor" answers a question they never asked and ignores the one
+   *    they have — what just happened, and did I lose my work?
+   *  - `expired-reloaded`: the same expiry, but reached through a reload. Split
+   *    from `expired` for one reason: the in-memory reassurance is false here.
+   *  - `sign-in-required`: they followed a project link and are not signed in.
+   *    Nothing ended and nothing was lost; they just need to know why a login is
+   *    standing between them and the project.
+   *  - `oauth-failed`: a provider round-trip came back without a session.
+   *  - `signed-out` (default): the plain "you are not signed in" case.
+   */
+  reason?: 'expired' | 'expired-reloaded' | 'sign-in-required' | 'oauth-failed' | 'signed-out'
+}
+
+/** Heading and supporting line for each reason the dialog can appear for. */
+const REASON_COPY = {
+  expired: {
+    title: 'Your session has expired',
+    // True here and NOWHERE else: this dialog is drawn over the live editor, so
+    // the open project and every unsaved edit are still in memory behind it.
+    subtitle: 'Sign in again to keep working. Nothing you typed is lost.',
+  },
+  'expired-reloaded': {
+    title: 'Your session has expired',
+    // Same expiry, one reload later — and that reload already discarded whatever
+    // was unsaved, because the web build holds the project in memory with nothing
+    // persisting it. Reusing the line above would promise the user their work was
+    // safe at the exact moment it was not. What IS true is that saved work comes
+    // back with them.
+    subtitle: 'Sign in again to reopen your project. Everything you saved is safe on the server.',
+  },
+  'sign-in-required': {
+    title: 'Sign in to open this project',
+    subtitle: 'Projects are private to their owner and the people they are shared with.',
+  },
+  'oauth-failed': {
+    title: 'That sign-in did not finish',
+    subtitle: 'Try again, or use your email and password below.',
+  },
+  'signed-out': {
+    title: 'Welcome to OpenPLC Editor',
+    subtitle: 'Sign in to your account',
+  },
+} as const
+
+type FormState = { kind: 'idle' } | { kind: 'error'; message: string } | { kind: 'unverified'; email: string }
+
+const FIELD_CLASSES =
+  'w-full rounded-lg border border-neutral-300 bg-transparent py-2 pr-9 text-sm text-neutral-900 outline-none placeholder:text-neutral-400 focus:border-brand dark:border-neutral-700 dark:text-neutral-100'
+
+const EdgeSignInModal = ({ open, onSignedIn, account, reason = 'signed-out' }: EdgeSignInModalProps) => {
+  const copy = REASON_COPY[reason]
+  const [formState, setFormState] = useState<FormState>({ kind: 'idle' })
+  const [submitting, setSubmitting] = useState(false)
+  const [showPassword, setShowPassword] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SignInValues>({ resolver: zodResolver(signInSchema) })
+
+  // The editor's own origin. The provider flow opens in a separate tab and lands
+  // on `/oauth-complete` there, so this tab — and the unsaved project in it — is
+  // never navigated away from.
+  const editorOrigin = typeof window === 'undefined' ? '' : window.location.origin
+
+  // Password recovery is an email flow that only exists on Edge, so this is one
+  // of the two links that still leave — there is nothing here to hand it to.
+  const forgotPasswordUrl = new URL('/forgot-password', account.frontendBaseUrl).toString()
+  // The other one. Registration is an Edge flow end to end (email verification,
+  // plan selection, onboarding) and none of it belongs in an editor dialog, so
+  // this hands off rather than pretending to start it here.
+  const signUpUrl = new URL('/signup', account.frontendBaseUrl).toString()
+
+  const onSubmit = async (values: SignInValues) => {
+    setSubmitting(true)
+    setFormState({ kind: 'idle' })
+
+    const outcome = await account.signIn(values.email, values.password)
+
+    setSubmitting(false)
+
+    switch (outcome.status) {
+      case 'signed-in':
+        onSignedIn()
+        return
+      // Correct password, unconfirmed address. Edge answers 200 for this, so
+      // calling it a login failure would send the user hunting for a typo that
+      // isn't there.
+      case 'email-unverified':
+        setFormState({ kind: 'unverified', email: outcome.email })
+        return
+      case 'invalid-credentials':
+        setFormState({ kind: 'error', message: 'Email or password is incorrect.' })
+        return
+      default:
+        setFormState({ kind: 'error', message: 'Could not sign in. Check your connection and try again.' })
+    }
+  }
+
+  return (
+    <Modal open={open}>
+      {/* `h-fit`, not `h-auto`: ModalContent hardcodes `h-[500px]` (so the provider
+          row rendered outside the dialog's border) AND positions itself with
+          `fixed inset-0 m-auto` — under which `height: auto` means "stretch from
+          top to bottom" and leaves a tall empty box. `max-h`/`overflow` then keep a
+          short viewport scrolling the dialog rather than clipping it. */}
+      <ModalContent className='flex h-fit max-h-[92vh] w-[400px] select-none flex-col gap-0 overflow-y-auto rounded-xl px-7 py-6'>
+        {/* Sized container, as Edge does it: an SVG given only a height collapses
+            its width to zero and the mark disappears. */}
+        <div className='mb-3 flex items-center justify-center'>
+          <AutonomyLogo className='h-9 w-auto text-brand' />
+        </div>
+
+        {/* The greeting names the app the user is actually in — welcoming them to
+            Edge from inside the editor read as the wrong product — but only for
+            someone who really is just arriving. Everyone else gets the sentence
+            that explains their own situation; see REASON_COPY. */}
+        <ModalTitle className='text-center text-xl font-normal text-neutral-900 dark:text-neutral-100'>
+          {copy.title}
+        </ModalTitle>
+        <p className='text-center text-sm text-neutral-500 dark:text-neutral-400'>{copy.subtitle}</p>
+        {/* Says out loud that these are the Edge credentials. Two logins live in
+            this app — this one and the PLC runtime's — and the user needs to know
+            which one is being asked for, and that no separate account exists. */}
+        <p className='mb-5 text-center text-xs text-neutral-500 dark:text-neutral-400'>
+          Use the same login as Autonomy Edge.
+        </p>
+
+        <form
+          className='flex flex-col gap-3.5'
+          onSubmit={(event) => {
+            void handleSubmit(onSubmit)(event)
+          }}
+        >
+          <div className='flex flex-col gap-1'>
+            <label htmlFor='edge-signin-email' className='text-sm font-medium text-neutral-900 dark:text-neutral-100'>
+              Email address
+            </label>
+            <div className='relative'>
+              <Mail className='pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-neutral-400' />
+              <input
+                id='edge-signin-email'
+                type='email'
+                autoComplete='email'
+                placeholder='Enter your email'
+                className={`${FIELD_CLASSES} pl-9`}
+                {...register('email')}
+              />
+            </div>
+            {errors.email && <span className='text-xs text-red-600'>{errors.email.message}</span>}
+          </div>
+
+          <div className='flex flex-col gap-1'>
+            <label
+              htmlFor='edge-signin-password'
+              className='text-sm font-medium text-neutral-900 dark:text-neutral-100'
+            >
+              Password
+            </label>
+            <div className='relative'>
+              <input
+                id='edge-signin-password'
+                type={showPassword ? 'text' : 'password'}
+                autoComplete='current-password'
+                placeholder='Enter your password'
+                className={`${FIELD_CLASSES} pl-3`}
+                {...register('password')}
+              />
+              <button
+                type='button'
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+                onClick={() => setShowPassword((shown) => !shown)}
+                className='absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer text-brand'
+              >
+                {showPassword ? <EyeOff className='h-4 w-4' /> : <Eye className='h-4 w-4' />}
+              </button>
+            </div>
+            {errors.password ? (
+              <span className='text-xs text-red-600'>{errors.password.message}</span>
+            ) : (
+              <span className='text-xs text-neutral-500 dark:text-neutral-400'>
+                Your password must be at least 8 characters long
+              </span>
+            )}
+          </div>
+
+          <div className='flex items-center justify-between'>
+            <label className='flex cursor-pointer items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300'>
+              <input
+                type='checkbox'
+                className='size-4 cursor-pointer rounded border-neutral-300 accent-brand dark:border-neutral-700'
+              />
+              Remember me
+            </label>
+            <a
+              href={forgotPasswordUrl}
+              className='cursor-pointer text-sm text-brand underline-offset-4 hover:underline'
+            >
+              Forgot your password?
+            </a>
+          </div>
+
+          {formState.kind === 'error' && <p className='text-sm text-red-600'>{formState.message}</p>}
+
+          {formState.kind === 'unverified' && (
+            <p className='text-sm text-amber-600 dark:text-amber-500'>
+              Confirm your email address first. Check the message sent to {formState.email}.
+            </p>
+          )}
+
+          <button
+            type='submit'
+            disabled={submitting}
+            className='w-full cursor-pointer rounded-lg bg-brand py-2.5 text-sm font-medium text-white transition-colors hover:bg-brand-dark disabled:cursor-not-allowed disabled:opacity-60'
+          >
+            {submitting ? 'Signing in…' : 'Sign In'}
+          </button>
+        </form>
+
+        <div className='my-4 flex items-center gap-3'>
+          <span className='h-px flex-1 bg-neutral-200 dark:bg-neutral-800' />
+          <span className='text-sm text-neutral-500 dark:text-neutral-400'>Or</span>
+          <span className='h-px flex-1 bg-neutral-200 dark:bg-neutral-800' />
+        </div>
+
+        {/* Three across, icon only: the row Edge shows, and what keeps the dialog
+            inside a laptop viewport without a scrollbar.
+
+            `target='_blank'` is load-bearing, not a nicety. The open project lives
+            in memory with nothing persisting it and the web build registers no
+            beforeunload guard, so navigating this tab to a provider would discard
+            every unsaved edit in silence. */}
+        <div className='grid grid-cols-3 gap-3'>
+          {account.oauthProviders.map((provider) => (
+            <a
+              key={provider.id}
+              href={account.oauthUrl(provider.id, editorOrigin)}
+              target='_blank'
+              rel='noreferrer'
+              aria-label={`Sign in with ${provider.label}`}
+              className='flex cursor-pointer items-center justify-center rounded-lg border border-neutral-300 py-2.5 text-neutral-900 transition-colors hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-100 dark:hover:bg-neutral-800'
+            >
+              <ProviderIcon provider={provider.id} />
+            </a>
+          ))}
+        </div>
+
+        {/* Edge closes its sign-in screen with this and so does this dialog.
+            It is load-bearing here in a way it is not there: the most common way
+            to arrive at this dialog is a shared project link, and the person who
+            followed it may not have an account at all. Without a way out, the
+            dialog is a dead end for exactly the visitor it was shown to.
+
+            `target='_blank'` for the same reason as the providers above — signing
+            up is a long flow, and it must not navigate a tab that may be holding
+            an unsaved project. */}
+        <p className='mt-5 text-center text-sm text-neutral-500 dark:text-neutral-400'>
+          Don&apos;t have an account?{' '}
+          <a
+            href={signUpUrl}
+            target='_blank'
+            rel='noreferrer'
+            className='cursor-pointer text-brand underline-offset-4 hover:underline'
+          >
+            Sign up
+          </a>
+        </p>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export { EdgeSignInModal }

--- a/src/frontend/components/_organisms/edge-sign-in-modal/index.tsx
+++ b/src/frontend/components/_organisms/edge-sign-in-modal/index.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
-import type { EdgeAccountPort } from '../../../../middleware/shared/ports/edge-account-port'
+import type { EdgeAccountPort, EdgeSignInOutcome } from '../../../../middleware/shared/ports/edge-account-port'
 import { AutonomyLogo } from '../../_atoms/autonomy-logo'
 import { ProviderIcon } from '../../_atoms/provider-icons'
 import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'
@@ -127,7 +127,13 @@ const EdgeSignInModal = ({ open, onSignedIn, account, reason = 'signed-out' }: E
     setSubmitting(true)
     setFormState({ kind: 'idle' })
 
-    const outcome = await account.signIn(values.email, values.password)
+    // The port contracts every failure into an outcome — `failed` — so a rejection
+    // is not a path the web adapter takes. Folded into that outcome anyway, because
+    // the type system does not enforce the contract: an unhandled rejection here
+    // would leave the button stuck on "Signing in…" having said nothing at all.
+    const outcome = await account
+      .signIn(values.email, values.password)
+      .catch((): EdgeSignInOutcome => ({ status: 'failed' }))
 
     setSubmitting(false)
 
@@ -236,16 +242,18 @@ const EdgeSignInModal = ({ open, onSignedIn, account, reason = 'signed-out' }: E
             )}
           </div>
 
-          <div className='flex items-center justify-between'>
-            <label className='flex cursor-pointer items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300'>
-              <input
-                type='checkbox'
-                className='size-4 cursor-pointer rounded border-neutral-300 accent-brand dark:border-neutral-700'
-              />
-              Remember me
-            </label>
+          {/* No "Remember me": the session length is Edge's to decide and it is
+              already a 30-day refresh cookie. A checkbox wired to nothing told the
+              user they were choosing something they were not.
+
+              `target='_blank'` for the same load-bearing reason as the providers
+              and the sign-up link below — recovery is an email round-trip, and it
+              must not navigate a tab holding an unsaved project. */}
+          <div className='flex items-center justify-end'>
             <a
               href={forgotPasswordUrl}
+              target='_blank'
+              rel='noreferrer'
               className='cursor-pointer text-sm text-brand underline-offset-4 hover:underline'
             >
               Forgot your password?

--- a/src/frontend/components/_organisms/workspace-activity-bar/index.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/index.tsx
@@ -1,7 +1,8 @@
 import { Files, GitBranch } from 'lucide-react'
 import { useCallback } from 'react'
 
-import { useNavigation } from '../../../../middleware/shared/providers'
+import { useCapabilities, useEdgeAccountPort, useNavigation } from '../../../../middleware/shared/providers'
+import { useEdgeAccount } from '../../../hooks/use-edge-account'
 import { useIsNinetiesTheme } from '../../../hooks/use-nineties-theme'
 import { useOpenPLCStore } from '../../../store'
 import { cn } from '../../../utils/cn'
@@ -9,6 +10,8 @@ import { RetroExplorer, RetroSourceControl } from '../../_atoms/retro-icons'
 import { DividerActivityBar } from '../../_atoms/workspace-activity-bar/divider'
 import { ExitButton } from '../../_molecules/workspace-activity-bar/default/exit'
 import { TooltipSidebarWrapperButton } from '../../_molecules/workspace-activity-bar/tooltip-button'
+import { EdgeAccountMenu } from '../edge-account-menu'
+import { EdgeSignInModal } from '../edge-sign-in-modal'
 import { DefaultWorkspaceActivityBar } from './default'
 import { FBDToolbox } from './fbd-toolbox'
 import { LadderToolbox } from './ladder-toolbox'
@@ -31,6 +34,16 @@ type ActivityBarProps = {
 }
 
 export const WorkspaceActivityBar = ({ defaultActivityBar, explorer, sourceControl }: ActivityBarProps) => {
+  const caps = useCapabilities()
+  const edgeAccount = useEdgeAccountPort()
+  const {
+    status: accountStatus,
+    user: accountUser,
+    planCaption: accountPlanCaption,
+    signedOutReason: accountSignedOutReason,
+    refresh: refreshAccount,
+    signOut: signOutOfAccount,
+  } = useEdgeAccount(caps.hasEdgeAccount, edgeAccount)
   const editor = useOpenPLCStore(useCallback((s) => s.editor, []))
   const { closeProject } = useOpenPLCStore(useCallback((s) => s.sharedWorkspaceActions, []))
   const navigation = useNavigation()
@@ -108,11 +121,43 @@ export const WorkspaceActivityBar = ({ defaultActivityBar, explorer, sourceContr
           </>
         )}
       </div>
-      <div className='flex h-7 w-full shrink-0 flex-col gap-6 pb-10'>
+      {/* Foot of the bar: leaving the project, then who is signed in. The account
+          sits below the exit arrow because it is a destination, not a tool — the
+          same reasoning that keeps it out of the toolbox above the divider. */}
+      <div className='flex w-full shrink-0 flex-col items-center gap-4 pb-3'>
         <TooltipSidebarWrapperButton tooltipContent='Exit'>
           <ExitButton onClick={handleExitApplication} />
         </TooltipSidebarWrapperButton>
+
+        {/* `hasEdgeAccount`, NOT `hasAuthentication`: the autonomy-node build is
+            also authenticated but talks to its own API, where Edge's account
+            endpoints do not exist — this would offer a sign-in that cannot work. */}
+        {/* No tooltip on this one: the menu it opens already leads with the name
+            and email, so a hover label just repeats itself over the open menu. */}
+        {caps.hasEdgeAccount && edgeAccount && accountStatus === 'signed-in' && accountUser && (
+          <EdgeAccountMenu
+            user={accountUser}
+            planCaption={accountPlanCaption}
+            edgeBaseUrl={edgeAccount.frontendBaseUrl}
+            onSignOut={() => {
+              void signOutOfAccount()
+            }}
+          />
+        )}
       </div>
+
+      {/* Gated on `signed-out` rather than `!user`, so a slow /auth/me never
+          flashes a sign-in prompt at someone who is already signed in. */}
+      {caps.hasEdgeAccount && edgeAccount && accountStatus === 'signed-out' && (
+        <EdgeSignInModal
+          open
+          account={edgeAccount}
+          reason={accountSignedOutReason}
+          onSignedIn={() => {
+            void refreshAccount()
+          }}
+        />
+      )}
     </>
   )
 }

--- a/src/frontend/components/_organisms/workspace-activity-bar/index.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/index.tsx
@@ -48,6 +48,14 @@ export const WorkspaceActivityBar = ({ defaultActivityBar, explorer, sourceContr
   const { closeProject } = useOpenPLCStore(useCallback((s) => s.sharedWorkspaceActions, []))
   const navigation = useNavigation()
 
+  /**
+   * Whether this build has an account slot at the foot of the bar at all.
+   *
+   * Deliberately not "is someone signed in": that would move the exit arrow on
+   * every sign-in and again on every sign-out. This is a property of the build.
+   */
+  const hasAccountSlot = caps.hasEdgeAccount && edgeAccount !== undefined
+
   const isFBDEditor = editor?.type === 'plc-graphical' && editor?.meta.language === 'fbd'
   const isLadderEditor = editor?.type === 'plc-graphical' && editor?.meta.language === 'ld'
   const isNineties = useIsNinetiesTheme()
@@ -123,8 +131,16 @@ export const WorkspaceActivityBar = ({ defaultActivityBar, explorer, sourceContr
       </div>
       {/* Foot of the bar: leaving the project, then who is signed in. The account
           sits below the exit arrow because it is a destination, not a tool — the
-          same reasoning that keeps it out of the toolbox above the divider. */}
-      <div className='flex w-full shrink-0 flex-col items-center gap-4 pb-3'>
+          same reasoning that keeps it out of the toolbox above the divider.
+
+          The bottom padding follows the account slot instead of being fixed. Where
+          there is no slot — the desktop editor, which mirrors this file and sets
+          `hasEdgeAccount` to false — the exit arrow is still the last thing in the
+          bar and keeps the `pb-10` it has always had. Making room for a menu that
+          build never renders had moved it ~28px down the activity bar, which is a
+          visible change to an existing control for no reason. Where the account
+          does render it is the last thing, and it wants the smaller gap. */}
+      <div className={cn('flex w-full shrink-0 flex-col items-center gap-4', hasAccountSlot ? 'pb-3' : 'pb-10')}>
         <TooltipSidebarWrapperButton tooltipContent='Exit'>
           <ExitButton onClick={handleExitApplication} />
         </TooltipSidebarWrapperButton>

--- a/src/frontend/hooks/use-edge-account.ts
+++ b/src/frontend/hooks/use-edge-account.ts
@@ -1,6 +1,11 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
-import type { EdgeAccountPort, EdgeUser } from '../../middleware/shared/ports/edge-account-port'
+import type {
+  EdgeAccountPort,
+  EdgeSessionState,
+  EdgeUser,
+  EdgeUserRead,
+} from '../../middleware/shared/ports/edge-account-port'
 
 /**
  * Who is signed in, according to the Edge API.
@@ -31,6 +36,26 @@ export interface UseEdgeAccountResult {
 }
 
 /**
+ * Why the account is signed out — told apart properly.
+ *
+ * The renewal layer marks the session expired for BOTH kinds of 401: one that ran
+ * out under a working user, and one where there was never a session to renew. So
+ * `isExpired()` on its own is also true for someone who just pressed Sign out, and
+ * for someone who never signed in at all — and both were then told "Your session
+ * has expired", a claim about their session that is simply false. `isAbsent()` is
+ * the discriminator the session layer already exposes for exactly this, and the
+ * web router uses it the same way (`no_auth` vs `session_expired`).
+ */
+function reasonFromSession(session: EdgeSessionState): 'expired' | 'signed-out' {
+  return session.isExpired() && !session.isAbsent() ? 'expired' : 'signed-out'
+}
+
+/** Widening gap before retrying a first read that never reached the server. */
+function retryDelay(attempt: number): number {
+  return Math.min(30_000, 1_000 * 2 ** (attempt - 1))
+}
+
+/**
  * `account` is the platform's Edge account port. Passed in rather than imported:
  * this file lives in `frontend/`, a surface mirrored into the desktop editor,
  * where reaching into the web adapter would compile the app against an API it
@@ -42,13 +67,56 @@ export function useEdgeAccount(enabled: boolean, account?: EdgeAccountPort): Use
   const [user, setUser] = useState<EdgeUser | null>(null)
   const [planCaption, setPlanCaption] = useState<string | null>(null)
   const [signedOutReason, setSignedOutReason] = useState<'expired' | 'signed-out'>('signed-out')
+  /** Consecutive reads that never reached the server. Drives the retry effect below. */
+  const [unreachable, setUnreachable] = useState(0)
+
+  /**
+   * Which read of the session is the current one.
+   *
+   * Bumped by every new refresh AND by everything that clears the account, so a
+   * read that resolves after one of those cannot apply what it found. Without it,
+   * an expiry landing while `fetchUser` was in flight was undone by that in-flight
+   * read: it came back with the user it had fetched BEFORE the session died, put
+   * the status back to `signed-in`, and called `markRestored()` — announcing a
+   * recovery that never happened, which replayed a queued save against a session
+   * that was already gone.
+   */
+  const generation = useRef(0)
 
   const refresh = useCallback(async () => {
     if (!active || !account) {
       return
     }
 
-    const nextUser = await account.fetchUser()
+    const readId = ++generation.current
+    const isCurrent = () => generation.current === readId
+
+    // `.catch` folds a rejection into the same "learned nothing" answer the port
+    // already has a name for. The web adapter contracts every failure into a read
+    // rather than rejecting, but nothing in the types enforces that — and a
+    // rejection here used to leave `status` on `loading` with no way back short of
+    // a reload, rendering neither the account menu nor the way to sign in.
+    const read = await account.fetchUser().catch((): EdgeUserRead => ({ status: 'unknown' }))
+
+    if (!isCurrent()) {
+      return
+    }
+
+    // Learned nothing, so change nothing.
+    //
+    // Falling to `signed-out` here is what dropped a blocking sign-in dialog over a
+    // live session — and over unsaved work — every time the network blipped for a
+    // second. Holding the current answer is the honest response to a question that
+    // was never actually asked. The retry effect below is what gets a FIRST read
+    // out of `loading`, since there is no answer to hold in that case.
+    if (read.status === 'unknown') {
+      setUnreachable((attempts) => attempts + 1)
+      return
+    }
+
+    setUnreachable(0)
+
+    const nextUser = read.status === 'signed-in' ? read.user : null
 
     // Announce the recovery from wherever a working session is OBSERVED, not only
     // from where this app performed a sign-in. A provider flow finishes in another
@@ -64,19 +132,48 @@ export function useEdgeAccount(enabled: boolean, account?: EdgeAccountPort): Use
 
     setUser(nextUser)
     setStatus(nextUser ? 'signed-in' : 'signed-out')
-    // `isEdgeSessionExpired` is the renewal layer's own verdict, so a refresh that
-    // finds nobody signed in still knows whether a session died to get here — the
-    // case where /auth/me 401s and the renewal behind it gave up.
-    setSignedOutReason(!nextUser && account.session.isExpired() ? 'expired' : 'signed-out')
+    // The renewal layer's own verdict, so a refresh that finds nobody signed in
+    // still knows whether a session died to get here — the case where /auth/me
+    // 401s and the renewal behind it gave up. See `reasonFromSession` for why that
+    // verdict alone is not enough to call it an expiry.
+    setSignedOutReason(nextUser ? 'signed-out' : reasonFromSession(account.session))
 
     // Only worth asking once we know someone is signed in, and it must not gate
     // the menu appearing: the caption is decoration next to the name.
-    setPlanCaption(nextUser ? await account.fetchPlanCaption() : null)
+    const caption = nextUser ? await account.fetchPlanCaption().catch(() => null) : null
+
+    if (!isCurrent()) {
+      return
+    }
+
+    setPlanCaption(caption)
   }, [active, account])
 
   useEffect(() => {
     void refresh()
   }, [refresh])
+
+  /**
+   * Retry a first read that never reached the server.
+   *
+   * Scoped to `loading` because that is the one state with nothing to hold on to —
+   * no account menu, no sign-in gate, nothing on screen at all — and no other way
+   * out, since the focus re-check below only runs while `signed-out`. Once there IS
+   * an answer, an unreachable read simply keeps it and this stays out of the way.
+   */
+  useEffect(() => {
+    if (!active || status !== 'loading' || unreachable === 0) {
+      return
+    }
+
+    const timer = setTimeout(() => {
+      void refresh()
+    }, retryDelay(unreachable))
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [active, status, unreachable, refresh])
 
   // The renewal layer already knows when a session is beyond saving; reusing its
   // signal keeps the menu from showing a user who can no longer save anything.
@@ -86,10 +183,11 @@ export function useEdgeAccount(enabled: boolean, account?: EdgeAccountPort): Use
     }
 
     return account.session.onExpired(() => {
+      generation.current += 1
       setUser(null)
       setPlanCaption(null)
       setStatus('signed-out')
-      setSignedOutReason('expired')
+      setSignedOutReason(reasonFromSession(account.session))
     })
   }, [active, account])
 
@@ -118,6 +216,10 @@ export function useEdgeAccount(enabled: boolean, account?: EdgeAccountPort): Use
   }, [active, status, refresh])
 
   const signOut = useCallback(async () => {
+    // Before the request, not after: the read to retire is the one already in
+    // flight, and awaiting first would let it land while the request is out.
+    generation.current += 1
+
     try {
       await account?.signOut()
     } finally {

--- a/src/frontend/hooks/use-edge-account.ts
+++ b/src/frontend/hooks/use-edge-account.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import type { EdgeAccountPort, EdgeUser } from '../../middleware/shared/ports/edge-account-port'
+
+/**
+ * Who is signed in, according to the Edge API.
+ *
+ * Deliberately holds no token and persists nothing. The session is the shared
+ * cookie session — the editor has no account state of its own to keep in sync, so
+ * the only thing cached here is the profile being displayed.
+ */
+export type EdgeAccountStatus = 'loading' | 'signed-in' | 'signed-out'
+
+export interface UseEdgeAccountResult {
+  status: EdgeAccountStatus
+  user: EdgeUser | null
+  /** e.g. `Pro Plan`; null when the account has no active subscription. */
+  planCaption: string | null
+  /**
+   * Why the account is signed out, when it is.
+   *
+   * `expired` means the user WAS working and the session died under them;
+   * `signed-out` means they simply are not signed in. The sign-in prompt reads
+   * very differently in those two cases — greeting someone who was mid-edit with
+   * "Welcome" tells them nothing about what just happened to their session.
+   */
+  signedOutReason: 'expired' | 'signed-out'
+  /** Re-read the session — call after a sign-in completes. */
+  refresh: () => Promise<void>
+  signOut: () => Promise<void>
+}
+
+/**
+ * `account` is the platform's Edge account port. Passed in rather than imported:
+ * this file lives in `frontend/`, a surface mirrored into the desktop editor,
+ * where reaching into the web adapter would compile the app against an API it
+ * does not speak. Undefined on such a platform, which reads the same as disabled.
+ */
+export function useEdgeAccount(enabled: boolean, account?: EdgeAccountPort): UseEdgeAccountResult {
+  const active = enabled && account !== undefined
+  const [status, setStatus] = useState<EdgeAccountStatus>(active ? 'loading' : 'signed-out')
+  const [user, setUser] = useState<EdgeUser | null>(null)
+  const [planCaption, setPlanCaption] = useState<string | null>(null)
+  const [signedOutReason, setSignedOutReason] = useState<'expired' | 'signed-out'>('signed-out')
+
+  const refresh = useCallback(async () => {
+    if (!active || !account) {
+      return
+    }
+
+    const nextUser = await account.fetchUser()
+
+    // Announce the recovery from wherever a working session is OBSERVED, not only
+    // from where this app performed a sign-in. A provider flow finishes in another
+    // tab, so this read is the only thing that learns about it — and the request
+    // succeeds, meaning the renewal layer never runs and never announces anything.
+    // Without this, work queued while the session was dead (an interrupted save)
+    // stayed queued forever after an OAuth sign-in, while the toast said it would
+    // finish on its own. Safe to call unconditionally: it no-ops unless something
+    // was previously announced dead.
+    if (nextUser) {
+      account.session.markRestored()
+    }
+
+    setUser(nextUser)
+    setStatus(nextUser ? 'signed-in' : 'signed-out')
+    // `isEdgeSessionExpired` is the renewal layer's own verdict, so a refresh that
+    // finds nobody signed in still knows whether a session died to get here — the
+    // case where /auth/me 401s and the renewal behind it gave up.
+    setSignedOutReason(!nextUser && account.session.isExpired() ? 'expired' : 'signed-out')
+
+    // Only worth asking once we know someone is signed in, and it must not gate
+    // the menu appearing: the caption is decoration next to the name.
+    setPlanCaption(nextUser ? await account.fetchPlanCaption() : null)
+  }, [active, account])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  // The renewal layer already knows when a session is beyond saving; reusing its
+  // signal keeps the menu from showing a user who can no longer save anything.
+  useEffect(() => {
+    if (!active || !account) {
+      return
+    }
+
+    return account.session.onExpired(() => {
+      setUser(null)
+      setPlanCaption(null)
+      setStatus('signed-out')
+      setSignedOutReason('expired')
+    })
+  }, [active, account])
+
+  /**
+   * Re-check when this tab regains focus while signed out.
+   *
+   * The provider flow finishes in a separate tab, so nothing in this one knows it
+   * happened. Coming back here is the signal. Scoped to the signed-out state so a
+   * working session never pays for it, and it is the only way the sign-in gate
+   * closes after an OAuth round-trip.
+   */
+  useEffect(() => {
+    if (!active || status !== 'signed-out') {
+      return
+    }
+
+    const onFocus = () => {
+      void refresh()
+    }
+
+    window.addEventListener('focus', onFocus)
+
+    return () => {
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [active, status, refresh])
+
+  const signOut = useCallback(async () => {
+    try {
+      await account?.signOut()
+    } finally {
+      // In `finally`, not after the await: the user asked to leave, so the UI has
+      // to reach the signed-out state even if the request throws. Leaving them
+      // looking at an account they just left is the worse failure, and relying on
+      // the callee never rejecting would put that guarantee in the wrong place.
+      setUser(null)
+      setPlanCaption(null)
+      setStatus('signed-out')
+      // Leaving on purpose is not an expiry: the prompt must not tell someone who
+      // just signed out that their session expired.
+      setSignedOutReason('signed-out')
+    }
+  }, [account])
+
+  return { status, user, planCaption, signedOutReason, refresh, signOut }
+}

--- a/src/frontend/services/resume-save-after-sign-in.ts
+++ b/src/frontend/services/resume-save-after-sign-in.ts
@@ -14,6 +14,7 @@
  */
 
 import type { EdgeSessionState } from '../../middleware/shared/ports/edge-account-port'
+import { openPLCStoreBase } from '../store'
 
 /**
  * The session signals, handed in at boot.
@@ -44,29 +45,70 @@ export function isSaveBlockedByEndedSession(): boolean {
 }
 
 /**
- * The save waiting for a working session, and how much of the project it covers.
+ * Which save is waiting, and what it covers.
  *
- * Exactly one entry, but "newest wins" is wrong on its own. A project save writes
- * every dirty file, so it supersedes a queued single-file save; a single-file save
- * does NOT supersede a queued project save — letting it would replay one file and
- * leave every other dirty file unwritten, while the toast said the save would
- * finish on its own. Widest scope wins; ties go to the newest.
+ * A project save writes every dirty file, so it supersedes any queued single-file
+ * save; a single-file save does NOT supersede a queued project save — letting it
+ * would replay one file and leave every other dirty file unwritten, while the toast
+ * said the save would finish on its own.
+ *
+ * A file save must name its file, because two of them for DIFFERENT files do not
+ * supersede each other either. That used to be a single slot, so the second Ctrl+S
+ * silently evicted the first: the user was told "sign in again and PouA saves on
+ * its own", then told the same about PouB, and only PouB was ever written.
  */
-type SaveScope = 'file' | 'project'
+export type SaveTarget = { scope: 'project' } | { scope: 'file'; fileName: string }
 
-let pending: { run: () => Promise<unknown>; scope: SaveScope } | null = null
+type QueuedSave = {
+  run: () => Promise<unknown>
+  /**
+   * The project this save was queued for.
+   *
+   * `run` closes over nothing that identifies it — both variants read the store at
+   * replay time — so without this a save queued for one project and replayed after
+   * the user opened another wrote whatever happened to be loaded, leaving the edits
+   * that were actually queued unsaved. The single-file variant announced it, too:
+   * `executeSaveFile('PouA', …)` against a project with no `PouA` toasted
+   * `File "PouA" not found` seconds after an unrelated sign-in.
+   */
+  projectPath: string
+}
+
+/** The queued project-wide save, if one is waiting. Excludes the per-file queue. */
+let pendingProject: QueuedSave | null = null
+
+/** Queued single-file saves, by file name. Empty whenever `pendingProject` is set. */
+const pendingFiles = new Map<string, QueuedSave>()
 
 /** Live only while something is actually waiting, so an idle editor holds no listener. */
 let unsubscribe: (() => void) | null = null
 
-export function resumeSaveAfterEdgeSignIn(run: () => Promise<unknown>, scope: SaveScope = 'project'): void {
+/** The project currently open, as the store knows it. */
+function currentProjectPath(): string {
+  return openPLCStoreBase.getState().project.meta.path
+}
+
+export function resumeSaveAfterEdgeSignIn(
+  run: () => Promise<unknown>,
+  target: SaveTarget = { scope: 'project' },
+): void {
   if (!session) {
     return
   }
 
-  // A narrower save never displaces a broader one already waiting.
-  if (pending?.scope === 'project' && scope === 'file') {
-    return
+  const projectPath = currentProjectPath()
+
+  if (target.scope === 'project') {
+    // Writes every dirty file, so whatever single files were waiting are covered.
+    pendingFiles.clear()
+    pendingProject = { run, projectPath }
+  } else {
+    // A narrower save never displaces a broader one already waiting.
+    if (pendingProject) {
+      return
+    }
+
+    pendingFiles.set(target.fileName, { run, projectPath })
   }
 
   // NOT guarded on `session.isExpired()`.
@@ -79,32 +121,51 @@ export function resumeSaveAfterEdgeSignIn(run: () => Promise<unknown>, scope: Sa
   // meant to defer. The window is a few microseconds (the caller checks expiry
   // immediately before calling), and losing a queued replay there is strictly
   // better than re-entering the save path.
-  pending = { run, scope }
-
   unsubscribe ??= session.onRestored(() => {
-    const queued = pending
+    const queued = pendingProject ? [pendingProject] : [...pendingFiles.values()]
 
-    // Cleared BEFORE running: the replay can fail again (the session could die a
+    // Cleared BEFORE running: a replay can fail again (the session could die a
     // second time), and it has to be free to register itself afresh rather than
     // being cancelled by this teardown.
-    pending = null
+    pendingProject = null
+    pendingFiles.clear()
     unsubscribe?.()
     unsubscribe = null
 
-    if (queued) {
-      void queued.run()
-    }
+    void replayQueued(queued, currentProjectPath())
   })
+}
+
+/**
+ * Run the queued saves, skipping any that belong to a project no longer open.
+ *
+ * Sequential rather than concurrent: these write into the same project through the
+ * same store, and interleaving two of them is how a half-written project happens.
+ */
+async function replayQueued(queued: QueuedSave[], openProject: string): Promise<void> {
+  for (const save of queued) {
+    if (save.projectPath !== openProject) {
+      continue
+    }
+
+    try {
+      await save.run()
+    } catch {
+      // Both save variants report their own failures and neither rejects; caught
+      // anyway so one throwing cannot strand the saves queued behind it.
+    }
+  }
 }
 
 /** True while a save is waiting for the session to come back. */
 export function hasSaveWaitingForSignIn(): boolean {
-  return pending !== null
+  return pendingProject !== null || pendingFiles.size > 0
 }
 
-/** Test seam: drop the queued save, the subscription and the wiring between cases. */
+/** Test seam: drop the queued saves, the subscription and the wiring between cases. */
 export function resetResumeSaveForTests(state?: EdgeSessionState): void {
-  pending = null
+  pendingProject = null
+  pendingFiles.clear()
   unsubscribe?.()
   unsubscribe = null
   session = state

--- a/src/frontend/services/resume-save-after-sign-in.ts
+++ b/src/frontend/services/resume-save-after-sign-in.ts
@@ -1,0 +1,111 @@
+/**
+ * Re-run a save that died because the Edge session ended.
+ *
+ * The problem this solves is narrow and specific. A save that fails on an expired
+ * session leaves the project dirty in memory and nothing on the server. The user
+ * then signs in — the modal is right there — and the save is still not done. The
+ * only signal was a toast that had already faded, so the normal outcome was
+ * assuming the work was stored and closing the tab.
+ *
+ * So the save is held here and replayed the moment the session works again. The
+ * user does not have to notice anything, which is the point: they never asked for
+ * their session to expire, and remembering to save twice is not a reasonable thing
+ * to ask of them.
+ */
+
+import type { EdgeSessionState } from '../../middleware/shared/ports/edge-account-port'
+
+/**
+ * The session signals, handed in at boot.
+ *
+ * Injected rather than imported: this file lives in `frontend/services`, which the
+ * architecture rules forbid from importing an adapter — and rightly so, since the
+ * desktop editor mirrors this surface and has no Edge session at all. The web
+ * adapter cannot import us either (adapters may not depend on services), so the
+ * wiring happens at the composition root (`App.tsx`).
+ *
+ * Undefined until wired, and on platforms that never wire it. Everything below
+ * degrades to "nothing is queued", which is the correct behaviour there.
+ */
+let session: EdgeSessionState | undefined
+
+export function configureSaveResume(state: EdgeSessionState): void {
+  session = state
+}
+
+/**
+ * Whether the Edge session is known to have failed.
+ *
+ * Re-exported through this module so `save-actions` can ask without importing the
+ * adapter itself — same reasoning as above.
+ */
+export function isSaveBlockedByEndedSession(): boolean {
+  return session?.isExpired() ?? false
+}
+
+/**
+ * The save waiting for a working session, and how much of the project it covers.
+ *
+ * Exactly one entry, but "newest wins" is wrong on its own. A project save writes
+ * every dirty file, so it supersedes a queued single-file save; a single-file save
+ * does NOT supersede a queued project save — letting it would replay one file and
+ * leave every other dirty file unwritten, while the toast said the save would
+ * finish on its own. Widest scope wins; ties go to the newest.
+ */
+type SaveScope = 'file' | 'project'
+
+let pending: { run: () => Promise<unknown>; scope: SaveScope } | null = null
+
+/** Live only while something is actually waiting, so an idle editor holds no listener. */
+let unsubscribe: (() => void) | null = null
+
+export function resumeSaveAfterEdgeSignIn(run: () => Promise<unknown>, scope: SaveScope = 'project'): void {
+  if (!session) {
+    return
+  }
+
+  // A narrower save never displaces a broader one already waiting.
+  if (pending?.scope === 'project' && scope === 'file') {
+    return
+  }
+
+  // NOT guarded on `session.isExpired()`.
+  //
+  // There is a narrow window where the session recovers between a save failing
+  // and this call, leaving the entry waiting for a restore that already happened.
+  // Running immediately instead looks like the fix and is not: a replay that fails
+  // again re-registers from inside the restore fan-out, at which point the session
+  // is already marked healthy — so "run it now" recurses into the save it was
+  // meant to defer. The window is a few microseconds (the caller checks expiry
+  // immediately before calling), and losing a queued replay there is strictly
+  // better than re-entering the save path.
+  pending = { run, scope }
+
+  unsubscribe ??= session.onRestored(() => {
+    const queued = pending
+
+    // Cleared BEFORE running: the replay can fail again (the session could die a
+    // second time), and it has to be free to register itself afresh rather than
+    // being cancelled by this teardown.
+    pending = null
+    unsubscribe?.()
+    unsubscribe = null
+
+    if (queued) {
+      void queued.run()
+    }
+  })
+}
+
+/** True while a save is waiting for the session to come back. */
+export function hasSaveWaitingForSignIn(): boolean {
+  return pending !== null
+}
+
+/** Test seam: drop the queued save, the subscription and the wiring between cases. */
+export function resetResumeSaveForTests(state?: EdgeSessionState): void {
+  pending = null
+  unsubscribe?.()
+  unsubscribe = null
+  session = state
+}

--- a/src/frontend/services/save-actions.ts
+++ b/src/frontend/services/save-actions.ts
@@ -31,6 +31,7 @@ import { collectDebugVariables, sanitizePou } from '../utils/save-project'
 import { toast } from '../utils/toast'
 import { pickContentForSave } from '../utils/version-control-content'
 import { collectScreenPersistenceKeys } from '../utils/vpp/persistence-keys'
+import { isSaveBlockedByEndedSession, resumeSaveAfterEdgeSignIn } from './resume-save-after-sign-in'
 
 /** Join path segments with forward slashes (platform-agnostic, works with Node's fs on all OSes). */
 const joinPath = (...parts: string[]): string => parts.join('/').replace(/\/+/g, '/')
@@ -557,6 +558,18 @@ export async function executeSaveProject(
           variant: 'default',
         })
       }
+    } else if (isSaveBlockedByEndedSession()) {
+      // A dead session is not a save error, and reporting it as one ("API error:
+      // 401 Unauthorized") told the user nothing they could act on. Say what
+      // happened, say the work is safe, and queue the save so signing in finishes
+      // it — the user should not have to remember to press save a second time.
+      setEditingState('unsaved')
+      resumeSaveAfterEdgeSignIn(() => executeSaveProject(projectPort, capabilities))
+      toast({
+        title: 'Not saved — your session ended',
+        description: 'Sign in again and this save finishes on its own. Everything you typed is still open here.',
+        variant: 'fail',
+      })
     } else {
       setEditingState('unsaved')
       toast({
@@ -623,6 +636,21 @@ export async function executeSaveFile(
 
   const fail = (description: string): { success: false } => {
     setEditingState('unsaved')
+
+    // Same reasoning as executeSaveProject: an expired session is not a file
+    // error, and the raw 401 text is useless to the reader. Queue the save so
+    // signing in completes it rather than leaving the file dirty and the user
+    // unaware.
+    if (isSaveBlockedByEndedSession()) {
+      resumeSaveAfterEdgeSignIn(() => executeSaveFile(fileName, projectPort, capabilities), 'file')
+      toast({
+        title: 'Not saved — your session ended',
+        description: `Sign in again and "${fileName}" saves on its own. Everything you typed is still open here.`,
+        variant: 'fail',
+      })
+      return { success: false }
+    }
+
     toast({ title: 'Error saving file', description, variant: 'fail' })
     return { success: false }
   }

--- a/src/frontend/services/save-actions.ts
+++ b/src/frontend/services/save-actions.ts
@@ -637,12 +637,32 @@ export async function executeSaveFile(
   const fail = (description: string): { success: false } => {
     setEditingState('unsaved')
 
-    // Same reasoning as executeSaveProject: an expired session is not a file
-    // error, and the raw 401 text is useless to the reader. Queue the save so
-    // signing in completes it rather than leaving the file dirty and the user
-    // unaware.
+    toast({ title: 'Error saving file', description, variant: 'fail' })
+    return { success: false }
+  }
+
+  /**
+   * A failure that came from the write itself, rather than from this function.
+   *
+   * The session check lives here and NOT in `fail`, which is the single error exit
+   * for everything — a POU that is not in the store, a ladder body that would not
+   * serialize (DOPE-495), an unexpected throw. With the check in `fail`, an expired
+   * session relabelled every one of those as "Not saved — your session ended" and
+   * queued them for a replay that could only fail the same way: the user with an
+   * invalid graphical body was told to sign in again instead of being told the one
+   * thing they could act on.
+   */
+  const failedWrite = (description: string): { success: false } => {
+    setEditingState('unsaved')
+
+    // An expired session is not a file error, and the raw 401 text is useless to
+    // the reader. Queue the save so signing in completes it rather than leaving the
+    // file dirty and the user unaware.
     if (isSaveBlockedByEndedSession()) {
-      resumeSaveAfterEdgeSignIn(() => executeSaveFile(fileName, projectPort, capabilities), 'file')
+      resumeSaveAfterEdgeSignIn(() => executeSaveFile(fileName, projectPort, capabilities), {
+        scope: 'file',
+        fileName,
+      })
       toast({
         title: 'Not saved — your session ended',
         description: `Sign in again and "${fileName}" saves on its own. Everything you typed is still open here.`,
@@ -682,24 +702,24 @@ export async function executeSaveFile(
       const folder = getFolderFromPouType(pou.pouType)
       const ext = getExtensionFromLanguage(pou.body.language)
       const res = await projectPort.saveFile(joinPath(projectPath, 'pous', folder, `${fileName}${ext}`), spec.content)
-      if (!res.success) return fail(res.error ?? 'Save failed')
+      if (!res.success) return failedWrite(res.error ?? 'Save failed')
     } else if (file.type === 'device') {
       const config = specs.find((s) => s.category === 'device-config')
       const pin = specs.find((s) => s.category === 'pin-mapping')
       if (!config || !pin) return fail('Save failed')
       const configRes = await projectPort.saveFile(joinPath(projectPath, 'devices/configuration.json'), config.content)
       const pinRes = await projectPort.saveFile(joinPath(projectPath, 'devices/pin-mapping.json'), pin.content)
-      if (!configRes.success || !pinRes.success) return fail('Save failed')
+      if (!configRes.success || !pinRes.success) return failedWrite('Save failed')
     } else if (file.type === 'server') {
       const spec = specs[0]
       if (!spec) return fail(`Server "${fileName}" not found.`)
       const res = await projectPort.saveFile(joinPath(projectPath, 'devices/servers', `${fileName}.json`), spec.content)
-      if (!res.success) return fail(res.error ?? 'Save failed')
+      if (!res.success) return failedWrite(res.error ?? 'Save failed')
     } else if (file.type === 'remote-device') {
       const spec = specs[0]
       if (!spec) return fail(`Remote device "${fileName}" not found.`)
       const res = await projectPort.saveFile(joinPath(projectPath, 'devices/remote', `${fileName}.json`), spec.content)
-      if (!res.success) return fail(res.error ?? 'Save failed')
+      if (!res.success) return failedWrite(res.error ?? 'Save failed')
     } else if (file.type === 'ethercat-device') {
       // Slave devices live inside the parent bus file. filePath holds the bus name.
       const spec = specs[0]
@@ -708,7 +728,7 @@ export async function executeSaveFile(
         joinPath(projectPath, 'devices/remote', `${file.filePath}.json`),
         spec.content,
       )
-      if (!res.success) return fail(res.error ?? 'Save failed')
+      if (!res.success) return failedWrite(res.error ?? 'Save failed')
     } else if (file.type === 'library-manager') {
       // Surgical save: read project.json from disk and replace only
       // the `data.libraries` field with the current in-memory list.
@@ -716,7 +736,7 @@ export async function executeSaveFile(
       // unsaved project-level changes (data types, resource config,
       // debug snapshot) that the user hasn't touched in this tab.
       const res = await saveLibraryManagerOnly(projectPath, projectPort, state)
-      if (!res.success) return fail(res.error ?? 'Save failed')
+      if (!res.success) return failedWrite(res.error ?? 'Save failed')
     } else if (file.type === 'vendor-screen') {
       // Surgical save: read devices/configuration.json from disk and
       // replace only the `vendorScreenData` keys this screen owns
@@ -726,7 +746,7 @@ export async function executeSaveFile(
       // serialised owned slice so the screen definition isn't needed
       // here.
       const res = await saveVendorScreenOnly(projectPath, projectPort, state, fileName)
-      if (!res.success) return fail(res.error ?? 'Save failed')
+      if (!res.success) return failedWrite(res.error ?? 'Save failed')
     } else if (file.type === 'library-manifest') {
       // Single-file save for the manifest tab: write the in-store
       // content (`project.data.libraryManifest`) to `library.json`.
@@ -735,12 +755,12 @@ export async function executeSaveFile(
       const spec = specs[0]
       if (!spec) return fail('Save failed')
       const res = await projectPort.saveFile(joinPath(projectPath, 'library.json'), spec.content)
-      if (!res.success) return fail(res.error ?? 'Save failed')
+      if (!res.success) return failedWrite(res.error ?? 'Save failed')
     } else if (file.type === 'data-type' && isDataTypeFilesEnabled()) {
       const spec = specs[0]
       if (!spec) return fail(`Data type "${fileName}" not found.`)
       const res = await projectPort.saveFile(joinPath(projectPath, 'datatypes', `${fileName}.dt`), spec.content)
-      if (!res.success) return fail(res.error ?? 'Save failed')
+      if (!res.success) return failedWrite(res.error ?? 'Save failed')
     } else {
       // resource (and data-type while the .dt flag is off): live in
       // project.json (legacy whole-file write) — cross-contamination
@@ -748,7 +768,7 @@ export async function executeSaveFile(
       const spec = specs[0]
       if (!spec) return fail('Save failed')
       const res = await projectPort.saveFile(joinPath(projectPath, 'project.json'), spec.content)
-      if (!res.success) return fail(res.error ?? 'Save failed')
+      if (!res.success) return failedWrite(res.error ?? 'Save failed')
     }
 
     // Tell the version-control slice exactly which paths/content were just

--- a/src/middleware/shared/ports/edge-account-port.ts
+++ b/src/middleware/shared/ports/edge-account-port.ts
@@ -29,6 +29,23 @@ export interface EdgeUser {
   emailVerifiedAt?: string | null
 }
 
+/**
+ * What asking "who is signed in?" actually established.
+ *
+ * `unknown` is the whole reason this is not just `EdgeUser | null`. A request that
+ * never reached the server says NOTHING about whether a session exists, and
+ * collapsing it into "nobody is signed in" put a blocking sign-in dialog over a
+ * perfectly valid session every time the network blipped for a second — over an
+ * editor holding unsaved work, with no way out until the window happened to be
+ * refocused. The caller has to be able to tell the two apart and hold its ground.
+ */
+export type EdgeUserRead =
+  | { status: 'signed-in'; user: EdgeUser }
+  /** The server answered, and there is no usable session. */
+  | { status: 'no-session' }
+  /** The question could not be asked — offline, DNS, CORS, a dropped connection. */
+  | { status: 'unknown' }
+
 export type EdgeSignInOutcome =
   | { status: 'signed-in'; user: EdgeUser }
   /**
@@ -84,8 +101,11 @@ export interface EdgeAccountPort {
    * on the app that started it rather than on Edge.
    */
   oauthUrl(provider: EdgeOAuthProviderId, returnTo: string): string
-  /** The signed-in user, or null when there is no usable session. */
-  fetchUser(): Promise<EdgeUser | null>
+  /**
+   * Who is signed in — and, when that could not be established, the fact that it
+   * could not be. See `EdgeUserRead`: a network failure is not a signed-out user.
+   */
+  fetchUser(): Promise<EdgeUserRead>
   /** e.g. `Pro Plan`; null when the account has no active subscription. */
   fetchPlanCaption(): Promise<string | null>
   signIn(email: string, password: string): Promise<EdgeSignInOutcome>

--- a/src/middleware/shared/ports/edge-account-port.ts
+++ b/src/middleware/shared/ports/edge-account-port.ts
@@ -1,0 +1,94 @@
+/**
+ * The Autonomy Edge account, as the frontend is allowed to see it.
+ *
+ * The account UI — the avatar, the menu, the sign-in dialog — needs to ask who is
+ * signed in, sign someone in or out, and know where Edge's own pages live. All of
+ * that is adapter knowledge: it speaks to a specific API over cookies on a shared
+ * parent domain, and only the web build has it at all.
+ *
+ * This port is what keeps that knowledge out of `frontend/`. The components used to
+ * import `adapters/web/services/edge-account` directly, which the architecture
+ * validator forbids for good reason: `frontend/` is a surface mirrored into the
+ * desktop editor, and a direct adapter import compiles that app against an API it
+ * does not talk to.
+ *
+ * OPTIONAL on `PlatformPorts`, like `ai` and `esi`: the desktop editor has no Edge
+ * account and sets `capabilities.hasEdgeAccount` to false. Gate on the capability,
+ * not on the port being present.
+ */
+
+/** Mirrors Edge's `UserProfile`, narrowed to what the account UI renders. */
+export interface EdgeUser {
+  id: string
+  name: string
+  email: string
+  username: string
+  profileImage?: string | null
+  customInitials?: string | null
+  initialsColor?: string | null
+  emailVerifiedAt?: string | null
+}
+
+export type EdgeSignInOutcome =
+  | { status: 'signed-in'; user: EdgeUser }
+  /**
+   * Credentials were right but the address is unverified. Edge answers 200 with
+   * null tokens for this — NOT an error — so reporting it as a failed sign-in
+   * would send the user hunting for a wrong password.
+   */
+  | { status: 'email-unverified'; email: string }
+  | { status: 'invalid-credentials' }
+  | { status: 'failed' }
+
+/** The providers Edge itself offers. */
+export type EdgeOAuthProviderId = 'google' | 'microsoft' | 'apple'
+
+export interface EdgeOAuthProvider {
+  id: EdgeOAuthProviderId
+  label: string
+}
+
+/**
+ * Why a renewal failed, when one did.
+ *
+ * `expired` and `no-session` are both 401s from the same endpoint, and telling
+ * them apart is what stops a stranger who followed a shared project link being
+ * told that *their* session ended.
+ */
+export interface EdgeSessionState {
+  /** True once a renewal has definitively failed. */
+  isExpired(): boolean
+  /** True when the last failure found no session to renew, rather than a dead one. */
+  isAbsent(): boolean
+  /** Fires when the session is gone for good. Returns an unsubscribe function. */
+  onExpired(listener: () => void): () => void
+  /** Fires when a session that HAD died works again. Returns an unsubscribe function. */
+  onRestored(listener: () => void): () => void
+  /**
+   * Announce that the session works again. A no-op unless something was
+   * previously announced dead, so it is safe to call on any healthy read — which
+   * is the point: a provider flow completes in another tab, and the only way this
+   * one finds out is by observing a request succeed.
+   */
+  markRestored(): void
+}
+
+export interface EdgeAccountPort {
+  /** Origin of the Edge SPA, for the pages the editor links out to. */
+  frontendBaseUrl: string
+  oauthProviders: readonly EdgeOAuthProvider[]
+  /**
+   * Where to send the browser to start a provider flow.
+   *
+   * `returnTo` is carried through the provider and back, so the round trip lands
+   * on the app that started it rather than on Edge.
+   */
+  oauthUrl(provider: EdgeOAuthProviderId, returnTo: string): string
+  /** The signed-in user, or null when there is no usable session. */
+  fetchUser(): Promise<EdgeUser | null>
+  /** e.g. `Pro Plan`; null when the account has no active subscription. */
+  fetchPlanCaption(): Promise<string | null>
+  signIn(email: string, password: string): Promise<EdgeSignInOutcome>
+  signOut(): Promise<void>
+  session: EdgeSessionState
+}

--- a/src/middleware/shared/ports/platform-capabilities.ts
+++ b/src/middleware/shared/ports/platform-capabilities.ts
@@ -24,6 +24,17 @@ export interface PlatformCapabilities {
   /** True if the app requires user authentication to access the workspace. */
   hasAuthentication: boolean
 
+  /**
+   * True if the Edge account UI belongs in this build — the profile menu in the
+   * title bar and the sign-in gate, both talking to the Edge API.
+   *
+   * Distinct from {@link hasAuthentication} on purpose. The autonomy-node build
+   * shares WEB_CAPABILITIES and is also authenticated, but its API is node's own,
+   * not Edge's: showing Edge's account UI there would offer a sign-in that cannot
+   * work. Gate the account UI on THIS flag, never on `hasAuthentication`.
+   */
+  hasEdgeAccount: boolean
+
   // --- Device & Hardware ---
 
   /** True if the app can detect local serial/communication ports. */
@@ -129,6 +140,8 @@ export const EDITOR_CAPABILITIES: PlatformCapabilities = {
   isNativeApplication: true,
   hasNativeFileDialogs: true,
   hasAuthentication: false,
+  // Desktop editor works against the local filesystem, with no Edge account.
+  hasEdgeAccount: false,
   hasLocalSerialPorts: true,
   hasOrchestratorDevices: false,
   hasWebRTC: false,
@@ -158,6 +171,8 @@ export const WEB_CAPABILITIES: PlatformCapabilities = {
   isNativeApplication: false,
   hasNativeFileDialogs: false,
   hasAuthentication: true,
+  // Default for the web build; the autonomy-node build turns this off via env.
+  hasEdgeAccount: true,
   hasLocalSerialPorts: false,
   hasOrchestratorDevices: true,
   hasWebRTC: true,

--- a/src/middleware/shared/ports/project-port.ts
+++ b/src/middleware/shared/ports/project-port.ts
@@ -93,6 +93,17 @@ export interface ProjectResponse {
   error?: {
     title: string
     description: string
+    /**
+     * HTTP status behind the failure, when the platform had one.
+     *
+     * Carried separately because the router has to tell "you cannot see this
+     * project" (403) from "the project would not load" (anything else), and those
+     * need opposite things said to the user. The status used to survive only
+     * inside `description` as prose, so the only way to classify was to match on
+     * the text — which is how a permission denial ended up telling people to
+     * contact support.
+     */
+    status?: number
   }
 }
 
@@ -198,7 +209,13 @@ export interface RawProjectFiles {
      */
     pendingPlcopenSource?: string
   }
-  error?: { title: string; description: string }
+  /**
+   * `status` carries the HTTP status when the platform had one, for the same
+   * reason it exists on `ProjectResponse`: this is the error `openProjectByPath`
+   * forwards, so a 403 that stops here can never be told apart from a broken
+   * project further up. See the note on `ProjectResponse['error']`.
+   */
+  error?: { title: string; description: string; status?: number }
 }
 
 export interface ProjectPort {

--- a/src/middleware/shared/providers/index.ts
+++ b/src/middleware/shared/providers/index.ts
@@ -7,6 +7,7 @@ export {
   useCompiler,
   useDebugger,
   useDevice,
+  useEdgeAccount as useEdgeAccountPort,
   useNavigation,
   useOrchestrator,
   useProject,

--- a/src/middleware/shared/providers/platform-context.tsx
+++ b/src/middleware/shared/providers/platform-context.tsx
@@ -118,6 +118,17 @@ export function useEsi() {
   return usePlatform().esi
 }
 
+/**
+ * The Edge account port, or undefined on a platform that has no Edge account.
+ *
+ * Named `useEdgeAccount` here and re-exported as `useEdgeAccountPort` so it does
+ * not collide with the `useEdgeAccount` hook in `frontend/hooks`, which is the
+ * stateful consumer of this port rather than an accessor for it.
+ */
+export function useEdgeAccount() {
+  return usePlatform().edgeAccount
+}
+
 export function useLibrary() {
   return usePlatform().library
 }

--- a/src/middleware/shared/providers/types.ts
+++ b/src/middleware/shared/providers/types.ts
@@ -8,6 +8,7 @@ import type { AIPort } from '../ports/ai-port'
 import type { CompilerPort } from '../ports/compiler-port'
 import type { DebuggerPort } from '../ports/debugger-port'
 import type { DevicePort } from '../ports/device-port'
+import type { EdgeAccountPort } from '../ports/edge-account-port'
 import type { EsiPort } from '../ports/esi-port'
 import type { LibraryPort } from '../ports/library-port'
 import type { NavigationPort } from '../ports/navigation-port'
@@ -42,6 +43,12 @@ export interface PlatformPorts {
   packages?: PackagePort
   esi?: EsiPort
   ai?: AIPort
+  /**
+   * Optional — the web build only. The desktop editor has no Edge account and
+   * sets `capabilities.hasEdgeAccount` false; gate on that capability rather than
+   * on this being present.
+   */
+  edgeAccount?: EdgeAccountPort
   /**
    * Optional — present only on platforms that intend to host the
    * STruC++ language server.  When `capabilities.hasStLSP` is true


### PR DESCRIPTION
Companion to **openplc-web#682** (merged) and **openplc-web#685** ([EDGE-602]). Mirrors the shared surface so the `Shared Surface Sync` check passes in both repos.

## What this PR is

`ci-sync.yml` compares `src/frontend/`, `src/middleware/shared/`, `src/backend/shared/` and `src/__architecture__/` **byte-for-byte** between the two repos. This PR carries the Edge account surface across so those paths are identical.

It has two halves now:

1. **The original mirror** of openplc-web#682 — 9 new files and 7 edited, the Edge account UI and the port it talks through.
2. **The review fixes**, mirroring openplc-web#685. A review here raised 12 findings and CodeRabbit 9; because these files are byte-identical to web's `development`, none of them could be fixed on this side alone. Both PRs carry the same fix.

## The surface

**9 new** — the Edge account UI and its port:

| file | |
|---|---|
| `_organisms/edge-sign-in-modal/index.tsx` | sign-in form + provider handoff |
| `_organisms/edge-account-menu/index.tsx` | profile menu |
| `_atoms/edge-avatar/{index.tsx,resolve-initials.ts}` | avatar with initials fallback |
| `_atoms/provider-icons/index.tsx` | Google / Microsoft / Apple marks |
| `_atoms/autonomy-logo/index.tsx` | wordmark |
| `hooks/use-edge-account.ts` | drives the above |
| `services/resume-save-after-sign-in.ts` | holds a save interrupted by an expired session |
| `middleware/shared/ports/edge-account-port.ts` | the boundary |

**7 edited** — files the surface already shared: `workspace-activity-bar`, `services/save-actions.ts`, `ports/platform-capabilities.ts`, `ports/project-port.ts`, `providers/{index.ts, platform-context.tsx, types.ts}`.

## What the review fixes changed

Full reasoning is in openplc-web#685 and in the replies on each thread here. In short:

- **`fetchUser` conflated "no session" with "could not ask."** A network blip therefore signed the user out and mounted a blocking sign-in dialog over unsaved work. The port now answers `EdgeUserRead` (`signed-in` / `no-session` / `unknown`); an `unknown` read changes nothing, and a first read retries with a widening gap.
- **`isAbsent()` was never consulted**, so someone who signed out — or never signed in — was told their session expired.
- **Concurrent reads were unsequenced**, so an expiry landing mid-read was undone by the reply already in flight, which also announced a false recovery and replayed a queued save against a dead session.
- **The interrupted-save queue was a single slot**, so two saves of different files collided and only the last was written, after the toast promised both. It is keyed per file now, each entry records its project so a replay cannot land in a project the user opened since, and replays are sequential.
- **The session check sat in the generic `fail()` helper**, so an expired session relabelled every unrelated `executeSaveFile` failure — including the DOPE-495 invalid graphical body — as "your session ended". It moved to the write it is about.
- **Sign-in dialog:** the inert "Remember me" is gone, the recovery link got the `target='_blank'` every other external link here already has, and a rejecting `signIn` no longer strands the button on "Signing in…".
- **Avatar** remembers the URL that failed rather than a boolean; **initials** are cut by code point, not UTF-16 code unit; the **Microsoft mark** got the `viewBox` it needs to stop being clipped.

## One fix is about THIS build specifically

The rest is inert here. This one is not: the activity-bar footer had gone from `h-7 … gap-6 pb-10` to `items-center gap-4 pb-3` to make room for the account menu. `_templates/[workspace]/side-content.tsx` applies `pb-10` in both repos, and `hasEdgeAccount` is false here, so the Exit arrow simply dropped ~28px for a second child this build never mounts. The padding now follows the account slot, so each build keeps its own spacing.

## Everything else stays inert in this build

Structurally, not by convention:

- `EDITOR_CAPABILITIES.hasEdgeAccount` is `false`
- `edgeAccount` on the platform context is **optional** (`edgeAccount?: EdgeAccountPort`)
- `editor-platform.ts` never supplies it
- both render sites in `workspace-activity-bar` require `caps.hasEdgeAccount && edgeAccount`

Nothing here reads an Edge cookie, calls an Edge endpoint, or renders account UI in this repo.

## What deliberately does NOT cross over

The web-side work — `middleware/adapters/web/`, `pages/`, `router/` — sits outside the compared paths and stays in openplc-web. That is the point of the port: the components ship in both repos, the adapter that knows Edge's API does not. Test files are excluded from the comparison too, so the web-side specs are not mirrored — including the ~40 added in #685 for these fixes.

## Verification

Run here, not assumed:

| check | result |
|---|---|
| `tsc --noEmit -p tsconfig.json` | clean |
| `eslint` on every changed file | **0 errors** |
| `prettier --check` | clean |
| `validate:arch` | no layer violations |
| `jest` full suite, this branch | 315 passed / 2 failed / **6729 tests passed** |
| `jest` full suite, `development` | 315 passed / 2 failed / **6729 tests passed** — identical |
| `compare-surfaces.py` vs openplc-web#685 | **`match: True, total_diffs: 0`** |

The 2 failures are a pre-existing worker crash on `use-device-connect` and its cascade; both fail the same way on `development`.

## Merge order

Either order, or both together. This PR's sync check falls back to scanning open PRs on the web side, so it passes while openplc-web#685 is merely *open* — and #685's does the same for this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDGE-602]: https://autonomylogic.atlassian.net/browse/EDGE-602


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Edge account sign-in, sign-out, password recovery, and OAuth authentication.
  - Added an account menu showing avatar, profile details, plan information, and account links.
  - Added provider icons and refreshed account-related workspace controls.
  - Added improved avatar fallbacks and branding visuals.

- **Bug Fixes**
  - Preserved emoji and other extended characters in user initials.
  - Improved session-expiration handling and resumed pending saves after sign-in.
  - Made account status and save recovery more reliable during network interruptions.
  - Improved handling of project access and loading errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->