### PR TITLE
feat(variables): a Flags column, and the qualifier reaches the compiler

### DIFF
--- a/scripts/dev-transpile-project.ts
+++ b/scripts/dev-transpile-project.ts
@@ -1,0 +1,93 @@
+/**
+ * Dev helper: run the editor's own project parse + ST transpile on a project
+ * directory and print the Structured Text it would hand to strucpp.
+ *
+ * Usage:
+ *   npx ts-node scripts/dev-transpile-project.ts "<path to project dir>" [out.st]
+ *
+ * Not part of the build — a manual verification aid for the compile pipeline.
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+import { fromSchemaShape, transpileToSt } from '../src/backend/shared/transpilers/st-transpiler'
+import { parseProjectFiles } from '../src/backend/shared/utils/parse-project-files'
+import type { RawProjectFile } from '../src/middleware/shared/ports/project-port'
+
+function collect(dir: string, exts: string[]): RawProjectFile[] {
+  if (!fs.existsSync(dir)) return []
+  const out: RawProjectFile[] = []
+  const walk = (d: string) => {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (exts.includes(path.extname(entry.name).toLowerCase())) {
+        out.push({ relativePath: path.relative(projectDir, full), content: fs.readFileSync(full, 'utf-8') })
+      }
+    }
+  }
+  walk(dir)
+  return out.sort((a, b) => a.relativePath.localeCompare(b.relativePath))
+}
+
+const projectDir = process.argv[2]
+if (!projectDir) {
+  console.error('usage: dev-transpile-project.ts <project-dir> [out.st]')
+  process.exit(1)
+}
+const outPath = process.argv[3]
+
+const read = (p: string) => (fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : '')
+
+const parsed = parseProjectFiles(
+  projectDir,
+  read(path.join(projectDir, 'project.json')),
+  read(path.join(projectDir, 'devices', 'configuration.json')),
+  read(path.join(projectDir, 'devices', 'pin-mapping.json')),
+  collect(path.join(projectDir, 'pous'), ['.st', '.il', '.ld', '.fbd', '.py', '.cpp', '.json']),
+  collect(path.join(projectDir, 'devices', 'servers'), ['.json']),
+  collect(path.join(projectDir, 'devices', 'remote'), ['.json']),
+  '',
+  collect(path.join(projectDir, 'datatypes'), ['.dt']),
+)
+
+for (const w of parsed.warnings ?? []) console.error(`[warn] ${w}`)
+
+// Same projection `compiler-adapter.toIpcProjectData` applies before handing
+// the project to the transpiler: flat port POUs become the discriminated
+// { type, data } form, and `configurations` is renamed to `configuration`.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const pd = parsed.projectData as any
+const ipc = {
+  dataTypes: pd.dataTypes,
+  pous: (pd.pous ?? []).map((pou: any) => ({
+    type: pou.pouType,
+    data: {
+      name: pou.name,
+      variables: pou.interface?.variables ?? [],
+      ...(pou.interface?.returnType ? { returnType: pou.interface.returnType } : {}),
+      body: pou.body,
+      documentation: pou.documentation ?? '',
+    },
+  })),
+  configuration: pd.configurations,
+  libraries: pd.libraries,
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const result = transpileToSt(fromSchemaShape(ipc as never))
+
+for (const w of result.warnings) console.error(`[transpile warn] ${w}`)
+for (const e of result.errors) console.error(`[transpile ERROR] ${e}`)
+
+if (!result.programSt) {
+  console.error('No ST produced')
+  process.exit(1)
+}
+if (outPath) {
+  fs.writeFileSync(outPath, result.programSt)
+  console.error(`wrote ${outPath} (POUs: ${result.pouNames.join(', ')})`)
+} else {
+  process.stdout.write(result.programSt)
+}

--- a/src/backend/editor/modbus/modbus-client.ts
+++ b/src/backend/editor/modbus/modbus-client.ts
@@ -55,6 +55,10 @@ export enum ModbusDebugResponse {
   /** PLC_SET_STATE only: a RUN request was refused because the hardware mode
    *  switch reads STOP. */
   REFUSED_BY_SWITCH = 0x86,
