### PR TITLE
task(DOPE-584): C++ function blocks reach IEC parity [phase 4]

### DIFF
--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -1255,7 +1255,11 @@ class CompilerModule {
       variables: pou.variables,
     })) as CppPouDataHeader[]
 
-    const headerContent: string = generateCBlocksHeader(cppPous)
+    // The project's data-type names let the generator tell a structure or
+    // enumeration (which strucpp aliases as `IEC_<NAME>`) from a function block
+    // instance (a bare `class <NAME>`), which the variable alone cannot say.
+    const userTypeNames = (projectData.dataTypes ?? []).map((dataType) => dataType.name)
+    const headerContent: string = generateCBlocksHeader(cppPous, userTypeNames)
     const headerFilePath = join(sourceTargetFolderPath, 'c_blocks.h')
 
     try {

--- a/src/backend/shared/compile/pipeline.ts
+++ b/src/backend/shared/compile/pipeline.ts
@@ -541,7 +541,7 @@ async function runCompilePipelineInner(
     }
 
     emit({ stage: 'runtime-v4-bundle', message: 'Composing Runtime v4 upload bundle...', level: 'info' })
-    const cBlocks = buildCBlocksFromPous(originalCppPous as never)
+    const cBlocks = buildCBlocksFromPous(originalCppPous as never, (projectData.dataTypes ?? []).map((dt) => dt.name))
     const bundle = composeRuntimeV4Bundle({
       programSt,
       md5,
@@ -812,7 +812,7 @@ async function runCompilePipelineInner(
   // c_blocks header/code + defines.h + optional vpp_config.h).
   // Pure function.
   emit({ stage: 'firmware-bundle', message: 'Composing firmware bundle...', level: 'info' })
-  const cBlocks = buildCBlocksFromPous(originalCppPous as never)
+  const cBlocks = buildCBlocksFromPous(originalCppPous as never, (projectData.dataTypes ?? []).map((dt) => dt.name))
   const firmwareFiles = composeFirmwareBundle({
     strucppFiles: strucppFilesMap,
     cBlocks,

--- a/src/backend/shared/compile/steps/compose-firmware-bundle.ts
+++ b/src/backend/shared/compile/steps/compose-firmware-bundle.ts
@@ -94,7 +94,10 @@ export type CBlocksCodePou = CppPouDataCode
  * `cBlocks` input shape" case.  Caller can either use this or hand
  * the composer the pre-rendered strings directly.
  */
-export function buildCBlocksFromPous(originalCppPous: CppPouDataCode[]): ComposeFirmwareBundleInput['cBlocks'] {
+export function buildCBlocksFromPous(
+  originalCppPous: CppPouDataCode[],
+  userTypeNames: Iterable<string> = [],
+): ComposeFirmwareBundleInput['cBlocks'] {
   if (originalCppPous.length === 0) {
     // Editor's behaviour: leave the static `c_blocks.h` baseline
     // in place (`null` here means the composer skips the write).
@@ -106,7 +109,7 @@ export function buildCBlocksFromPous(originalCppPous: CppPouDataCode[]): Compose
     variables: pou.variables,
   }))
   return {
-    header: generateCBlocksHeader(headers),
+    header: generateCBlocksHeader(headers, userTypeNames),
     code: generateCBlocksCode(originalCppPous),
   }
 }

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
@@ -166,17 +166,21 @@ describe('generateCBlocksCode', () => {
     expect(result).toContain('// comment about setup')
   })
 
-  it('filters variables by class (only input and output)', () => {
+  it('binds every class the user can declare, and nothing the toolchain injected', () => {
+    const byClass = (name: string, cls: PLCVariable['class'], type: string): PLCVariable => ({
+      name,
+      class: cls,
+      type: { definition: 'base-type', value: type },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
     const variables: PLCVariable[] = [
       makeScalarVar('inVar', 'input', 'INT'),
-      {
-        name: 'localVar',
-        class: 'local',
-        type: { definition: 'base-type', value: 'INT' },
-        location: '',
-        documentation: '',
-        debug: false,
-      },
+      byClass('localVar', 'local', 'INT'),
+      byClass('tempVar', 'temp', 'INT'),
+      byClass('ioVar', 'inOut', 'INT'),
+      byClass('hasBeenInitialized', 'local', 'BOOL'),
       makeScalarVar('outVar', 'output', 'INT'),
     ]
     const code = 'void setup() { }\nvoid loop() { }'
@@ -185,9 +189,16 @@ describe('generateCBlocksCode', () => {
 
     expect(result).toContain('#define inVar')
     expect(result).toContain('#define outVar')
-    expect(result).not.toContain('#define localVar')
+    expect(result).toContain('#define localVar')
+    expect(result).toContain('#define tempVar')
+    expect(result).toContain('#define ioVar')
+    // The setup() latch stays out of the user's reach — see the header tests.
+    expect(result).not.toContain('#define hasBeenInitialized')
     expect(result).toContain('#undef inVar')
     expect(result).toContain('#undef outVar')
-    expect(result).not.toContain('#undef localVar')
+    expect(result).toContain('#undef localVar')
+    expect(result).toContain('#undef tempVar')
+    expect(result).toContain('#undef ioVar')
+    expect(result).not.toContain('#undef hasBeenInitialized')
   })
 })

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
@@ -32,16 +32,14 @@ describe('generateCBlocksCode', () => {
     expect(result).toBe('')
   })
 
-  it('emits the c_blocks baseline (strucpp includes + raw IEC typedefs) before per-POU code', () => {
+  it('emits the c_blocks baseline (interface header + raw IEC typedefs) before per-POU code', () => {
     const variables: PLCVariable[] = [makeScalarVar('x', 'input', 'INT')]
     const code = 'void setup() { }\nvoid loop() { }'
     const result = generateCBlocksCode([{ name: 'B', code, variables }])
 
-    // Baseline: strucpp wrappers visible to the auto-generated struct
-    // — covers numeric AND STRING pins now (every pin field qualifies
-    // as `strucpp::IEC_*`).
-    expect(result).toContain('#include "iec_var.hpp"')
-    expect(result).toContain('#include "iec_string.hpp"')
+    // Baseline: the interface header, which defines the struct and carries the
+    // strucpp wrappers and the project's own types transitively.
+    expect(result).toContain('#include "c_blocks.h"')
     // Baseline: raw file-scope typedefs for user-local variables.
     expect(result).toContain('typedef int16_t   IEC_INT;')
     expect(result).toContain('typedef float    IEC_REAL;')
@@ -57,9 +55,9 @@ describe('generateCBlocksCode', () => {
 
   it("undefines Arduino.h's min/max macros before pulling in strucpp/std headers", () => {
     // Regression guard: Arduino.h defines `min` / `max` as preprocessor
-    // macros that wreck `<algorithm>` / `<limits>` (both transitively
-    // included via iec_string.hpp). Order must be:
-    //   include <Arduino.h>  ->  #undef min/max  ->  #include "iec_string.hpp"
+    // macros that wreck `<algorithm>` / `<limits>` (pulled in transitively by
+    // the strucpp headers behind c_blocks.h). Order must be:
+    //   include <Arduino.h>  ->  #undef min/max  ->  #include "c_blocks.h"
     const variables: PLCVariable[] = [makeScalarVar('x', 'input', 'INT')]
     const code = 'void setup() { }\nvoid loop() { }'
     const result = generateCBlocksCode([{ name: 'B', code, variables }])
@@ -67,13 +65,13 @@ describe('generateCBlocksCode', () => {
     const arduinoIdx = result.indexOf('#include <Arduino.h>')
     const undefMinIdx = result.indexOf('#undef min')
     const undefMaxIdx = result.indexOf('#undef max')
-    const iecStringIdx = result.indexOf('#include "iec_string.hpp"')
+    const strucppIdx = result.indexOf('#include "c_blocks.h"')
 
     expect(arduinoIdx).toBeGreaterThan(-1)
     expect(undefMinIdx).toBeGreaterThan(arduinoIdx)
     expect(undefMaxIdx).toBeGreaterThan(arduinoIdx)
-    expect(iecStringIdx).toBeGreaterThan(undefMinIdx)
-    expect(iecStringIdx).toBeGreaterThan(undefMaxIdx)
+    expect(strucppIdx).toBeGreaterThan(undefMinIdx)
+    expect(strucppIdx).toBeGreaterThan(undefMaxIdx)
   })
 
   it('generates struct, extern declarations, defines, code, and undefs for a pou', () => {
@@ -82,17 +80,15 @@ describe('generateCBlocksCode', () => {
 
     const result = generateCBlocksCode([{ name: 'MyBlock', code, variables }])
 
-    // Struct definition — fields are strucpp::IEC_* so user writes
-    // route through IECVar::operator= (force-respect).
-    expect(result).toContain('//definition of external blocks - MYBLOCK')
-    expect(result).toContain('typedef struct {')
-    expect(result).toContain('  strucpp::IEC_INT *SPEED;')
-    expect(result).toContain('  strucpp::IEC_REAL *RESULT;')
-    expect(result).toContain('} MYBLOCK_VARS;')
-
-    // Extern declarations
-    expect(result).toContain('extern "C" void myblock_setup(MYBLOCK_VARS *vars);')
-    expect(result).toContain('extern "C" void myblock_loop(MYBLOCK_VARS *vars);')
+    // The struct and the two entry-point declarations belong to c_blocks.h and
+    // must NOT be restated here. Two definitions of one typedef is what broke
+    // enumeration pins: the header spelled the field `strucpp::IEC_MODE` and
+    // this file spelled it `strucpp::MODE`, so the assignment in the POU glue
+    // failed to compile. Pin the absence so the duplication cannot come back.
+    expect(result).not.toContain('typedef struct {')
+    expect(result).not.toContain('} MYBLOCK_VARS;')
+    expect(result).not.toContain('strucpp::IEC_INT *SPEED;')
+    expect(result).not.toContain('extern "C" void myblock_setup(MYBLOCK_VARS *vars);')
 
     // Defines for input and output
     expect(result).toContain('#define speed (*(vars->SPEED))')
@@ -125,8 +121,9 @@ describe('generateCBlocksCode', () => {
 
     const result = generateCBlocksCode([{ name: 'empty', code, variables: [] }])
 
-    expect(result).toContain('typedef struct {')
-    expect(result).toContain('} EMPTY_VARS;')
+    // The struct lives in c_blocks.h — see the duplication regression above.
+    expect(result).not.toContain('typedef struct {')
+    expect(result).not.toContain('} EMPTY_VARS;')
     // No #define / #undef for variables (the only `#define`s in the
     // baseline now are the Arduino min/max macro guards).
     expect(result).not.toMatch(/^#define\s+\w+\s+\(/m)

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
@@ -34,15 +34,82 @@ describe('generateCBlocksHeader', () => {
     expect(result).toContain('#endif // C_BLOCKS_H')
   })
 
-  it('pulls in the strucpp wrapper headers so `strucpp::IEC_*` qualifications resolve', () => {
-    // Every struct field this header emits is fully qualified as
-    // `strucpp::IEC_*` (numeric, bit-string, STRING, WSTRING). Without
-    // these includes, a TU that does `#include "c_blocks.h"` without
-    // first pulling in the strucpp runtime would fail with
-    // `'IEC_STRING' does not name a type`.
+  it('pulls in the generated declarations so every field type resolves', () => {
+    // Struct fields name strucpp types across the whole range the Variables
+    // Table can declare: `strucpp::IEC_*` wrappers for elementary pins, and the
+    // project's own structures, enumerations and function block classes for the
+    // rest. `generated.hpp` carries all of them (and the runtime wrappers
+    // transitively), so a TU that includes c_blocks.h without any other setup
+    // still compiles instead of failing with `'IEC_STRING' does not name a
+    // type` or `'MOTOR' does not name a type`.
     const result = generateCBlocksHeader([])
-    expect(result).toContain('#include "iec_var.hpp"')
-    expect(result).toContain('#include "iec_string.hpp"')
+    expect(result).toContain('#include "generated.hpp"')
+  })
+
+  describe('user-defined types', () => {
+    // strucpp spells the two shapes differently, and the variable alone cannot
+    // say which it is:
+    //
+    //   struct MOTOR { … };  using IEC_MOTOR = MOTOR;
+    //   enum class MODE { … }; using IEC_MODE = IEC_ENUM<MODE>;
+    //   class HELPER { … };                    // no alias at all
+    //
+    // A structure and an enumeration are both declared in the project's data
+    // types, so both get the `IEC_` alias. A function block instance is not,
+    // and taking `&instance` yields the bare class — spelling that field
+    // `IEC_HELPER` would name a type that does not exist.
+    const userVar = (name: string, cls: PLCVariable['class'], typeName: string): PLCVariable => ({
+      name,
+      class: cls,
+      type: { definition: 'user-data-type', value: typeName },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+
+    it('aliases a data type but leaves a function block instance bare', () => {
+      const variables: PLCVariable[] = [
+        userVar('m', 'input', 'Motor'),
+        userVar('md', 'input', 'Mode'),
+        userVar('h', 'input', 'Helper'),
+      ]
+
+      const result = generateCBlocksHeader([{ name: 'Blk', variables }], ['Motor', 'Mode'])
+
+      expect(result).toContain('  strucpp::IEC_MOTOR *M;')
+      expect(result).toContain('  strucpp::IEC_MODE *MD;')
+      expect(result).toContain('  strucpp::HELPER *H;')
+    })
+
+    it('spells an array of a data type through the same rule', () => {
+      const variables: PLCVariable[] = [
+        {
+          name: 'bank',
+          class: 'input',
+          type: {
+            definition: 'array',
+            value: 'ARRAY [0..3] OF Motor',
+            data: {
+              baseType: { definition: 'user-data-type', value: 'Motor' },
+              dimensions: [{ dimension: '0..3' }],
+            },
+          },
+          location: '',
+          documentation: '',
+          debug: false,
+        },
+      ]
+
+      const result = generateCBlocksHeader([{ name: 'Blk', variables }], ['Motor'])
+
+      expect(result).toContain('  strucpp::IEC_MOTOR *BANK;')
+    })
+
+    it('leaves every user type bare when the project declares no data types', () => {
+      const variables: PLCVariable[] = [userVar('h', 'input', 'Helper')]
+
+      expect(generateCBlocksHeader([{ name: 'Blk', variables }])).toContain('  strucpp::HELPER *H;')
+    })
   })
 
   it('generates struct and function declarations for a pou with scalar variables', () => {

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
@@ -174,13 +174,31 @@ describe('generateCBlocksHeader', () => {
     expect(generateCBlocksHeader([{ name: 'test', variables }])).not.toContain('HASBEENINITIALIZED')
   })
 
-  it('leaves out a VAR_EXTERNAL, which is not a plain member', () => {
-    // A `VAR_EXTERNAL` is a `GlobalVar<V>*` carrying the global's mutex, not a
-    // value member. Emitting a plain pointer to it would compile and silently
-    // drop the lock, so it is handled separately rather than folded in here.
+  it('gives a VAR_EXTERNAL an ordinary field, pointing at the global’s value', () => {
+    // From inside the block a global should read and write like any other
+    // variable, which is what it already does in ST. The difference is not in
+    // the field's type but in where the pointer comes from: the ST glue takes
+    // it under the global's own lock (see generateSTCode).
     const variables: PLCVariable[] = [makeScalarVar('inVar', 'input', 'INT'), byClass('gCounter', 'external', 'DINT')]
 
-    expect(generateCBlocksHeader([{ name: 'test', variables }])).not.toContain('GCOUNTER')
+    const result = generateCBlocksHeader([{ name: 'test', variables }])
+
+    expect(result).toContain('strucpp::IEC_DINT *GCOUNTER;')
+  })
+
+  it('places externals after the declared classes, in name order', () => {
+    // Name order is what makes the lock nesting identical in every block, so
+    // two blocks can never take the same pair of globals in opposite orders.
+    const variables: PLCVariable[] = [
+      byClass('gZulu', 'external', 'INT'),
+      makeScalarVar('inVar', 'input', 'INT'),
+      byClass('gAlpha', 'external', 'INT'),
+    ]
+
+    const result = generateCBlocksHeader([{ name: 'test', variables }])
+    const order = ['INVAR', 'GALPHA', 'GZULU'].map((n) => result.indexOf(`*${n};`))
+
+    expect(order).toEqual([...order].sort((a, b) => a - b))
   })
 
   it('generates declarations for multiple pous', () => {

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
@@ -10,6 +10,16 @@ const makeScalarVar = (name: string, cls: 'input' | 'output', baseType: string):
   debug: false,
 })
 
+/** Same shape, for the classes beyond input/output that the struct now carries. */
+const byClass = (name: string, cls: PLCVariable['class'], baseType: string): PLCVariable => ({
+  name,
+  class: cls,
+  type: { definition: 'base-type', value: baseType },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
 const makeArrayVar = (name: string, cls: 'input' | 'output', baseType: string, dimension: string): PLCVariable => ({
   name,
   class: cls,
@@ -126,25 +136,51 @@ describe('generateCBlocksHeader', () => {
     expect(result).toContain('extern "C" void myblock_loop(MYBLOCK_VARS *vars);')
   })
 
-  it('includes only input and output variables in the struct', () => {
+  it('carries every class the user can declare, grouped in a stable order', () => {
+    // A native block should see its own Variables Table the way an ST block
+    // does. `inOut`, `local` and `temp` are all plain members on the strucpp
+    // side, so a pointer to each is exactly as valid as one to an input.
     const variables: PLCVariable[] = [
-      makeScalarVar('inVar', 'input', 'INT'),
-      {
-        name: 'localVar',
-        class: 'local',
-        type: { definition: 'base-type', value: 'BOOL' },
-        location: '',
-        documentation: '',
-        debug: false,
-      },
       makeScalarVar('outVar', 'output', 'BOOL'),
+      byClass('tempVar', 'temp', 'INT'),
+      makeScalarVar('inVar', 'input', 'INT'),
+      byClass('localVar', 'local', 'DINT'),
+      byClass('ioVar', 'inOut', 'REAL'),
     ]
 
     const result = generateCBlocksHeader([{ name: 'test', variables }])
 
     expect(result).toContain('strucpp::IEC_INT *INVAR;')
     expect(result).toContain('strucpp::IEC_BOOL *OUTVAR;')
-    expect(result).not.toContain('LOCALVAR')
+    expect(result).toContain('strucpp::IEC_REAL *IOVAR;')
+    expect(result).toContain('strucpp::IEC_DINT *LOCALVAR;')
+    expect(result).toContain('strucpp::IEC_INT *TEMPVAR;')
+
+    // Grouped by class regardless of declaration order, so the header stays
+    // readable and its diffs stay meaningful.
+    const order = ['INVAR', 'OUTVAR', 'IOVAR', 'LOCALVAR', 'TEMPVAR'].map((n) => result.indexOf(`*${n};`))
+    expect(order).toEqual([...order].sort((a, b) => a - b))
+  })
+
+  it('leaves out the latch the toolchain injects into every C++ block', () => {
+    // `hasBeenInitialized` drives the one-shot setup() call. It is machinery,
+    // not a declaration, and a block able to write it could re-run or skip its
+    // own initialisation.
+    const variables: PLCVariable[] = [
+      makeScalarVar('inVar', 'input', 'INT'),
+      byClass('hasBeenInitialized', 'local', 'BOOL'),
+    ]
+
+    expect(generateCBlocksHeader([{ name: 'test', variables }])).not.toContain('HASBEENINITIALIZED')
+  })
+
+  it('leaves out a VAR_EXTERNAL, which is not a plain member', () => {
+    // A `VAR_EXTERNAL` is a `GlobalVar<V>*` carrying the global's mutex, not a
+    // value member. Emitting a plain pointer to it would compile and silently
+    // drop the lock, so it is handled separately rather than folded in here.
+    const variables: PLCVariable[] = [makeScalarVar('inVar', 'input', 'INT'), byClass('gCounter', 'external', 'DINT')]
+
+    expect(generateCBlocksHeader([{ name: 'test', variables }])).not.toContain('GCOUNTER')
   })
 
   it('generates declarations for multiple pous', () => {

--- a/src/backend/shared/utils/cpp/generateCBlocksCode.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksCode.ts
@@ -1,4 +1,4 @@
-import { generateStructMember, isArrayVariable } from '../../../../frontend/utils/PLC/array-codegen-helpers'
+import { isArrayVariable } from '../../../../frontend/utils/PLC/array-codegen-helpers'
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 
 type CppPouData = {
@@ -8,32 +8,29 @@ type CppPouData = {
 }
 
 /**
- * Self-contained baseline for c_blocks_code.cpp. Carries:
+ * Baseline preamble for c_blocks_code.cpp. Carries:
  *
- *   - The strucpp runtime includes so the auto-generated POU struct
- *     fields (`strucpp::IEC_INT*` / `strucpp::IEC_STRING*` etc.,
- *     emitted by `generateStructMember`) resolve to IECVar /
- *     IECStringVar wrappers.  Force semantics flow through
- *     `IECVar::operator=` (and `IECStringVar::operator=`) on every
- *     user write — uniform across numeric, bit-string, and string
- *     pins.
+ *   - `c_blocks.h`, which defines the interface struct for every C++ POU in the
+ *     project and declares the two entry points this file goes on to define.
+ *     It is included rather than restated: the POU glue includes the same
+ *     header, so the two sides describe one struct and cannot drift apart.
+ *     Through it comes `generated.hpp` — the strucpp runtime wrappers plus this
+ *     project's own structures, enumerations and function block classes — so a
+ *     C block can name every type the Variables Table can declare, and force
+ *     semantics flow through `IECVar::operator=` on every user write.
  *
- *   - File-scope raw numeric typedefs (`IEC_BOOL` / `IEC_INT` /
- *     `IEC_REAL` / etc.) preserved from the MatIEC era.  These exist
- *     ONLY for the user's *local* variables inside `setup()` /
- *     `loop()` (e.g. `IEC_INT my_temp = 0;`).  They never collide
- *     with the auto-generated struct fields because the struct
- *     fully qualifies as `strucpp::IEC_*`.
+ *   - File-scope raw numeric typedefs (`IEC_BOOL` / `IEC_INT` / `IEC_REAL` /
+ *     etc.) preserved from the MatIEC era. These exist ONLY for the user's
+ *     *local* variables inside `setup()` / `loop()` (e.g. `IEC_INT my_temp =
+ *     0;`). They never collide with the struct fields because those fully
+ *     qualify as `strucpp::IEC_*`.
  *
- *   - No raw `IEC_STRING` / `IEC_WSTRING` typedef.  STRING pins now
- *     use the strucpp wrapper end-to-end (`strucpp::IEC_STRING =
- *     IECStringVar<254>`), so user code interacts with them via
- *     `name = "hello";` / `name.length()` / `name[i]` /
- *     `name.c_str()` / `name == "stop"` — the same surface every
- *     other pin already exposes.  Local STRING variables inside
- *     setup() / loop() can also be declared as
- *     `strucpp::IEC_STRING my_buf;` (or `using strucpp::IEC_STRING;`
- *     at the top of the user's POU body, opt-in).
+ *   - No raw `IEC_STRING` / `IEC_WSTRING` typedef. STRING pins use the strucpp
+ *     wrapper end-to-end (`strucpp::IEC_STRING = IECStringVar<254>`), so user
+ *     code interacts with them via `name = "hello";` / `name.length()` /
+ *     `name[i]` / `name.c_str()` / `name == "stop"` — the same surface every
+ *     other pin already exposes. A local STRING inside setup() / loop() can be
+ *     declared `strucpp::IEC_STRING my_buf;` too.
  */
 const C_BLOCKS_BASELINE = `#include <cstdint>
 #include <cstring>
@@ -51,13 +48,22 @@ const C_BLOCKS_BASELINE = `#include <cstdint>
 #undef max
 #endif
 
-// STruC++ runtime types — IECVar<T> / IECStringVar<N> wrappers under
-// namespace strucpp.  The auto-generated POU struct refers to them
-// as \`strucpp::IEC_*\` for every pin (numeric, bit-string, STRING,
-// WSTRING), keeping force-aware semantics on the user's writes via
-// the wrapper's operator=.
-#include "iec_var.hpp"
-#include "iec_string.hpp"
+// The C block interface — the \`<POU>_VARS\` struct for every C++ POU in this
+// project, and the \`extern "C"\` declarations of the setup/loop entry points
+// defined below.  Declared once, in c_blocks.h, and included rather than
+// restated here: the POU glue strucpp emits includes the same header, so the
+// two sides cannot describe the struct differently.
+//
+// It transitively carries \`generated.hpp\` — the strucpp runtime wrappers plus
+// this project's own structures, enumerations and function block classes — so a
+// C block can name every type the Variables Table can declare.
+//
+// This TU is pre-compiled with the board's toolchain at -std=gnu++17 into
+// libOpenPLCUserLib.a, on the same side of the isolation seam as the rest of
+// the generated code, so the header's C++17 surface is available here. The
+// arduino-cli pass compiles the core in its own (older) standard and never
+// sees this file.
+#include "c_blocks.h"
 
 /*********************/
 /*  IEC Types defs   */
@@ -107,6 +113,46 @@ const generateUndef = (variable: PLCVariable): string => {
   return `#undef ${variable.name}\n`
 }
 
+/**
+ * Bring the project's own type names into the C block's scope.
+ *
+ * The generated declarations live in `namespace strucpp`, so without this a
+ * user has to write `strucpp::Motor` / `(strucpp::Mode)` in their own block —
+ * the namespace is an implementation detail of the toolchain leaking into code
+ * that is supposed to look like ordinary C++ against the Variables Table.
+ *
+ * A blanket `using namespace strucpp;` is not an option: the baseline defines
+ * raw `IEC_BOOL` / `IEC_INT` / … typedefs at file scope for the user's local
+ * variables, and strucpp declares the same names as `IECVar<T>` wrappers, so
+ * every one of them would become ambiguous. Aliasing only the names this
+ * project actually defines keeps the natural spelling without that collision.
+ *
+ * The bare strucpp name is the right target for both shapes: `strucpp::MOTOR`
+ * is the structure itself and `strucpp::MODE` the enumeration, which is what a
+ * user casts to. The `IEC_`-prefixed aliases stay reserved for pin types in the
+ * generated struct.
+ */
+const generateUserTypeAliases = (cppPous: CppPouData[]): string => {
+  const referenced = new Set<string>()
+  for (const pou of cppPous) {
+    for (const variable of pou.variables) {
+      if (variable.type.definition === 'user-data-type') {
+        referenced.add(variable.type.value.toUpperCase())
+      }
+      if (variable.type.definition === 'array' && variable.type.data?.baseType.definition === 'user-data-type') {
+        referenced.add(variable.type.data.baseType.value.toUpperCase())
+      }
+    }
+  }
+  if (referenced.size === 0) return ''
+
+  let code = "// Project types, reachable without the toolchain's namespace\n"
+  for (const name of Array.from(referenced).sort()) {
+    code += `using ${name} = strucpp::${name};\n`
+  }
+  return code + '\n'
+}
+
 const processUserCode = (pou: CppPouData): string => {
   const structName = `${pou.name.toUpperCase()}_VARS`
   const setupFunctionName = `${pou.name.toLowerCase()}_setup`
@@ -115,21 +161,10 @@ const processUserCode = (pou: CppPouData): string => {
   const inputVariables = pou.variables.filter((v) => v.class === 'input')
   const outputVariables = pou.variables.filter((v) => v.class === 'output')
 
-  let processedCode = `//definition of external blocks - ${pou.name.toUpperCase()}\n`
-  processedCode += `typedef struct {\n`
-
-  inputVariables.forEach((variable) => {
-    processedCode += generateStructMember(variable)
-  })
-
-  outputVariables.forEach((variable) => {
-    processedCode += generateStructMember(variable)
-  })
-
-  processedCode += `} ${structName};\n\n`
-
-  processedCode += `extern "C" void ${setupFunctionName}(${structName} *vars);\n`
-  processedCode += `extern "C" void ${loopFunctionName}(${structName} *vars);\n\n`
+  // The struct and the two entry-point declarations come from c_blocks.h, which
+  // the baseline includes. Only the name-binding macros and the user's own body
+  // are emitted here.
+  let processedCode = `// ${pou.name.toUpperCase()} — Variables Table names bound to the interface struct\n`
 
   inputVariables.forEach((variable) => {
     processedCode += generateDefine(variable)
@@ -173,6 +208,7 @@ const generateCBlocksCode = (cppPous: CppPouData[]): string => {
   if (cppPous.length === 0) return ''
 
   let codeContent = C_BLOCKS_BASELINE
+  codeContent += generateUserTypeAliases(cppPous)
 
   cppPous.forEach((pou) => {
     codeContent += processUserCode(pou)

--- a/src/backend/shared/utils/cpp/generateCBlocksCode.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksCode.ts
@@ -1,4 +1,4 @@
-import { cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
+import { cBlockExternalVariables, cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
 import { isArrayVariable } from '../../../../frontend/utils/PLC/array-codegen-helpers'
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 
@@ -159,7 +159,7 @@ const processUserCode = (pou: CppPouData): string => {
   const setupFunctionName = `${pou.name.toLowerCase()}_setup`
   const loopFunctionName = `${pou.name.toLowerCase()}_loop`
 
-  const interfaceVariables = cBlockInterfaceVariables(pou.variables)
+  const interfaceVariables = [...cBlockInterfaceVariables(pou.variables), ...cBlockExternalVariables(pou.variables)]
 
   // The struct and the two entry-point declarations come from c_blocks.h, which
   // the baseline includes. Only the name-binding macros and the user's own body

--- a/src/backend/shared/utils/cpp/generateCBlocksCode.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksCode.ts
@@ -1,3 +1,4 @@
+import { cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
 import { isArrayVariable } from '../../../../frontend/utils/PLC/array-codegen-helpers'
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 
@@ -158,19 +159,14 @@ const processUserCode = (pou: CppPouData): string => {
   const setupFunctionName = `${pou.name.toLowerCase()}_setup`
   const loopFunctionName = `${pou.name.toLowerCase()}_loop`
 
-  const inputVariables = pou.variables.filter((v) => v.class === 'input')
-  const outputVariables = pou.variables.filter((v) => v.class === 'output')
+  const interfaceVariables = cBlockInterfaceVariables(pou.variables)
 
   // The struct and the two entry-point declarations come from c_blocks.h, which
   // the baseline includes. Only the name-binding macros and the user's own body
   // are emitted here.
   let processedCode = `// ${pou.name.toUpperCase()} — Variables Table names bound to the interface struct\n`
 
-  inputVariables.forEach((variable) => {
-    processedCode += generateDefine(variable)
-  })
-
-  outputVariables.forEach((variable) => {
+  interfaceVariables.forEach((variable) => {
     processedCode += generateDefine(variable)
   })
 
@@ -188,10 +184,7 @@ const processUserCode = (pou: CppPouData): string => {
   processedCode += modifiedUserCode
   processedCode += '\n'
 
-  inputVariables.forEach((variable) => {
-    processedCode += generateUndef(variable)
-  })
-  outputVariables.forEach((variable) => {
+  interfaceVariables.forEach((variable) => {
     processedCode += generateUndef(variable)
   })
   processedCode += '\n'

--- a/src/backend/shared/utils/cpp/generateCBlocksCode.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksCode.ts
@@ -1,5 +1,5 @@
 import { cBlockExternalVariables, cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
-import { isArrayVariable } from '../../../../frontend/utils/PLC/array-codegen-helpers'
+import { isArrayVariable, multiDimensionalContainerType } from '../../../../frontend/utils/PLC/array-codegen-helpers'
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 
 type CppPouData = {
@@ -104,7 +104,13 @@ const generateDefine = (variable: PLCVariable): string => {
   const name = variable.name
   const upperName = name.toUpperCase()
 
-  if (isArrayVariable(variable)) {
+  // A one-dimensional array is a pointer to its first element offset by the
+  // lower bound, so the name binds to the pointer itself and `name[i]` indexes
+  // by the declared IEC range. Everything else — scalars, structures, function
+  // block instances, and multi-dimensional arrays, which are passed as the
+  // container — binds to the dereferenced pointer, so the user writes
+  // `name = 5`, `name.field`, `name()` or `name(i, j)` as the type allows.
+  if (isArrayVariable(variable) && !multiDimensionalContainerType(variable)) {
     return `#define ${name} (vars->${upperName})\n`
   }
   return `#define ${name} (*(vars->${upperName}))\n`

--- a/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
@@ -1,4 +1,4 @@
-import { cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
+import { cBlockExternalVariables, cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
 import { generateStructMember } from '../../../../frontend/utils/PLC/array-codegen-helpers'
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 
@@ -55,6 +55,14 @@ const generateCBlocksHeader = (cppPous: CppPouData[], userTypeNames: Iterable<st
     headerContent += `typedef struct {\n`
 
     cBlockInterfaceVariables(pou.variables).forEach((variable) => {
+      headerContent += generateStructMember(variable, typeNames)
+    })
+
+    // A `VAR_EXTERNAL` field looks like any other: the pointer is to the
+    // global's value, so the block reads and writes it exactly as it does a
+    // local. What differs is that the ST glue takes that pointer under the
+    // global's lock — see `cBlockExternalVariables`.
+    cBlockExternalVariables(pou.variables).forEach((variable) => {
       headerContent += generateStructMember(variable, typeNames)
     })
 

--- a/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
@@ -1,3 +1,4 @@
+import { cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
 import { generateStructMember } from '../../../../frontend/utils/PLC/array-codegen-helpers'
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 
@@ -50,17 +51,10 @@ const generateCBlocksHeader = (cppPous: CppPouData[], userTypeNames: Iterable<st
     const setupFunctionName = `${pou.name.toLowerCase()}_setup`
     const loopFunctionName = `${pou.name.toLowerCase()}_loop`
 
-    const inputVariables = pou.variables.filter((v) => v.class === 'input')
-    const outputVariables = pou.variables.filter((v) => v.class === 'output')
-
     headerContent += `//definition of external blocks - ${pou.name.toUpperCase()}\n`
     headerContent += `typedef struct {\n`
 
-    inputVariables.forEach((variable) => {
-      headerContent += generateStructMember(variable, typeNames)
-    })
-
-    outputVariables.forEach((variable) => {
+    cBlockInterfaceVariables(pou.variables).forEach((variable) => {
       headerContent += generateStructMember(variable, typeNames)
     })
 

--- a/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
@@ -6,17 +6,42 @@ type CppPouData = {
   variables: PLCVariable[]
 }
 
-const generateCBlocksHeader = (cppPous: CppPouData[]): string => {
+/**
+ * The one place a C block's interface struct is written.
+ *
+ * `c_blocks_code.cpp` used to re-emit the same `<POU>_VARS` typedef from its own
+ * call into `generateStructMember`, so the project carried two independent
+ * spellings of one fact. They agreed only for as long as both call sites were
+ * edited together, and the moment a type needed more than a name lookup — an
+ * enumeration is `strucpp::IEC_MODE` in the struct but a structure is
+ * `strucpp::MOTOR` — they diverged, producing two conflicting definitions of the
+ * same typedef and a compile error at the assignment in the POU glue.
+ *
+ * Now the header is the definition and `c_blocks_code.cpp` includes it. Drift is
+ * not a bug that can be reintroduced: there is nothing left to disagree with.
+ */
+const generateCBlocksHeader = (cppPous: CppPouData[], userTypeNames: Iterable<string> = []): string => {
+  const typeNames: ReadonlySet<string> = new Set(Array.from(userTypeNames, (name) => name.toUpperCase()))
+
   let headerContent = `#ifndef C_BLOCKS_H
 #define C_BLOCKS_H
 
-// The user-visible struct fields are fully qualified as
-// \`strucpp::IEC_*\` (numeric, bit-string, STRING, WSTRING — every pin
-// is an \`IECVar<T>\` / \`IECStringVar<N>\` wrapper).  Pull the runtime
-// headers in here so any TU that includes this header gets the
-// wrappers in scope without depending on include order.
-#include "iec_var.hpp"
-#include "iec_string.hpp"
+// The project's own generated declarations. Every struct field below is a
+// strucpp type: an \`IECVar<T>\` / \`IECStringVar<N>\` wrapper for an elementary
+// pin, and for a user-defined type the structure, enumeration or function block
+// class the project declares. \`generated.hpp\` carries all of them, and pulls in
+// the runtime headers transitively, so any translation unit that includes this
+// header gets the whole surface regardless of include order.
+//
+// Every translation unit that includes this header is built at -std=gnu++17,
+// which is what \`generated.hpp\` needs. On a Runtime v4 or Arduino target the
+// POU glue and \`c_blocks_code.cpp\` are pre-compiled from
+// \`precompile/sources/\` with the board's toolchain at that standard; on the
+// baremetal/simulator path the flag is appended to the arduino-cli invocation
+// so the sketch-side copy of \`c_blocks_code.cpp\` compiles identically. Only
+// the core itself is left on whatever standard it ships with, and the core
+// never includes this header.
+#include "generated.hpp"
 
 `
 
@@ -32,18 +57,18 @@ const generateCBlocksHeader = (cppPous: CppPouData[]): string => {
     headerContent += `typedef struct {\n`
 
     inputVariables.forEach((variable) => {
-      headerContent += generateStructMember(variable)
+      headerContent += generateStructMember(variable, typeNames)
     })
 
     outputVariables.forEach((variable) => {
-      headerContent += generateStructMember(variable)
+      headerContent += generateStructMember(variable, typeNames)
     })
 
     headerContent += `} ${structName};\n`
-    // c_blocks_code.cpp defines these with `extern "C"` so the user's
-    // setup()/loop() bodies link unmangled. The header has to match —
-    // without `extern "C"` here, the per-POU call sites mangle the
-    // symbol and the dynamic loader fails with `undefined symbol:
+    // The user's setup()/loop() bodies are defined with `extern "C"` in
+    // c_blocks_code.cpp so they link unmangled. The declarations here have to
+    // match — without `extern "C"` the per-POU call sites mangle the symbol and
+    // the dynamic loader fails with `undefined symbol:
     // _Z<N><name>P<N><STRUCT>_VARS`.
     headerContent += `extern "C" void ${setupFunctionName}(${structName} *vars);\n`
     headerContent += `extern "C" void ${loopFunctionName}(${structName} *vars);\n\n`

--- a/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
+++ b/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
@@ -8,6 +8,7 @@ import {
   isArrayVariable,
   mapBaseTypeToIEC,
   mapUserTypeToIEC,
+  multiDimensionalContainerType,
 } from '../array-codegen-helpers'
 
 // ---------------------------------------------------------------------------
@@ -292,6 +293,87 @@ describe('mapUserTypeToIEC', () => {
 
   it('matches case-insensitively, since the set is uppercased by the caller', () => {
     expect(mapUserTypeToIEC('mOtOr', new Set(['MOTOR']))).toBe('IEC_MOTOR')
+  })
+})
+
+describe('multiDimensionalContainerType', () => {
+  const arrayOfRank = (dimensions: string[], baseType = 'INT'): PLCVariable => ({
+    name: 'grid',
+    class: 'input',
+    type: {
+      definition: 'array',
+      value: `ARRAY [${dimensions.join(', ')}] OF ${baseType}`,
+      data: {
+        baseType: { definition: 'base-type', value: baseType },
+        dimensions: dimensions.map((dimension) => ({ dimension })),
+      },
+    },
+    location: '',
+    documentation: '',
+    debug: false,
+  })
+
+  it('names the 2-D container with the user’s own bounds', () => {
+    expect(multiDimensionalContainerType(arrayOfRank(['1..2', '0..3']))).toBe('Array2D<strucpp::IEC_INT, 1, 2, 0, 3>')
+  })
+
+  it('names the 3-D container', () => {
+    expect(multiDimensionalContainerType(arrayOfRank(['0..1', '0..1', '0..1']))).toBe(
+      'Array3D<strucpp::IEC_INT, 0, 1, 0, 1, 0, 1>',
+    )
+  })
+
+  it('returns null for rank one, which is passed as an offset element pointer', () => {
+    // `arr[i]` with IEC indices is a better surface than `arr(i)`, and rank one
+    // is the only rank where the offset trick works.
+    expect(multiDimensionalContainerType(arrayOfRank(['0..9']))).toBeNull()
+  })
+
+  it('returns null past rank three, for which strucpp declares no alias', () => {
+    expect(multiDimensionalContainerType(arrayOfRank(['0..1', '0..1', '0..1', '0..1']))).toBeNull()
+  })
+
+  it('returns null when a bound cannot be read rather than guessing one', () => {
+    expect(multiDimensionalContainerType(arrayOfRank(['0..1', 'nonsense']))).toBeNull()
+  })
+
+  it('returns null for anything that is not an array', () => {
+    const scalar: PLCVariable = {
+      name: 'x',
+      class: 'input',
+      type: { definition: 'base-type', value: 'INT' },
+      location: '',
+      documentation: '',
+      debug: false,
+    }
+
+    expect(multiDimensionalContainerType(scalar)).toBeNull()
+  })
+
+  it('returns null for an array declaration carrying no dimension data', () => {
+    const bare: PLCVariable = {
+      name: 'grid',
+      class: 'input',
+      type: { definition: 'array', value: 'ARRAY [0..1, 0..1] OF INT' },
+      location: '',
+      documentation: '',
+      debug: false,
+    }
+
+    expect(multiDimensionalContainerType(bare)).toBeNull()
+  })
+
+  it('applies the user-defined type spelling to the element type', () => {
+    const v = arrayOfRank(['0..1', '0..1'], 'Motor')
+    v.type.data!.baseType = { definition: 'user-data-type', value: 'Motor' }
+
+    expect(multiDimensionalContainerType(v, new Set(['MOTOR']))).toBe('Array2D<strucpp::IEC_MOTOR, 0, 1, 0, 1>')
+  })
+
+  it('makes generateStructMember emit a pointer to the container', () => {
+    expect(generateStructMember(arrayOfRank(['1..2', '0..3']))).toBe(
+      '  strucpp::Array2D<strucpp::IEC_INT, 1, 2, 0, 3> *GRID;\n',
+    )
   })
 })
 

--- a/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
+++ b/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   getVariableIECType,
   isArrayVariable,
   mapBaseTypeToIEC,
+  mapUserTypeToIEC,
 } from '../array-codegen-helpers'
 
 // ---------------------------------------------------------------------------
@@ -269,6 +270,31 @@ describe('getArrayStartIndex', () => {
 // ---------------------------------------------------------------------------
 // generateStructMember
 // ---------------------------------------------------------------------------
+describe('mapUserTypeToIEC', () => {
+  // strucpp declares a structure or enumeration and then aliases it
+  // (`using IEC_MOTOR = MOTOR`), but a function block class gets no alias. Only
+  // the project's declared data types carry the prefix; anything else — an FB
+  // instance — keeps the bare class name, because `IEC_HELPER` would name a
+  // type that was never declared.
+  it('prefixes a name the project declares as a data type', () => {
+    expect(mapUserTypeToIEC('Motor', new Set(['MOTOR']))).toBe('IEC_MOTOR')
+  })
+
+  it('leaves a name the project does not declare bare', () => {
+    expect(mapUserTypeToIEC('Helper', new Set(['MOTOR']))).toBe('HELPER')
+  })
+
+  it('leaves every name bare when no data-type set is supplied', () => {
+    // The set is optional so call sites that predate user types keep working;
+    // with nothing to match against, no name can be a data type.
+    expect(mapUserTypeToIEC('Motor')).toBe('MOTOR')
+  })
+
+  it('matches case-insensitively, since the set is uppercased by the caller', () => {
+    expect(mapUserTypeToIEC('mOtOr', new Set(['MOTOR']))).toBe('IEC_MOTOR')
+  })
+})
+
 describe('generateStructMember', () => {
   // Numeric/time/bit base types resolve to strucpp's IECVar wrapper —
   // the c_blocks_code.cpp baseline keeps file-scope raw typedefs for

--- a/src/frontend/utils/PLC/array-codegen-helpers.ts
+++ b/src/frontend/utils/PLC/array-codegen-helpers.ts
@@ -114,6 +114,43 @@ const getArrayStartIndex = (variable: PLCVariable): number => {
 }
 
 /**
+ * strucpp container type for an array of rank two or three, or `null` for
+ * anything else.
+ *
+ * A one-dimensional array is passed as a pointer to its first element, offset by
+ * the lower bound, so the block writes `arr[i]` with the declared IEC indices
+ * and the element type is all the struct has to name. That trick does not extend
+ * past rank one: `IEC_ARRAY_2D` deliberately has no `operator[]` — a row
+ * subscript would have to return a view — and takes every index in one
+ * `operator()` call instead. So a multi-dimensional array is passed as a pointer
+ * to the container itself, and the block indexes it as `grid(i, j)`, which is
+ * the same accessor the compiler's own generated code uses.
+ *
+ * `Array2D` / `Array3D` are strucpp's documented public aliases, and the bounds
+ * handed to them come from the user's own declaration rather than from any
+ * assumption about how the container is laid out.
+ *
+ * Rank four and beyond returns `null`: strucpp declares no alias for it, so
+ * there is no type to name and no array to describe.
+ */
+const multiDimensionalContainerType = (variable: PLCVariable, userTypeNames?: ReadonlySet<string>): string | null => {
+  if (variable.type.definition !== 'array' || !variable.type.data) return null
+
+  const dimensions = variable.type.data.dimensions
+  if (dimensions.length < 2 || dimensions.length > 3) return null
+
+  const bounds: number[] = []
+  for (const dimension of dimensions) {
+    const range = parseDimensionRange(dimension.dimension)
+    if (!range) return null
+    bounds.push(range.lower, range.upper)
+  }
+
+  const elementType = mapBaseTypeToIEC(variable.type.data.baseType.value, userTypeNames)
+  return `Array${dimensions.length}D<strucpp::${elementType}, ${bounds.join(', ')}>`
+}
+
+/**
  * Generate a C struct member declaration for a variable.
  * Both scalars and arrays use pointers:
  * - Scalars: pointer to the single value
@@ -136,13 +173,17 @@ const getArrayStartIndex = (variable: PLCVariable): number => {
  * declarations inside `setup()` / `loop()`.
  */
 const generateStructMember = (variable: PLCVariable, userTypeNames?: ReadonlySet<string>): string => {
-  const iecType = getVariableIECType(variable, userTypeNames)
   const name = variable.name.toUpperCase()
+  const multiDimensional = multiDimensionalContainerType(variable, userTypeNames)
+  if (multiDimensional) return `  strucpp::${multiDimensional} *${name};\n`
+
+  const iecType = getVariableIECType(variable, userTypeNames)
   return `  strucpp::${iecType} *${name};\n`
 }
 
 export {
   generateStructMember,
+  multiDimensionalContainerType,
   mapUserTypeToIEC,
   getArrayBaseTypeValue,
   getArrayStartIndex,

--- a/src/frontend/utils/PLC/array-codegen-helpers.ts
+++ b/src/frontend/utils/PLC/array-codegen-helpers.ts
@@ -55,8 +55,35 @@ const getArrayBaseTypeValue = (variable: PLCVariable): string => {
  * Map a base type string to its IEC C type name.
  * Falls back to uppercasing the type value if not found.
  */
-const mapBaseTypeToIEC = (baseType: string): string => {
-  return BASE_TYPE_TO_IEC[baseType.toLowerCase()] || baseType.toUpperCase()
+/**
+ * Spell a user-defined type the way strucpp declares it.
+ *
+ * The compiler emits two different shapes and there is no single rule that
+ * covers both, so the caller has to say which names are data types:
+ *
+ *   - A data type gets an `IEC_`-prefixed alias — `struct MOTOR { … };
+ *     using IEC_MOTOR = MOTOR;` for a structure, and
+ *     `enum class MODE { … }; using IEC_MODE = IEC_ENUM<MODE>;` for an
+ *     enumeration. The alias is the one to use: for an enumeration the bare
+ *     name is the raw C++ `enum class`, while `IEC_MODE` is the force-aware
+ *     wrapper, and a pin must be the wrapper like every other pin.
+ *   - A function block instance is a plain `class HELPER;` with no alias, so
+ *     the bare name is the only spelling that exists.
+ *
+ * Without `userTypeNames` the bare name is returned, which is the correct
+ * answer for a function block and the historical behaviour for everything else.
+ */
+const mapUserTypeToIEC = (typeName: string, userTypeNames?: ReadonlySet<string>): string => {
+  const upper = typeName.toUpperCase()
+  return userTypeNames?.has(upper) ? `IEC_${upper}` : upper
+}
+
+const mapBaseTypeToIEC = (baseType: string, userTypeNames?: ReadonlySet<string>): string => {
+  const elementary = BASE_TYPE_TO_IEC[baseType.toLowerCase()]
+  if (elementary) return elementary
+  // Not elementary: an array of a user-defined type, or a type the map does not
+  // know. Both go through the same spelling rule as a scalar of that type.
+  return mapUserTypeToIEC(baseType, userTypeNames)
 }
 
 /**
@@ -64,14 +91,14 @@ const mapBaseTypeToIEC = (baseType: string): string => {
  * For arrays, returns the IEC type of the base element type.
  * For scalars, returns the IEC type of the variable's type.
  */
-const getVariableIECType = (variable: PLCVariable): string => {
+const getVariableIECType = (variable: PLCVariable, userTypeNames?: ReadonlySet<string>): string => {
   if (variable.type.definition === 'array' && variable.type.data) {
-    return mapBaseTypeToIEC(variable.type.data.baseType.value)
+    return mapBaseTypeToIEC(variable.type.data.baseType.value, userTypeNames)
   }
   if (variable.type.definition === 'base-type') {
-    return mapBaseTypeToIEC(variable.type.value)
+    return mapBaseTypeToIEC(variable.type.value, userTypeNames)
   }
-  return variable.type.value.toUpperCase()
+  return mapUserTypeToIEC(variable.type.value, userTypeNames)
 }
 
 /**
@@ -108,14 +135,15 @@ const getArrayStartIndex = (variable: PLCVariable): number => {
  * numeric raw typedefs that still cover the user's local-variable
  * declarations inside `setup()` / `loop()`.
  */
-const generateStructMember = (variable: PLCVariable): string => {
-  const iecType = getVariableIECType(variable)
+const generateStructMember = (variable: PLCVariable, userTypeNames?: ReadonlySet<string>): string => {
+  const iecType = getVariableIECType(variable, userTypeNames)
   const name = variable.name.toUpperCase()
   return `  strucpp::${iecType} *${name};\n`
 }
 
 export {
   generateStructMember,
+  mapUserTypeToIEC,
   getArrayBaseTypeValue,
   getArrayStartIndex,
   getArrayTotalElements,

--- a/src/frontend/utils/cpp/__tests__/block-interface.test.ts
+++ b/src/frontend/utils/cpp/__tests__/block-interface.test.ts
@@ -1,6 +1,6 @@
 import type { PLCVariable, VariableClass } from '../../../../middleware/shared/ports/types'
 import { CPP_RUNTIME_INTERNAL_VARIABLE } from '../addCppLocalVariables'
-import { cBlockInterfaceVariables, INTERFACE_CLASSES } from '../block-interface'
+import { cBlockExternalVariables, cBlockInterfaceVariables, INTERFACE_CLASSES } from '../block-interface'
 
 const variable = (name: string, cls?: VariableClass): PLCVariable => ({
   name,
@@ -41,9 +41,9 @@ describe('cBlockInterfaceVariables', () => {
     expect(names(result)).toEqual(['i1', 'i2', 'o1', 'o2', 't1', 't2'])
   })
 
-  it('leaves out a VAR_EXTERNAL, which is a GlobalVar pointer rather than a member', () => {
-    // Emitting a plain pointer to one would compile and silently drop the
-    // global's mutex, so externals are handled separately.
+  it('leaves out a VAR_EXTERNAL, which is collected separately', () => {
+    // An external reaches the same struct, but its pointer has to be taken
+    // under the global's lock, so the glue collects it on its own.
     expect(names(cBlockInterfaceVariables([variable('i', 'input'), variable('g', 'external')]))).toEqual(['i'])
   })
 
@@ -72,6 +72,45 @@ describe('cBlockInterfaceVariables', () => {
     cBlockInterfaceVariables(input)
 
     expect(names(input)).toEqual(['t', 'i'])
+  })
+
+  describe('cBlockExternalVariables', () => {
+    it('collects only the externals', () => {
+      const result = cBlockExternalVariables([
+        variable('i', 'input'),
+        variable('g', 'external'),
+        variable('l', 'local'),
+      ])
+
+      expect(names(result)).toEqual(['g'])
+    })
+
+    it('orders them by name, so the lock nesting is the same in every block', () => {
+      const result = cBlockExternalVariables([
+        variable('gZulu', 'external'),
+        variable('gAlpha', 'external'),
+        variable('gmike', 'external'),
+      ])
+
+      expect(names(result)).toEqual(['gAlpha', 'gmike', 'gZulu'])
+    })
+
+    it('orders case-insensitively, since the emitted names are uppercased', () => {
+      const result = cBlockExternalVariables([variable('gb', 'external'), variable('gA', 'external')])
+
+      expect(names(result)).toEqual(['gA', 'gb'])
+    })
+
+    it('does not reorder the caller’s array', () => {
+      const input = [variable('gZulu', 'external'), variable('gAlpha', 'external')]
+      cBlockExternalVariables(input)
+
+      expect(names(input)).toEqual(['gZulu', 'gAlpha'])
+    })
+
+    it('returns nothing when the block declares no externals', () => {
+      expect(cBlockExternalVariables([variable('i', 'input')])).toEqual([])
+    })
   })
 
   it('exposes the class order it applies', () => {

--- a/src/frontend/utils/cpp/__tests__/block-interface.test.ts
+++ b/src/frontend/utils/cpp/__tests__/block-interface.test.ts
@@ -1,0 +1,80 @@
+import type { PLCVariable, VariableClass } from '../../../../middleware/shared/ports/types'
+import { CPP_RUNTIME_INTERNAL_VARIABLE } from '../addCppLocalVariables'
+import { cBlockInterfaceVariables, INTERFACE_CLASSES } from '../block-interface'
+
+const variable = (name: string, cls?: VariableClass): PLCVariable => ({
+  name,
+  ...(cls ? { class: cls } : {}),
+  type: { definition: 'base-type', value: 'INT' },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const names = (variables: PLCVariable[]): string[] => variables.map((v) => v.name)
+
+describe('cBlockInterfaceVariables', () => {
+  it('carries every class a C++ block can reach as a plain member', () => {
+    const result = cBlockInterfaceVariables([
+      variable('i', 'input'),
+      variable('o', 'output'),
+      variable('io', 'inOut'),
+      variable('l', 'local'),
+      variable('t', 'temp'),
+    ])
+
+    expect(names(result)).toEqual(['i', 'o', 'io', 'l', 't'])
+  })
+
+  it('groups by class and keeps declaration order inside a class', () => {
+    // Grouping is cosmetic — the struct is filled by name — but a stable order
+    // keeps the generated header readable and its diffs meaningful.
+    const result = cBlockInterfaceVariables([
+      variable('t1', 'temp'),
+      variable('o1', 'output'),
+      variable('i1', 'input'),
+      variable('o2', 'output'),
+      variable('i2', 'input'),
+      variable('t2', 'temp'),
+    ])
+
+    expect(names(result)).toEqual(['i1', 'i2', 'o1', 'o2', 't1', 't2'])
+  })
+
+  it('leaves out a VAR_EXTERNAL, which is a GlobalVar pointer rather than a member', () => {
+    // Emitting a plain pointer to one would compile and silently drop the
+    // global's mutex, so externals are handled separately.
+    expect(names(cBlockInterfaceVariables([variable('i', 'input'), variable('g', 'external')]))).toEqual(['i'])
+  })
+
+  it('leaves out a configuration global, which is not a POU variable at all', () => {
+    expect(names(cBlockInterfaceVariables([variable('i', 'input'), variable('g', 'global')]))).toEqual(['i'])
+  })
+
+  it('leaves out the latch the toolchain injects into every C++ block', () => {
+    const result = cBlockInterfaceVariables([variable('i', 'input'), variable(CPP_RUNTIME_INTERNAL_VARIABLE, 'local')])
+
+    expect(names(result)).toEqual(['i'])
+  })
+
+  it('leaves out a variable with no class rather than guessing one', () => {
+    expect(names(cBlockInterfaceVariables([variable('i', 'input'), variable('mystery')]))).toEqual(['i'])
+  })
+
+  it('returns nothing for an empty interface', () => {
+    expect(cBlockInterfaceVariables([])).toEqual([])
+  })
+
+  it('does not mutate or alias the caller’s array', () => {
+    // The sort is on an internal copy: the emitters share one variable list and
+    // reordering it under them would be a very quiet bug.
+    const input = [variable('t', 'temp'), variable('i', 'input')]
+    cBlockInterfaceVariables(input)
+
+    expect(names(input)).toEqual(['t', 'i'])
+  })
+
+  it('exposes the class order it applies', () => {
+    expect(INTERFACE_CLASSES).toEqual(['input', 'output', 'inOut', 'local', 'temp'])
+  })
+})

--- a/src/frontend/utils/cpp/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/cpp/__tests__/generateSTCode.test.ts
@@ -153,21 +153,51 @@ describe('generateSTCode (cpp)', () => {
     expect(result).toContain('vars.D = &D[0] - 0;')
   })
 
-  it('filters out local variables', () => {
-    const localVar: PLCVariable = {
-      name: 'localVal',
-      class: 'local',
+  it('assigns a pointer for every class the struct carries', () => {
+    // The assignments and the struct must select the same variables: a field
+    // the assignments skip is a dangling pointer the user's first write
+    // follows. Both read `cBlockInterfaceVariables`, and this pins the result.
+    const byClass = (name: string, cls: PLCVariable['class']): PLCVariable => ({
+      name,
+      class: cls,
       type: { definition: 'base-type', value: 'INT' },
       location: '',
       documentation: '',
       debug: false,
-    }
+    })
 
     const result = generateSTCode({
       pouName: 'test',
-      allVariables: [makeScalarVar('x', 'input', 'INT'), localVar],
+      allVariables: [
+        makeScalarVar('x', 'input', 'INT'),
+        byClass('localVal', 'local'),
+        byClass('tempVal', 'temp'),
+        byClass('ioVal', 'inOut'),
+      ],
     })
 
-    expect(result).not.toContain('LOCALVAL')
+    expect(result).toContain('vars.X = &X;')
+    expect(result).toContain('vars.LOCALVAL = &LOCALVAL;')
+    expect(result).toContain('vars.TEMPVAL = &TEMPVAL;')
+    expect(result).toContain('vars.IOVAL = &IOVAL;')
+  })
+
+  it('does not assign the latch the toolchain injects', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [
+        makeScalarVar('x', 'input', 'INT'),
+        {
+          name: 'hasBeenInitialized',
+          class: 'local',
+          type: { definition: 'base-type', value: 'BOOL' },
+          location: '',
+          documentation: '',
+          debug: false,
+        },
+      ],
+    })
+
+    expect(result).not.toContain('vars.HASBEENINITIALIZED')
   })
 })

--- a/src/frontend/utils/cpp/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/cpp/__tests__/generateSTCode.test.ts
@@ -182,6 +182,103 @@ describe('generateSTCode (cpp)', () => {
     expect(result).toContain('vars.IOVAL = &IOVAL;')
   })
 
+  describe('VAR_EXTERNAL', () => {
+    const ext = (name: string): PLCVariable => ({
+      name,
+      class: 'external',
+      type: { definition: 'base-type', value: 'DINT' },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+
+    const extArray = (name: string, dimension: string): PLCVariable => ({
+      name,
+      class: 'external',
+      type: {
+        definition: 'array',
+        value: `ARRAY [${dimension}] OF INT`,
+        data: { baseType: { definition: 'base-type', value: 'INT' }, dimensions: [{ dimension }] },
+      },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+
+    it('takes each global’s pointer inside that global’s own lock', () => {
+      // strucpp holds a global as a `GlobalVar<V>` — value plus mutex — and
+      // hands out a `V*` only through `with_lock`. Filling the field anywhere
+      // else would compile and silently drop the lock.
+      const result = generateSTCode({ pouName: 'blk', allVariables: [ext('gCount')] })
+
+      expect(result).toContain('GCOUNT->with_lock([&](auto* g0) {')
+      expect(result).toContain('vars.GCOUNT = g0;')
+    })
+
+    it('deduces the pointer type instead of naming it', () => {
+      // `V` is IEC_DINT for a scalar, MOTOR for a structure, IEC_MODE for an
+      // enumeration and Array1D<IEC_INT, 0, 3> for an array. Writing any of
+      // those here would restate the compiler's layout, which has to stay
+      // stated in one place.
+      const result = generateSTCode({ pouName: 'blk', allVariables: [ext('gCount')] })
+
+      expect(result).toContain('auto* g0')
+      expect(result).not.toContain('GlobalVar<')
+    })
+
+    it('holds the lock across the call, not merely around the assignment', () => {
+      const result = generateSTCode({ pouName: 'blk', allVariables: [ext('gCount')] })
+      const openIdx = result.indexOf('GCOUNT->with_lock')
+      const callIdx = result.indexOf('blk_loop(&vars);')
+      const closeIdx = result.indexOf('});', callIdx)
+
+      expect(openIdx).toBeGreaterThan(-1)
+      expect(callIdx).toBeGreaterThan(openIdx)
+      expect(closeIdx).toBeGreaterThan(callIdx)
+    })
+
+    it('wraps setup as well as loop, since setup may touch a global too', () => {
+      const result = generateSTCode({ pouName: 'blk', allVariables: [ext('gCount')] })
+
+      expect(result.match(/GCOUNT->with_lock/g)).toHaveLength(2)
+    })
+
+    it('nests several globals in name order, identically in every block', () => {
+      // A fixed order is what stops two blocks taking the same pair of globals
+      // in opposite orders and deadlocking.
+      const result = generateSTCode({
+        pouName: 'blk',
+        allVariables: [ext('gZulu'), ext('gAlpha'), ext('gMike')],
+      })
+
+      const order = ['GALPHA', 'GMIKE', 'GZULU'].map((n) => result.indexOf(`${n}->with_lock`))
+      expect(order).toEqual([...order].sort((a, b) => a - b))
+    })
+
+    it('offsets an array global so it indexes by the declared IEC range', () => {
+      const result = generateSTCode({ pouName: 'blk', allVariables: [extArray('gArr', '2..5')] })
+
+      expect(result).toContain('vars.GARR = &g0_arr[2] - 2;')
+    })
+
+    it('binds the array dereference to a reference, never inline as `(*g)`', () => {
+      // This C++ sits inside an `{external}` block that the ST front end still
+      // scans, and `(*` opens a block comment there: inline would swallow the
+      // rest of the POU and fail as `Unclosed block comment`.
+      const result = generateSTCode({ pouName: 'blk', allVariables: [extArray('gArr', '0..3')] })
+
+      expect(result).toContain('auto& g0_arr = *g0;')
+      expect(result).not.toContain('(*g0)')
+    })
+
+    it('emits no wrapper at all when the block declares no externals', () => {
+      const result = generateSTCode({ pouName: 'blk', allVariables: [makeScalarVar('x', 'input', 'INT')] })
+
+      expect(result).not.toContain('with_lock')
+      expect(result).toContain('blk_loop(&vars);')
+    })
+  })
+
   it('does not assign the latch the toolchain injects', () => {
     const result = generateSTCode({
       pouName: 'test',

--- a/src/frontend/utils/cpp/addCppLocalVariables.ts
+++ b/src/frontend/utils/cpp/addCppLocalVariables.ts
@@ -1,8 +1,18 @@
 import type { PLCPou, PLCProjectData, PLCVariable } from '../../../middleware/shared/ports/types'
 
+/**
+ * Name of the latch this module injects into every C++ POU.
+ *
+ * Exported so the interface builder can leave it out of the block's struct:
+ * it is the toolchain's own machinery for calling `setup()` exactly once, not
+ * something the user declared, and a block that could write to it could
+ * re-run or skip its own initialisation.
+ */
+const CPP_RUNTIME_INTERNAL_VARIABLE = 'hasBeenInitialized'
+
 const createHasBeenInitializedVariable = (): PLCVariable => {
   return {
-    name: 'hasBeenInitialized',
+    name: CPP_RUNTIME_INTERNAL_VARIABLE,
     class: 'local',
     type: {
       definition: 'base-type',
@@ -34,4 +44,4 @@ const addCppLocalVariables = (projectData: PLCProjectData): PLCProjectData => {
   return processedData
 }
 
-export { addCppLocalVariables }
+export { addCppLocalVariables, CPP_RUNTIME_INTERNAL_VARIABLE }

--- a/src/frontend/utils/cpp/block-interface.ts
+++ b/src/frontend/utils/cpp/block-interface.ts
@@ -1,0 +1,65 @@
+import type { PLCVariable, VariableClass } from '../../../middleware/shared/ports/types'
+import { CPP_RUNTIME_INTERNAL_VARIABLE } from './addCppLocalVariables'
+
+/**
+ * Which of a C++ block's variables cross into its `<POU>_VARS` struct, and in
+ * what order.
+ *
+ * Three emitters have to describe the same interface: `generateCBlocksHeader`
+ * writes the struct, `generateSTCode` writes the pointer assignments that fill
+ * it, and `generateCBlocksCode` writes the macros that bind the user's names to
+ * it. If any one of them selects a different set, the mismatch is not a caught
+ * error — a field the assignments skip is a dangling pointer the user's first
+ * write follows. So the selection is made once, here, and all three read it.
+ *
+ * Selection rule: everything the user declared, minus what this toolchain
+ * injected. That is the whole point of the parity work — a native block should
+ * see its own Variables Table the way an ST block does, not a curated subset.
+ *
+ * `external` is deliberately absent. A `VAR_EXTERNAL` is not a plain member on
+ * the strucpp side but a `GlobalVar<V>*` carrying the global's mutex, so it
+ * needs a pointer of a different shape and an accessor that holds the lock —
+ * handled separately rather than folded in here, where it would silently lose
+ * the lock. `global` is absent for the same reason it is absent from a POU: it
+ * is a configuration-level declaration, not a POU variable.
+ */
+const INTERFACE_CLASSES: readonly VariableClass[] = ['input', 'output', 'inOut', 'local', 'temp']
+
+/**
+ * Rank used to group struct fields by class.
+ *
+ * Grouping is cosmetic — the struct is filled by name, so order changes nothing
+ * about correctness — but a stable order keeps the generated header readable and
+ * keeps its diffs meaningful when a user adds a variable. Declaration order is
+ * preserved inside each class.
+ */
+const CLASS_ORDER = new Map<VariableClass, number>(INTERFACE_CLASSES.map((cls, index) => [cls, index]))
+
+/**
+ * The variables that cross into the C block, grouped by class and stable within
+ * each group.
+ *
+ * `hasBeenInitialized` is filtered out: the toolchain adds it to every C++ POU
+ * to drive the one-shot `setup()` call, so it is machinery rather than something
+ * the user declared, and exposing it would both clutter the struct and let a
+ * block overwrite its own initialisation latch.
+ */
+const cBlockInterfaceVariables = (variables: readonly PLCVariable[]): PLCVariable[] => {
+  // The rank is captured while filtering rather than looked up again in the
+  // comparator: there it would need a fallback for a class that cannot occur,
+  // which is an unreachable branch and a lie about what the data can be.
+  const ranked: Array<{ variable: PLCVariable; rank: number; position: number }> = []
+
+  variables.forEach((variable, position) => {
+    if (variable.name === CPP_RUNTIME_INTERNAL_VARIABLE) return
+    const rank = variable.class === undefined ? undefined : CLASS_ORDER.get(variable.class)
+    if (rank === undefined) return
+    ranked.push({ variable, rank, position })
+  })
+
+  return ranked
+    .sort((a, b) => (a.rank !== b.rank ? a.rank - b.rank : a.position - b.position))
+    .map(({ variable }) => variable)
+}
+
+export { cBlockInterfaceVariables, INTERFACE_CLASSES }

--- a/src/frontend/utils/cpp/block-interface.ts
+++ b/src/frontend/utils/cpp/block-interface.ts
@@ -16,12 +16,11 @@ import { CPP_RUNTIME_INTERNAL_VARIABLE } from './addCppLocalVariables'
  * injected. That is the whole point of the parity work — a native block should
  * see its own Variables Table the way an ST block does, not a curated subset.
  *
- * `external` is deliberately absent. A `VAR_EXTERNAL` is not a plain member on
- * the strucpp side but a `GlobalVar<V>*` carrying the global's mutex, so it
- * needs a pointer of a different shape and an accessor that holds the lock —
- * handled separately rather than folded in here, where it would silently lose
- * the lock. `global` is absent for the same reason it is absent from a POU: it
- * is a configuration-level declaration, not a POU variable.
+ * `external` is absent here and handled by `cBlockExternalVariables` below: it
+ * reaches the same struct, but the pointer that fills the field has to be taken
+ * under the global's lock, so the two are collected separately. `global` is
+ * absent for the reason it is absent from a POU at all: it is a
+ * configuration-level declaration, not a POU variable.
  */
 const INTERFACE_CLASSES: readonly VariableClass[] = ['input', 'output', 'inOut', 'local', 'temp']
 
@@ -62,4 +61,33 @@ const cBlockInterfaceVariables = (variables: readonly PLCVariable[]): PLCVariabl
     .map(({ variable }) => variable)
 }
 
-export { cBlockInterfaceVariables, INTERFACE_CLASSES }
+/**
+ * The block's `VAR_EXTERNAL` declarations, in a fixed order.
+ *
+ * These end up in the same struct and are used by the same name as everything
+ * else — from inside the block, a global should read and write like any other
+ * variable, which is what it already does in ST. What differs is how the
+ * pointer is obtained.
+ *
+ * strucpp holds a global as a `GlobalVar<V>`: the value together with that
+ * global's own mutex, reached through `with_lock`, which runs a callable with a
+ * `V*` while holding the lock. The ST glue therefore wraps the block's entry
+ * points in one such callable per external and takes each pointer inside. The
+ * lambda's parameter is deduced, so nothing here has to name `V` — the
+ * compiler's own layout stays the only statement of it, arrays and structures
+ * included.
+ *
+ * The lock is held across the whole call rather than per access, which is
+ * stronger than what an ST body gets and is the right default for a block that
+ * may read a global, compute, and write it back. Ordering the externals by name
+ * makes the nesting order the same in every block, so two blocks holding two
+ * globals can never take them in opposite orders; an ST body never holds more
+ * than one lock at a time and so can never close a cycle either.
+ */
+const cBlockExternalVariables = (variables: readonly PLCVariable[]): PLCVariable[] =>
+  variables
+    .filter((variable) => variable.class === 'external')
+    .slice()
+    .sort((a, b) => a.name.toUpperCase().localeCompare(b.name.toUpperCase()))
+
+export { cBlockExternalVariables, cBlockInterfaceVariables, INTERFACE_CLASSES }

--- a/src/frontend/utils/cpp/generateSTCode.ts
+++ b/src/frontend/utils/cpp/generateSTCode.ts
@@ -1,6 +1,6 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
 import { getArrayStartIndex, isArrayVariable } from '../PLC/array-codegen-helpers'
-import { cBlockInterfaceVariables } from './block-interface'
+import { cBlockExternalVariables, cBlockInterfaceVariables } from './block-interface'
 
 type STCodeGenerationParams = {
   pouName: string
@@ -32,6 +32,56 @@ const generateVariableAssignment = (variable: PLCVariable): string => {
   return `vars.${name} = &${name};\n`
 }
 
+/**
+ * Wrap a call to the block so every `VAR_EXTERNAL` pointer is taken, and held,
+ * under its global's own lock.
+ *
+ * strucpp holds a global as a `GlobalVar<V>` — the value plus that global's
+ * mutex — and hands out access through `with_lock`, which runs a callable with a
+ * `V*` while the lock is held. So the call is nested inside one such callable
+ * per external, and each `vars` field is filled from the pointer that arrives.
+ *
+ * The lambda parameter is `auto*`, deduced. That matters beyond brevity: `V` is
+ * `IEC_DINT` for a scalar, `MOTOR` for a structure, `IEC_MODE` for an
+ * enumeration and `Array1D<IEC_INT, 0, 3>` for an array, and writing those out
+ * here would be this file restating the compiler's layout — the one thing that
+ * has to stay stated in exactly one place. Deduction keeps it there.
+ *
+ * An array is offset the same way a non-global one is, so the field stays a
+ * pointer to the element type and `name[i]` indexes by the declared IEC range.
+ * The dereference is bound to a reference on its own line rather than written
+ * inline as `(*g)[lo]`: this C++ sits inside an `{external}` block that the ST
+ * front end still scans, and `(*` opens a block comment there — inline would
+ * swallow the rest of the POU and fail as `Unclosed block comment`.
+ *
+ * Nesting is in name order (see `cBlockExternalVariables`), identical in every
+ * block, so no two blocks can take the same pair of globals in opposite orders.
+ * The lock is therefore held for the whole call rather than per access —
+ * stronger than an ST body gets, and the right default for code that may read a
+ * global, compute from it, and write it back.
+ */
+const wrapInGlobalLocks = (externals: PLCVariable[], call: string): string => {
+  if (externals.length === 0) return call
+
+  let open = ''
+  let close = ''
+  externals.forEach((variable, depth) => {
+    const name = variable.name.toUpperCase()
+    const held = `g${depth}`
+    open += `${name}->with_lock([&](auto* ${held}) {\n`
+    if (isArrayVariable(variable)) {
+      const startIndex = getArrayStartIndex(variable)
+      open += `auto& ${held}_arr = *${held};\n`
+      open += `vars.${name} = &${held}_arr[${startIndex}] - ${startIndex};\n`
+    } else {
+      open += `vars.${name} = ${held};\n`
+    }
+    close = `});\n` + close
+  })
+
+  return `${open}${call}\n${close}`.trimEnd()
+}
+
 const generateSTCode = (params: STCodeGenerationParams): string => {
   const { pouName, allVariables } = params
 
@@ -43,6 +93,10 @@ const generateSTCode = (params: STCodeGenerationParams): string => {
   for (const variable of cBlockInterfaceVariables(allVariables)) {
     variableAssignments += generateVariableAssignment(variable)
   }
+
+  // Externals are filled inside the lock wrapper instead, immediately before
+  // each call — their pointers are only valid while that lock is held.
+  const externals = cBlockExternalVariables(allVariables)
 
   // Header `{external}` block: declare the user-visible struct, fill
   // the pointer fields. STruC++ emits this body verbatim into the
@@ -56,12 +110,12 @@ ${structName} vars;
 ${variableAssignments}}
 if hasBeenInitialized = False then
 {external
-${setupFunctionName}(&vars);
+${wrapInGlobalLocks(externals, `${setupFunctionName}(&vars);`)}
 }
 hasBeenInitialized := True;
 end_if;
 {external
-${loopFunctionName}(&vars);
+${wrapInGlobalLocks(externals, `${loopFunctionName}(&vars);`)}
 }`
 }
 

--- a/src/frontend/utils/cpp/generateSTCode.ts
+++ b/src/frontend/utils/cpp/generateSTCode.ts
@@ -1,5 +1,5 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
-import { getArrayStartIndex, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { getArrayStartIndex, isArrayVariable, multiDimensionalContainerType } from '../PLC/array-codegen-helpers'
 import { cBlockExternalVariables, cBlockInterfaceVariables } from './block-interface'
 
 type STCodeGenerationParams = {
@@ -17,14 +17,23 @@ type STCodeGenerationParams = {
  *   `*name = 5` / `name = "hi"` routes through the wrapper's
  *   `operator=`, which respects forcing.
  *
- * - Base-type arrays: `vars.NAME = &NAME[lower] - lower`. `Array1D<T>`
+ * - One-dimensional arrays: `vars.NAME = &NAME[lower] - lower`. `Array1D<T>`
  *   stores `std::array<IECVar<T>, N>`; element 0 sits at `&NAME[lower]`.
  *   Subtracting `lower` shifts the pointer so `vars->NAME[iec_idx]`
  *   works for any IEC index in the declared range. Per-element forcing
  *   is preserved.
+ *
+ * - Multi-dimensional arrays: `vars.NAME = &NAME`. The offset trick does not
+ *   extend past rank one — `IEC_ARRAY_2D` has no `operator[]` and takes every
+ *   index in one `operator()` call — so the container itself is passed and the
+ *   block indexes it as `grid(i, j)`, the same accessor the compiler's own
+ *   generated code uses.
  */
 const generateVariableAssignment = (variable: PLCVariable): string => {
   const name = variable.name.toUpperCase()
+  if (multiDimensionalContainerType(variable)) {
+    return `vars.${name} = &${name};\n`
+  }
   if (isArrayVariable(variable)) {
     const startIndex = getArrayStartIndex(variable)
     return `vars.${name} = &${name}[${startIndex}] - ${startIndex};\n`
@@ -69,11 +78,13 @@ const wrapInGlobalLocks = (externals: PLCVariable[], call: string): string => {
     const name = variable.name.toUpperCase()
     const held = `g${depth}`
     open += `${name}->with_lock([&](auto* ${held}) {\n`
-    if (isArrayVariable(variable)) {
+    if (isArrayVariable(variable) && !multiDimensionalContainerType(variable)) {
       const startIndex = getArrayStartIndex(variable)
       open += `auto& ${held}_arr = *${held};\n`
       open += `vars.${name} = &${held}_arr[${startIndex}] - ${startIndex};\n`
     } else {
+      // Scalars, structures, function block instances and multi-dimensional
+      // arrays are all passed as the pointer `with_lock` already hands over.
       open += `vars.${name} = ${held};\n`
     }
     close = `});\n` + close

--- a/src/frontend/utils/cpp/generateSTCode.ts
+++ b/src/frontend/utils/cpp/generateSTCode.ts
@@ -1,5 +1,6 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
 import { getArrayStartIndex, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { cBlockInterfaceVariables } from './block-interface'
 
 type STCodeGenerationParams = {
   pouName: string
@@ -34,16 +35,14 @@ const generateVariableAssignment = (variable: PLCVariable): string => {
 const generateSTCode = (params: STCodeGenerationParams): string => {
   const { pouName, allVariables } = params
 
-  const inputVariables = allVariables.filter((v) => v.class === 'input')
-  const outputVariables = allVariables.filter((v) => v.class === 'output')
-
   const structName = `${pouName.toUpperCase()}_VARS`
   const setupFunctionName = `${pouName.toLowerCase()}_setup`
   const loopFunctionName = `${pouName.toLowerCase()}_loop`
 
   let variableAssignments = ''
-  for (const variable of inputVariables) variableAssignments += generateVariableAssignment(variable)
-  for (const variable of outputVariables) variableAssignments += generateVariableAssignment(variable)
+  for (const variable of cBlockInterfaceVariables(allVariables)) {
+    variableAssignments += generateVariableAssignment(variable)
+  }
 
   // Header `{external}` block: declare the user-visible struct, fill
   // the pointer fields. STruC++ emits this body verbatim into the


### PR DESCRIPTION
## What this is

Phase 4 of DOPE-584: a C++ function block now sees the same Variables Table an ST block does.

Before this, a native block could name two variable classes and the elementary types. Everything else the editor lets a user declare — a structure, an enumeration, a function block instance, a `VAR`, a `VAR_TEMP`, a `VAR_IN_OUT`, a `VAR_EXTERNAL`, a multi-dimensional array — was accepted by the Variables Table and then rejected by the compiler as an undeclared identifier. That reads as a compiler bug rather than an unimplemented feature.

## Commits

1. **Let a C++ block name every type the project declares.** The block's translation unit now includes the project's generated declarations, and the toolchain's namespace is aliased away so a user writes `MOTOR`, not `strucpp::MOTOR`. Also collapses the interface struct's two emitters into one — it was written verbatim into both `c_blocks.h` and `c_blocks_code.cpp`, and the two spellings diverged the moment a user-defined type needed more than a name lookup, meeting in the POU glue as `cannot convert IEC_MODE* to MODE*`.
2. **Give a C++ block its whole Variables Table.** `inOut`, `local` and `temp` join the struct; the selection rule moves into `cBlockInterfaceVariables` so the header, the ST glue and the macro emitter cannot disagree. Disagreement here has no error to report — a field the glue skips is a dangling pointer the user's first write follows.
3. **Let a C++ block use a global, without dropping its lock.** A `VAR_EXTERNAL` is a `GlobalVar<V>*` carrying the global's mutex, so the pointer is taken inside `with_lock` and held across the call. The lambda parameter is deduced, so nothing restates the compiler's layout; nesting is name-ordered so no two blocks can take a pair of globals in opposite orders.
4. **Index a multi-dimensional array.** Rank one keeps the offset element pointer (`arr[i]` with declared IEC indices); rank two and three pass the container and index as `grid(i, j)`, the accessor the compiler's own code uses.

## Hardware verification

Every phase was run on slm-rp4 (Runtime v4) and compiled for baremetal AVR.

| What | Result |
|---|---|
| struct field, nested array, enum pin, FB instance | values exact; the instance's output matched the block's copy |
| `temp` / `local` / `inOut` | over 406 scans: `406 x 10` accumulated, `100 + 406` round-tripped through the caller |
| scalar / struct / array / enum globals | over 333 scans: 333, 666, 999, RUNNING — block outputs mirroring each |
| 2-D input, 3-D local, 2-D global | corners summed to 11 + 22; two independent counters agreed on the scan count |
| baremetal ATmega2560 | 6-7% flash, 3-6% RAM across the same blocks |

## Not in scope here

- **CONSTANT / RETAIN / NON_RETAIN** wait on NODE-94 (#1034), which has yet to land the qualifier on a POU variable. The interface builder is the single place they will need to be applied.
- **Python** parity is phases 5 onward.

## Worth knowing

Multi-dimensional arrays could not build at all before this, in any project: strucpp's debug table emitted `GRID[0][0]` against a container with no `operator[]`. Fixed in strucpp v0.6.3, which both repos already pin. A stale copy under `release/app/node_modules` can shadow the pinned version, because `src/node_modules` symlinks there — worth checking before diagnosing a codegen bug that is really a resolution one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaSZK4LqFWtZpERcqnZ8uQ