### PR TITLE
fix(python): one table for the SHM layout, and make WSTRING work [DOPE-584 P2]

### DIFF
--- a/src/backend/shared/utils/PLC/preprocess-pous.ts
+++ b/src/backend/shared/utils/PLC/preprocess-pous.ts
@@ -4,6 +4,7 @@ import { validateCppCode } from '../../../../frontend/utils/cpp/validateCppCode'
 import { addPythonLocalVariables } from '../../../../frontend/utils/python/addPythonLocalVariables'
 import { generateSTCode } from '../../../../frontend/utils/python/generateSTCode'
 import { injectPythonCode } from '../../../../frontend/utils/python/injectPythonCode'
+import { describeShmField, describeVariableType } from '../../../../frontend/utils/python/shm-type-map'
 import type { PLCPou, PLCProjectData, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { generateSoftMotionArtifacts } from '../../ethercat/generate-softmotion'
 
@@ -97,6 +98,38 @@ function preprocessPous(
       projectData: processedProjectData as ProjectDataWithCpp,
       validationFailed: true,
       validationError: message,
+    }
+  }
+
+  // A Python POU's interface can only carry types both sides of the shared
+  // memory boundary describe identically. Anything else is refused here rather
+  // than skipped during encoding: a field the Python format string omits does
+  // not go missing, it shifts every later field's offset, so the failure lands
+  // on unrelated variables and looks like corrupted data instead of an
+  // unsupported type. Structures, enumerations and function block instances
+  // arrive in later phases.
+  if (hasPythonCode) {
+    const unsupported: string[] = []
+    for (const pou of projectData.pous) {
+      if (pou.body.language !== 'python') continue
+      for (const variable of pou.interface?.variables ?? []) {
+        if (variable.class !== 'input' && variable.class !== 'output') continue
+        if (describeShmField(variable) === null) {
+          unsupported.push(`"${pou.name}.${variable.name}" (${describeVariableType(variable)})`)
+        }
+      }
+    }
+    if (unsupported.length > 0) {
+      const message =
+        `Python function blocks cannot exchange these variable types yet: ${unsupported.join(', ')}. ` +
+        'Supported types are BOOL, the integer and bit-string types, REAL/LREAL, TIME/DATE/TOD/DT, ' +
+        'STRING, WSTRING, and arrays of those.'
+      log('error', message)
+      return {
+        projectData: processedProjectData as ProjectDataWithCpp,
+        validationFailed: true,
+        validationError: message,
+      }
     }
   }
 

--- a/src/frontend/utils/python/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/python/__tests__/generateSTCode.test.ts
@@ -19,6 +19,15 @@ const makeStringVar = (name: string, cls: 'input' | 'output'): PLCVariable => ({
   debug: false,
 })
 