+  /** DEBUG_SET only: refused because the variable is an IEC `CONSTANT`.
+   *  Mirrors `STATUS_READ_ONLY` in STruC++'s `debug_dispatch.hpp`, and the copy
+   *  of this enum in `backend/shared/simulator/types.ts`. */
+  READ_ONLY = 0x87,
 }
 
 interface ModbusTcpClientOptions {
@@ -271,6 +275,15 @@ export class ModbusTcpClient implements DeviceModbusTransport {
         return { success: false, error: 'ERROR_OUT_OF_MEMORY' }
       }
 
+      // Refused because the variable is an IEC CONSTANT. The target is what
+      // enforces it — a constant is emitted as a `const` C++ member and the
+      // debug table reaches it through a cast that strips the qualifier — so
+      // this decode is the difference between a usable message and
+      // "Unknown error code: 0x87".
+      if (statusCode === (ModbusDebugResponse.READ_ONLY as number)) {
+        return { success: false, error: 'This variable is declared CONSTANT and cannot be written or forced' }
+      }
+
       if (statusCode !== (ModbusDebugResponse.SUCCESS as number)) {
         return { success: false, error: `Unknown error code: 0x${statusCode.toString(16)}` }
       }
@@ -375,6 +388,15 @@ export class ModbusTcpClient implements DeviceModbusTransport {
 
       if (statusCode === (ModbusDebugResponse.ERROR_OUT_OF_MEMORY as number)) {
         return { success: false, error: 'ERROR_OUT_OF_MEMORY' }
+      }
+
+      // Refused because the variable is an IEC CONSTANT. The target is what
+      // enforces it — a constant is emitted as a `const` C++ member and the
+      // debug table reaches it through a cast that strips the qualifier — so
+      // this decode is the difference between a usable message and
+      // "Unknown error code: 0x87".
+      if (statusCode === (ModbusDebugResponse.READ_ONLY as number)) {
+        return { success: false, error: 'This variable is declared CONSTANT and cannot be written or forced' }
       }
 
       if (statusCode !== (ModbusDebugResponse.SUCCESS as number)) {

--- a/src/backend/editor/modbus/modbus-rtu-client.ts
+++ b/src/backend/editor/modbus/modbus-rtu-client.ts
@@ -469,6 +469,15 @@ export class ModbusRtuClient implements DeviceModbusTransport {
         return { success: false, error: 'ERROR_OUT_OF_MEMORY' }
       }
 
+      // Refused because the variable is an IEC CONSTANT. The target is what
+      // enforces it — a constant is emitted as a `const` C++ member and the
+      // debug table reaches it through a cast that strips the qualifier — so
+      // this decode is the difference between a usable message and
+      // "Unknown error code: 0x87".
+      if (statusCode === (ModbusDebugResponse.READ_ONLY as number)) {
+        return { success: false, error: 'This variable is declared CONSTANT and cannot be written or forced' }
+      }
+
       if (statusCode !== (ModbusDebugResponse.SUCCESS as number)) {
         return { success: false, error: `Unknown error code: 0x${statusCode.toString(16)}` }
       }
@@ -555,6 +564,15 @@ export class ModbusRtuClient implements DeviceModbusTransport {
 
       if (statusCode === (ModbusDebugResponse.ERROR_OUT_OF_MEMORY as number)) {
         return { success: false, error: 'ERROR_OUT_OF_MEMORY' }
+      }
+
+      // Refused because the variable is an IEC CONSTANT. The target is what
+      // enforces it — a constant is emitted as a `const` C++ member and the
+      // debug table reaches it through a cast that strips the qualifier — so
+      // this decode is the difference between a usable message and
+      // "Unknown error code: 0x87".
+      if (statusCode === (ModbusDebugResponse.READ_ONLY as number)) {
+        return { success: false, error: 'This variable is declared CONSTANT and cannot be written or forced' }
       }
 
       if (statusCode !== (ModbusDebugResponse.SUCCESS as number)) {

--- a/src/backend/shared/debug/modbus-pdu.ts
+++ b/src/backend/shared/debug/modbus-pdu.ts
@@ -105,6 +105,14 @@ function readU32BE(buf: Uint8Array, offset: number): number {
 function statusError(code: number): string {
   if (code === ModbusDebugResponse.ERROR_OUT_OF_BOUNDS) return 'ERROR_OUT_OF_BOUNDS'
   if (code === ModbusDebugResponse.ERROR_OUT_OF_MEMORY) return 'ERROR_OUT_OF_MEMORY'
+  // A CONSTANT is refused by the target, not by us: it is emitted as a `const`
+  // C++ member and the debug table reaches it through a cast that strips the
+  // qualifier, so the runtime's own gate is what holds — which is what keeps an
+  // OPC-UA client or an older editor from writing through to it. Decoded here
+  // so the user reads the reason instead of "Unknown error code: 0x87".
+  if (code === ModbusDebugResponse.READ_ONLY) {
+    return 'This variable is declared CONSTANT and cannot be written or forced'
+  }
   return `Unknown error code: 0x${code.toString(16)}`
 }
 

--- a/src/backend/shared/simulator/modbus-rtu-client.ts
+++ b/src/backend/shared/simulator/modbus-rtu-client.ts
@@ -381,6 +381,13 @@ export class ModbusRtuClient {
         return { success: false, error: 'ERROR_OUT_OF_MEMORY' }
       }
 
+      if (statusCode === (ModbusDebugResponse.READ_ONLY as number)) {
+        return {
+          success: false,
+          error: 'This variable is declared CONSTANT and cannot be written or forced',
+        }
+      }
+
       if (statusCode !== (ModbusDebugResponse.SUCCESS as number)) {
         return { success: false, error: `Unknown error code: 0x${statusCode.toString(16)}` }
       }
@@ -465,6 +472,13 @@ export class ModbusRtuClient {
 
       if (statusCode === (ModbusDebugResponse.ERROR_OUT_OF_MEMORY as number)) {
         return { success: false, error: 'ERROR_OUT_OF_MEMORY' }
+      }
+
+      if (statusCode === (ModbusDebugResponse.READ_ONLY as number)) {
+        return {
+          success: false,
+          error: 'This variable is declared CONSTANT and cannot be written or forced',
+        }
       }
 
       if (statusCode !== (ModbusDebugResponse.SUCCESS as number)) {

--- a/src/backend/shared/simulator/types.ts
+++ b/src/backend/shared/simulator/types.ts
@@ -33,6 +33,15 @@ export enum ModbusDebugResponse {
   /** PLC_SET_STATE only: a RUN request was refused because the hardware mode
    *  switch reads STOP. */
   REFUSED_BY_SWITCH = 0x86,
+  /** DEBUG_SET only: the target refused to write or force this variable because
+   *  it is an IEC `CONSTANT`.
+   *
+   *  Mirrors `STATUS_READ_ONLY` in STruC++'s `debug_dispatch.hpp`. A constant is
+   *  emitted as a `const` C++ member and the debug table reaches it through a
+   *  cast that strips the qualifier, so the runtime is what refuses — which is
+   *  what keeps an older editor build, or an OPC-UA client, from writing
+   *  through to it. */
+  READ_ONLY = 0x87,
 }
 
 /** Runtime states reported by DEBUG_GET_STATUS and PLC_SET_STATE (and by

--- a/src/backend/shared/transpilers/st-transpiler/emit/pou-graphical.ts
+++ b/src/backend/shared/transpilers/st-transpiler/emit/pou-graphical.ts
@@ -26,6 +26,8 @@ interface InterfaceEntry {
   keyword: string
   vars: TranspileVariable[]
   located?: boolean
+  /** Block qualifier for this group; absent = plain `VAR`. */
+  flag?: TranspileVariable['flag']
 }
 
 /* ─────────────────────────── public entry ───────────────────────────────── */
@@ -67,7 +69,7 @@ export function generateGraphicalPou(pou: TranspilePou, project: TranspileProjec
   const iface = computeInterface(pou.interface?.variables ?? [], emitted.syntheticVars)
   for (const entry of iface) {
     const variableType = locationCategory(entry.keyword)
-    program.push([`  ${entry.keyword}`, []])
+    program.push([`  ${entry.keyword}${flagKeyword(entry.flag)}`, []])
     program.push(['\n', []])
     entry.vars.forEach((v, varNumber) => {
       program.push(['    ', []])
@@ -216,6 +218,11 @@ function buildTypeContext(pou: TranspilePou, project: TranspileProject): TypeCon
   return { variableType, resolveBlock }
 }
 
+/** `CONSTANT` / `RETAIN` suffix for a var-block header; empty for a plain VAR. */
+function flagKeyword(flag: TranspileVariable['flag']): string {
+  return flag === 'constant' ? ' CONSTANT' : flag === 'retain' ? ' RETAIN' : ''
+}
+
 function computeInterface(variables: TranspileVariable[], syntheticVars: SyntheticVar[]): InterfaceEntry[] {
   const classToKeyword: Record<TranspileVariableClass, string> = {
     input: varTypeNames.inputVars,
@@ -225,21 +232,25 @@ function computeInterface(variables: TranspileVariable[], syntheticVars: Synthet
     local: varTypeNames.localVars,
     temp: varTypeNames.tempVars,
   }
-  // Group by keyword, preserving IR insertion order.
-  const grouped = new Map<string, TranspileVariable[]>()
+  // Group by keyword × flag, preserving IR insertion order. The flag belongs to
+  // the var BLOCK in IEC, so variables of one class with different qualifiers
+  // cannot share a `…END_VAR` pair.
+  const grouped = new Map<string, { keyword: string; flag?: TranspileVariable['flag']; vars: TranspileVariable[] }>()
   for (const v of variables) {
     const keyword = classToKeyword[v.class ?? 'local'] ?? varTypeNames.localVars
-    const bucket = grouped.get(keyword) ?? []
-    bucket.push(v)
-    grouped.set(keyword, bucket)
+    const key = `${keyword}\u0000${v.flag ?? ''}`
+    const bucket = grouped.get(key) ?? { keyword, ...(v.flag !== undefined ? { flag: v.flag } : {}), vars: [] }
+    bucket.vars.push(v)
+    grouped.set(key, bucket)
   }
   // python splits each varlist into an unlocated block then a located one (DIV-03)
   const out: InterfaceEntry[] = []
-  for (const [keyword, vars] of grouped) {
+  for (const { keyword, flag, vars } of grouped.values()) {
+    const flagPart = flag !== undefined ? { flag } : {}
     const unlocated = vars.filter((v) => !v.location)
     const located = vars.filter((v) => v.location)
-    if (unlocated.length > 0) out.push({ keyword, vars: unlocated })
-    if (located.length > 0) out.push({ keyword, vars: located, located: true })
+    if (unlocated.length > 0) out.push({ keyword, vars: unlocated, ...flagPart })
+    if (located.length > 0) out.push({ keyword, vars: located, located: true, ...flagPart })
   }
   if (syntheticVars.length > 0) {
     const synth: TranspileVariable[] = syntheticVars.map((sv) => {
@@ -254,7 +265,12 @@ function computeInterface(variables: TranspileVariable[], syntheticVars: Synthet
     })
     const last = out[out.length - 1]
     // python reuses the trailing block only when it is a plain unlocated VAR (DIV-16)
-    if (last !== undefined && last.keyword === varTypeNames.localVars && !last.located) {
+    if (
+      last !== undefined &&
+      last.keyword === varTypeNames.localVars &&
+      !last.located &&
+      last.flag === undefined
+    ) {
       last.vars.push(...synth)
     } else {
       out.push({ keyword: varTypeNames.localVars, vars: synth })

--- a/src/backend/shared/transpilers/st-transpiler/emit/pou-textual.ts
+++ b/src/backend/shared/transpilers/st-transpiler/emit/pou-textual.ts
@@ -35,6 +35,8 @@ function formatReturnType(returnType: string | undefined): string {
 interface InterfaceEntry {
   keyword: string
   located: boolean
+  /** Block qualifier for this group; absent = plain `VAR`. */
+  flag?: TranspileVariable['flag']
   vars: TranspileVariable[]
 }
 
@@ -77,7 +79,7 @@ export function generateTextualPou(pou: TranspilePou, project: TranspileProject,
   let varNumber = 0
   for (const entry of iface) {
     const variableType = locationCategory(entry.keyword)
-    program.push([`  ${entry.keyword}`, []])
+    program.push([`  ${entry.keyword}${flagKeyword(entry.flag)}`, []])
     program.push(['\n', []])
 
     for (const v of entry.vars) {
@@ -149,29 +151,44 @@ function computeInterface(variables: TranspileVariable[]): InterfaceEntry[] {
     temp: varTypeNames.tempVars,
   }
 
-  const grouped = new Map<string, { located: TranspileVariable[]; unlocated: TranspileVariable[] }>()
+  // Keyed by class × flag: IEC puts the qualifier on the var BLOCK, not on the
+  // declaration, so two variables of the same class with different flags cannot
+  // share a block — `VAR CONSTANT` and `VAR` are separate `…END_VAR` pairs.
+  // The key keeps `keyword` first so a Map iteration still yields the class
+  // order the DOM emitter produced.
+  const grouped = new Map<
+    string,
+    { keyword: string; flag?: TranspileVariable['flag']; located: TranspileVariable[]; unlocated: TranspileVariable[] }
+  >()
   // Maintain insertion order matching the IR's variable order.
   for (const v of variables) {
     const keyword = classToKeyword[v.class ?? 'local'] ?? varTypeNames.localVars
-    let bucket = grouped.get(keyword)
+    const key = `${keyword}\u0000${v.flag ?? ''}`
+    let bucket = grouped.get(key)
     if (!bucket) {
-      bucket = { located: [], unlocated: [] }
-      grouped.set(keyword, bucket)
+      bucket = { keyword, ...(v.flag !== undefined ? { flag: v.flag } : {}), located: [], unlocated: [] }
+      grouped.set(key, bucket)
     }
     if (v.location) bucket.located.push(v)
     else bucket.unlocated.push(v)
   }
 
   const out: InterfaceEntry[] = []
-  for (const [keyword, bucket] of grouped) {
+  for (const bucket of grouped.values()) {
+    const flagPart = bucket.flag !== undefined ? { flag: bucket.flag } : {}
     if (bucket.unlocated.length > 0) {
-      out.push({ keyword, located: false, vars: bucket.unlocated })
+      out.push({ keyword: bucket.keyword, located: false, ...flagPart, vars: bucket.unlocated })
     }
     if (bucket.located.length > 0) {
-      out.push({ keyword, located: true, vars: bucket.located })
+      out.push({ keyword: bucket.keyword, located: true, ...flagPart, vars: bucket.located })
     }
   }
   return out
+}
+
+/** `CONSTANT` / `RETAIN` suffix for a var-block header; empty for a plain VAR. */
+function flagKeyword(flag: TranspileVariable['flag']): string {
+  return flag === 'constant' ? ' CONSTANT' : flag === 'retain' ? ' RETAIN' : ''
 }
 
 const ERROR_VAR_TYPES: Record<string, string> = {

--- a/src/backend/shared/transpilers/st-transpiler/from-schema.ts
+++ b/src/backend/shared/transpilers/st-transpiler/from-schema.ts
@@ -230,6 +230,7 @@ function projectVariable(v: SchemaVariable): TranspileVariable {
       ? { initialValue: v.initialValue }
       : {}),
     ...(v.documentation !== undefined && v.documentation !== '' ? { documentation: v.documentation } : {}),
+    ...(v.flag !== undefined ? { flag: v.flag } : {}),
   }
 }
 

--- a/src/backend/shared/transpilers/st-transpiler/types.ts
+++ b/src/backend/shared/transpilers/st-transpiler/types.ts
@@ -90,7 +90,19 @@ export interface TranspileVariable {
   /** Raw initial-value text — caller-supplied, no quote-wrapping. */
   initialValue?: string
   documentation?: string
+  /**
+   * IEC block qualifier. Absent = plain `VAR` (IEC's NON_RETAIN default).
+   *
+   * IEC puts the qualifier on the var *block*, not on the declaration, so this
+   * is a bucketing key for emission rather than something printed per line —
+   * see `computeInterface`, which groups by class × located × flag and opens a
+   * `VAR CONSTANT` / `VAR RETAIN` block per group.
+   */
+  flag?: TranspileVariableFlag
 }
+
+/** Mirrors `VariableFlag` in middleware/shared/ports/types.ts. */
+export type TranspileVariableFlag = 'constant' | 'retain'
 
 /* ──────────────────────────── variable type ─────────────────────────────── */
 

--- a/src/backend/shared/types/PLC/open-plc.ts
+++ b/src/backend/shared/types/PLC/open-plc.ts
@@ -155,6 +155,16 @@ const PLCVariableSchema = z.object({
   initialValue: z.string().or(z.null()).optional(),
   documentation: z.string(),
   debug: z.boolean().optional(),
+  /**
+   * IEC block qualifier — the variables table's **Flags** column.
+   *
+   * Optional, so every project written before this field existed still
+   * validates: absent means a plain `VAR`, which is IEC's NON_RETAIN default
+   * and exactly what those projects meant. One field rather than two booleans
+   * because CONSTANT and RETAIN are mutually exclusive — the invalid pair is
+   * unrepresentable instead of merely rejected.
+   */
+  flag: z.enum(['constant', 'retain']).optional(),
 })
 
 type PLCVariable = z.infer<typeof PLCVariableSchema>

--- a/src/cli/__tests__/force-settle.test.ts
+++ b/src/cli/__tests__/force-settle.test.ts
@@ -97,6 +97,21 @@ describe('force read-back', () => {
     expect(response.ok).toBe(true)
   })
 
+  it('does not mark a refused force as [FORCED] in later reads', async () => {
+    // `setVariable` succeeding only means the request was QUEUED on runtime v4;
+    // the .so's refusal of a CONSTANT leaf lands later at the dispatcher's drain
+    // and never travels back. Recording the force before the read-back had
+    // confirmed it labelled a refused force `[FORCED]` for the rest of the
+    // session — observed on an SLM-RP4 against a real `VAR CONSTANT`.
+    const core = makeCore()
+    await core.handle({ id: 1, kind: 'force', name: 'main:flag', value: 'FALSE' })
+
+    const read = await core.handle({ id: 2, kind: 'read', names: ['main:flag'] })
+    if (!read.ok) throw new Error('expected the read to succeed')
+    const values = (read.data as { kind: 'read'; values: Array<{ forced?: boolean }> }).values
+    expect(values[0]?.forced).not.toBe(true)
+  })
+
   it('still reports a read failure as a connection problem, not a target error', async () => {
     // The two failures are different: one means the channel died, the other
     // means the device answered and ignored us.

--- a/src/cli/session/session-core.ts
+++ b/src/cli/session/session-core.ts
@@ -305,10 +305,18 @@ export class SessionCore {
     if (!result.success) {
       return this.fail(id, ErrorCode.TargetError, result.error ?? 'The target refused the force')
     }
-    this.forced.add(variable.name)
 
+    // Recorded only AFTER the value is confirmed to have taken.
+    //
+    // A successful `setVariable` is not proof the force landed: on runtime v4 it
+    // means the request was QUEUED — `runtime_external_write` enqueues it and
+    // answers 0x7E, and the .so's own refusal (a CONSTANT leaf answers
+    // STATUS_READ_ONLY) happens later at the dispatcher's drain, where nothing
+    // carries it back to us. Marking the variable forced at that point labelled
+    // a refused force as `[FORCED]` in every later read of the session.
     const readBack = await this.readBackAfterWrite(variable, input)
     if ('error' in readBack) return this.fail(id, readBack.code, readBack.error)
+    this.forced.add(variable.name)
     return { id, ok: true, data: { kind: 'force', value: readBack.value } }
   }
 

--- a/src/frontend/components/_molecules/variables-table/index.tsx
+++ b/src/frontend/components/_molecules/variables-table/index.tsx
@@ -10,7 +10,7 @@ import {
   EditableLocationCell,
   EditableNameCell,
 } from './editable-cell'
-import { SelectableClassCell, SelectableDebugCell, SelectableTypeCell } from './selectable-cell'
+import { SelectableClassCell, SelectableDebugCell, SelectableFlagCell, SelectableTypeCell } from './selectable-cell'
 
 const columnHelper = createColumnHelper<PLCVariable>()
 
@@ -36,6 +36,14 @@ const columnsPrograms = [
     header: 'Class',
     enableResizing: true,
     cell: SelectableClassCell,
+  }),
+  columnHelper.accessor('flag', {
+    header: 'Flags',
+    enableResizing: true,
+    size: 120,
+    minSize: 90,
+    maxSize: 160,
+    cell: SelectableFlagCell,
   }),
   columnHelper.accessor('type', {
     header: 'Type',
@@ -88,6 +96,14 @@ const columns = [
     header: 'Class',
     enableResizing: true,
     cell: SelectableClassCell,
+  }),
+  columnHelper.accessor('flag', {
+    header: 'Flags',
+    enableResizing: true,
+    size: 120,
+    minSize: 90,
+    maxSize: 160,
+    cell: SelectableFlagCell,
   }),
   columnHelper.accessor('type', {
     header: 'Type',

--- a/src/frontend/components/_molecules/variables-table/selectable-cell.tsx
+++ b/src/frontend/components/_molecules/variables-table/selectable-cell.tsx
@@ -539,4 +539,91 @@ const SelectableDebugCell = ({ getValue, row: { index }, column: { id }, table }
   )
 }
 
-export { SelectableClassCell, SelectableDebugCell, SelectableTypeCell }
+
+/**
+ * The **Flags** column: the IEC block qualifier a variable is declared under.
+ *
+ * Three choices, because `CONSTANT` and `RETAIN` are mutually exclusive and the
+ * model stores one optional value rather than two booleans. The blank option is
+ * a real choice, not a placeholder — it means a plain `VAR`, which is IEC's
+ * NON_RETAIN default — so it has to be selectable to undo a flag.
+ *
+ * Radix rejects an empty string as a `SelectItem` value (it reserves "" for
+ * "nothing selected"), so the blank option carries a sentinel that is mapped
+ * back to `undefined` on the way into the store.
+ */
+const NO_FLAG = '__none__'
+
+const VARIABLE_FLAGS: Array<{ value: string; label: string }> = [
+  { value: NO_FLAG, label: '—' },
+  { value: 'constant', label: 'Constant' },
+  { value: 'retain', label: 'Retain' },
+]
+
+const SelectableFlagCell = ({
+  getValue,
+  row: { index },
+  column: { id },
+  table,
+  selected = true,
+}: ISelectableCellProps) => {
+  const {
+    workspace: { isDebuggerVisible },
+  } = useOpenPLCStore()
+
+  const currentValue = getValue<string | undefined>() ?? NO_FLAG
+  const [cellValue, setCellValue] = useState(currentValue)
+
+  const onValueChange = (value: string) => {
+    setCellValue(value)
+    // Store `undefined`, never the sentinel: the persisted schema's `flag` is
+    // an optional enum, so a plain VAR must carry no field at all.
+    table.options.meta?.updateData(index, id, value === NO_FLAG ? undefined : value)
+
+    // A CONSTANT cannot be located: it is folded at compile time and has no
+    // storage to bind an address to. Clearing here matches how the Class cell
+    // clears `location` when the class stops being `local`.
+    if (value === 'constant') {
+      table.options.meta?.updateData(index, 'location', '')
+    }
+  }
+
+  useEffect(() => {
+    setCellValue(currentValue)
+  }, [currentValue])
+
+  return (
+    <Select value={cellValue} onValueChange={(value) => onValueChange(value)} disabled={isDebuggerVisible}>
+      <SelectTrigger
+        placeholder={VARIABLE_FLAGS.find((f) => f.value === cellValue)?.label ?? '—'}
+        className={cn(
+          'flex h-full w-full justify-center p-2 font-caption text-cp-sm font-medium text-neutral-850 outline-none dark:text-neutral-300',
+          {
+            'pointer-events-none': !selected || isDebuggerVisible,
+            'cursor-not-allowed': isDebuggerVisible,
+          },
+        )}
+      />
+      <SelectContent
+        position='popper'
+        side='bottom'
+        sideOffset={-20}
+        className='box h-fit w-[200px] overflow-hidden rounded-lg bg-white outline-none dark:bg-neutral-950'
+      >
+        {VARIABLE_FLAGS.map((flag) => (
+          <SelectItem
+            key={flag.value}
+            value={flag.value}
+            className='flex w-full cursor-pointer items-center justify-center py-1 outline-none hover:bg-neutral-100 dark:hover:bg-neutral-900'
+          >
+            <span className='text-center font-caption text-xs font-normal text-neutral-700 dark:text-neutral-500'>
+              {flag.label}
+            </span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+export { SelectableClassCell, SelectableDebugCell, SelectableFlagCell, SelectableTypeCell }

--- a/src/frontend/utils/generate-iec-string-to-variables.ts
+++ b/src/frontend/utils/generate-iec-string-to-variables.ts
@@ -2,6 +2,61 @@ import type { LibraryState } from '../../middleware/shared/ports/library-types'
 import { baseTypeSchema } from '../../middleware/shared/ports/plc-schemas'
 import type { PLCDataType, PLCPou, PLCVariable } from '../../middleware/shared/ports/types'
 
+/**
+ * Block header with its optional IEC qualifiers, e.g. `VAR RETAIN PERSISTENT`.
+ *
+ * The qualifiers are captured as one run and split afterwards rather than
+ * enumerated in the pattern, so an unknown or repeated one produces a message
+ * naming it instead of the header silently failing to match — which is how a
+ * mistyped qualifier used to turn every declaration under it into a syntax
+ * error on the following line.
+ */
+const blockStartRegex =
+  /^(VAR_INPUT|VAR_OUTPUT|VAR_IN_OUT|VAR_EXTERNAL|VAR_TEMP|VAR_GLOBAL|VAR)(?<qualifiers>(?:\s+[A-Za-z_]\w*)*)\s*$/i
+
+/**
+ * Reduce a block header's qualifier run to the single flag the model carries.
+ *
+ * `NON_RETAIN` is IEC's name for the default, so it maps to no flag at all —
+ * accepted and then forgotten, which is exactly what it means. `PERSISTENT`
+ * folds into `retain`: CODESYS also keeps it across a download and this
+ * toolchain does not, so the honest mapping is the weaker guarantee both
+ * share (STruC++ treats the keyword the same way).
+ *
+ * Returns an `Error` rather than throwing so the caller can attach the line
+ * number and the offending text.
+ */
+function parseBlockFlag(qualifiers: string): PLCVariable['flag'] | Error {
+  let flag: PLCVariable['flag'] | undefined
+  let sawNonRetain = false
+
+  for (const word of qualifiers.trim().split(/\s+/).filter(Boolean)) {
+    switch (word.toUpperCase()) {
+      case 'CONSTANT':
+        if (flag === 'retain') return new Error('A variable cannot be both RETAIN and CONSTANT.')
+        flag = 'constant'
+        break
+      case 'RETAIN':
+      case 'PERSISTENT':
+        if (flag === 'constant') return new Error('A variable cannot be both RETAIN and CONSTANT.')
+        flag = 'retain'
+        break
+      case 'NON_RETAIN':
+        sawNonRetain = true
+        break
+      default:
+        return new Error(
+          `Unknown variable block qualifier "${word}". Expected CONSTANT, RETAIN, NON_RETAIN or PERSISTENT.`,
+        )
+    }
+  }
+
+  if (sawNonRetain && flag !== undefined) {
+    return new Error(`A variable cannot be both ${flag.toUpperCase()} and NON_RETAIN.`)
+  }
+  return flag
+}
+
 const varBlockToClass: Record<string, PLCVariable['class']> = {
   VAR: 'local',
   VAR_INPUT: 'input',
@@ -141,20 +196,29 @@ export const parseIecStringToVariables = (
   const variables: PLCVariable[] = []
   const lines = iecString.split(/\r?\n/)
   let currentClass: PLCVariable['class'] | null = null
+  // The block qualifier in force. IEC puts it on the block header, so every
+  // declaration under it inherits the same value until END_VAR.
+  let currentFlag: PLCVariable['flag'] | undefined
 
   lines.forEach((rawLine, idx) => {
     const lineNumber = idx + 1
     const line = rawLine.trim()
     if (line === '') return
 
-    const blockStart = line.match(/^(VAR_INPUT|VAR_OUTPUT|VAR_IN_OUT|VAR_EXTERNAL|VAR_TEMP|VAR_GLOBAL|VAR)\b/i)
+    const blockStart = line.match(blockStartRegex)
     if (blockStart) {
       currentClass = varBlockToClass[blockStart[1].toUpperCase()]
+      const parsedFlag = parseBlockFlag(blockStart.groups?.qualifiers ?? '')
+      if (parsedFlag instanceof Error) {
+        throw new Error(`Syntax error on line ${lineNumber}: "${line}". ${parsedFlag.message}`)
+      }
+      currentFlag = parsedFlag
       return
     }
 
     if (/^END_VAR\b/i.test(line)) {
       currentClass = null
+      currentFlag = undefined
       return
     }
 
@@ -196,6 +260,7 @@ export const parseIecStringToVariables = (
         initialValue: initialValue ? initialValue.trim() : null,
         documentation: documentation ? documentation.trim() : '',
         debug: false,
+        ...(currentFlag !== undefined ? { flag: currentFlag } : {}),
       })
       return
     }
@@ -246,6 +311,7 @@ export const parseIecStringToVariables = (
       initialValue: initialValue ? initialValue.trim() : null,
       documentation: documentation ? documentation.trim() : '',
       debug: false,
+      ...(currentFlag !== undefined ? { flag: currentFlag } : {}),
     })
   })
 

--- a/src/frontend/utils/generate-iec-variables-to-string.ts
+++ b/src/frontend/utils/generate-iec-variables-to-string.ts
@@ -28,9 +28,13 @@ export const generateIecVariablesToString = (variables: PLCVariable[]): string =
     return `${VAR_BLOCK_INDENT}VAR\n${VAR_BLOCK_INDENT}END_VAR`
   }
 
+  // Grouped by class AND flag: IEC puts the qualifier on the block header, so a
+  // `VAR CONSTANT` and a plain `VAR` are separate `…END_VAR` pairs even for
+  // variables of the same class. Grouping by class alone silently dropped the
+  // qualifier, which is what made a CONSTANT unrepresentable in this view.
   const groupedVariables = variables.reduce(
     (acc, variable) => {
-      const key = (variable.class ?? 'global').toLowerCase()
+      const key = `${(variable.class ?? 'global').toLowerCase()}\u0000${variable.flag ?? ''}`
 
       if (!acc[key]) {
         acc[key] = []
@@ -43,40 +47,47 @@ export const generateIecVariablesToString = (variables: PLCVariable[]): string =
 
   let textualDeclaration = ''
   const orderedGroups = ['global', 'external', 'input', 'output', 'inout', 'local', 'temp']
+  // Plain block first, then the qualified ones — stable output regardless of
+  // the order the variables happen to sit in.
+  const orderedFlags: Array<PLCVariable['flag']> = [undefined, 'constant', 'retain']
 
   orderedGroups.forEach((groupName) => {
-    if (groupedVariables[groupName]) {
-      const blockHeader = classToVarBlock[groupName]
-      textualDeclaration += `${VAR_BLOCK_INDENT}${blockHeader}\n`
+    orderedFlags.forEach((flag) => {
+      const groupKey = `${groupName}\u0000${flag ?? ''}`
+      if (groupedVariables[groupKey]) {
+        const blockHeader = classToVarBlock[groupName]
+        const qualifier = flag === 'constant' ? ' CONSTANT' : flag === 'retain' ? ' RETAIN' : ''
+        textualDeclaration += `${VAR_BLOCK_INDENT}${blockHeader}${qualifier}\n`
 
-      groupedVariables[groupName].forEach((v) => {
-        let line = `${VAR_DECL_INDENT}${v.name} : ${v.type.value}`
+        groupedVariables[groupKey].forEach((v) => {
+          let line = `${VAR_DECL_INDENT}${v.name} : ${v.type.value}`
 
-        if (v.location) {
-          line += ` AT ${v.location}`
-        }
-
-        if (v.initialValue) {
-          line += ` := ${v.initialValue}`
-        }
-
-        line += ';'
-
-        if (v.documentation) {
-          const singleLineDoc = v.documentation.replace(/(\r\n|\n|\r)/gm, ' ').trim()
-          if (singleLineDoc) {
-            line += ` (* ${singleLineDoc} *)`
+          if (v.location) {
+            line += ` AT ${v.location}`
           }
-        }
 
-        textualDeclaration += line + '\n'
-      })
+          if (v.initialValue) {
+            line += ` := ${v.initialValue}`
+          }
 
-      // the legacy generator emits consecutive var-class blocks back-to-back with no
-      // blank line between them — `  END_VAR\n  VAR_INPUT\n...`.  Drop
-      // the prior `END_VAR\n\n` that left a separator behind.
-      textualDeclaration += `${VAR_BLOCK_INDENT}END_VAR\n`
-    }
+          line += ';'
+
+          if (v.documentation) {
+            const singleLineDoc = v.documentation.replace(/(\r\n|\n|\r)/gm, ' ').trim()
+            if (singleLineDoc) {
+              line += ` (* ${singleLineDoc} *)`
+            }
+          }
+
+          textualDeclaration += line + '\n'
+        })
+
+        // the legacy generator emits consecutive var-class blocks back-to-back with no
+        // blank line between them — `  END_VAR\n  VAR_INPUT\n...`.  Drop
+        // the prior `END_VAR\n\n` that left a separator behind.
+        textualDeclaration += `${VAR_BLOCK_INDENT}END_VAR\n`
+      }
+    })
   })
 
   return textualDeclaration.trimEnd()
@@ -102,9 +113,13 @@ export function getIecVariableLineMap(variables: PLCVariable[]): Map<string, { l
   const map = new Map<string, { line: number; column: number }>()
   if (!variables || variables.length === 0) return map
 
+  // Same class × flag key and same block order as `generateIecVariablesToString`
+  // — the two walk in lockstep by construction. Grouping by class alone here
+  // would put Go-to-Definition on the wrong line for every variable after the
+  // first qualified block.
   const groupedVariables = variables.reduce(
     (acc, variable) => {
-      const key = (variable.class ?? 'global').toLowerCase()
+      const key = `${(variable.class ?? 'global').toLowerCase()}\u0000${variable.flag ?? ''}`
       if (!acc[key]) acc[key] = []
       acc[key].push(variable)
       return acc
@@ -113,6 +128,7 @@ export function getIecVariableLineMap(variables: PLCVariable[]): Map<string, { l
   )
 
   const orderedGroups = ['global', 'external', 'input', 'output', 'inout', 'local', 'temp']
+  const orderedFlags: Array<PLCVariable['flag']> = [undefined, 'constant', 'retain']
 
   // Variable names start at column `VAR_DECL_INDENT.length + 1`
   // (4 spaces + Monaco's 1-indexed column).
@@ -123,14 +139,16 @@ export function getIecVariableLineMap(variables: PLCVariable[]): Map<string, { l
   // declaration counts as a line, END_VAR counts as a line.
   let currentLine = 1
   for (const groupName of orderedGroups) {
-    const group = groupedVariables[groupName]
-    if (!group) continue
-    currentLine++ // skip the VAR_xxx header line
-    for (const v of group) {
-      map.set(v.name, { line: currentLine, column: varNameColumn })
-      currentLine++ // advance past the declaration
+    for (const flag of orderedFlags) {
+      const group = groupedVariables[`${groupName}\u0000${flag ?? ''}`]
+      if (!group) continue
+      currentLine++ // skip the VAR_xxx header line
+      for (const v of group) {
+        map.set(v.name, { line: currentLine, column: varNameColumn })
+        currentLine++ // advance past the declaration
+      }
+      currentLine++ // skip the END_VAR line
     }
-    currentLine++ // skip the END_VAR line
   }
 
   return map

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -43,6 +43,22 @@ export type VariableClass = 'input' | 'output' | 'inOut' | 'external' | 'local' 
 
 export type VariableTypeDefinition = 'base-type' | 'user-data-type' | 'array' | 'derived'
 
+/**
+ * The IEC block qualifier a variable is declared under — what the variables
+ * table shows in its **Flags** column.
+ *
+ * Single-valued, and deliberately so: `CONSTANT` and `RETAIN` are mutually
+ * exclusive (STruC++ rejects the combination), so one optional field makes the
+ * invalid pair unrepresentable rather than merely validated. Absent means a
+ * plain `VAR` — which is IEC's `NON_RETAIN`, the default.
+ *
+ * CODESYS's `PERSISTENT` maps to `'retain'` on import. It promises more than
+ * that (it also survives a program download) and the toolchain does not deliver
+ * the difference yet, so it is folded in rather than given a value of its own —
+ * matching how STruC++ treats the keyword.
+ */
+export type VariableFlag = 'constant' | 'retain'
+
 export interface PLCVariableType {
   definition: VariableTypeDefinition
   value: string
@@ -66,6 +82,8 @@ export interface PLCVariable {
   initialValue?: string | null
   documentation: string
   debug?: boolean
+  /** IEC block qualifier; absent = plain `VAR`. See {@link VariableFlag}. */
+  flag?: VariableFlag
 }
 
 export interface PLCTask {


### PR DESCRIPTION
Phase 1 of NODE-94, editor half. **Pairs with openplc-web #687** — shared surface, both must land together. Compiler half is **strucpp #219**.

Until now the editor could not express an IEC block qualifier at all: a `VAR CONSTANT` typed into the variables code view was collapsed into the plain `VAR` block (`parseIecStringToVariables` matched `VAR\b` and dropped the rest of the header), so the qualifier never reached STruC++. That is why the CONSTANT write-gate from strucpp #218 was unreachable — nothing could produce a const member.

- **`PLCVariable.flag?: 'constant' | 'retain'`** — one optional field, not two booleans. CONSTANT and RETAIN are mutually exclusive, so the invalid pair is *unrepresentable* rather than merely validated. Absent = plain `VAR` = IEC's NON_RETAIN, so every existing project still loads and means what it meant.
- **A `Flags` dropdown column** in the POU and global variables tables (blank / Constant / Retain), on the existing `SelectableClassCell` pattern.
- **Emission groups by class × located × flag.** The qualifier belongs to the var *block* in IEC, not the declaration, so it is a bucketing key and each group opens its own `VAR CONSTANT` / `VAR RETAIN` … `END_VAR`.
- **Text round-trip both ways**, including `NON_RETAIN` (→ no flag) and `PERSISTENT` (→ `retain`, matching STruC++).

## Notes for review

**The serializer and the Go-to-Definition line map changed in lockstep.** They walk the same grouped shape by construction; grouping the map by class alone would have put Go-to-Definition on the wrong line for every variable after the first qualified block.

**The parser captures the qualifier run and resolves it afterwards** rather than enumerating keywords in the pattern. A typo now names itself — `Unknown variable block qualifier "RETAINN"` — instead of the header silently failing to match and every declaration under it erroring on the *following* line, which is the failure mode this whole area already had.

**Two findings came from hardware, not from the plan:**

1. `READ_ONLY = 0x87` was not decoded anywhere. The P1AM refused a force on a CONSTANT with `Unknown error code: 0x87` — the target was right and the editor had no idea what it was saying. The status is duplicated across **four** places (two enum definitions, two sets of inline client checks); all four now carry it. That duplication is pre-existing and worth collapsing separately.
2. `applyForce` recorded a variable as forced **before** confirming the value took. A successful `setVariable` is not proof — on runtime v4 it means *queued*, and the `.so`'s refusal lands later at the dispatcher's drain where nothing carries it back — so a refused force showed `[FORCED]` in every later read of the session. Moved after the read-back, with a test.

## Verified end to end on both devices

`VAR CONSTANT LIMIT` and `VAR RETAIN boots` now survive the pipeline into `program.st`, and the gate is live:

```
      INSTANCE0.COUNTER  DINT
      INSTANCE0.ENABLE   BOOL
  RO  INSTANCE0.LIMIT    DINT      <- readOnly in debug-map.json
      INSTANCE0.BOOTS    DINT
{ (void*)&g_config.INSTANCE0.LIMIT, TAG_DINT, LEAF_FLAG_READONLY },
```

**P1AM-100** (baremetal, refusal comes straight back on the PDU):
```
ok   force main:counter 7  -> main:counter : DINT = 7
ERR  force main:LIMIT 99   -> This variable is declared CONSTANT and cannot be written or forced
```

**SLM-RP4** (runtime v4 — the refusal is journaled, so it surfaces via the read-back):
```
ok   force main:counter 7  -> main:counter : DINT = 7
ERR  force main:LIMIT 99   -> The target acknowledged the force but main:LIMIT did not take the value within 1500 ms (still 10)
```

Both correct; the difference is inherent to where each target enforces it, and #1029's force-settle change is what makes the v4 case visible at all rather than silently reporting success.

Editor suite: **331 suites / 6898 tests**, failures unchanged (the two in `device-types` / `use-device-connect` reproduce on the untouched integration branch). Mirror gate: **1052 files, 0 diffs**. `tsc --noEmit` clean.

## Not in this PR

Edit-time validation of the combinations STruC++ rejects (CONSTANT without an initial value; RETAIN on `external` / `temp`). The compiler reports all of them with a source span today, and the dropdown makes contradictions unrepresentable, so this is a nicer-error change rather than a correctness one.

Refs NODE-94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FNp61926UEggtmsQPj3A3