### PR TITLE
fix(python): reject Python blocks on targets that cannot run them [DOPE-584 P1]

### DIFF
--- a/src/backend/shared/utils/PLC/__tests__/preprocess-pous.test.ts
+++ b/src/backend/shared/utils/PLC/__tests__/preprocess-pous.test.ts
@@ -286,6 +286,64 @@ describe('preprocessPous — C++', () => {
 // ---------------------------------------------------------------------------
 // Mixed scenarios
 // ---------------------------------------------------------------------------
+describe('preprocessPous — Python target support', () => {
+  it('rejects Python POUs when the target cannot run them', () => {
+    const project = makeProjectData([makePythonPou('PyBlock', 'def block_loop():\n    pass')])
+    const logs: Array<[string, string]> = []
+    const result = preprocessPous(project, false, (level, message) => logs.push([level, message]), {
+      supported: false,
+      targetLabel: 'Arduino Mega',
+    })
+
+    expect(result.validationFailed).toBe(true)
+    expect(result.validationError).toContain('Python function blocks are not supported on Arduino Mega')
+    expect(result.validationError).toContain('"PyBlock"')
+    expect(logs.some(([level]) => level === 'error')).toBe(true)
+  })
+
+  it('names every offending POU in the rejection', () => {
+    const project = makeProjectData([
+      makePythonPou('First', 'def block_loop():\n    pass'),
+      makePythonPou('Second', 'def block_loop():\n    pass'),
+    ])
+    const result = preprocessPous(project, false, () => {}, { supported: false, targetLabel: 'Arduino Uno' })
+
+    expect(result.validationError).toContain('"First", "Second"')
+  })
+
+  it('leaves the project untouched when it rejects', () => {
+    const project = makeProjectData([makePythonPou('PyBlock', 'def block_loop():\n    pass')])
+    const result = preprocessPous(project, false, () => {}, { supported: false, targetLabel: 'Arduino Mega' })
+
+    // No ST lowering, no injected runtime variables — the POU is as authored.
+    expect(result.projectData.pous[0].body.language).toBe('python')
+  })
+
+  it('does not reject a project with no Python POUs', () => {
+    const project = makeProjectData([makeStPou('Main', 'x := 1;')])
+    const result = preprocessPous(project, false, () => {}, { supported: false, targetLabel: 'Arduino Mega' })
+
+    expect(result.validationFailed).toBe(false)
+    expect(result.validationError).toBeUndefined()
+  })
+
+  it('processes Python normally when the target supports it', () => {
+    const project = makeProjectData([makePythonPou('PyBlock', 'def block_loop():\n    pass')])
+    const result = preprocessPous(project, false, () => {}, { supported: true, targetLabel: 'OpenPLC Runtime v4' })
+
+    expect(result.validationFailed).toBe(false)
+    expect(result.projectData.pous[0].body.language).toBe('st')
+  })
+
+  it('processes Python normally when no support hint is given (library builds)', () => {
+    const project = makeProjectData([makePythonPou('PyBlock', 'def block_loop():\n    pass')])
+    const result = preprocessPous(project, false, () => {})
+
+    expect(result.validationFailed).toBe(false)
+    expect(result.projectData.pous[0].body.language).toBe('st')
+  })
+})
+
 describe('preprocessPous — mixed', () => {
   it('handles a project with ST, Python, and C++ POUs', () => {
     const project = makeProjectData([

--- a/src/backend/shared/utils/PLC/preprocess-pous.ts
+++ b/src/backend/shared/utils/PLC/preprocess-pous.ts
@@ -22,6 +22,35 @@ type LogFn = (level: 'info' | 'error', message: string) => void
 type PreprocessResult = {
   projectData: ProjectDataWithCpp
   validationFailed: boolean
+  /**
+   * Human-facing reason for `validationFailed`, when one is known.
+   *
+   * Callers used to hard-code the C/C++ setup()/loop() message, which was the
+   * only way validation could fail. Python-on-an-unsupported-target is a second
+   * way, and reporting it as a C/C++ problem would send the user looking in the
+   * wrong file. Absent → the caller's default message still applies.
+   */
+  validationError?: string
+}
+
+/**
+ * Whether the selected target can host Python function blocks, and what to call
+ * it when it cannot.
+ *
+ * Mirrors `TargetCapabilities.pythonFunctionBlocks`, which already states the
+ * contract: Runtime v3 / v4 run them natively, the Simulator compiles them as
+ * no-op stubs, and arduino-cli targets reject them at build time. The rejection
+ * half was never implemented — a Python block on an Arduino target took the
+ * full Linux pipeline and died inside avr-g++ with `'python_block_loader' was
+ * not declared in this scope`, which tells the user nothing.
+ *
+ * Optional so the library build paths, which have no board in hand, keep their
+ * existing behaviour.
+ */
+type PythonTargetSupport = {
+  supported: boolean
+  /** Board name as the user selected it, for the error message. */
+  targetLabel: string
 }
 
 const extractPythonData = (pous: PLCPou[]) => {
@@ -40,11 +69,36 @@ const extractPythonData = (pous: PLCPou[]) => {
     }))
 }
 
-function preprocessPous(projectData: PLCProjectData, isSimulator: boolean, log: LogFn): PreprocessResult {
+function preprocessPous(
+  projectData: PLCProjectData,
+  isSimulator: boolean,
+  log: LogFn,
+  pythonSupport?: PythonTargetSupport,
+): PreprocessResult {
   let processedProjectData: PLCProjectData = projectData
 
   // --- Python processing ---
   const hasPythonCode = projectData.pous.some((pou: PLCPou) => pou.body.language === 'python')
+
+  if (hasPythonCode && pythonSupport && !pythonSupport.supported) {
+    // Reject before any Python processing runs. Generating the shared-memory
+    // stub for a target that cannot load it only moves the failure into the
+    // board's C++ toolchain, where the message is about `python_block_loader`
+    // rather than about Python blocks being unsupported here.
+    const names = projectData.pous
+      .filter((pou: PLCPou) => pou.body.language === 'python')
+      .map((pou: PLCPou) => `"${pou.name}"`)
+      .join(', ')
+    const message =
+      `Python function blocks are not supported on ${pythonSupport.targetLabel} — ` +
+      `they require the OpenPLC Linux runtime. Remove or change ${names}, or select a Runtime target.`
+    log('error', message)
+    return {
+      projectData: processedProjectData as ProjectDataWithCpp,
+      validationFailed: true,
+      validationError: message,
+    }
+  }
 
   if (hasPythonCode) {
     const pythonPous = projectData.pous.filter((pou: PLCPou) => pou.body.language === 'python')
@@ -134,7 +188,11 @@ function preprocessPous(projectData: PLCProjectData, isSimulator: boolean, log: 
     }
 
     if (validationFailed) {
-      return { projectData: processedProjectData as ProjectDataWithCpp, validationFailed: true }
+      return {
+        projectData: processedProjectData as ProjectDataWithCpp,
+        validationFailed: true,
+        validationError: 'POU validation failed. Check C/C++ code for missing setup()/loop() functions.',
+      }
     }
 
     processedProjectData = addCppLocalVariables(processedProjectData)
@@ -186,4 +244,4 @@ function preprocessPous(projectData: PLCProjectData, isSimulator: boolean, log: 
   return { projectData: processedProjectData as ProjectDataWithCpp, validationFailed: false }
 }
 
-export { preprocessPous, type ProjectDataWithCpp }
+export { preprocessPous, type ProjectDataWithCpp, type PythonTargetSupport }

--- a/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
@@ -987,7 +987,9 @@ describe('compileForDebug with invalid C++ POU', () => {
     )
 
     expect(result.success).toBe(false)
-    expect(result.error).toBe('POU validation failed.')
+    // The debug path now surfaces the specific reason instead of a bare
+    // "POU validation failed." — the same text the build path already showed.
+    expect(result.error).toBe('POU validation failed. Check C/C++ code for missing setup()/loop() functions.')
     // The bridge should NOT have been called because validation failed early
     expect(window.bridge.runDebugCompilation).not.toHaveBeenCalled()
     void debugCallback // suppress unused warning

--- a/src/middleware/adapters/editor/compile-program-flow.ts
+++ b/src/middleware/adapters/editor/compile-program-flow.ts
@@ -16,6 +16,7 @@
  */
 
 import { preprocessPous } from '../../../backend/shared/utils/PLC/preprocess-pous'
+import { resolveTargetCapabilities } from '../../shared/utils/target-capabilities'
 import type { CompileProgramArgs } from '../../shared/ports/compiler-port'
 import type { StlibArchiveDTO } from '../../shared/ports/library-port'
 import type { BoardInfo, CompileProgressEvent, CompileResult, StructuredCompileError } from '../../shared/ports/types'
@@ -86,6 +87,18 @@ export async function compileProgramFlow(
   const boardCore = boardInfo?.core ?? null
   const isSimulator = args.isSimulator ?? boardInfo?.compiler === 'simulator'
 
+  // `pythonFunctionBlocks` has always described the contract (v3 / v4 run them,
+  // the Simulator stubs them, arduino-cli targets reject them); until now
+  // nothing enforced the rejection half, so a Python block on an Arduino board
+  // reached the board's C++ toolchain and failed there instead.
+  //
+  // Only gate on a board we actually resolved: `resolveTargetCapabilities`
+  // returns an all-false block for `undefined`, so gating on an unresolved
+  // board would turn a catalog lookup miss into a Python build failure.
+  const pythonSupport = boardInfo
+    ? { supported: resolveTargetCapabilities(boardInfo).pythonFunctionBlocks, targetLabel: args.boardTarget }
+    : undefined
+
   // Graft library-supplied C++ blocks into the project's POU
   // list before preprocessing.  They behave like user-defined
   // C++ POUs from this point on — same `preprocessPous` branch,
@@ -96,18 +109,23 @@ export async function compileProgramFlow(
   const dataWithLibCpp = injectLibraryCppBlocks(args.projectData, archives)
 
   // Preprocess POUs (comment wrapping, Python->ST stubs, C++ validation/ST generation)
-  const { projectData: processedData, validationFailed } = preprocessPous(
+  const {
+    projectData: processedData,
+    validationFailed,
+    validationError,
+  } = preprocessPous(
     dataWithLibCpp,
     isSimulator,
     (level, message) => {
       onProgress({ stage: 'st', message, level })
     },
+    pythonSupport,
   )
 
   if (validationFailed) {
     return {
       success: false,
-      error: 'POU validation failed. Check C/C++ code for missing setup()/loop() functions.',
+      error: validationError ?? 'POU validation failed. Check C/C++ code for missing setup()/loop() functions.',
     }
   }
 

--- a/src/middleware/adapters/editor/compiler-adapter.ts
+++ b/src/middleware/adapters/editor/compiler-adapter.ts
@@ -12,6 +12,7 @@
  */
 
 import { preprocessPous } from '../../../backend/shared/utils/PLC/preprocess-pous'
+import { resolveTargetCapabilities } from '../../shared/utils/target-capabilities'
 import type {
   CompileLibraryArgs,
   CompileProgramArgs,
@@ -213,17 +214,31 @@ export function createEditorCompilerAdapter(): CompilerPort {
       const archives = (await window.bridge.loadAllLibraries()) as StlibArchiveDTO[]
       const dataWithLibCpp = injectLibraryCppBlocks(args.projectData, archives)
 
-      // Preprocess for debug compilation too
-      const { projectData: processedData, validationFailed } = preprocessPous(
+      // Preprocess for debug compilation too. Same target gate as the build
+      // path — a Python block is no more loadable on an Arduino board when the
+      // build is for debugging.
+      const debugBoards = await window.bridge.getAvailableBoards()
+      const debugBoardInfo = debugBoards.get(args.boardTarget)
+      const {
+        projectData: processedData,
+        validationFailed,
+        validationError,
+      } = preprocessPous(
         dataWithLibCpp,
         false,
         (level, message) => {
           onProgress({ stage: 'st', message, level })
         },
+        debugBoardInfo
+          ? {
+              supported: resolveTargetCapabilities(debugBoardInfo).pythonFunctionBlocks,
+              targetLabel: args.boardTarget,
+            }
+          : undefined,
       )
 
       if (validationFailed) {
-        return { success: false, error: 'POU validation failed.' }
+        return { success: false, error: validationError ?? 'POU validation failed.' }
       }
 
       const ipcData = toIpcProjectData(processedData)


### PR DESCRIPTION
Phase 1 of DOPE-584. Merges into the task branch, not `development`.

## What this fixes

`TargetCapabilities.pythonFunctionBlocks` has always declared the contract — Runtime v3 / v4 run Python blocks natively, the Simulator compiles them as no-op stubs, arduino-cli targets reject them at build time. **Only the rejection was never implemented.** Its single consumer was a soft warning in the board picker, and `preprocessPous` branched solely on `isSimulator`, so a real baremetal target took the full Linux pipeline and died inside the board toolchain:

```
error: 'create_shm_name' was not declared in this scope
error: 'python_block_loader' was not declared in this scope
error: Arduino compilation failed
```

Nothing in that tells a user their board cannot host Python blocks.

The UI gate (`isPythonBlockedForArduino`) only guards POU **creation** while an Arduino board is selected, so it is bypassed by switching the board afterwards, opening a project authored elsewhere, or declaring through the variables text view.

## Approach

`preprocessPous` takes an optional target-support hint and refuses **before** any Python processing runs, naming the board and every offending POU. `PreprocessResult` gains `validationError`, so callers stop reporting a Python problem as a C/C++ `setup()/loop()` problem — the debug path in particular gains a specific message where it previously said only "POU validation failed."

**The gate only applies to a board that actually resolved.** `resolveTargetCapabilities(undefined)` returns an all-false block, so keying off an unresolved board would turn a catalog lookup miss into a Python build failure. Library builds pass no hint and keep their existing behaviour.

## Hardware verification

Per the task, every phase is proven against real toolchains rather than unit tests alone.

| target | result |
| --- | --- |
| Arduino Mega | rejected with the message; avr-g++ never invoked |
| OpenPLC Simulator | still compiles Python as no-op stubs, unchanged |
| OpenPLC Runtime v4 (slm-rp4) | uploaded, PLC started, no regression |

The rejection as the user now sees it:

```
error: Python function blocks are not supported on Arduino Mega — they require
the OpenPLC Linux runtime. Remove or change "TempAlarm", or select a Runtime target.
```

## Checks

- 6 new tests on `preprocessPous`; 427 passing across the touched suites
- `tsc --noEmit` clean in both repos
- `validate:arch` passes
- `compare-surfaces.py`: 1,053 files, **0 diffs** — the shared surface stays byte-identical

## Acceptance criteria covered

AC1 (clean rejection naming the board, before Python processing), AC2 (Simulator stubs unchanged), and AC12 for this phase (verified on real hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaSZK4LqFWtZpERcqnZ8uQ