+const makeWStringVar = (name: string, cls: 'input' | 'output'): PLCVariable => ({
+  name,
+  class: cls,
+  type: { definition: 'base-type', value: 'wstring' },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
 const makeArrayVar = (name: string, cls: 'input' | 'output', baseType: string, dimension: string): PLCVariable => ({
   name,
   class: cls,
@@ -153,8 +162,74 @@ describe('generateSTCode (python)', () => {
     })
 
     expect(result).toContain('auto __s = MSG.get();')
-    expect(result).toContain('data_in.msg.len = (__strlen_t)__s.length();')
-    expect(result).toContain('std::memcpy(data_in.msg.body, __s.c_str(), STR_MAX_LEN);')
+    // The length is clamped to the transport budget and the body zero-filled
+    // before the copy, so a short string cannot carry the previous tail.
+    expect(result).toContain('data_in.msg.len = __n;')
+    expect(result).toContain('std::memset(data_in.msg.body, 0, STR_MAX_LEN);')
+    expect(result).toContain('std::memcpy(data_in.msg.body, __s.c_str(), (size_t)__n);')
+  })
+
+  it('packs the string typedefs themselves, not just the structs using them', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [makeWStringVar('wmsg', 'input')],
+      processedPythonCode: '',
+    })
+
+    // Regression: `#pragma pack` applies to the struct being defined, not to a
+    // member type already laid out elsewhere. Without its own packed region,
+    // shm_iec_wstring_t's uint16_t body forces a padding byte after `len` and
+    // the field becomes 254 bytes where Python packs 253 — every later field
+    // then decodes from the wrong offset. Only a real compile surfaced this.
+    const preamble = result.slice(0, result.indexOf('shm_data_in_t'))
+    const packedRegion = preamble.slice(preamble.indexOf('#pragma pack(push, 1)'), preamble.indexOf('#pragma pack(pop)'))
+    expect(packedRegion).toContain('shm_iec_string_t')
+    expect(packedRegion).toContain('shm_iec_wstring_t')
+  })
+
+  it('reads WSTRING inputs as UTF-16 code units, not bytes', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [makeWStringVar('wmsg', 'input')],
+      processedPythonCode: '',
+    })
+
+    // WSTRING gets its own struct shape; sharing STRING's meant copying
+    // STR_MAX_LEN *bytes* (half the characters) under a character count.
+    expect(result).toContain('shm_iec_wstring_t wmsg;')
+    expect(result).toContain('std::memcpy(data_in.wmsg.body, __s.c_str(), (size_t)__n * sizeof(uint16_t));')
+    expect(result).toContain('std::memset(data_in.wmsg.body, 0, STR_MAX_LEN * sizeof(uint16_t));')
+  })
+
+  it('writes WSTRING outputs back through char16_t, not a reinterpreted char*', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [makeWStringVar('wmsg', 'output')],
+      processedPythonCode: '',
+    })
+
+    expect(result).toContain('reinterpret_cast<const char16_t*>(data_out.wmsg.body)')
+    expect(result).toContain('strucpp::IECWString<254>')
+  })
+
+  it('emits int64 fields for the duration and calendar types', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [
+        makeScalarVar('t', 'input', 'time'),
+        makeScalarVar('d', 'input', 'date'),
+        makeScalarVar('td', 'input', 'tod'),
+        makeScalarVar('dt', 'input', 'dt'),
+      ],
+      processedPythonCode: '',
+    })
+
+    // Previously these reached the C struct as int64_t while the Python format
+    // string omitted them entirely, shifting every later field.
+    expect(result).toContain('int64_t t;')
+    expect(result).toContain('int64_t d;')
+    expect(result).toContain('int64_t td;')
+    expect(result).toContain('int64_t dt;')
   })
 
   it('writes STRING outputs back through IECStringVar (force-respect)', () => {

--- a/src/frontend/utils/python/__tests__/shm-type-map.test.ts
+++ b/src/frontend/utils/python/__tests__/shm-type-map.test.ts
@@ -1,0 +1,153 @@
+import { execFileSync } from 'node:child_process'
+
+import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import {
+  describeShmField,
+  describeVariableType,
+  SHM_SCALAR_TYPES,
+  SHM_STRING,
+  SHM_STRING_CHARS,
+  SHM_WSTRING,
+} from '../shm-type-map'
+
+const scalar = (name: string, value: string): PLCVariable => ({
+  name,
+  class: 'input',
+  type: { definition: 'base-type', value },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const arrayOf = (name: string, baseType: string, dimension = '0..3'): PLCVariable => ({
+  name,
+  class: 'input',
+  type: {
+    definition: 'array',
+    value: `ARRAY [${dimension}] OF ${baseType}`,
+    data: { baseType: { definition: 'base-type', value: baseType }, dimensions: [{ dimension }] },
+  },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const userType = (name: string, typeName: string): PLCVariable => ({
+  name,
+  class: 'input',
+  type: { definition: 'user-data-type', value: typeName },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+/**
+ * Ask a real Python interpreter what a format string measures.
+ *
+ * The point of the descriptor table is that the C struct and the Python format
+ * describe the same bytes. Asserting the declared size against a hand-written
+ * constant would only restate the table; asking `struct.calcsize` measures the
+ * side that actually decodes the buffer at runtime.
+ */
+function pythonCalcsize(format: string): number {
+  const out = execFileSync('python3', ['-c', `import struct;print(struct.calcsize(${JSON.stringify(format)}))`], {
+    encoding: 'utf-8',
+  })
+  return Number.parseInt(out.trim(), 10)
+}
+
+describe('SHM type map — the C and Python sides describe the same bytes', () => {
+  const entries = Object.entries(SHM_SCALAR_TYPES)
+
+  it.each(entries)('%s: declared size matches struct.calcsize of its format', (_name, descriptor) => {
+    expect(pythonCalcsize(`=${descriptor.pyFormat}`)).toBe(descriptor.size)
+  })
+
+  it('STRING is a length byte plus its character budget', () => {
+    expect(pythonCalcsize(`=${SHM_STRING.pyFormat}`)).toBe(SHM_STRING.size)
+    expect(SHM_STRING.size).toBe(1 + SHM_STRING_CHARS)
+  })
+
+  it('WSTRING is a length byte plus two bytes per character', () => {
+    expect(pythonCalcsize(`=${SHM_WSTRING.pyFormat}`)).toBe(SHM_WSTRING.size)
+    expect(SHM_WSTRING.size).toBe(1 + SHM_STRING_CHARS * 2)
+  })
+
+  it('STRING and WSTRING match the sizes the debug map reports', () => {
+    // strucpp emits these for the same variables; the transport must agree with
+    // what the debugger already speaks.
+    expect(SHM_STRING.size).toBe(127)
+    expect(SHM_WSTRING.size).toBe(253)
+  })
+
+  it('every scalar has a distinct, non-empty C type and format', () => {
+    for (const [name, descriptor] of entries) {
+      expect(descriptor.cType).not.toBe('')
+      expect(descriptor.pyFormat).not.toBe('')
+      expect(descriptor.kind).toBe('scalar')
+      expect(descriptor.size).toBeGreaterThan(0)
+      expect(name).toBe(name.toLowerCase())
+    }
+  })
+})
+
+describe('describeShmField', () => {
+  it.each(['bool', 'sint', 'int', 'dint', 'lint', 'usint', 'uint', 'udint', 'ulint'])(
+    'resolves the integer type %s',
+    (t) => {
+      expect(describeShmField(scalar('v', t))).toBe(SHM_SCALAR_TYPES[t])
+    },
+  )
+
+  it.each(['time', 'date', 'tod', 'dt'])('resolves the duration/calendar type %s as int64', (t) => {
+    const descriptor = describeShmField(scalar('v', t))
+    expect(descriptor?.cType).toBe('int64_t')
+    expect(descriptor?.pyFormat).toBe('q')
+    expect(descriptor?.size).toBe(8)
+  })
+
+  it('is case-insensitive about the declared type name', () => {
+    expect(describeShmField(scalar('v', 'DINT'))).toBe(SHM_SCALAR_TYPES.dint)
+    expect(describeShmField(scalar('v', 'Real'))).toBe(SHM_SCALAR_TYPES.real)
+  })
+
+  it('resolves STRING and WSTRING to distinct descriptors', () => {
+    expect(describeShmField(scalar('v', 'string'))).toBe(SHM_STRING)
+    expect(describeShmField(scalar('v', 'wstring'))).toBe(SHM_WSTRING)
+    expect(SHM_STRING.cType).not.toBe(SHM_WSTRING.cType)
+    expect(SHM_STRING.size).not.toBe(SHM_WSTRING.size)
+  })
+
+  it('resolves an array through its element type', () => {
+    expect(describeShmField(arrayOf('v', 'INT'))).toBe(SHM_SCALAR_TYPES.int)
+    expect(describeShmField(arrayOf('v', 'TIME'))).toBe(SHM_SCALAR_TYPES.time)
+  })
+
+  it('refuses a user-defined type rather than describing it', () => {
+    expect(describeShmField(userType('v', 'Motor'))).toBeNull()
+  })
+
+  it('refuses an array of a user-defined type', () => {
+    const v = arrayOf('v', 'Motor')
+    v.type.data!.baseType = { definition: 'user-data-type', value: 'Motor' }
+    expect(describeShmField(v)).toBeNull()
+  })
+
+  it('refuses an unknown base type rather than guessing a width', () => {
+    expect(describeShmField(scalar('v', 'float32'))).toBeNull()
+  })
+})
+
+describe('describeVariableType', () => {
+  it('names a scalar type', () => {
+    expect(describeVariableType(scalar('v', 'dint'))).toBe('DINT')
+  })
+
+  it('names an array by its element type', () => {
+    expect(describeVariableType(arrayOf('v', 'INT'))).toBe('ARRAY OF INT')
+  })
+
+  it('names a user-defined type', () => {
+    expect(describeVariableType(userType('v', 'Motor'))).toBe('MOTOR')
+  })
+})

--- a/src/frontend/utils/python/encodeCharactersFromVariable.ts
+++ b/src/frontend/utils/python/encodeCharactersFromVariable.ts
@@ -1,33 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
-import { getArrayBaseTypeValue, getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
-
-const TYPE_ENCODING_MAP: Record<string, string> = {
-  bool: 'B',
-  sint: 'b',
-  int: 'h',
-  dint: 'i',
-  lint: 'q',
-  usint: 'B',
-  uint: 'H',
-  udint: 'I',
-  ulint: 'Q',
-  real: 'f',
-  lreal: 'd',
-  byte: 'B',
-  word: 'H',
-  dword: 'I',
-  lword: 'Q',
-  string: 'b126s',
-}
+import { getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { describeShmField } from './shm-type-map'
 
 /**
- * Converts an array of PLC variables into a format string for Python's struct.pack/unpack.
- * For scalar variables, returns the corresponding format character.
- * For array variables, repeats the base type's format character N times (e.g., ARRAY[0..9] OF INT -> '10h').
- * @param variables Array of PLC variables
- * @returns String in the format '=hfb126sib126sH' for use with struct.pack/unpack
+ * Convert a POU's interface variables into the format string Python's
+ * `struct.pack` / `struct.unpack` use for the shared-memory exchange.
+ *
+ * The per-type formats come from `shm-type-map.ts`, which the C-side struct
+ * emitter reads as well — the two sides cannot drift because there is only one
+ * table. This function's own job is just repetition and ordering.
+ *
+ * Unsupported types are refused upstream (`preprocessPous`) rather than skipped
+ * here. Skipping was the original defect: a dropped field does not merely go
+ * missing, it shifts every later field's offset and silently corrupts them.
+ *
+ * @returns a `struct` format string such as `'=hfb126s'`, native byte order and
+ *   no alignment, matching the `#pragma pack(push, 1)` struct on the C side.
  */
-
 const encodeCharactersFromVariable = (variables: PLCVariable[]): string => {
   if (!variables || variables.length === 0) {
     return '='
@@ -35,32 +26,26 @@ const encodeCharactersFromVariable = (variables: PLCVariable[]): string => {
 
   const encodedChars = variables
     .map((variable) => {
-      if (isArrayVariable(variable)) {
-        const baseType = getArrayBaseTypeValue(variable).toLowerCase()
-        const encodingChar = TYPE_ENCODING_MAP[baseType]
-        if (!encodingChar) {
-          console.warn(`Warning: Unknown base type "${baseType}" for array variable "${variable.name}". Skipping.`)
-          return ''
-        }
-        const totalElements = getArrayTotalElements(variable)
-        // For multi-char encodings (e.g., 'b126s' for STRING), the repeat count
-        // only applies to the first char in Python struct format ('10b126s' != 10x'b126s').
-        // Repeat the full encoding string instead.
-        if (encodingChar.length > 1) {
-          return encodingChar.repeat(totalElements)
-        }
-        return `${totalElements}${encodingChar}`
-      }
-
-      const typeValue = variable.type.value.toLowerCase()
-      const encodingChar = TYPE_ENCODING_MAP[typeValue]
-
-      if (!encodingChar) {
-        console.warn(`Warning: Unknown type "${typeValue}" for variable "${variable.name}". Skipping.`)
+      const descriptor = describeShmField(variable)
+      if (!descriptor) {
+        // Unreachable through the compile path — `preprocessPous` rejects an
+        // unsupported type before any of this runs. Kept as a total function so
+        // a direct caller cannot produce a half-formed layout.
         return ''
       }
 
-      return encodingChar
+      if (isArrayVariable(variable)) {
+        const totalElements = getArrayTotalElements(variable)
+        // A repeat count applies only to the FIRST character of a struct
+        // format, so `10b126s` is not ten strings. Multi-character formats are
+        // repeated whole.
+        if (descriptor.pyFormat.length > 1) {
+          return descriptor.pyFormat.repeat(totalElements)
+        }
+        return `${totalElements}${descriptor.pyFormat}`
+      }
+
+      return descriptor.pyFormat
     })
     .filter((char) => char !== '')
 

--- a/src/frontend/utils/python/generateSTCode.ts
+++ b/src/frontend/utils/python/generateSTCode.ts
@@ -1,10 +1,6 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
-import {
-  getArrayStartIndex,
-  getArrayTotalElements,
-  getVariableIECType,
-  isArrayVariable,
-} from '../PLC/array-codegen-helpers'
+import { getArrayStartIndex, getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { describeShmField, SHM_STRING_CHARS } from './shm-type-map'
 
 type STCodeGenerationParams = {
   pouName: string
@@ -13,71 +9,26 @@ type STCodeGenerationParams = {
 }
 
 /**
- * Detect a STRING / WSTRING base-type variable. Strings flow through the
- * SHM struct as `{ len; body[STR_MAX_LEN]; }` (mirroring the historical
- * MatIEC-era layout the Python runtime side already speaks). The C-side
- * stub copies in/out of strucpp's IECStringVar at the boundary.
+ * Which of the three SHM shapes a field takes, from the one table both sides
+ * read (`shm-type-map.ts`). `null` never reaches here in a real compile —
+ * `preprocessPous` refuses an unsupported type first — but the emitters stay
+ * total so a direct caller cannot produce a half-formed struct.
  */
-const isStringVariable = (variable: PLCVariable): boolean => {
-  if (variable.type.definition !== 'base-type') return false
-  const v = variable.type.value.toLowerCase()
-  return v === 'string' || v === 'wstring'
-}
-
-/** A STRING field inside the SHM struct uses the local raw layout — see
- *  the typedef emitted in the stub preamble. */
-const isStringStructField = (variable: PLCVariable): boolean => isStringVariable(variable)
+const fieldKind = (variable: PLCVariable): 'scalar' | 'string' | 'wstring' | null =>
+  describeShmField(variable)?.kind ?? null
 
 /**
- * Raw C type used for an SHM struct field. SHM is a packed binary
- * protocol the Python runtime decodes via `struct.unpack`, so each
- * field has to be a trivially-copyable C primitive. The strucpp
- * IEC_T aliases resolve to IECVar<T> (wrappers with a non-trivial
- * copy assignment), so memcpy'ing into them is UB and gcc rightly
- * fires `-Wclass-memaccess`. Map to the raw underlying type instead;
- * the C-side stub bridges between IECVar (force-aware reads/writes
- * on the IEC side) and these raw fields at the boundary.
+ * Raw C type for an SHM struct field.
+ *
+ * SHM is a packed binary protocol Python decodes with `struct.unpack`, so every
+ * field must be a trivially-copyable C primitive. The strucpp `IEC_T` aliases
+ * resolve to `IECVar<T>` wrappers with a non-trivial copy assignment, so
+ * memcpy'ing into them is UB and gcc fires `-Wclass-memaccess`. The C stub
+ * bridges between the wrapper (force-aware reads and writes on the IEC side)
+ * and these raw fields at the boundary.
  */
-const RAW_TYPE_BY_BASETYPE: Record<string, string> = {
-  bool: 'uint8_t',
-  sint: 'int8_t',
-  int: 'int16_t',
-  dint: 'int32_t',
-  lint: 'int64_t',
-  usint: 'uint8_t',
-  uint: 'uint16_t',
-  udint: 'uint32_t',
-  ulint: 'uint64_t',
-  byte: 'uint8_t',
-  word: 'uint16_t',
-  dword: 'uint32_t',
-  lword: 'uint64_t',
-  real: 'float',
-  lreal: 'double',
-  time: 'int64_t',
-  date: 'int64_t',
-  tod: 'int64_t',
-  dt: 'int64_t',
-}
-
-const shmFieldType = (variable: PLCVariable): string => {
-  if (isStringStructField(variable)) return 'shm_iec_string_t'
-
-  if (variable.type.definition === 'array' && variable.type.data) {
-    const elemType = variable.type.data.baseType.value.toLowerCase()
-    if (elemType === 'string') return 'shm_iec_string_t'
-    return RAW_TYPE_BY_BASETYPE[elemType] ?? 'uint8_t'
-  }
-
-  if (variable.type.definition === 'base-type') {
-    return RAW_TYPE_BY_BASETYPE[variable.type.value.toLowerCase()] ?? 'uint8_t'
-  }
-
-  // Defensive fallback — non-base, non-array variables shouldn't appear
-  // in a Python POU's interface; emit a single byte to keep the struct
-  // layout deterministic.
-  return 'uint8_t'
-}
+const shmFieldType = (variable: PLCVariable): string =>
+  describeShmField(variable)?.cType ?? 'uint8_t'
 
 const generateStructField = (variable: PLCVariable): string => {
   const fieldType = shmFieldType(variable)
@@ -129,6 +80,7 @@ const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
   inputVars.forEach((variable) => {
     const upperName = variable.name.toUpperCase()
     const fieldName = variable.name
+    const kind = fieldKind(variable)
 
     if (isArrayVariable(variable)) {
       // Iterate IEC indices and pull each element through `.get()` so
@@ -137,12 +89,26 @@ const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
       const totalElements = getArrayTotalElements(variable)
       const startIdx = getArrayStartIndex(variable)
       code += `        for (int __i = 0; __i < ${totalElements}; __i++) data_in.${fieldName}[__i] = ${upperName}[${startIdx} + __i].get();\n`
-    } else if (isStringStructField(variable)) {
-      // IECStringVar::get() returns IECString<N> by value — bind once
-      // to a local so c_str() / length() refer to the same temporary.
+    } else if (kind === 'string') {
+      // IECStringVar::get() returns IECString<N> by value — bind once to a
+      // local so c_str() / length() refer to the same temporary. Copy only the
+      // characters that exist and zero the rest, so the body is deterministic
+      // rather than carrying whatever the wrapper's tail held.
       code += `        { auto __s = ${upperName}.get();\n`
-      code += `          data_in.${fieldName}.len = (__strlen_t)__s.length();\n`
-      code += `          std::memcpy(data_in.${fieldName}.body, __s.c_str(), STR_MAX_LEN); }\n`
+      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
+      code += `          data_in.${fieldName}.len = __n;\n`
+      code += `          std::memset(data_in.${fieldName}.body, 0, STR_MAX_LEN);\n`
+      code += `          std::memcpy(data_in.${fieldName}.body, __s.c_str(), (size_t)__n); }\n`
+    } else if (kind === 'wstring') {
+      // WSTRING is UTF-16: `length()` counts code units and `c_str()` yields
+      // `const char16_t*`, so the byte count is twice the length. The previous
+      // code copied STR_MAX_LEN *bytes* (63 code units) while writing a length
+      // in characters, which put the two sides permanently out of step.
+      code += `        { auto __s = ${upperName}.get();\n`
+      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
+      code += `          data_in.${fieldName}.len = __n;\n`
+      code += `          std::memset(data_in.${fieldName}.body, 0, STR_MAX_LEN * sizeof(uint16_t));\n`
+      code += `          std::memcpy(data_in.${fieldName}.body, __s.c_str(), (size_t)__n * sizeof(uint16_t)); }\n`
     } else {
       // Scalar — IECVar's implicit conversion to T routes through .get()
       // so a forced input is observed correctly.
@@ -164,6 +130,7 @@ const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
   outputVars.forEach((variable) => {
     const upperName = variable.name.toUpperCase()
     const fieldName = variable.name
+    const kind = fieldKind(variable)
 
     if (isArrayVariable(variable)) {
       const totalElements = getArrayTotalElements(variable)
@@ -172,10 +139,13 @@ const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
       // .set(), which is a no-op when forced — Python user writes to a
       // forced array element are silently dropped on the IEC side.
       code += `        for (int __i = 0; __i < ${totalElements}; __i++) ${upperName}[${startIdx} + __i] = data_out.${fieldName}[__i];\n`
-    } else if (isStringStructField(variable)) {
-      const iecType = getVariableIECType(variable)
-      const innerType = iecType === 'IEC_WSTRING' ? 'strucpp::IECWString<254>' : 'strucpp::IECString<254>'
-      code += `        ${upperName} = ${innerType}(reinterpret_cast<const char*>(data_out.${fieldName}.body), data_out.${fieldName}.len);\n`
+    } else if (kind === 'string') {
+      code += `        ${upperName} = strucpp::IECString<254>(reinterpret_cast<const char*>(data_out.${fieldName}.body), data_out.${fieldName}.len);\n`
+    } else if (kind === 'wstring') {
+      // Reconstruct from char16_t units, not bytes — the mirror of the copy-in
+      // fix above. Reinterpreting the body as `char*` (what this did before)
+      // handed IECWString half a string.
+      code += `        ${upperName} = strucpp::IECWString<254>(reinterpret_cast<const char16_t*>(data_out.${fieldName}.body), data_out.${fieldName}.len);\n`
     } else {
       // Scalar — IECVar::operator=(T) → set(), force-respect.
       code += `        ${upperName} = data_out.${fieldName};\n`
@@ -218,12 +188,24 @@ const generateSTCode = (params: STCodeGenerationParams): string => {
   const stCode = `(* Type definitions *)
 {external
     #define STR_LEN_TYPE int8_t
-    #define STR_MAX_LEN 126
+    #define STR_MAX_LEN ${SHM_STRING_CHARS}
     typedef STR_LEN_TYPE __strlen_t;
+    // These MUST be packed in their own right, not merely used inside a packed
+    // struct: #pragma pack applies to the struct being defined, never to a
+    // member type that was already laid out. shm_iec_string_t survived without
+    // it only because uint8_t needs no alignment; the wstring uint16_t body
+    // forces a padding byte after the length field, making it 254 bytes where
+    // Python packs 253 - a one-byte shift that corrupts every later field.
+    #pragma pack(push, 1)
     typedef struct {
         __strlen_t len;
         uint8_t body[STR_MAX_LEN];
     } shm_iec_string_t;
+    typedef struct {
+        __strlen_t len;
+        uint16_t body[STR_MAX_LEN];
+    } shm_iec_wstring_t;
+    #pragma pack(pop)
 
 ${cStructs}
 }

--- a/src/frontend/utils/python/injectPythonRuntime.ts
+++ b/src/frontend/utils/python/injectPythonRuntime.ts
@@ -1,5 +1,6 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
 import { getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { describeShmField, SHM_STRING_CHARS } from './shm-type-map'
 
 type PythonRuntimeInjectionParams = {
   fmtIn: string
@@ -19,7 +20,8 @@ const generateOutputInitialization = (outputVariables: PLCVariable[]): string =>
         const totalElements = getArrayTotalElements(variable)
         return `${variable.name} = [0] * ${totalElements}`
       }
-      const defaultValue = variable.type?.value === 'string' ? '""' : variable.initialValue || 0
+      const kind = describeShmField(variable)?.kind
+      const defaultValue = kind === 'string' || kind === 'wstring' ? '""' : variable.initialValue || 0
       return `${variable.name} = ${defaultValue}`
     })
     .join('\n')
@@ -41,12 +43,24 @@ const generateInputUnpackCode = (inputVariables: PLCVariable[]): string => {
       const count = getArrayTotalElements(variable)
       code += `    ${variable.name} = list(_vals[_idx:_idx+${count}])\n`
       code += `    _idx += ${count}\n`
-    } else if (variable.type?.definition === 'base-type' && variable.type?.value === 'string') {
+    } else if (describeShmField(variable)?.kind === 'string') {
       code += `    ${variable.name}_len = _vals[_idx]\n`
       code += `    _idx += 1\n`
       code += `    ${variable.name}_body = _vals[_idx]\n`
       code += `    _idx += 1\n`
+      // The C side clamps the length to the budget, but the prefix is a signed
+      // int8 and the buffer starts zeroed, so clamp on read too: a negative
+      // slice bound would silently truncate from the end instead of failing.
+      code += `    ${variable.name}_len = max(0, min(${variable.name}_len, ${SHM_STRING_CHARS}))\n`
       code += `    ${variable.name} = ${variable.name}_body[:${variable.name}_len].decode('utf-8', errors='ignore')\n`
+    } else if (describeShmField(variable)?.kind === 'wstring') {
+      // The length counts UTF-16 code units, so the byte slice is twice it.
+      code += `    ${variable.name}_len = _vals[_idx]\n`
+      code += `    _idx += 1\n`
+      code += `    ${variable.name}_body = _vals[_idx]\n`
+      code += `    _idx += 1\n`
+      code += `    ${variable.name}_len = max(0, min(${variable.name}_len, ${SHM_STRING_CHARS}))\n`
+      code += `    ${variable.name} = ${variable.name}_body[:${variable.name}_len * 2].decode('utf-16-le', errors='ignore')\n`
     } else {
       code += `    ${variable.name} = _vals[_idx]\n`
       code += `    _idx += 1\n`
@@ -69,10 +83,20 @@ const generateOutputPackCode = (outputVariables: PLCVariable[]): string => {
   outputVariables.forEach((variable) => {
     if (isArrayVariable(variable)) {
       code += `    _out.extend(${variable.name})\n`
-    } else if (variable.type?.definition === 'base-type' && variable.type?.value === 'string') {
-      code += `    _body = ${variable.name}.encode('utf-8')[:126]\n`
+    } else if (describeShmField(variable)?.kind === 'string') {
+      code += `    _body = ${variable.name}.encode('utf-8')[:${SHM_STRING_CHARS}]\n`
       code += `    _len = len(_body)\n`
-      code += `    _body = _body.ljust(126, b'\\0')\n`
+      code += `    _body = _body.ljust(${SHM_STRING_CHARS}, b'\\0')\n`
+      code += `    _out.append(_len)\n`
+      code += `    _out.append(_body)\n`
+    } else if (describeShmField(variable)?.kind === 'wstring') {
+      // Truncate on a code-unit boundary, never mid-unit: encode, clip to the
+      // byte budget, then round down to an even length. `_len` is the code-unit
+      // count the C side expects, not the byte count.
+      code += `    _body = ${variable.name}.encode('utf-16-le')[:${SHM_STRING_CHARS * 2}]\n`
+      code += `    _body = _body[: len(_body) - (len(_body) % 2)]\n`
+      code += `    _len = len(_body) // 2\n`
+      code += `    _body = _body.ljust(${SHM_STRING_CHARS * 2}, b'\\0')\n`
       code += `    _out.append(_len)\n`
       code += `    _out.append(_body)\n`
     } else {

--- a/src/frontend/utils/python/shm-type-map.ts
+++ b/src/frontend/utils/python/shm-type-map.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * The shared-memory layout for a Python function block's interface — one table,
+ * read by both sides of the boundary.
+ *
+ * Why this file exists.  The C side (`generateSTCode`) and the Python side
+ * (`encodeCharactersFromVariable`) each used to carry their own hand-maintained
+ * type table, and they disagreed in three places.  Every disagreement was
+ * silent and corrupting, because a field the Python format string omits does
+ * not merely go missing: `struct.unpack` reads every *later* field from the
+ * wrong offset.
+ *
+ *   - TIME / DATE / TOD / DT — the C side emitted `int64_t`, the Python side
+ *     had no entry, so eight bytes vanished from the format string.
+ *   - WSTRING — the C side emitted a byte-oriented STRING field (and copied
+ *     UTF-16 into it with a character count for a length), the Python side had
+ *     no entry at all.
+ *   - User-defined types — the C side emitted a one-byte pad, the Python side
+ *     had no entry.
+ *
+ * The fix is structural rather than three more table rows: a descriptor names
+ * the C type, the Python `struct` code and the size, and both emitters read it.
+ * A field can no longer be added to one side alone, and `shm-type-map.test.ts`
+ * asserts every descriptor's declared size against what `struct.calcsize` would
+ * compute for its format, so a future edit that breaks the correspondence fails
+ * a test instead of a customer's data.
+ *
+ * This is the local expression of the project rule: layout facts are stated
+ * once.  When the codec generator lands (DOPE-584 P6) these descriptors are
+ * what it reads, and eventually what it derives from the compiler's own layout
+ * output rather than restating at all.
+ */
+
+import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import { getArrayBaseTypeValue, isArrayVariable } from '../PLC/array-codegen-helpers'
+
+/**
+ * How one interface field crosses the boundary.
+ *
+ * `size` is the packed byte width — the struct is emitted under
+ * `#pragma pack(push, 1)` and decoded with Python's `=` prefix, so neither side
+ * inserts padding and the two must agree exactly.
+ */
+export interface ShmFieldDescriptor {
+  /** Raw C type for the packed SHM struct field. */
+  cType: string
+  /** Python `struct` format for the same field. */
+  pyFormat: string
+  /** Packed width in bytes. */
+  size: number
+  /**
+   * How Python presents the value.
+   *
+   *   - `scalar`  — a plain int / float / bool, unpacked as-is.
+   *   - `string`  — length-prefixed 8-bit body, decoded as UTF-8.
+   *   - `wstring` — length-prefixed UTF-16 body; the length counts code units,
+   *     so the byte count is twice it.
+   */
+  kind: 'scalar' | 'string' | 'wstring'
+}
+
+/**
+ * Maximum characters carried across the boundary for STRING and WSTRING.
+ *
+ * Not a limit this code chooses: it is the transport convention the debugger
+ * already speaks (`debug-map.json` reports STRING at 127 bytes and WSTRING at
+ * 253, both being one length byte plus 126 characters).  Stated once here and
+ * read by every emitter, rather than written as a literal in four places as it
+ * was before.
+ */
+export const SHM_STRING_CHARS = 126
+
+/** Signed 8-bit length prefix, matching the `__strlen_t` the C stub emits. */
+const LEN_PREFIX_BYTES = 1
+
+/**
+ * Scalar base types, keyed by the lowercase IEC type name.
+ *
+ * The C types are the raw underlying representations rather than the strucpp
+ * `IEC_*` aliases: those alias `IECVar<T>` wrappers, which are not trivially
+ * copyable, so memcpy'ing them into a packed struct is undefined behaviour that
+ * gcc rightly rejects.  The C stub bridges between the wrapper and these raw
+ * fields at the boundary.
+ */
+export const SHM_SCALAR_TYPES: Readonly<Record<string, ShmFieldDescriptor>> = {
+  bool: { cType: 'uint8_t', pyFormat: 'B', size: 1, kind: 'scalar' },
+  sint: { cType: 'int8_t', pyFormat: 'b', size: 1, kind: 'scalar' },
+  int: { cType: 'int16_t', pyFormat: 'h', size: 2, kind: 'scalar' },
+  dint: { cType: 'int32_t', pyFormat: 'i', size: 4, kind: 'scalar' },
+  lint: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
+  usint: { cType: 'uint8_t', pyFormat: 'B', size: 1, kind: 'scalar' },
+  uint: { cType: 'uint16_t', pyFormat: 'H', size: 2, kind: 'scalar' },
+  udint: { cType: 'uint32_t', pyFormat: 'I', size: 4, kind: 'scalar' },
+  ulint: { cType: 'uint64_t', pyFormat: 'Q', size: 8, kind: 'scalar' },
+  byte: { cType: 'uint8_t', pyFormat: 'B', size: 1, kind: 'scalar' },
+  word: { cType: 'uint16_t', pyFormat: 'H', size: 2, kind: 'scalar' },
+  dword: { cType: 'uint32_t', pyFormat: 'I', size: 4, kind: 'scalar' },
+  lword: { cType: 'uint64_t', pyFormat: 'Q', size: 8, kind: 'scalar' },
+  real: { cType: 'float', pyFormat: 'f', size: 4, kind: 'scalar' },
+  lreal: { cType: 'double', pyFormat: 'd', size: 8, kind: 'scalar' },
+
+  // Duration and calendar types are 64-bit counts on the strucpp side — TIME is
+  // nanoseconds (`T#1s` lowers to `1000000000LL`).  Python receives the raw
+  // integer, which is what the compiler stores; presenting it as a `timedelta`
+  // would be a second representation of the same fact and is deliberately not
+  // done here.
+  time: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
+  date: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
+  tod: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
+  dt: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
+}
+
+/**
+ * STRING — one length byte plus a 126-byte UTF-8 body.  127 bytes packed,
+ * matching what the debug map reports for the same variable.
+ */
+export const SHM_STRING: ShmFieldDescriptor = {
+  cType: 'shm_iec_string_t',
+  pyFormat: `b${SHM_STRING_CHARS}s`,
+  size: LEN_PREFIX_BYTES + SHM_STRING_CHARS,
+  kind: 'string',
+}
+
+/**
+ * WSTRING — one length byte plus 126 UTF-16 code units.  253 bytes packed,
+ * again matching the debug map.
+ *
+ * This previously shared STRING's descriptor, which was wrong in both
+ * directions: the C stub copied `STR_MAX_LEN` *bytes* out of a `char16_t`
+ * buffer (63 characters, not 126) while writing a length counted in
+ * characters, and read back by reinterpreting a `char16_t` body as `char*`.
+ * A distinct layout is what makes the two sides describable at all.
+ */
+export const SHM_WSTRING: ShmFieldDescriptor = {
+  cType: 'shm_iec_wstring_t',
+  pyFormat: `b${SHM_STRING_CHARS * 2}s`,
+  size: LEN_PREFIX_BYTES + SHM_STRING_CHARS * 2,
+  kind: 'wstring',
+}
+
+/** Lowercased base-type name of a variable, or `null` when it has none. */
+function baseTypeName(variable: PLCVariable): string | null {
+  if (isArrayVariable(variable)) {
+    const inner = getArrayBaseTypeValue(variable)
+    return inner ? inner.toLowerCase() : null
+  }
+  if (variable.type.definition !== 'base-type') return null
+  return variable.type.value.toLowerCase()
+}
+
+/**
+ * Descriptor for the element type of `variable`, or `null` when the type cannot
+ * cross the boundary today.
+ *
+ * `null` is a refusal, not a silent skip: callers surface it to the user.  That
+ * is the whole point — a type the emitters cannot agree on must stop the build
+ * rather than quietly shift every field after it.  Structures, enumerations and
+ * function block instances land in later phases and will return descriptors
+ * then.
+ */
+export function describeShmField(variable: PLCVariable): ShmFieldDescriptor | null {
+  const name = baseTypeName(variable)
+  if (!name) return null
+  if (name === 'string') return SHM_STRING
+  if (name === 'wstring') return SHM_WSTRING
+  return SHM_SCALAR_TYPES[name] ?? null
+}
+
+/**
+ * Human-readable type for an error message — the array form included, so a
+ * refusal names what the user actually declared.
+ */
+export function describeVariableType(variable: PLCVariable): string {
+  if (isArrayVariable(variable)) {
+    const inner = getArrayBaseTypeValue(variable)
+    return `ARRAY OF ${(inner || 'unknown').toUpperCase()}`
+  }
+  return variable.type.value.toUpperCase()
+}


### PR DESCRIPTION
Phase 2 of DOPE-584. Merges into the task branch.

## The defect

The C struct emitter and the Python format-string emitter each carried their own hand-maintained type table, and they disagreed in three places. Every disagreement was **silent and corrupting**: a field the Python format omits does not go missing, `struct.unpack` reads every *later* field from the wrong offset, so the damage lands on unrelated variables.

| type | C side emitted | Python side |
| --- | --- | --- |
| TIME / DATE / TOD / DT | `int64_t`, 8 bytes | no entry |
| WSTRING | a byte-oriented STRING field | no entry |
| user-defined types | `uint8_t` pad, 1 byte | no entry |

## Approach: one table, not three more rows

`shm-type-map.ts` names each type once — C type, Python `struct` format, packed size — and **both emitters read it**. A field can no longer be added to one side alone. This is the local form of the task rule that the compiler is the single source of truth; when the codec generator lands in P6, these descriptors are what it reads.

The guard test shells out to a real `python3` and asserts every declared size against `struct.calcsize`, measuring the side that actually decodes the buffer rather than restating the table.

## WSTRING needed more than a table row

It shared STRING's descriptor, so the C stub copied `STR_MAX_LEN` **bytes** out of a `char16_t` buffer (63 code units, not 126) while writing a length counted in characters, then read back by reinterpreting the body as `char*`. It now has its own `shm_iec_wstring_t` and copies `char16_t` in both directions.

## Two further defects found while proving it on hardware

**The string typedefs were emitted outside the `#pragma pack` region.** `pack` applies to the struct being defined, never to a member type already laid out — so `shm_iec_wstring_t`'s `uint16_t` body took a padding byte after the length and measured **254 bytes where Python packs 253**. `shm_iec_string_t` had survived only because `uint8_t` needs no alignment. One byte of shift corrupted every later field. A unit test on generated text could not see this; it took a real compile and a debugger read.

**The string copy-in left the body tail undefined.** Now zeroed before the copy, so a shorter value cannot carry the previous one's bytes.

## Hardware verification (slm-rp4, Runtime v4)

A Python block echoing DINT, TIME, WSTRING, STRING and a second DINT, with scalars deliberately on **both sides** of the previously-dropped fields so misalignment would be visible:

| variable | in | out |
| --- | --- | --- |
| before (DINT) | 111 | **111** — alignment held |
| dur (TIME) | T#2s | **2s** — was dropped entirely |
| wtext (WSTRING) | "wide" | **wideW** — was `wid` + U+5765 before the packing fix |
| text (STRING) | narrow | **narrow!** |
| after (DINT) | 999 | **999** — alignment held |

And a struct-typed variable on a Python POU is refused by name:

```
error: Python function blocks cannot exchange these variable types yet:
"TypeProbe.m" (MOTOR). Supported types are BOOL, the integer and bit-string
types, REAL/LREAL, TIME/DATE/TOD/DT, STRING, WSTRING, and arrays of those.
```

## Checks

- 4,174 tests pass in the editor; 201 in the mirrored web suites
- `tsc --noEmit` clean in both repos
- `validate:arch` passes
- `compare-surfaces.py`: 1,054 files, **0 diffs**

## Acceptance criteria covered

AC3 (unsupported types marshal correctly or are refused, never silently disagreeing), and AC12 for this phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaSZK4LqFWtZpERcqnZ8uQ