### PR TITLE
fix(vpp): forward the package signature, and let a HAL include the runtime's contracts [NODE-94]

### DIFF
--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -2415,6 +2415,46 @@ class CompilerModule {
       const combinedHash = hash.digest('hex')
       await writeFile(join(destPluginDir, 'checksum.sha256'), combinedHash + '\n', 'utf-8')
 
+      // The package signature, forwarded so the runtime can verify what it is
+      // about to compile.
+      //
+      // `vpp_plugin/` is the only content in an upload that the runtime builds
+      // with a Makefile that came from the upload itself, so the runtime
+      // requires it to be signed by a trusted key. It cannot re-derive the
+      // signature: the plugin tree it receives is a SUBSET of the package
+      // (config_template.json and requirements.txt are dropped above, and
+      // trusted_keys.c / checksum.sha256 are generated here), so only the
+      // original package's detached signature can attest to it.
+      //
+      // `pluginDir` tells the runtime which signed subtree to compare the
+      // upload against — the same relative path this function copied from.
+      //
+      // Without this the runtime refuses every VPP upload with "vpp_signature
+      // .json is missing or unreadable". The contract was written on the
+      // runtime side (webserver/vpp_package_signature.py, whose comment names
+      // this very function as its author) and never implemented here, so no
+      // VPP could be uploaded to a runtime that enforces it.
+      const packageSignaturePath = join(matchingPackagePath, 'signature.json')
+      try {
+        const signatureRaw = await readFile(packageSignaturePath, 'utf-8')
+        await writeFile(
+          join(sourceTargetFolderPath, 'vpp_signature.json'),
+          `${JSON.stringify({ package: JSON.parse(signatureRaw), pluginDir: pluginDirRelPath.split(path.sep).join('/') }, null, 2)}\n`,
+          'utf-8',
+        )
+      } catch (err) {
+        // Non-fatal HERE, and refused THERE. An unsigned package is a normal
+        // thing to have during vendor development (`build.ts --unsigned`), and
+        // failing the local build would make that workflow impossible. The
+        // runtime is the boundary that matters, and it rejects the upload with
+        // a message naming the fix — which is better than this build guessing
+        // whether the target enforces signatures.
+        handleOutputData(
+          `VPP package has no usable signature.json (${getErrorMessage(err)}); a runtime that requires signed plugins will refuse this upload`,
+          'warning',
+        )
+      }
+
       handleOutputData(
         `Copied ${copiedFiles.length} VPP plugin ${isPrebuilt ? 'prebuilt' : 'source'} file(s) to vpp_plugin/ (checksum: ${combinedHash.slice(0, 12)}...)`,
         'info',

--- a/src/backend/shared/compile/__tests__/merge-strucpp-runtime-into-skeleton.test.ts
+++ b/src/backend/shared/compile/__tests__/merge-strucpp-runtime-into-skeleton.test.ts
@@ -80,4 +80,43 @@ describe('mergeStrucppRuntimeIntoSkeleton', () => {
     })
     expect(input).toEqual(before)
   })
+
+  // --- vendor-facing contract headers ------------------------------------
+  //
+  // The HAL lands at `src/arduino.cpp` while the firmware's own headers stay
+  // under `examples/Baremetal/`, so without this mirroring a HAL cannot
+  // `#include "openplc_retain.h"` at all — the two directories never see each
+  // other, and a vendor implementing retain has to restate the ABI by hand.
+
+  it('mirrors openplc_retain.h into src/ so the HAL can include it', () => {
+    const merged = mergeStrucppRuntimeIntoSkeleton({
+      firmwareSkeleton: { 'examples/Baremetal/openplc_retain.h': '/* contract */' },
+      strucppRuntimeHeaders: {},
+      boardHalContent: '#include "openplc_retain.h"',
+    })
+    expect(merged['src/openplc_retain.h']).toBe('/* contract */')
+    // Copied, not moved: the Baremetal build still compiles its own copy.
+    expect(merged['examples/Baremetal/openplc_retain.h']).toBe('/* contract */')
+  })
+
+  it('mirrors nothing when there is no HAL to include it', () => {
+    // No HAL means no `src/` at all; putting a lone header there would give
+    // arduino-cli a library directory with nothing in it.
+    const merged = mergeStrucppRuntimeIntoSkeleton({
+      firmwareSkeleton: { 'examples/Baremetal/openplc_retain.h': '/* contract */' },
+      strucppRuntimeHeaders: {},
+    })
+    expect(merged['src/openplc_retain.h']).toBeUndefined()
+  })
+
+  it('skips a contract header the skeleton does not carry', () => {
+    // A skeleton assembled before the header existed must still merge, rather
+    // than writing `undefined` into src/ and failing the build later.
+    const merged = mergeStrucppRuntimeIntoSkeleton({
+      firmwareSkeleton: { 'examples/Baremetal/Baremetal.ino': '/* sketch */' },
+      strucppRuntimeHeaders: {},
+      boardHalContent: 'hal',
+    })
+    expect('src/openplc_retain.h' in merged).toBe(false)
+  })
 })

