### PR TITLE
fix(cli,compile): exit-code-driven build outcome, drop the soft-write verb, remove a live credential

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -224,7 +224,7 @@ command.
 
 ```sh
 openplc-cli debug open ./my-project --target "OpenPLC Runtime v4" \
-  --host 192.168.2.4 --credentials op:op        # -> 8df020af1234
+  --host 10.0.0.10 --credentials user:pass      # -> 8df020af1234
 
 openplc-cli debug list                          # every live session
 openplc-cli debug read main:counter
@@ -264,8 +264,8 @@ point of naming a timeout is that the default was wrong for this run.
 | `--idle-timeout <ms>`  | `debug open`                        | idle budget; `0` disables (see above)                                                               |
 | `--force-new`          | `debug open`                        | start a session even if one is already open for this project and target                             |
 | `--upload-if-needed`   | `debug open`                        | upload first when the target's program does not match                                               |
-| `--var <name>`         | `read`, `write`, `force`, `unforce` | the variable, when you would rather not pass it positionally                                        |
-| `--value <literal>`    | `write`, `force`                    | the value — `16#FF`, `TRUE`, `T#5s`, all as the GUI accepts them                                    |
+| `--var <name>`         | `read`, `force`, `unforce`           | the variable, when you would rather not pass it positionally                                        |
+| `--value <literal>`    | `force`                             | the value — `16#FF`, `TRUE`, `T#5s`, all as the GUI accepts them                                    |
 | `--filter <substring>` | `list-vars`                         | only variables whose path contains it                                                               |
 | `--interval <ms>`      | `watch`                             | sampling cadence; floor 20 ms                                                                       |
 | `--since <seq>`        | `poll`                              | only samples after this sequence number                                                             |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -318,7 +318,6 @@ a line it received.
 | `status`            | `probe?` — true means "only listing", which does not count as activity | `status`                        |
 | `list-vars`         | `filter?`                                                              | `list-vars`                     |
 | `read`              | `names[]`                                                              | `read` — `values[]`             |
-| `write`             | `name`, `value`                                                        | `write` — the value read back   |
 | `force` / `unforce` | `name`, plus `value` for `force`                                       | `force` / `unforce`             |
 | `start` / `stop`    | —                                                                      | `plc-state`                     |
 | `watch`             | `names[]`, `intervalMs?`                                               | `watch` — what is recording     |

