### PR TITLE
fix(python): seed block outputs from the PLC, not their declarations [DOPE-584 P3]

### DIFF
--- a/src/frontend/utils/python/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/python/__tests__/generateSTCode.test.ts
@@ -169,6 +169,47 @@ describe('generateSTCode (python)', () => {
     expect(result).toContain('std::memcpy(data_in.msg.body, __s.c_str(), (size_t)__n);')
   })
 
+  it('publishes the live IEC output values into shared memory at startup', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [makeScalarVar('count', 'output', 'dint'), makeStringVar('msg', 'output')],
+      processedPythonCode: '',
+    })
+
+    // Shared memory is created zeroed, so without this the Python side has
+    // nothing to seed from and falls back to its declarations — overwriting
+    // the IEC value (a retained one included) on the first write-back.
+    expect(result).toContain('shm_data_out_t seed_out;')
+    expect(result).toContain('seed_out.count = COUNT;')
+    expect(result).toContain('seed_out.msg.len = __n;')
+    expect(result).toContain('memcpy(shm_out_ptr, &seed_out, sizeof(seed_out));')
+  })
+
+  it('publishes the seed inside the first_run branch, after the loader maps the segment', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [makeScalarVar('count', 'output', 'dint')],
+      processedPythonCode: '',
+    })
+
+    const loaderAt = result.indexOf('python_block_loader')
+    const seedAt = result.indexOf('memcpy(shm_out_ptr, &seed_out')
+    const firstRunSetAt = result.indexOf('first_run := true;')
+    expect(loaderAt).toBeGreaterThan(-1)
+    expect(seedAt).toBeGreaterThan(loaderAt)
+    expect(seedAt).toBeLessThan(firstRunSetAt)
+  })
+
+  it('emits no seed block when the POU has no outputs', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [makeScalarVar('v', 'input', 'int')],
+      processedPythonCode: '',
+    })
+
+    expect(result).not.toContain('seed_out')
+  })
+
   it('packs the string typedefs themselves, not just the structs using them', () => {
     const result = generateSTCode({
       pouName: 'test',

--- a/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
+++ b/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
@@ -150,7 +150,7 @@ describe('injectPythonRuntime', () => {
     expect(result).toContain('_out.append(_body)')
   })
 
-  it('generates output initialization for scalar output variables', () => {
+  it('seeds scalar outputs from shared memory, not from the declaration', () => {
     const result = injectPythonRuntime({
       fmtIn: '=',
       fmtOut: '=h',
@@ -160,10 +160,15 @@ describe('injectPythonRuntime', () => {
       pouName: 'test',
     })
 
-    expect(result).toContain('count = 0')
+    // The old behaviour set `count = 0` from the declaration and wrote that
+    // back on the first cycle, destroying whatever the PLC held.
+    expect(result).toContain('# Seed outputs from the values the PLC already holds')
+    expect(result).toContain('_vals = struct.unpack(fmt_out, shm_out.buf[:data_size_out])')
+    expect(result).toContain('count = _vals[_idx]')
+    expect(result).not.toContain('count = 0')
   })
 
-  it('generates output initialization for array output variables', () => {
+  it('seeds array outputs from shared memory', () => {
     const result = injectPythonRuntime({
       fmtIn: '=',
       fmtOut: '=3h',
@@ -173,10 +178,11 @@ describe('injectPythonRuntime', () => {
       pouName: 'test',
     })
 
-    expect(result).toContain('arr = [0] * 3')
+    expect(result).toContain('arr = list(_vals[_idx:_idx+3])')
+    expect(result).not.toContain('arr = [0] * 3')
   })
 
-  it('generates output initialization for string output variables', () => {
+  it('seeds string outputs by decoding the shared-memory body', () => {
     const outputVar: PLCVariable = {
       name: 'msg',
       class: 'output',
@@ -195,10 +201,11 @@ describe('injectPythonRuntime', () => {
       pouName: 'test',
     })
 
-    expect(result).toContain('msg = ""')
+    expect(result).toContain("msg = msg_body[:msg_len].decode('utf-8', errors='ignore')")
+    expect(result).not.toContain('msg = ""')
   })
 
-  it('uses initialValue when present for scalar output initialization', () => {
+  it('ignores a declared initialValue on an output — the PLC value wins', () => {
     const outputVar: PLCVariable = {
       name: 'count',
       class: 'output',
@@ -218,10 +225,29 @@ describe('injectPythonRuntime', () => {
       pouName: 'test',
     })
 
-    expect(result).toContain('count = 42')
+    // The declaration's initial value is applied by the runtime on the IEC
+    // side and reaches Python through shared memory. Re-applying it here is
+    // what overwrote a retained value on restart.
+    expect(result).not.toContain('count = 42')
+    expect(result).toContain('count = _vals[_idx]')
   })
 
-  it('outputs comment for no output variables in initialization', () => {
+  it('seeds before block_init so the user sees real values in it', () => {
+    const result = injectPythonRuntime({
+      fmtIn: '=',
+      fmtOut: '=h',
+      inputVariables: [],
+      outputVariables: [makeScalarVar('count', 'output', 'INT')],
+      originalCode: '',
+      pouName: 'test',
+    })
+
+    expect(result.indexOf('# Seed outputs')).toBeLessThan(result.indexOf('block_init()'))
+    // calcsize has to precede the seed — the seed reads that many bytes.
+    expect(result.indexOf('data_size_out = struct.calcsize')).toBeLessThan(result.indexOf('# Seed outputs'))
+  })
+
+  it('says so plainly when there are no outputs to seed', () => {
     const result = injectPythonRuntime({
       fmtIn: '=',
       fmtOut: '=',
@@ -231,7 +257,7 @@ describe('injectPythonRuntime', () => {
       pouName: 'test',
     })
 
-    expect(result).toContain('# No output variables to initialize')
+    expect(result).toContain('# No output variables to seed')
   })
 
   it('outputs comment for no input variables', () => {

--- a/src/frontend/utils/python/generateSTCode.ts
+++ b/src/frontend/utils/python/generateSTCode.ts
@@ -121,6 +121,55 @@ const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
   return code
 }
 
+/**
+ * Publish the IEC-side output values into shared memory once, at startup.
+ *
+ * Without this the Python block seeds its output globals from the declaration
+ * (`initialValue || 0`) and writes them back after its very first
+ * `block_loop()`, before the user's code has assigned anything — so whatever
+ * the IEC variable held is destroyed. Today that discards a declared initial
+ * value; once a Python block can carry RETAIN it destroys the retained value on
+ * every restart, which is the exact opposite of what retain is for.
+ *
+ * Shared memory is created zeroed, so there is nothing for Python to seed from
+ * unless the C side puts it there. This is the mirror of `generateOutputCopyCode`
+ * — same fields, opposite direction — and runs in the `first_run` branch right
+ * after the loader has mapped the segment.
+ */
+const generateOutputSeedCode = (outputVars: PLCVariable[]): string => {
+  if (outputVars.length === 0) return ''
+
+  let code = '        shm_data_out_t seed_out;\n'
+  code += '        std::memset(&seed_out, 0, sizeof(seed_out));\n'
+
+  outputVars.forEach((variable) => {
+    const upperName = variable.name.toUpperCase()
+    const fieldName = variable.name
+    const kind = fieldKind(variable)
+
+    if (isArrayVariable(variable)) {
+      const totalElements = getArrayTotalElements(variable)
+      const startIdx = getArrayStartIndex(variable)
+      code += `        for (int __i = 0; __i < ${totalElements}; __i++) seed_out.${fieldName}[__i] = ${upperName}[${startIdx} + __i].get();\n`
+    } else if (kind === 'string') {
+      code += `        { auto __s = ${upperName}.get();\n`
+      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
+      code += `          seed_out.${fieldName}.len = __n;\n`
+      code += `          std::memcpy(seed_out.${fieldName}.body, __s.c_str(), (size_t)__n); }\n`
+    } else if (kind === 'wstring') {
+      code += `        { auto __s = ${upperName}.get();\n`
+      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
+      code += `          seed_out.${fieldName}.len = __n;\n`
+      code += `          std::memcpy(seed_out.${fieldName}.body, __s.c_str(), (size_t)__n * sizeof(uint16_t)); }\n`
+    } else {
+      code += `        seed_out.${fieldName} = ${upperName};\n`
+    }
+  })
+
+  code += '        memcpy(shm_out_ptr, &seed_out, sizeof(seed_out));\n'
+  return code
+}
+
 const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
   if (outputVars.length === 0) return ''
 
@@ -164,6 +213,7 @@ const generateSTCode = (params: STCodeGenerationParams): string => {
   const cStructs = generateCStructs(inputVariables, outputVariables)
   const inputCopyCode = generateInputCopyCode(inputVariables)
   const outputCopyCode = generateOutputCopyCode(outputVariables)
+  const outputSeedCode = generateOutputSeedCode(outputVariables)
 
   const escapedPythonCode = processedPythonCode
     .replace(/\\/g, '\\\\')
@@ -230,7 +280,12 @@ if first_run = false then
 
         SHM_IN_PTR = (uint64_t)shm_in_ptr;
         SHM_OUT_PTR = (uint64_t)shm_out_ptr;
-    }
+
+        // Publish the current IEC output values so the Python side can seed
+        // from them instead of from its declarations. Shared memory is created
+        // zeroed; without this the block's first write-back would overwrite the
+        // IEC value (a retained one included) with a default.
+${outputSeedCode}    }
     first_run := true;
 else
     {external

--- a/src/frontend/utils/python/injectPythonRuntime.ts
+++ b/src/frontend/utils/python/injectPythonRuntime.ts
@@ -11,59 +11,84 @@ type PythonRuntimeInjectionParams = {
   pouName: string
 }
 
-const generateOutputInitialization = (outputVariables: PLCVariable[]): string => {
-  if (outputVariables.length === 0) return '# No output variables to initialize'
-
-  return outputVariables
-    .map((variable) => {
-      if (isArrayVariable(variable)) {
-        const totalElements = getArrayTotalElements(variable)
-        return `${variable.name} = [0] * ${totalElements}`
-      }
-      const kind = describeShmField(variable)?.kind
-      const defaultValue = kind === 'string' || kind === 'wstring' ? '""' : variable.initialValue || 0
-      return `${variable.name} = ${defaultValue}`
-    })
-    .join('\n')
+const generateInputUnpackCode = (inputVariables: PLCVariable[]): string => {
+  if (inputVariables.length === 0) return '    # No input variables to read'
+  return generateUnpackCode(inputVariables, {
+    header: '    # Read input variables',
+    buffer: 'shm_in',
+    fmt: 'fmt_in',
+    size: 'data_size_in',
+    indent: '    ',
+  })
 }
 
 /**
- * Generate Python code that extracts variables from the flat unpacked tuple using index slicing.
- * Handles scalars, strings (len+body pairs), and arrays (N consecutive elements -> list).
+ * Seed the output globals from what the PLC currently holds, before
+ * `block_init()` runs.
+ *
+ * Previously the outputs were initialised from their declarations
+ * (`initialValue || 0`) and written back after the first `block_loop()`, before
+ * the user's code had assigned anything — so the IEC-side value was replaced by
+ * a default on every start. With RETAIN that is destructive rather than merely
+ * wrong. The C stub publishes the live values into shared memory when it maps
+ * the segment (see `generateOutputSeedCode`), and this reads them back.
+ *
+ * A block that never assigns an output now leaves it exactly as the PLC had it.
  */
-const generateInputUnpackCode = (inputVariables: PLCVariable[]): string => {
-  if (inputVariables.length === 0) return '    # No input variables to read'
+const generateOutputSeedCode = (outputVariables: PLCVariable[]): string => {
+  if (outputVariables.length === 0) return '# No output variables to seed'
+  return generateUnpackCode(outputVariables, {
+    header: '# Seed outputs from the values the PLC already holds',
+    buffer: 'shm_out',
+    fmt: 'fmt_out',
+    size: 'data_size_out',
+    indent: '',
+  })
+}
 
-  let code = '    # Read input variables\n'
-  code += '    _vals = struct.unpack(fmt_in, shm_in.buf[:data_size_in])\n'
-  code += '    _idx = 0\n'
+/**
+ * Emit the unpack sequence for a set of variables.
+ *
+ * Shared by the per-cycle input read and the one-time output seed: both decode
+ * the same packed layout, differing only in which buffer they read and at what
+ * indentation. Keeping one generator means the two cannot drift in how they
+ * interpret a field — the same reason the type table is shared.
+ */
+const generateUnpackCode = (
+  variables: PLCVariable[],
+  opts: { header: string; buffer: string; fmt: string; size: string; indent: string },
+): string => {
+  const { header, buffer, fmt, size, indent } = opts
 
-  inputVariables.forEach((variable) => {
+  let code = `${header}\n`
+  code += `${indent}_vals = struct.unpack(${fmt}, ${buffer}.buf[:${size}])\n`
+  code += `${indent}_idx = 0\n`
+
+  variables.forEach((variable) => {
+    const kind = describeShmField(variable)?.kind
+
     if (isArrayVariable(variable)) {
       const count = getArrayTotalElements(variable)
-      code += `    ${variable.name} = list(_vals[_idx:_idx+${count}])\n`
-      code += `    _idx += ${count}\n`
-    } else if (describeShmField(variable)?.kind === 'string') {
-      code += `    ${variable.name}_len = _vals[_idx]\n`
-      code += `    _idx += 1\n`
-      code += `    ${variable.name}_body = _vals[_idx]\n`
-      code += `    _idx += 1\n`
+      code += `${indent}${variable.name} = list(_vals[_idx:_idx+${count}])\n`
+      code += `${indent}_idx += ${count}\n`
+    } else if (kind === 'string' || kind === 'wstring') {
+      code += `${indent}${variable.name}_len = _vals[_idx]\n`
+      code += `${indent}_idx += 1\n`
+      code += `${indent}${variable.name}_body = _vals[_idx]\n`
+      code += `${indent}_idx += 1\n`
       // The C side clamps the length to the budget, but the prefix is a signed
       // int8 and the buffer starts zeroed, so clamp on read too: a negative
       // slice bound would silently truncate from the end instead of failing.
-      code += `    ${variable.name}_len = max(0, min(${variable.name}_len, ${SHM_STRING_CHARS}))\n`
-      code += `    ${variable.name} = ${variable.name}_body[:${variable.name}_len].decode('utf-8', errors='ignore')\n`
-    } else if (describeShmField(variable)?.kind === 'wstring') {
-      // The length counts UTF-16 code units, so the byte slice is twice it.
-      code += `    ${variable.name}_len = _vals[_idx]\n`
-      code += `    _idx += 1\n`
-      code += `    ${variable.name}_body = _vals[_idx]\n`
-      code += `    _idx += 1\n`
-      code += `    ${variable.name}_len = max(0, min(${variable.name}_len, ${SHM_STRING_CHARS}))\n`
-      code += `    ${variable.name} = ${variable.name}_body[:${variable.name}_len * 2].decode('utf-16-le', errors='ignore')\n`
+      code += `${indent}${variable.name}_len = max(0, min(${variable.name}_len, ${SHM_STRING_CHARS}))\n`
+      if (kind === 'wstring') {
+        // The length counts UTF-16 code units, so the byte slice is twice it.
+        code += `${indent}${variable.name} = ${variable.name}_body[:${variable.name}_len * 2].decode('utf-16-le', errors='ignore')\n`
+      } else {
+        code += `${indent}${variable.name} = ${variable.name}_body[:${variable.name}_len].decode('utf-8', errors='ignore')\n`
+      }
     } else {
-      code += `    ${variable.name} = _vals[_idx]\n`
-      code += `    _idx += 1\n`
+      code += `${indent}${variable.name} = _vals[_idx]\n`
+      code += `${indent}_idx += 1\n`
     }
   })
 
@@ -113,7 +138,7 @@ const generateOutputPackCode = (outputVariables: PLCVariable[]): string => {
 const injectPythonRuntime = (params: PythonRuntimeInjectionParams): string => {
   const { fmtIn, fmtOut, inputVariables, outputVariables, originalCode, pouName } = params
 
-  const outputInitialization = generateOutputInitialization(outputVariables)
+  const outputSeeding = generateOutputSeedCode(outputVariables)
   const readInputSection = generateInputUnpackCode(inputVariables)
   const writeOutputSection = generateOutputPackCode(outputVariables)
 
@@ -130,13 +155,17 @@ except Exception as e:
     print(f'Error on shared memory: {e}')
     exit(1)
 
-# Initialize output variables here - if any
-${outputInitialization}
+data_size_in = struct.calcsize(fmt_in)
+data_size_out = struct.calcsize(fmt_out)
+
+# Outputs start from what the PLC already holds, not from their declarations.
+# The stub publishes the live values into shared memory when it maps the
+# segment, so a block that never assigns an output leaves it untouched — and a
+# RETAIN output survives the restart it exists to survive.
+${outputSeeding}
 
 # Initialize block
 block_init()
-data_size_in = struct.calcsize(fmt_in)
-data_size_out = struct.calcsize(fmt_out)
 while True:
     try:
         os.kill(plc_pid, 0)


### PR DESCRIPTION
Phase 3 of DOPE-584. Merges into the task branch.

## The defect

A Python block initialised its output globals from `initialValue || 0`, and the wrapper wrote them back after the **first** `block_loop()` — before the user's code had assigned anything. Whatever the IEC side held was replaced by a default on every start.

Today that discards a declared initial value. Once a Python block can carry `RETAIN` (editor #1034 / web #691) it **destroys the retained value on every restart**, which is the opposite of what retain exists for. That is why this is scheduled ahead of the parity work rather than inside it.

## Why this could not be a Python-side fix

Shared memory is created **zeroed**. Seeding Python from it would have read `0` rather than the IEC value — trading one wrong default for another. Both sides had to move:

- **C stub** publishes the live IEC output values into shared memory in the `first_run` branch, right after the loader maps the segment (`generateOutputSeedCode`).
- **Python script** unpacks them into its output globals **before** `block_init()`, so a user's `block_init` sees real values rather than zeros.

The declaration-based initialiser is **removed**, not kept as a fallback — a second source for the same fact is what produced the defect. The per-cycle input read and the one-time output seed now share one generator, for the same reason the type table is shared.

## Hardware verification (slm-rp4, Runtime v4)

A block declaring `keeper : DINT := 777` whose Python code **never assigns it**:

| variable | value | what it proves |
| --- | --- | --- |
| `keeper` | **777** | the PLC's value survives the block's first write-back |
| `counter` | **777** | `counter` is set from what `block_init()` *saw* in `keeper` — so the seed lands **before** `block_init` runs, not merely at some point |

Both read `0` before this change.

A first attempt used a forced value instead of a declared one; forces are released on PLC stop, so that test could not isolate the behaviour. The declared-initial-value form is deterministic and does not depend on forcing semantics.

## Checks

- 3,583 tests pass in the editor
- Five tests that asserted the old behaviour (`count = 0`, `msg = ""`, `count = 42` from `initialValue`) encoded the defect and were replaced with tests for the new contract, including ordering assertions that `calcsize -> seed -> block_init` holds
- `tsc --noEmit` clean in both repos
- `validate:arch` passes
- `compare-surfaces.py`: 1,054 files, **0 diffs**

## Acceptance criteria covered

AC4 (an unassigned output no longer overwrites the IEC value; seeded from shared memory before `block_init`), and AC12 for this phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaSZK4LqFWtZpERcqnZ8uQ