--- a/src/backend/shared/compile/steps/merge-strucpp-runtime-into-skeleton.ts
+++ b/src/backend/shared/compile/steps/merge-strucpp-runtime-into-skeleton.ts
@@ -57,6 +57,16 @@ export interface MergeStrucppRuntimeArgs {
  * (web's simulator HAL is dropped in favour of the editor's
  * per-board variant when both are present).
  */
+/**
+ * Firmware headers a board HAL is expected to be able to include.
+ *
+ * Deliberately a short, explicit list rather than "every header in
+ * examples/Baremetal": these are the ones that describe a contract a VENDOR
+ * implements, and copying the whole firmware into `src/` would put two copies
+ * of every translation unit in front of arduino-cli.
+ */
+const VENDOR_FACING_CONTRACT_HEADERS = ['openplc_retain.h'] as const
+
 export function mergeStrucppRuntimeIntoSkeleton(args: MergeStrucppRuntimeArgs): Record<string, string> {
   const merged: Record<string, string> = { ...args.firmwareSkeleton }
   for (const [v4Key, content] of Object.entries(args.strucppRuntimeHeaders)) {
@@ -66,6 +76,23 @@ export function mergeStrucppRuntimeIntoSkeleton(args: MergeStrucppRuntimeArgs): 
   }
   if (typeof args.boardHalContent === 'string' && args.boardHalContent.length > 0) {
     merged['src/arduino.cpp'] = args.boardHalContent
+
+    // Vendor-facing runtime contracts, mirrored into `src/` beside the HAL.
+    //
+    // The HAL lands at `src/arduino.cpp` while the firmware's own headers stay
+    // under `examples/Baremetal/`, so a HAL that implements one of these
+    // contracts could not `#include` it — the two directories never see each
+    // other. A vendor writing a retain backend hits this immediately: the
+    // include fails, and the only workaround is to restate the contract by
+    // hand in the HAL, which is how two copies of an ABI start drifting.
+    //
+    // Copied rather than moved: the Baremetal build still compiles its own
+    // copy, and arduino-cli's `--library src` pass is what makes this one
+    // visible to the HAL.
+    for (const contract of VENDOR_FACING_CONTRACT_HEADERS) {
+      const header = merged[`examples/Baremetal/${contract}`]
+      if (typeof header === 'string') merged[`src/${contract}`] = header
+    }
   }
   return merged
 }


### PR DESCRIPTION
Two fixes found by putting a signed VPP on real hardware. Both are prerequisites for testing any VPP feature at all, which is why they are here rather than buried in the retain branches.

## 1. The editor never forwarded the package signature

Every VPP upload to a runtime that enforces signatures was refused:

```
this upload contains a VPP plugin but no usable package signature:
vpp_signature.json is missing or unreadable
```

`vpp_plugin/` is the only content in an upload the runtime compiles with a Makefile that came from the upload itself, so it requires that tree to be signed by a trusted key. It **cannot re-derive the signature**: the tree it receives is a *subset* of the package (`config_template.json` and `requirements.txt` are dropped, `trusted_keys.c` and `checksum.sha256` are generated by the editor), so only the original package's detached signature can attest to it.

The contract was written on the runtime side, and its comment in `webserver/vpp_package_signature.py` names `handleVendorPluginPackaging` — this very function — as the sidecar's author. **It was never implemented here.** So the editor copied the plugin tree, wrote its checksum, and sent an upload the runtime was always going to reject.

`vpp_signature.json` now carries the package's `signature.json` verbatim plus `pluginDir`, the relative path the copy came from, which is how the runtime knows which signed subtree to compare against.

A package with no `signature.json` is a **warning** here and a refusal there. `build.ts --unsigned` is a normal vendor-development workflow and failing the local build would make it impossible; the runtime is the boundary that matters and it rejects with a message naming the fix. This build has no business guessing whether the target enforces signatures.

## 2. A board HAL could not include the runtime's own contracts

The HAL lands at `src/arduino.cpp`; the firmware's headers stay under `examples/Baremetal/`. The two directories never see each other, so a HAL could not `#include "openplc_retain.h"` — the contract a vendor is supposed to implement was unreachable from the only file that implements it.

Found building the P1AM retain backend: the include fails, and the only way forward is restating the four signatures by hand inside the HAL. That is how two copies of an ABI start drifting, and the drift stays silent until a retained value comes back wrong.

`openplc_retain.h` is mirrored into `src/` beside the HAL, where arduino-cli's `--library src` pass finds it. Copied, not moved — the Baremetal build still compiles its own copy. An explicit list, not "every header in `examples/Baremetal`": these are the headers describing a contract a *vendor* implements, and copying the whole firmware into `src/` would put two copies of every translation unit in front of arduino-cli.

## Verification

On a real SLM-RP4, with your production-signed package:

```
VPP plugin verified against the signed package (digest 3ff71879cb22...)
PLC started.
Upload complete.
```

That is the first VPP upload this device has accepted. Confirmed twice: once with a package I built and signed, once with the **stock installed 0.4.2** — so the path works on shipped packages, not just freshly built ones.

`merge-strucpp-runtime-into-skeleton.ts` is back to **100%** coverage (3 new cases: the mirror, no-HAL, and a skeleton that predates the header). Mirror gate: **1057 files, 0 diffs**. Pairs with openplc-web for the shared half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FNp61926UEggtmsQPj3A3