--- a/src/backend/editor/compiler/__tests__/editor-compiler-platform-port.test.ts
+++ b/src/backend/editor/compiler/__tests__/editor-compiler-platform-port.test.ts
@@ -231,7 +231,7 @@ describe('createEditorCompilerPlatformPort', () => {
   // ---- uploadArduinoBoard — port wiring (regression for issue #5) ----
 
   it('uploadArduinoBoard forwards args.port to the handler as communicationPort', async () => {
-    const handleUploadProgram = jest.fn(async () => undefined)
+    const handleUploadProgram = jest.fn(async () => ({ success: true, data: '' }))
     const port = createEditorCompilerPlatformPort(makeHandlers({ handleUploadProgram }), makeContext())
     await port.uploadArduinoBoard(
       { compilationPath: '', fqbn: 'arduino:avr:mega', port: '/dev/cu.usbmodem1101' },
@@ -250,7 +250,7 @@ describe('createEditorCompilerPlatformPort', () => {
     // handler must fall back to the disk-persisted value rather than
     // call arduino-cli with `--port ""`.  The undefined sentinel
     // signals "fall through" to the handler's legacy code path.
-    const handleUploadProgram = jest.fn(async () => undefined)
+    const handleUploadProgram = jest.fn(async () => ({ success: true, data: '' }))
     const port = createEditorCompilerPlatformPort(makeHandlers({ handleUploadProgram }), makeContext())
     await port.uploadArduinoBoard({ compilationPath: '', fqbn: 'arduino:avr:mega', port: '' }, () => undefined)
     expect(handleUploadProgram).toHaveBeenCalledWith(expect.objectContaining({ communicationPort: undefined }))

--- a/src/backend/editor/compiler/compiler-module.spec.ts
+++ b/src/backend/editor/compiler/compiler-module.spec.ts
@@ -99,6 +99,38 @@ describe('CompilerModule', () => {
     expect(compilerModule).toBeInstanceOf(CompilerModule)
   })
 
+  describe('handleUploadProgram (no serial port)', () => {
+    /**
+     * A step that cannot run must FAIL, not return quietly.
+     *
+     * `uploadArduinoBoard` only awaits this method and reports `{ ok: true }` on
+     * any normal return, and the build's outcome now comes from the pipeline's
+     * verdict rather than from whether an error was logged. So a silent bail
+     * here told the user their board had been flashed when nothing was sent —
+     * red "No communication port specified", then "Arduino upload complete.",
+     * then success.
+     */
+    it('throws when no port is passed and none is persisted', async () => {
+      const logged: Array<{ message: string; level?: string }> = []
+
+      await expect(
+        compilerModule.handleUploadProgram({
+          // A directory with no devices/configuration.json, so the disk
+          // fallback finds nothing either.
+          projectPath: join(tmpdir(), 'openplc-no-such-project'),
+          arduinoPlatform: 'arduino:avr:uno',
+          compilationPath: join(tmpdir(), 'openplc-no-such-build'),
+          handleOutputData: (chunk, level) => {
+            logged.push({ message: typeof chunk === 'string' ? chunk : chunk.toString(), ...(level ? { level } : {}) })
+          },
+        }),
+      ).rejects.toThrow(/No communication port specified/)
+
+      // It must not have announced anything that reads like progress.
+      expect(logged.some((entry) => /upload complete/i.test(entry.message))).toBe(false)
+    })
+  })
+
   it('should have expected static properties', () => {
     expect(typeof CompilerModule.HOST_PLATFORM).toBe('string')
     expect(['x64', 'arm64', 'ia32', 'arm']).toContain(CompilerModule.HOST_ARCHITECTURE)

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -1879,8 +1879,16 @@ class CompilerModule {
     const baremetalPath = join(compilationPath, 'examples', 'Baremetal')
 
     if (!port) {
-      handleOutputData('No communication port specified', 'error')
-      return
+      // THROW rather than return. `uploadArduinoBoard` only awaits this call
+      // and reports `{ ok: true }` on any normal return, so bailing out here
+      // told the pipeline the board had been flashed when nothing was sent.
+      //
+      // That used to be masked: the error-level log line set the compile
+      // flow's `hasError`, which failed the build for the wrong reason. The
+      // outcome now comes from the pipeline's verdict, so a step that cannot
+      // run has to fail through the channel the verdict is built from — the
+      // catch in `uploadArduinoBoard` turns this into `{ ok: false }`.
+      throw new Error('No communication port specified — select a serial port for this board')
     }
 
     return new Promise<MethodsResult<string | Buffer>>((resolve, reject) => {
@@ -3045,7 +3053,12 @@ class CompilerModule {
     // --- Editor-specific epilogue: simulator firmware path + closePort ---
     if (isSimulator) {
       if (compileOnly) {
-        _mainProcessPort.postMessage({ logLevel: 'info', message: 'Compilation successful.' })
+        // Gated on the verdict: this line used to be unconditional, so a
+        // simulator compile-only build whose strucpp step failed printed the
+        // real error and then "Compilation successful." directly under it.
+        if (result.success) {
+          _mainProcessPort.postMessage({ logLevel: 'info', message: 'Compilation successful.' })
+        }
         _mainProcessPort.postMessage({ closePort: true, success: result.success })
         _mainProcessPort.close()
         return

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -3046,7 +3046,7 @@ class CompilerModule {
     if (isSimulator) {
       if (compileOnly) {
         _mainProcessPort.postMessage({ logLevel: 'info', message: 'Compilation successful.' })
-        _mainProcessPort.postMessage({ closePort: true })
+        _mainProcessPort.postMessage({ closePort: true, success: result.success })
         _mainProcessPort.close()
         return
       }
@@ -3063,15 +3063,16 @@ class CompilerModule {
           logLevel: 'info',
           message: 'Compilation successful. Loading firmware into simulator...',
         })
-        _mainProcessPort.postMessage({ simulatorFirmwarePath: hexPath, closePort: true })
+        _mainProcessPort.postMessage({ simulatorFirmwarePath: hexPath, closePort: true, success: true })
         _mainProcessPort.close()
         return
       }
-      // Failure path on simulator — separator + close.
+      // Failure path on simulator — separator + verdict + close.
       _mainProcessPort.postMessage({
         message:
           '-------------------------------------------------------------------------------------------------------------\n',
       })
+      _mainProcessPort.postMessage({ closePort: true, success: false })
       _mainProcessPort.close()
       return
     }
@@ -3087,6 +3088,20 @@ class CompilerModule {
       message:
         '-------------------------------------------------------------------------------------------------------------\n',
     })
+    // The build's verdict, from the layer that owns it. Every step the pipeline
+    // ran reported through a real exit code — arduino-cli's process status, or
+    // the runtime's `/api/compilation-status` exit_code by way of
+    // `deployRuntimeProgram` — and `runCompilePipeline` already reduced those to
+    // one boolean.
+    //
+    // This used to be dropped on the floor here: only the simulator branch read
+    // `result.success`, so the consumer was left to infer an outcome from
+    // whether any log line had arrived at error level. Those are different
+    // questions. A compiler writes warnings to stderr, so a build that merely
+    // warned resolved as a failure — `upload_rejected`, with a bare `^~~~`
+    // caret line as its message, on a build the device had completed and
+    // started.
+    _mainProcessPort.postMessage({ closePort: true, success: result.success })
     setTimeout(() => {
       _mainProcessPort.close()
     }, 25)

--- a/src/cli/__tests__/force-settle.test.ts
+++ b/src/cli/__tests__/force-settle.test.ts
@@ -1,0 +1,113 @@
+/**
+ * A force that never lands must not report success.
+ *
+ * `readBackAfterWrite` used to give up quietly on a value that never took,
+ * justified by the soft-`write` verb ("a mismatch is legitimate for a write the
+ * program overwrites next scan"). That verb has been removed — it had no wire
+ * representation — so `force` is the only caller, and forcing PINS a value: the
+ * program cannot overwrite it. A forced variable that has not taken the value
+ * by the deadline means the target acked the PDU and the force did not land.
+ *
+ * Before this, `openplc-cli debug force main:flag FALSE` printed
+ * `main:flag : BOOL = TRUE` and exited 0, so a harness asserting on the exit
+ * code passed on a force that never applied.
+ */
+
+import type { DebugVariableIndex, ResolvedVariable } from '../debug/variables'
+import { ErrorCode } from '../exit-codes'
+import type { PlcControl } from '../session/session-core'
+import { SessionCore } from '../session/session-core'
+
+const variable: ResolvedVariable = { name: 'main:flag', index: 0, arr: 0, elem: 0, type: 'BOOL', size: 1 }
+
+const plc: PlcControl = {
+  start: () => Promise.resolve({ success: true }),
+  stop: () => Promise.resolve({ success: true }),
+  state: () => Promise.resolve('running' as const),
+}
+
+/**
+ * A channel whose BOOL always reads TRUE, whatever is forced onto it — which is
+ * what a force that does not land looks like from the outside.
+ *
+ * The clock is driven by the number of reads rather than by wall time, so the
+ * 1500 ms settle window costs no real time and the test cannot flake on a slow
+ * machine.
+ */
+function makeCore() {
+  let reads = 0
+  const channel = {
+    connect: () => Promise.resolve(),
+    disconnect: () => undefined,
+    getVariablesList: (indexes: number[]) => {
+      reads += 1
+      return Promise.resolve({
+        success: true as const,
+        tick: 1,
+        lastIndex: indexes.length - 1,
+        data: new Uint8Array([1]),
+      })
+    },
+    setVariable: () => Promise.resolve({ success: true as const }),
+    getMd5Hash: () => Promise.resolve({ success: true as const, md5: 'abc', targetEndian: 'le' as const }),
+  }
+
+  const index: DebugVariableIndex = {
+    md5: 'abc',
+    warnings: [],
+    all: [variable],
+    byName: new Map([['MAIN:FLAG', variable]]),
+    byIndex: new Map([[0, variable]]),
+  }
+
+  const core = new SessionCore({
+    sessionId: 'test',
+    projectPath: '/tmp/project',
+    target: 'Test Board',
+    transport: 'rtu',
+    descriptor: '/dev/null',
+    channel,
+    index,
+    plc,
+    programMd5: 'abc',
+    endian: 'le',
+    batchSize: 8,
+    // 400 ms of "elapsed" per read: the 1500 ms window closes after four.
+    now: () => reads * 400,
+  })
+  return core
+}
+
+describe('force read-back', () => {
+  it('reports a target error when the forced value never takes', async () => {
+    const response = await makeCore().handle({ id: 1, kind: 'force', name: 'main:flag', value: 'FALSE' })
+
+    expect(response.ok).toBe(false)
+    if (response.ok) throw new Error('expected a failure')
+    expect(response.error.code).toBe(ErrorCode.TargetError)
+    // Names the variable and what it still reads, so the message is actionable.
+    expect(response.error.message).toContain('main:flag')
+    expect(response.error.message).toContain('did not take the value')
+  })
+
+  it('succeeds when the value does take', async () => {
+    // Same channel, but forcing TRUE — which is what it already reads.
+    const response = await makeCore().handle({ id: 1, kind: 'force', name: 'main:flag', value: 'TRUE' })
+
+    expect(response.ok).toBe(true)
+  })
+
+  it('still reports a read failure as a connection problem, not a target error', async () => {
+    // The two failures are different: one means the channel died, the other
+    // means the device answered and ignored us.
+    const core = makeCore()
+    ;(core as unknown as { options: { channel: { getVariablesList: () => unknown } } }).options.channel.getVariablesList =
+      () => Promise.resolve({ success: false, error: 'link down' })
+
+    const response = await core.handle({ id: 1, kind: 'force', name: 'main:flag', value: 'TRUE' })
+
+    expect(response.ok).toBe(false)
+    if (response.ok) throw new Error('expected a failure')
+    expect(response.error.code).toBe(ErrorCode.NotConnected)
+  })
+})

--- a/src/cli/__tests__/repl-vocabulary.test.ts
+++ b/src/cli/__tests__/repl-vocabulary.test.ts
@@ -2,12 +2,18 @@
  * The REPL and the subcommands are two front ends over one session protocol, so
  * a verb that works in one has to work in the other. It did not: `debug read x`
  * was fine as a subcommand and `read x` was rejected as unknown inside
- * `debug exec` / the REPL, which spelled the same three operations `vars`,
- * `get` and `set` (the `strucpp` vocabulary this REPL deliberately mirrors).
+ * `debug exec` / the REPL, which spelled the same operations `vars` and `get`
+ * (the `strucpp` vocabulary this REPL deliberately mirrors).
  *
  * Both spellings are kept — one for the muscle memory of each surface — and
  * these tests hold them to the SAME protocol request, which is the only thing
  * that must not fork.
+ *
+ * `set` / `write` are deliberately NOT among them: the protocol has no
+ * soft-write verb, because the wire has no way to express one (FC 0x42 carries
+ * a force flag, so force=0 is an UNFORCE and discards the value). Both
+ * spellings must now be rejected outright rather than quietly forcing or
+ * unforcing something.
  */
 
 import { parseReplLine } from '../commands/debug'
@@ -24,7 +30,6 @@ describe('parseReplLine — one operation, either spelling', () => {
   it.each([
     ['vars', 'list-vars'],
     ['get main:blink', 'read main:blink'],
-    ['set main:blink true', 'write main:blink true'],
   ])('%s and %s produce the same request', (terse, canonical) => {
     expect(requestFor(terse)).toEqual(requestFor(canonical))
   })
@@ -32,9 +37,15 @@ describe('parseReplLine — one operation, either spelling', () => {
   it('names the verb the caller actually typed when the arguments are wrong', () => {
     expect(parseReplLine('read', 1)).toEqual({ error: 'read needs at least one variable name' })
     expect(parseReplLine('get', 1)).toEqual({ error: 'get needs at least one variable name' })
-    expect(parseReplLine('write main:blink', 1)).toEqual({ error: 'write needs a variable name and a value' })
-    expect(parseReplLine('set main:blink', 1)).toEqual({ error: 'set needs a variable name and a value' })
   })
+
+  it.each(['write main:blink true', 'set main:blink true'])(
+    'rejects "%s" — there is no soft-write verb on the wire',
+    (line) => {
+      const verb = line.split(' ')[0]
+      expect(parseReplLine(line, 1)).toEqual({ error: `Unknown command "${verb}" — type help` })
+    },
+  )
 
   it('still rejects a verb that is neither', () => {
     expect(parseReplLine('compile', 1)).toEqual({ error: 'Unknown command "compile" — type help' })

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -224,7 +224,13 @@ async function executeBuild(request: BuildRequest, reporter: Reporter): Promise<
 
   reporter.progress(`${request.withUpload ? 'Building and uploading' : 'Building'} "${project.name}" for ${target}…`)
 
-  let streamedError = false
+  // Did the build get as far as talking to the device? This is what separates
+  // "the device refused it" from "it never compiled", and it replaces a check
+  // on whether any line was logged at error level — which classified an ST
+  // syntax error on an `upload` run as `upload_rejected` / exit 7, blaming a
+  // device the build never reached. Every upload path emits `stage: 'upload'`
+  // before it attempts anything (pipeline.ts: runtime v4, v3, arduino).
+  let reachedUpload = false
   const warnings: string[] = []
 
   const result = await compileProgramFlow(
@@ -242,7 +248,7 @@ async function executeBuild(request: BuildRequest, reporter: Reporter): Promise<
     },
     createCliCompileTransport(runtime),
     (event: CompileProgressEvent) => {
-      if (event.level === 'error' || event.stage === 'error') streamedError = true
+      if (event.stage === 'upload') reachedUpload = true
       if (event.level === 'warning' && event.message) warnings.push(event.message)
       if (event.message) reporter.progress(event.level === 'error' ? `error: ${event.message}` : event.message)
     },
@@ -251,10 +257,10 @@ async function executeBuild(request: BuildRequest, reporter: Reporter): Promise<
   if (!result.success) {
     return reporter.failure(
       {
-        code: request.withUpload && streamedError ? ErrorCode.UploadRejected : ErrorCode.CompileFailed,
+        code: request.withUpload && reachedUpload ? ErrorCode.UploadRejected : ErrorCode.CompileFailed,
         message: result.error ?? 'Compilation failed',
       },
-      request.withUpload && streamedError ? ExitCode.TargetError : ExitCode.CompileFailed,
+      request.withUpload && reachedUpload ? ExitCode.TargetError : ExitCode.CompileFailed,
     )
   }
 

--- a/src/cli/commands/debug.ts
+++ b/src/cli/commands/debug.ts
@@ -169,7 +169,6 @@ export async function runDebug(args: ParsedArgs, reporter: Reporter, context: De
     case 'status':
     case 'list-vars':
     case 'read':
-    case 'write':
     case 'force':
     case 'unforce':
     case 'start':
@@ -183,7 +182,7 @@ export async function runDebug(args: ParsedArgs, reporter: Reporter, context: De
         {
           code: ErrorCode.MissingArgument,
           message:
-            'Name a debug subcommand: open, list, close, status, list-vars, read, write, force, unforce, start, stop, watch, poll, unwatch, repl',
+            'Name a debug subcommand: open, list, close, status, list-vars, read, force, unforce, start, stop, watch, poll, unwatch, repl',
         },
         ExitCode.Usage,
       )
@@ -500,7 +499,6 @@ export function buildRequest(
     case 'read':
       if (names.length === 0) return { error: 'read needs at least one variable name' }
       return { request: { id, kind, names } }
-    case 'write':
     case 'force': {
       const name = args.positionals[0] ?? stringFlag(args, 'var')
       const value = args.positionals[1] ?? stringFlag(args, 'value')
@@ -583,7 +581,6 @@ export function renderOk(response: OkResponse): string {
           )
     case 'read':
       return formatVariableList(data.values)
-    case 'write':
     case 'force':
     case 'unforce':
       return `${data.value.name} : ${data.value.type} = ${formatValue(data.value)}${data.value.forced ? ' [FORCED]' : ''}`
@@ -619,8 +616,8 @@ export function renderOk(response: OkResponse): string {
  * they single-step a compiled binary, which a live PLC cannot do — `start` and
  * `stop` are the equivalents here.
  *
- * Three of those verbs are spelled differently as subcommands — `vars`/`get`/
- * `set` here against `list-vars`/`read`/`write` outside — so BOTH spellings are
+ * Two of those verbs are spelled differently as subcommands — `vars`/`get`
+ * here against `list-vars`/`read` outside — so BOTH spellings are
  * accepted for each. They are one operation reached two ways, and a caller who
  * learned `openplc-cli debug read x` should not be told `read` is unknown the
  * first time it types it into `debug exec`. (It was: that is why this is here.)
@@ -628,7 +625,6 @@ export function renderOk(response: OkResponse): string {
 const REPL_HELP = `Commands
   vars | list-vars [filter]  list variables in the program
   get | read <name>...       read one or more variables
-  set | write <name> <value> write a variable (program may overwrite next scan)
   force <name> <value>       pin a variable until unforced
   unforce <name>             release a pinned variable
   watch <name> [name...]     start recording; use poll to drain
@@ -662,10 +658,6 @@ export function parseReplLine(
     case 'read':
       if (rest.length === 0) return { error: `${verb} needs at least one variable name` }
       return { request: { id, kind: 'read', names: rest } }
-    case 'set':
-    case 'write':
-      if (rest.length < 2) return { error: `${verb} needs a variable name and a value` }
-      return { request: { id, kind: 'write', name: rest[0], value: rest.slice(1).join(' ') } }
     case 'force':
       if (rest.length < 2) return { error: 'force needs a variable name and a value' }
       return { request: { id, kind: 'force', name: rest[0], value: rest.slice(1).join(' ') } }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -83,7 +83,7 @@ Usage
   openplc-cli upload  <project> (--host <address> | --port <serial>) [--target <board>] [--clean] [-y|--yes]
   openplc-cli debug open <project> --target <board> (--host <address> | --port <serial>) [--upload-if-needed]
   openplc-cli debug list
-  openplc-cli debug status | list-vars | read | write | force | unforce | start | stop | watch | poll | unwatch
+  openplc-cli debug status | list-vars | read | force | unforce | start | stop | watch | poll | unwatch
   openplc-cli debug close --session <id> | --all [--keep-forces]
   openplc-cli debug repl [--session <id>]                       (interactive; needs a terminal)
   openplc-cli debug exec [script|-] [--session <id>] [--keep-going]  (one command per line)

--- a/src/cli/session/protocol.ts
+++ b/src/cli/session/protocol.ts
@@ -43,7 +43,6 @@ export const RequestKindSchema = z.enum([
   'status',
   'list-vars',
   'read',
-  'write',
   'force',
   'unforce',
   'start',
@@ -76,9 +75,17 @@ export const RequestSchema = z.discriminatedUnion('kind', [
   }),
   z.object({ id: idField, kind: z.literal('list-vars'), filter: z.string().optional() }),
   z.object({ id: idField, kind: z.literal('read'), names: nonEmptyNames }),
-  /** Soft write — the program may overwrite it on the next scan. */
-  z.object({ id: idField, kind: z.literal('write'), name: z.string(), value: z.string() }),
-  /** Force — pinned until unforced; survives the program's own writes. */
+  /**
+   * Force — pinned until unforced; survives the program's own writes.
+   *
+   * There is deliberately no soft-write verb. The debug protocol's only
+   * mutation PDU (FC 0x42) carries a force flag, not a three-way op, so a
+   * "write" could only ever be sent as force=0 — which the target reads as an
+   * UNFORCE and which discards the value bytes. The in-process soft write
+   * (`DBGW_OP_WRITE` / `handle_write`) exists for consumers that run inside
+   * the runtime, such as the OPC-UA plugin and retain restore; it has no wire
+   * representation and does not need one.
+   */
   z.object({ id: idField, kind: z.literal('force'), name: z.string(), value: z.string() }),
   z.object({ id: idField, kind: z.literal('unforce'), name: z.string() }),
   z.object({ id: idField, kind: z.literal('start') }),
@@ -177,7 +184,6 @@ const ResponseDataSchema = z.discriminatedUnion('kind', [
     variables: z.array(z.object({ name: z.string(), type: z.string(), size: z.number() })),
   }),
   z.object({ kind: z.literal('read'), values: z.array(VariableValueSchema) }),
-  z.object({ kind: z.literal('write'), value: VariableValueSchema }),
   z.object({ kind: z.literal('force'), value: VariableValueSchema }),
   z.object({ kind: z.literal('unforce'), value: VariableValueSchema }),
   z.object({ kind: z.literal('plc-state'), plcState: z.enum(['running', 'stopped']) }),

--- a/src/cli/session/session-core.ts
+++ b/src/cli/session/session-core.ts
@@ -26,7 +26,7 @@ import {
   findVariable,
   type ResolvedVariable,
 } from '../debug/variables'
-import { ErrorCode } from '../exit-codes'
+import { ErrorCode, type ErrorCodeValue } from '../exit-codes'
 import type { Request, Response, SessionStatus, VariableValue, WatchSample } from './protocol'
 
 /** How a session controls run/stop, which differs by target family. */
@@ -308,7 +308,7 @@ export class SessionCore {
     this.forced.add(variable.name)
 
     const readBack = await this.readBackAfterWrite(variable, input)
-    if ('error' in readBack) return this.fail(id, ErrorCode.NotConnected, readBack.error)
+    if ('error' in readBack) return this.fail(id, readBack.code, readBack.error)
     return { id, ok: true, data: { kind: 'force', value: readBack.value } }
   }
 
@@ -322,24 +322,51 @@ export class SessionCore {
    * report `0`, and a test asserting on that reply would fail against a PLC that
    * had done exactly what it was told.
    *
-   * Polls briefly for the value to match what was asked, and gives up quietly
-   * after that: a mismatch is legitimate for a soft `write` the program
-   * overwrites on the next scan, so a timeout here is not an error.
+   * Polls briefly for the value to match what was asked. A timeout is now an
+   * ERROR: `force` is the only caller (the soft-write verb was removed, and it
+   * had no wire representation), and forcing PINS a value — the program cannot
+   * overwrite it. So a forced variable that has not taken the value by the
+   * deadline means the target acked the PDU and the force did not land, which
+   * is precisely what a caller needs to hear. It used to give up quietly on the
+   * rationale that "a mismatch is legitimate for a soft write the program
+   * overwrites next scan" — true of the verb that no longer exists, and it let
+   * `debug force main:enable TRUE` print FALSE and exit 0.
+   *
+   * False positives are already excluded by `writeHasSettled`, which reports
+   * "settled" for anything it cannot compare — an unparseable literal, a
+   * non-primitive value — and compares numbers with a 1e-6 epsilon. A timeout
+   * therefore only happens when the value was comparable and genuinely differs.
    */
   private async readBackAfterWrite(
     variable: ResolvedVariable,
     requested: string,
-  ): Promise<{ value: VariableValue } | { error: string }> {
+  ): Promise<{ value: VariableValue } | { error: string; code: ErrorCodeValue }> {
     const deadline = this.now() + WRITE_SETTLE_TIMEOUT_MS
     let last: VariableValue | undefined
+    let settled = false
 
     for (;;) {
       const result = await this.readValues([variable])
-      if ('error' in result) return { error: result.error }
+      if ('error' in result) return { error: result.error, code: ErrorCode.NotConnected }
       last = result.values[0]
-      if (last && writeHasSettled(last, requested)) break
+      if (last && writeHasSettled(last, requested)) {
+        settled = true
+        break
+      }
       if (this.now() >= deadline) break
       await delay(WRITE_SETTLE_POLL_MS)
+    }
+
+    if (!settled) {
+      return {
+        // TargetError, not NotConnected: the reads succeeded, so the channel is
+        // fine — the device took the PDU and the value did not change.
+        code: ErrorCode.TargetError,
+        error:
+          `The target acknowledged the force but ${variable.name} did not take the value ` +
+          `within ${WRITE_SETTLE_TIMEOUT_MS} ms` +
+          (last === undefined ? '' : ` (still ${String(last.value)})`),
+      }
     }
 
     return {

--- a/src/cli/session/session-core.ts
+++ b/src/cli/session/session-core.ts
@@ -167,9 +167,8 @@ export class SessionCore {
         return { id: request.id, ok: true, data: { kind: 'read', values: values.values } }
       }
 
-      case 'write':
       case 'force':
-        return this.applyWrite(request.id, request.name, request.value, request.kind === 'force')
+        return this.applyForce(request.id, request.name, request.value)
 
       case 'unforce':
         return this.applyUnforce(request.id, request.name)
@@ -294,7 +293,7 @@ export class SessionCore {
     return { values }
   }
 
-  private async applyWrite(id: number, name: string, input: string, force: boolean): Promise<Response> {
+  private async applyForce(id: number, name: string, input: string): Promise<Response> {
     const variable = findVariable(this.options.index, name)
     if (!variable) {
       return this.fail(id, ErrorCode.VariableNotFound, `No variable "${name}" in this program's debug map`)
@@ -302,15 +301,15 @@ export class SessionCore {
     const encoded = encodeValue(variable, input)
     if (!encoded.success) return this.fail(id, ErrorCode.ValueInvalid, encoded.error)
 
-    const result = await this.options.channel.setVariable(variable.index, force, encoded.bytes)
+    const result = await this.options.channel.setVariable(variable.index, true, encoded.bytes)
     if (!result.success) {
-      return this.fail(id, ErrorCode.TargetError, result.error ?? `The target refused the ${force ? 'force' : 'write'}`)
+      return this.fail(id, ErrorCode.TargetError, result.error ?? 'The target refused the force')
     }
-    if (force) this.forced.add(variable.name)
+    this.forced.add(variable.name)
 
     const readBack = await this.readBackAfterWrite(variable, input)
     if ('error' in readBack) return this.fail(id, ErrorCode.NotConnected, readBack.error)
-    return { id, ok: true, data: { kind: force ? 'force' : 'write', value: readBack.value } }
+    return { id, ok: true, data: { kind: 'force', value: readBack.value } }
   }
 
   /**

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -49,6 +49,19 @@ type CompilerPortMessage = {
   simulatorFirmwarePath?: string
   plcStatus?: string
   closePort?: boolean
+  /** The build's verdict, carried on the `closePort` message. Sourced from
+   *  `runCompilePipeline`, which reduces every step's process exit code to one
+   *  boolean, so it — not the presence of error-level log lines — is what
+   *  decides whether a build failed.
+   *
+   *  Declared here because the seam is typed: `onmessage` currently forwards
+   *  `event.data` wholesale, so a consumer reading a `Record<string, unknown>`
+   *  sees the field regardless. A bridge refactor that reconstructs the
+   *  message field-by-field (the shape the `libraryBuildResult` path already
+   *  uses) would otherwise drop it silently, and `compileProgramFlow` would
+   *  fall back to its `hasError` heuristic — reintroducing a resolved bug with
+   *  no compile error and no failing test. */
+  success?: boolean
   /** Final structured outcome of a library build.  Set only on the
    *  close-port message emitted by `compileLibrary`; absent from
    *  intermediate log entries and from program-build / debug-build

--- a/src/middleware/adapters/editor/__tests__/compile-program-flow-verdict.test.ts
+++ b/src/middleware/adapters/editor/__tests__/compile-program-flow-verdict.test.ts
@@ -1,0 +1,145 @@
+/**
+ * A build's outcome comes from the pipeline's verdict, not from whether
+ * anything was logged at error level.
+ *
+ * The two are different questions, and conflating them broke real uploads. A
+ * compiler writes warnings to stderr; the device tags that stream and streams
+ * it back; so a build that merely warned arrived with error-level lines in it
+ * and resolved as a FAILURE — reported as `upload_rejected` whose message was
+ * a bare `^~~~` caret line, on a build the device had completed and started.
+ *
+ * `runCompilePipeline` already reduces every step's process exit code to one
+ * boolean (arduino-cli's status, or the runtime's `/api/compilation-status`
+ * exit_code by way of `deployRuntimeProgram`). It is now carried on the
+ * terminal `closePort` message, and it wins.
+ *
+ * `hasError` survives as a fallback for a transport that can only observe the
+ * channel closing — the CLI synthesises `closePort` from the socket's close
+ * event, with no verdict to attach (see cli-transport.ts).
+ */
+
+import type { BoardInfo, CompileProgressEvent, PLCProjectData } from '../../../shared/ports/types'
+import { compileProgramFlow, type CompileProgramTransport } from '../compile-program-flow'
+
+const projectData: PLCProjectData = {
+  dataTypes: [],
+  pous: [
+    {
+      name: 'main',
+      pouType: 'program',
+      interface: {
+        variables: [
+          {
+            name: 'x',
+            class: 'local',
+            type: { definition: 'base-type', value: 'BOOL' },
+            location: '',
+            documentation: '',
+          },
+        ],
+      },
+      body: { language: 'st', value: 'x := TRUE;' },
+      documentation: '',
+    },
+  ],
+  configuration: {
+    resource: {
+      tasks: [{ name: 'task0', triggering: 'Cyclic', interval: 'T#20ms', priority: 1 }],
+      instances: [{ name: 'instance0', program: 'main', task: 'task0' }],
+      globalVariables: [],
+    },
+  },
+} as unknown as PLCProjectData
+
+const boards = new Map<string, BoardInfo>([
+  ['Test Board', { core: 'arduino:avr', compiler: 'arduino-cli' } as unknown as BoardInfo],
+])
+
+/**
+ * Run the flow, feeding it a scripted message stream, and return what it
+ * resolved to. `messages` is delivered in order as soon as the flow subscribes.
+ */
+async function runWith(messages: Array<Record<string, unknown>>) {
+  const events: CompileProgressEvent[] = []
+  const transport: CompileProgramTransport = {
+    getAvailableBoards: async () => boards,
+    loadAllLibraries: async () => [],
+    runCompileProgram: (_args, onMessage) => {
+      for (const message of messages) onMessage(message)
+    },
+  }
+
+  const result = await compileProgramFlow(
+    { projectData, boardTarget: 'Test Board', projectPath: '/tmp/project' },
+    transport,
+    (event) => events.push(event),
+  )
+  return { result, events }
+}
+
+const ERROR_LINE = { message: "foo.cpp:1:1: warning: unused variable 'tmp'", logLevel: 'error' }
+
+describe('compileProgramFlow — the verdict decides, not the log level', () => {
+  it('succeeds on a positive verdict even though a line arrived at error level', async () => {
+    // The regression. Without the verdict this resolved `success: false` with
+    // the error line as its message.
+    const { result } = await runWith([ERROR_LINE, { closePort: true, success: true }])
+
+    expect(result.success).toBe(true)
+  })
+
+  it('fails on a negative verdict even though nothing was logged at error level', async () => {
+    // The mirror case: a step that failed on its exit code without printing a
+    // diagnostic. Inferring from the log would have called this a success.
+    const { result } = await runWith([
+      { message: 'Compiling...', logLevel: 'info' },
+      { closePort: true, success: false },
+    ])
+
+    expect(result.success).toBe(false)
+  })
+
+  it('explains a failure whose only evidence is the verdict', async () => {
+    // `lastError` is empty here, and an empty error string reads as "no reason
+    // given" to every caller that surfaces it.
+    const { result } = await runWith([{ closePort: true, success: false }])
+
+    expect(result).toEqual({ success: false, error: 'Compilation failed' })
+  })
+
+  it('still reports the logged error when the verdict agrees with it', async () => {
+    const { result } = await runWith([
+      { message: 'foo.cpp:9:1: error: expected ";"', logLevel: 'error' },
+      { closePort: true, success: false },
+    ])
+
+    expect(result).toEqual({ success: false, error: 'foo.cpp:9:1: error: expected ";"' })
+  })
+
+  it('falls back to the log level when the transport sends no verdict', async () => {
+    // A transport that only sees the channel close cannot supply one.
+    const withError = await runWith([ERROR_LINE, { closePort: true }])
+    const withoutError = await runWith([{ message: 'Compiling...', logLevel: 'info' }, { closePort: true }])
+
+    expect(withError.result.success).toBe(false)
+    expect(withoutError.result.success).toBe(true)
+  })
+
+  it('announces completion only when the build actually succeeded', async () => {
+    const passed = await runWith([ERROR_LINE, { closePort: true, success: true }])
+    const failed = await runWith([{ closePort: true, success: false }])
+
+    expect(passed.events.some((e) => e.stage === 'done' && e.message === 'Compilation complete')).toBe(true)
+    expect(failed.events.some((e) => e.stage === 'done')).toBe(false)
+  })
+
+  it('ignores a second terminal message, so a synthesised close cannot overturn the verdict', async () => {
+    // The CLI posts `{closePort: true}` from the socket's close event AFTER the
+    // backend's own verdict has already arrived. Without the `settled` guard
+    // that second message would re-resolve from `hasError` — reintroducing the
+    // bug on exactly the path that reported it.
+    const { result } = await runWith([ERROR_LINE, { closePort: true, success: true }, { closePort: true }])
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/middleware/adapters/editor/compile-program-flow.ts
+++ b/src/middleware/adapters/editor/compile-program-flow.ts
@@ -72,6 +72,11 @@ export interface CompileProgramTransport {
   /**
    * Start the compile pipeline and stream its messages back. Fire-and-forget:
    * completion is signalled by a `closePort` message, not by resolution.
+   *
+   * That message carries `success` — the pipeline's verdict, derived from the
+   * exit codes of the processes it ran. A transport that cannot supply one
+   * (because it only sees the channel close) may omit it, and the flow falls
+   * back to whether anything was logged at error level.
    */
   runCompileProgram: (compileArgs: CompileProgramIpcArgs, onMessage: (data: Record<string, unknown>) => void) => void
 }
@@ -146,11 +151,28 @@ export async function compileProgramFlow(
       if (data.closePort) {
         if (settled) return
         settled = true
-        if (!hasError) {
+        // Prefer the pipeline's own verdict when it sent one. It comes from the
+        // exit code of every process the build ran, which is the only thing
+        // that actually knows whether the build failed.
+        //
+        // `hasError` is the fallback, and it is a weaker signal: it is set by
+        // ANY message that arrived at error level, and a compiler writes
+        // warnings to stderr, so "an error was logged" and "the build failed"
+        // are different questions. Trusting it made a warning-only build
+        // resolve as a failure whose message was a bare `^~~~` caret line.
+        // It is still needed, because a transport can close the channel
+        // without a verdict — the CLI synthesises `closePort` from the
+        // socket's close event (see cli-transport.ts).
+        const failed = typeof data.success === 'boolean' ? !data.success : hasError
+        if (!failed) {
           onProgress({ stage: 'done', message: 'Compilation complete' })
         }
         resolve(
-          hasError ? { success: false, error: lastError } : { success: true, message: 'Compilation complete', hexPath },
+          failed
+            ? // `lastError` can be empty when the verdict is the only evidence:
+              // a step failed on its exit code without logging at error level.
+              { success: false, error: lastError || 'Compilation failed' }
+            : { success: true, message: 'Compilation complete', hexPath },
         )
         return
       }


### PR DESCRIPTION
Three fixes found while testing phase 0 on hardware. None is retain-specific; all three ride the retain feature branch so they merge with it. **Editor-only** — `src/cli/`, `docs/CLI.md` and `adapters/editor/` have no counterpart in openplc-web (whose compiler adapter already returns the pipeline's `success` directly), and nothing here touches the mirrored surface. No web pair.

---

### 1. A build's outcome came from its log, not its exit code

An upload the device had **completed and started** was reported as `upload_rejected`, with a bare `^~~~` caret line as the reason:

```json
{"ok":false,"error":{"code":"upload_rejected","message":"|     ^~~~~~~~~~~~~~~~~~~~..."}}
```

`runCompilePipeline` already reduces every step's process exit code to one boolean — arduino-cli's process status, or the runtime's `/api/compilation-status` `exit_code` by way of `deployRuntimeProgram`. The epilogue in `compileProgram` **dropped it**: only the simulator branch read `result.success`, while the runtime-v4, v3 and arduino-direct paths posted a separator and closed the channel, leaving `compileProgramFlow` to infer an outcome from whether any message had arrived at error level.

Those are different questions. A compiler writes warnings to stderr, the device tags that stream and streams it back, so a warning-only build arrived carrying error-level lines — `hasError` latched on the first, `lastError` kept the last, and in a g++ diagnostic the last line is the caret under the source line.

The verdict now travels on the terminal `closePort` message and the flow prefers it. All four terminal paths carry one, including the simulator failure path, which previously posted no `closePort` at all.

### 2. `debug write` silently unforced

The debug protocol has one mutation PDU — `FC 0x42`, carrying a `force` flag rather than a three-way op. `applyWrite` sent *both* verbs through the same `setVariable(index, force, bytes)`, so a soft write arrived as `handle_set(…, forcing = false, …)`, which runs `unforce` and **discards the value bytes**. Reproduced on both targets: reports success, value never moves.

Removed rather than implemented. A soft write has no wire representation and needs none — `DBGW_OP_WRITE` / `handle_write` serve consumers running *inside* the runtime (OPC-UA reaches it today via `args->debug_write`; retain restore will do the same), so widening the protocol would add a command with no caller.

### 3. A working credential in the docs

`docs/CLI.md` used `--credentials op:op` against `192.168.2.4` — a real account on a real device, in a checked-in file next to the host it opens. Now `user:pass` / `10.0.0.10`. A scan of `docs/` across all five repos found no others.

---

## Notes for review

**`hasError` is kept as a fallback, not deleted.** A transport that only observes the channel closing has no verdict to attach — which is exactly what the CLI does (`cli-transport.ts` synthesises `closePort` from the socket's close event). That synthesised message also arrives *after* the backend's, so the existing `settled` guard is what stops it re-resolving from `hasError` and reintroducing the bug on the very path that reported it. There is a test for that case specifically.

**An earlier revision of this work tried to fix it device-side** by classifying g++ stderr severity with regexes (openplc-runtime #171, now closed). Rejected in review as fragile, correctly: diagnostics are localised, every tool formats differently, and the failure mode runs the dangerous direction — a parser that misses a real error relabels it as a warning. No runtime change is needed at all; the exit code was already there.

## Verification

- 7 new unit tests on the verdict path, including the disagreement case (positive verdict + error-level lines) and the synthesised-close case.
- Hardware: a normal upload to the SLM-RP4 reports success; a deliberate ST syntax error still exits 4 with `compile_failed`.
- **The disagreement case is covered by test, not on-device** — the device-side warnings that trigger it could not be reproduced on demand (a warm build serves the VPP from ccache and emits nothing; clearing ccache did not bring them back).
- `36 suites / 688 tests` green across `adapters/editor`, `src/cli` and `backend/shared/compile`. `tsc --noEmit` clean.

## Not in this PR

Nothing further — the `hasError` fallback is now only reachable for transports that cannot supply a verdict, which is by design rather than a gap.

Refs NODE-94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FNp61926UEggtmsQPj3A3