### PR TITLE
fix(save-resume): scope the replay queue to its own project [DOPE-568]

### DIFF
--- a/src/frontend/services/resume-save-after-sign-in.ts
+++ b/src/frontend/services/resume-save-after-sign-in.ts
@@ -77,7 +77,10 @@ type QueuedSave = {
 /** The queued project-wide save, if one is waiting. Excludes the per-file queue. */
 let pendingProject: QueuedSave | null = null
 
-/** Queued single-file saves, by file name. Empty whenever `pendingProject` is set. */
+/**
+ * Queued single-file saves, keyed by project AND file name. Empty whenever
+ * `pendingProject` is set.
+ */
 const pendingFiles = new Map<string, QueuedSave>()
 
 /** Live only while something is actually waiting, so an idle editor holds no listener. */
@@ -86,6 +89,22 @@ let unsubscribe: (() => void) | null = null
 /** The project currently open, as the store knows it. */
 function currentProjectPath(): string {
   return openPLCStoreBase.getState().project.meta.path
+}
+
+/**
+ * The queue key for a single-file save.
+ *
+ * Scoped to the project, not just the file. Two projects can each hold a POU of
+ * the same name, and keying on the name alone let the second queue call evict the
+ * first. If the evicted entry was the one belonging to the project still open at
+ * restore, it was gone and the survivor was skipped for a path mismatch — so
+ * neither save ran, which is the exact failure a per-file queue exists to prevent.
+ *
+ * NUL joins the two parts because it cannot occur in a path or a file name, so no
+ * two different pairs can collide on one key.
+ */
+function fileKey(projectPath: string, fileName: string): string {
+  return `${projectPath}\u0000${fileName}`
 }
 
 export function resumeSaveAfterEdgeSignIn(
@@ -108,7 +127,7 @@ export function resumeSaveAfterEdgeSignIn(
       return
     }
 
-    pendingFiles.set(target.fileName, { run, projectPath })
+    pendingFiles.set(fileKey(projectPath, target.fileName), { run, projectPath })
   }
 
   // NOT guarded on `session.isExpired()`.
@@ -132,7 +151,7 @@ export function resumeSaveAfterEdgeSignIn(
     unsubscribe?.()
     unsubscribe = null
 
-    void replayQueued(queued, currentProjectPath())
+    void replayQueued(queued)
   })
 }
 
@@ -142,9 +161,14 @@ export function resumeSaveAfterEdgeSignIn(
  * Sequential rather than concurrent: these write into the same project through the
  * same store, and interleaving two of them is how a half-written project happens.
  */
-async function replayQueued(queued: QueuedSave[], openProject: string): Promise<void> {
+async function replayQueued(queued: QueuedSave[]): Promise<void> {
   for (const save of queued) {
-    if (save.projectPath !== openProject) {
+    // Re-read the open project on every iteration rather than once before the
+    // loop. Because the replays are sequential awaits, the user can open another
+    // project while an earlier one is still running; a path captured up front
+    // would still match, and `run` — which reads the store at the moment it runs,
+    // not when it was queued — would write this project's content into that one.
+    if (save.projectPath !== currentProjectPath()) {
       continue
     }
 


### PR DESCRIPTION
# Pull request info

## References

### If applicable substitute the issue reference to the one that this PR refers

No GitHub issue — raised in review on #1027 and deferred when that PR merged. The `replayQueued` half was raised there by CodeRabbit.

### Link to Jira task

*[DOPE-568](https://autonomylogic.atlassian.net/browse/DOPE-568)* — items 3 and 4 of four. The first two (the exit-arrow `pb-2` correction and its non-geometric test assertion) are **not** in this PR and remain open on the ticket.

## Description of the changes proposed

Mirror half of **[openplc-web#686](https://github.com/Autonomy-Logic/openplc-web/pull/686)**. `src/frontend/services/resume-save-after-sign-in.ts` is on the byte-identical shared surface, so both repos change together or neither does. Source only here — this repo runs Jest, the tests for this file are Vitest and live on the web side, which is the same split #1027 used.

Two defects in the save-resume queue, both letting a queued save reach a project it does not belong to. The queue knew *which file* a save was for, but not reliably *which project*.

- **`replayQueued` captured the open project once, before the loop.** The replays are sequential `await`s, so the user can open another project while an earlier one is still in flight — the captured path still matched, and `run` reads the store at the moment it runs, not when it was queued. The later save wrote its content into whatever project had just been opened. It takes no path parameter now and re-reads `currentProjectPath()` on every iteration.
- **`pendingFiles` was keyed on the file name alone.** Two projects can each hold a POU named `Main`. The second queue call evicted the first, and because the survivor belonged to the project no longer open, the replay skipped it too — so *neither* save ran, though a toast had promised both would. That is the exact failure a per-file queue exists to prevent. The key now carries the project, joined by NUL, which cannot occur in a path or a file name, so no two pairs can collide.
- Same file in the *same* project still shares a key, so the existing newest-wins behaviour is unchanged.

What was run here:

```
npx jest src/frontend/services --no-coverage    185 passed, 14 suites (incl. save-actions, this service's only caller)
npx tsc --noEmit -p tsconfig.json              0 errors, fully clean
npx eslint <changed file>                       0 errors
npx prettier --check <changed file>             clean
npm run validate:arch                           no layer violations
python3 scripts/compare-surfaces.py             match: true, 1048 files, total_diffs: 0
```

On the web side the two new regression tests were checked against the pre-fix source: reverting only the source and keeping the tests produces exactly those two failures, with all sixteen existing cases still green.

## DOD checklist

- [x] The code is complete and according to developers’ standards.
- [x] I have performed a self-review of my code.
- [x] Meet the acceptance criteria.
- [ ] Unit tests are written and green. — written and green, but in openplc-web#686; this repo has no test for this mirrored file, matching #1027
- [ ] Test coverage: __ %. — unchanged here; `src/frontend/services/` is not one of the 100%-threshold directories
- [ ] Integration tests are written and green. — none for this path
- [x] Changes were communicated and updated in the ticket description.
- [ ] Reviewed and accepted by the Product Owner.
- [ ] End-to-end test are successful. — not run

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOPE-568]: https://autonomylogic.atlassian.net/browse/DOPE-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unsaved files with the same name in different projects from overwriting each other.
  * Improved queued save recovery when switching projects, ensuring saves are applied only to the currently open project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->