### PR TITLE
task(DOPE-584): Python function blocks reach class parity [phase 5]

### DIFF
--- a/src/backend/shared/utils/PLC/preprocess-pous.ts
+++ b/src/backend/shared/utils/PLC/preprocess-pous.ts
@@ -4,6 +4,7 @@ import { validateCppCode } from '../../../../frontend/utils/cpp/validateCppCode'
 import { addPythonLocalVariables } from '../../../../frontend/utils/python/addPythonLocalVariables'
 import { generateSTCode } from '../../../../frontend/utils/python/generateSTCode'
 import { injectPythonCode } from '../../../../frontend/utils/python/injectPythonCode'
+import { pythonInterfaceVariables, pythonRefusedVariables } from '../../../../frontend/utils/python/block-interface'
 import { describeShmField, describeVariableType } from '../../../../frontend/utils/python/shm-type-map'
 import type { PLCPou, PLCProjectData, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { generateSoftMotionArtifacts } from '../../ethercat/generate-softmotion'
@@ -109,11 +110,30 @@ function preprocessPous(
   // unsupported type. Structures, enumerations and function block instances
   // arrive in later phases.
   if (hasPythonCode) {
+    // A class this side of the boundary cannot express is refused first, and on
+    // its own terms: telling a user their VAR_TEMP is an unsupported *type*
+    // would send them to change the type, which is not the problem.
+    const refusedClasses: string[] = []
+    for (const pou of projectData.pous) {
+      if (pou.body.language !== 'python') continue
+      for (const { variable, reason } of pythonRefusedVariables(pou.interface?.variables ?? [])) {
+        refusedClasses.push(`"${pou.name}.${variable.name}": ${reason}`)
+      }
+    }
+    if (refusedClasses.length > 0) {
+      const message = refusedClasses.join(' ')
+      log('error', message)
+      return {
+        projectData: processedProjectData as ProjectDataWithCpp,
+        validationFailed: true,
+        validationError: message,
+      }
+    }
+
     const unsupported: string[] = []
     for (const pou of projectData.pous) {
       if (pou.body.language !== 'python') continue
-      for (const variable of pou.interface?.variables ?? []) {
-        if (variable.class !== 'input' && variable.class !== 'output') continue
+      for (const variable of pythonInterfaceVariables(pou.interface?.variables ?? [])) {
         if (describeShmField(variable) === null) {
           unsupported.push(`"${pou.name}.${variable.name}" (${describeVariableType(variable)})`)
         }

--- a/src/frontend/utils/python/__tests__/block-interface.test.ts
+++ b/src/frontend/utils/python/__tests__/block-interface.test.ts
@@ -1,0 +1,121 @@
+import type { PLCVariable, VariableClass } from '../../../../middleware/shared/ports/types'
+import {
+  INBOUND_CLASSES,
+  OUTBOUND_CLASSES,
+  pythonInboundVariables,
+  pythonInterfaceVariables,
+  pythonOutboundVariables,
+  pythonRefusedVariables,
+} from '../block-interface'
+
+const variable = (name: string, cls?: VariableClass): PLCVariable => ({
+  name,
+  ...(cls ? { class: cls } : {}),
+  type: { definition: 'base-type', value: 'INT' },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const names = (variables: PLCVariable[]): string[] => variables.map((v) => v.name)
+
+describe('python block interface', () => {
+  const all = [
+    variable('i', 'input'),
+    variable('o', 'output'),
+    variable('io', 'inOut'),
+    variable('l', 'local'),
+    variable('g', 'external'),
+  ]
+
+  it('sends an input in only', () => {
+    expect(names(pythonInboundVariables(all))).toContain('i')
+    expect(names(pythonOutboundVariables(all))).not.toContain('i')
+  })
+
+  it('brings an output back only', () => {
+    expect(names(pythonOutboundVariables(all))).toContain('o')
+    expect(names(pythonInboundVariables(all))).not.toContain('o')
+  })
+
+  it.each(['io', 'l', 'g'])('carries %s both ways, so the PLC keeps owning the value', (name) => {
+    // A block that never assigns one sends back what it received. That is what
+    // makes a VAR the block's own state and keeps it visible to the debugger.
+    expect(names(pythonInboundVariables(all))).toContain(name)
+    expect(names(pythonOutboundVariables(all))).toContain(name)
+  })
+
+  it('orders both directions by class, then by declaration', () => {
+    // The order carries no meaning; it only has to be identical everywhere,
+    // because the struct layout and the format string are positional.
+    expect(names(pythonInboundVariables(all))).toEqual(['i', 'io', 'l', 'g'])
+    expect(names(pythonOutboundVariables(all))).toEqual(['o', 'io', 'l', 'g'])
+  })
+
+  it('keeps declaration order within one class', () => {
+    const vars = [variable('b', 'input'), variable('a', 'input')]
+    expect(names(pythonInboundVariables(vars))).toEqual(['b', 'a'])
+  })
+
+  it('carries no temp in either direction — it is refused instead', () => {
+    const vars = [variable('i', 'input'), variable('scratch', 'temp')]
+    expect(names(pythonInboundVariables(vars))).toEqual(['i'])
+    expect(names(pythonOutboundVariables(vars))).toEqual([])
+  })
+
+  it('carries no configuration global, which is not a POU variable', () => {
+    expect(names(pythonInboundVariables([variable('g', 'global')]))).toEqual([])
+  })
+
+  it('carries no variable that has no class rather than guessing one', () => {
+    expect(names(pythonInboundVariables([variable('mystery')]))).toEqual([])
+  })
+
+  it.each(['first_run', 'shm_in_ptr', 'shm_out_ptr'])('leaves the injected %s out of the structs', (name) => {
+    // These are declared `local` by the toolchain. Marshalling them would hand
+    // the block its own mapped segment addresses to overwrite.
+    const vars = [variable('i', 'input'), variable(name, 'local')]
+    expect(names(pythonInboundVariables(vars))).toEqual(['i'])
+    expect(names(pythonOutboundVariables(vars))).toEqual([])
+  })
+
+  it('does not reorder the caller’s array', () => {
+    const input = [variable('l', 'local'), variable('i', 'input')]
+    pythonInboundVariables(input)
+    expect(names(input)).toEqual(['l', 'i'])
+  })
+
+  describe('pythonInterfaceVariables', () => {
+    it('lists every variable that crosses at all, each exactly once', () => {
+      expect(names(pythonInterfaceVariables(all))).toEqual(['i', 'io', 'l', 'g', 'o'])
+    })
+
+    it('is empty when nothing crosses', () => {
+      expect(pythonInterfaceVariables([variable('scratch', 'temp')])).toEqual([])
+    })
+  })
+
+  describe('pythonRefusedVariables', () => {
+    it('refuses a temp, and says what to do instead', () => {
+      const refused = pythonRefusedVariables([variable('i', 'input'), variable('scratch', 'temp')])
+
+      expect(refused).toHaveLength(1)
+      expect(refused[0].variable.name).toBe('scratch')
+      expect(refused[0].reason).toContain('VAR_TEMP')
+      expect(refused[0].reason).toContain('Declare it under VAR instead')
+    })
+
+    it('refuses nothing a Python block can express', () => {
+      expect(pythonRefusedVariables(all)).toEqual([])
+    })
+
+    it('refuses nothing for a variable with no class', () => {
+      expect(pythonRefusedVariables([variable('mystery')])).toEqual([])
+    })
+  })
+
+  it('exposes the class order each direction applies', () => {
+    expect(INBOUND_CLASSES).toEqual(['input', 'inOut', 'local', 'external'])
+    expect(OUTBOUND_CLASSES).toEqual(['output', 'inOut', 'local', 'external'])
+  })
+})

--- a/src/frontend/utils/python/__tests__/generatePythonLspPreamble.test.ts
+++ b/src/frontend/utils/python/__tests__/generatePythonLspPreamble.test.ts
@@ -42,17 +42,11 @@ describe('generatePythonLspPreamble', () => {
       expect(result.lineCount).toBe(0)
     })
 
-    it('returns empty text when no variables are input/output class', () => {
-      // The runtime injection only wires `input` and `output` through
-      // shared memory.  Local / temp / external would never become
-      // runtime globals — preamble must skip them so the LSP doesn't
-      // pretend they exist.
-      const vars = [
-        makeScalar('localOnly', 'local', 'INT'),
-        makeScalar('tempOnly', 'temp', 'BOOL'),
-        makeScalar('externOnly', 'external', 'REAL'),
-        makeScalar('ioOnly', 'inOut', 'INT'),
-      ]
+    it('returns empty text when no variable crosses the boundary', () => {
+      // The preamble declares exactly what the runtime injection makes a module
+      // global. A VAR_TEMP is refused outright for a Python block, so it never
+      // becomes one — declaring it would have the LSP pretend it exists.
+      const vars = [makeScalar('tempOnly', 'temp', 'BOOL')]
       const result = generatePythonLspPreamble(vars)
       expect(result.text).toBe('')
       expect(result.lineCount).toBe(0)
@@ -139,22 +133,78 @@ describe('generatePythonLspPreamble', () => {
   })
 
   describe('class filtering', () => {
-    it('includes only input + output, excludes local / temp / inOut / external', () => {
+    it('declares every class the runtime makes a module global, and no other', () => {
+      // The preamble has to match the injection exactly: anything it omits shows
+      // as an undefined name in the editor for a variable that does exist, and
+      // anything it adds is a name that will not be there at runtime.
       const vars = [
         makeScalar('inA', 'input', 'INT'),
         makeScalar('outB', 'output', 'REAL'),
         makeScalar('localC', 'local', 'BOOL'),
-        makeScalar('tempD', 'temp', 'INT'),
         makeScalar('ioE', 'inOut', 'INT'),
         makeScalar('extF', 'external', 'INT'),
+        makeScalar('tempD', 'temp', 'INT'),
       ]
       const result = generatePythonLspPreamble(vars)
       expect(result.text).toContain('inA: int = 0')
       expect(result.text).toContain('outB: float = 0.0')
-      expect(result.text).not.toContain('localC')
+      expect(result.text).toContain('localC: bool = False')
+      expect(result.text).toContain('ioE: int = 0')
+      expect(result.text).toContain('extF: int = 0')
+      // VAR_TEMP is refused for a Python block, so it is never a global.
       expect(result.text).not.toContain('tempD')
-      expect(result.text).not.toContain('ioE')
-      expect(result.text).not.toContain('extF')
+    })
+
+    it('declares a variable that travels both ways exactly once', () => {
+      const vars = [makeScalar('ioE', 'inOut', 'INT')]
+      const result = generatePythonLspPreamble(vars)
+
+      expect(result.text.match(/ioE: int = 0/g)).toHaveLength(1)
+    })
+  })
+
+  describe('types the annotation cannot map', () => {
+    it('declares a STRING as an empty str, not None', () => {
+      // Pyright needs a definite assignment compatible with the annotation, so
+      // the literal has to match the declared type rather than be a placeholder.
+      const result = generatePythonLspPreamble([makeScalar('label', 'input', 'STRING')])
+
+      expect(result.text).toContain("label: str = ''")
+    })
+
+    it('skips an array whose element type has no Python equivalent', () => {
+      // The runtime does not marshal one either, so declaring it would have the
+      // editor offer a name that will not exist at runtime.
+      const arrayOfStructs: PLCVariable = {
+        name: 'bank',
+        class: 'input',
+        type: {
+          definition: 'array',
+          value: 'ARRAY [0..3] OF Motor',
+          data: {
+            baseType: { definition: 'user-data-type', value: 'Motor' },
+            dimensions: [{ dimension: '0..3' }],
+          },
+        },
+        location: '',
+        documentation: '',
+        debug: false,
+      }
+
+      expect(generatePythonLspPreamble([arrayOfStructs]).text).toBe('')
+    })
+
+    it('skips an array whose declaration carries no element type', () => {
+      const malformed: PLCVariable = {
+        name: 'bank',
+        class: 'input',
+        type: { definition: 'array', value: 'ARRAY [0..3] OF INT' },
+        location: '',
+        documentation: '',
+        debug: false,
+      }
+
+      expect(generatePythonLspPreamble([malformed]).text).toBe('')
     })
   })
 
@@ -224,7 +274,9 @@ describe('generatePythonLspPreamble', () => {
   describe('variableNameByPreambleLine', () => {
     it('is empty when no variables produce declaration lines', () => {
       expect(generatePythonLspPreamble([]).variableNameByPreambleLine.size).toBe(0)
-      expect(generatePythonLspPreamble([makeScalar('x', 'local', 'BOOL')]).variableNameByPreambleLine.size).toBe(0)
+      // `temp` is the class a Python block cannot express, so it is the one that
+      // produces no declaration. A `local` does become a module global now.
+      expect(generatePythonLspPreamble([makeScalar('x', 'temp', 'BOOL')]).variableNameByPreambleLine.size).toBe(0)
     })
 
     it('maps each declaration line to the corresponding variable name in order', () => {

--- a/src/frontend/utils/python/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/python/__tests__/generateSTCode.test.ts
@@ -223,7 +223,10 @@ describe('generateSTCode (python)', () => {
     // the field becomes 254 bytes where Python packs 253 — every later field
     // then decodes from the wrong offset. Only a real compile surfaced this.
     const preamble = result.slice(0, result.indexOf('shm_data_in_t'))
-    const packedRegion = preamble.slice(preamble.indexOf('#pragma pack(push, 1)'), preamble.indexOf('#pragma pack(pop)'))
+    const packedRegion = preamble.slice(
+      preamble.indexOf('#pragma pack(push, 1)'),
+      preamble.indexOf('#pragma pack(pop)'),
+    )
     expect(packedRegion).toContain('shm_iec_string_t')
     expect(packedRegion).toContain('shm_iec_wstring_t')
   })
@@ -318,24 +321,102 @@ describe('generateSTCode (python)', () => {
     expect(result).toContain('python_block_loader')
   })
 
-  it('skips locals — only input/output appear in SHM structs', () => {
-    const localVar: PLCVariable = {
-      name: 'localVal',
-      class: 'local',
-      type: { definition: 'base-type', value: 'INT' },
+  describe('variable classes', () => {
+    const byClass = (name: string, cls: PLCVariable['class'], type = 'INT'): PLCVariable => ({
+      name,
+      class: cls,
+      type: { definition: 'base-type', value: type },
       location: '',
       documentation: '',
       debug: false,
-    }
-
-    const result = generateSTCode({
-      pouName: 'test',
-      allVariables: [makeScalarVar('x', 'input', 'INT'), localVar, makeScalarVar('y', 'output', 'INT')],
-      processedPythonCode: '',
     })
 
-    expect(result).toContain('int16_t x;')
-    expect(result).toContain('int16_t y;')
-    expect(result).not.toContain('localVal')
+    const structs = (result: string) => {
+      const inStart = result.indexOf('typedef struct {')
+      const inEnd = result.indexOf('} shm_data_in_t;')
+      const outStart = result.indexOf('typedef struct {', inEnd)
+      const outEnd = result.indexOf('} shm_data_out_t;')
+      return { inbound: result.slice(inStart, inEnd), outbound: result.slice(outStart, outEnd) }
+    }
+
+    it('sends an input in only and an output back only', () => {
+      const result = generateSTCode({
+        pouName: 'test',
+        allVariables: [makeScalarVar('x', 'input', 'INT'), makeScalarVar('y', 'output', 'INT')],
+        processedPythonCode: '',
+      })
+      const { inbound, outbound } = structs(result)
+
+      expect(inbound).toContain('int16_t x;')
+      expect(inbound).not.toContain('int16_t y;')
+      expect(outbound).toContain('int16_t y;')
+      expect(outbound).not.toContain('int16_t x;')
+    })
+
+    it.each([
+      ['inOut', 'ioVal'],
+      ['local', 'localVal'],
+      ['external', 'gVal'],
+    ])('sends a %s both ways, so the PLC keeps owning the value', (cls, name) => {
+      // A block that never assigns one sends back what it received. That is what
+      // makes a VAR the block's own state, keeps it visible to the debugger, and
+      // lets it be retained.
+      const result = generateSTCode({
+        pouName: 'test',
+        allVariables: [makeScalarVar('x', 'input', 'INT'), byClass(name, cls as PLCVariable['class'])],
+        processedPythonCode: '',
+      })
+      const { inbound, outbound } = structs(result)
+
+      expect(inbound).toContain(`int16_t ${name};`)
+      expect(outbound).toContain(`int16_t ${name};`)
+    })
+
+    it('leaves a temp out entirely — it is refused before reaching here', () => {
+      const result = generateSTCode({
+        pouName: 'test',
+        allVariables: [makeScalarVar('x', 'input', 'INT'), byClass('scratch', 'temp')],
+        processedPythonCode: '',
+      })
+
+      expect(result).not.toContain('scratch')
+    })
+
+    it('copies an external under the global’s own lock', () => {
+      // A VAR_EXTERNAL is a `GlobalVar<V>*`, not a member. Naming it directly
+      // would compile and copy from the wrong place holding no lock at all.
+      const result = generateSTCode({
+        pouName: 'test',
+        allVariables: [byClass('gVal', 'external')],
+        processedPythonCode: '',
+      })
+
+      expect(result).toContain('GVAL->with_lock([&](auto* __g) {')
+      expect(result).toContain('auto& __r = *__g;')
+      expect(result).toContain('data_in.gVal = __r;')
+    })
+
+    it('never writes `(*` inside the external block, which the ST lexer reads as a comment', () => {
+      const result = generateSTCode({
+        pouName: 'test',
+        allVariables: [byClass('gVal', 'external')],
+        processedPythonCode: '',
+      })
+
+      expect(result).not.toContain('(*__g)')
+    })
+
+    it('locks each external on its own rather than nesting them', () => {
+      // The stub only copies values; it runs no user code, so one lock at a time
+      // is enough and there is no lock ordering to reason about.
+      const result = generateSTCode({
+        pouName: 'test',
+        allVariables: [byClass('gA', 'external'), byClass('gB', 'external')],
+        processedPythonCode: '',
+      })
+      const closeBeforeSecondOpen = result.indexOf('});') < result.indexOf('GB->with_lock')
+
+      expect(closeBeforeSecondOpen).toBe(true)
+    })
   })
 })

--- a/src/frontend/utils/python/__tests__/injectPythonCode.test.ts
+++ b/src/frontend/utils/python/__tests__/injectPythonCode.test.ts
@@ -62,26 +62,69 @@ describe('injectPythonCode', () => {
     expect(result).toHaveLength(0)
   })
 
-  it('separates variables by class for format encoding', () => {
+  it('separates variables by direction for format encoding', () => {
     const variables: PLCVariable[] = [
       makeScalarVar('a', 'input', 'INT'),
       makeScalarVar('b', 'input', 'REAL'),
       makeScalarVar('c', 'output', 'BOOL'),
-      {
-        name: 'local',
-        class: 'local',
-        type: { definition: 'base-type', value: 'INT' },
-        location: '',
-        documentation: '',
-        debug: false,
-      },
     ]
 
     const result = injectPythonCode([{ name: 'test', code: 'pass', type: 'function-block', variables }])
 
-    // Input format: =hf (INT + REAL)
+    // Inbound: =hf (INT + REAL). Outbound: =B (BOOL).
     expect(result[0]).toContain("fmt_in = ('=hf')")
-    // Output format: =B (BOOL)
     expect(result[0]).toContain("fmt_out = ('=B')")
+  })
+
+  it('puts a round-tripping class into both formats', () => {
+    // A VAR, a VAR_IN_OUT and a VAR_EXTERNAL all travel out and back, so each
+    // appears in both structs. The PLC keeps owning the value; a block that
+    // never assigns one sends back what it received.
+    const byClass = (name: string, cls: PLCVariable['class']): PLCVariable => ({
+      name,
+      class: cls,
+      type: { definition: 'base-type', value: 'INT' },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+    const variables: PLCVariable[] = [
+      makeScalarVar('a', 'input', 'INT'),
+      makeScalarVar('c', 'output', 'BOOL'),
+      byClass('io', 'inOut'),
+      byClass('keep', 'local'),
+      byClass('g', 'external'),
+    ]
+
+    const result = injectPythonCode([{ name: 'test', code: 'pass', type: 'function-block', variables }])
+
+    // Inbound: input then inOut, local, external — all INT (h).
+    expect(result[0]).toContain("fmt_in = ('=hhhh')")
+    // Outbound: output (B) then the same three.
+    expect(result[0]).toContain("fmt_out = ('=Bhhh')")
+  })
+
+  it('leaves the toolchain’s own injected locals out of both formats', () => {
+    // `first_run` and the two segment addresses are declared `local`. Sweeping
+    // them in would hand the block its own segment pointers to overwrite.
+    const internal = (name: string, type: string): PLCVariable => ({
+      name,
+      class: 'local',
+      type: { definition: 'base-type', value: type },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+    const variables: PLCVariable[] = [
+      makeScalarVar('a', 'input', 'INT'),
+      internal('first_run', 'BOOL'),
+      internal('shm_in_ptr', 'ULINT'),
+      internal('shm_out_ptr', 'ULINT'),
+    ]
+
+    const result = injectPythonCode([{ name: 'test', code: 'pass', type: 'function-block', variables }])
+
+    expect(result[0]).toContain("fmt_in = ('=h')")
+    expect(result[0]).toContain("fmt_out = ('=')")
   })
 })

--- a/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
+++ b/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
@@ -35,6 +35,71 @@ const makeArrayVar = (name: string, cls: 'input' | 'output', baseType: string, d
   debug: false,
 })
 
+const makeWStringVar = (name: string, cls: 'input' | 'output'): PLCVariable => ({
+  name,
+  class: cls,
+  type: { definition: 'base-type', value: 'wstring' },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+describe('WSTRING crosses as UTF-16, counted in code units', () => {
+  // WSTRING shared STRING's handling until DOPE-584 P2, which was wrong in both
+  // directions: the body is char16_t, so the byte count is twice the length, and
+  // the length the C side writes counts code units rather than bytes. These pin
+  // the distinction on both sides of the boundary.
+  const run = (variables: PLCVariable[]) =>
+    injectPythonRuntime({
+      fmtIn: '=b252s',
+      fmtOut: '=b252s',
+      inputVariables: variables.filter((v) => v.class === 'input'),
+      outputVariables: variables.filter((v) => v.class === 'output'),
+      originalCode: '',
+      pouName: 'test',
+    })
+
+  it('decodes an inbound WSTRING as utf-16-le over twice the length', () => {
+    const result = run([makeWStringVar('label', 'input')])
+
+    expect(result).toContain("label = label_body[:label_len * 2].decode('utf-16-le', errors='ignore')")
+  })
+
+  it('decodes an inbound STRING as utf-8 over the length itself', () => {
+    const result = run([makeStringVar('label', 'input')])
+
+    expect(result).toContain("label = label_body[:label_len].decode('utf-8', errors='ignore')")
+  })
+
+  it('encodes an outbound WSTRING to the doubled byte budget', () => {
+    const result = run([makeWStringVar('label', 'output')])
+
+    expect(result).toContain("_body = label.encode('utf-16-le')[:252]")
+    expect(result).toContain("_body = _body.ljust(252, b'\\0')")
+  })
+
+  it('truncates an outbound WSTRING on a code-unit boundary, never mid-unit', () => {
+    // Clipping to an odd byte count would split a UTF-16 unit and hand the C
+    // side half a character.
+    const result = run([makeWStringVar('label', 'output')])
+
+    expect(result).toContain('_body = _body[: len(_body) - (len(_body) % 2)]')
+  })
+
+  it('reports an outbound WSTRING length in code units, not bytes', () => {
+    const result = run([makeWStringVar('label', 'output')])
+
+    expect(result).toContain('_len = len(_body) // 2')
+  })
+
+  it('reports an outbound STRING length in bytes, which for utf-8 is what it is', () => {
+    const result = run([makeStringVar('label', 'output')])
+
+    expect(result).toContain('_len = len(_body)')
+    expect(result).not.toContain('_len = len(_body) // 2')
+  })
+})
+
 describe('injectPythonRuntime', () => {
   it('injects runtime wrapper around original code with no variables', () => {
     const result = injectPythonRuntime({

--- a/src/frontend/utils/python/addPythonLocalVariables.ts
+++ b/src/frontend/utils/python/addPythonLocalVariables.ts
@@ -1,5 +1,16 @@
 import type { PLCPou, PLCProjectData, PLCVariable } from '../../../middleware/shared/ports/types'
 
+/**
+ * Names this module injects into every Python POU.
+ *
+ * Exported so the interface builder can leave them out of the shared-memory
+ * structs: they are the toolchain's own machinery — the one-shot latch and the
+ * two mapped segment addresses — not variables the user declared. Marshalling
+ * them would hand the block its own segment pointers to overwrite, and would put
+ * three fields into a layout the user cannot see or account for.
+ */
+const PYTHON_RUNTIME_INTERNAL_VARIABLES: ReadonlySet<string> = new Set(['first_run', 'shm_in_ptr', 'shm_out_ptr'])
+
 const createRuntimeVariables = (): PLCVariable[] => {
   return [
     {
@@ -57,4 +68,4 @@ const addPythonLocalVariables = (projectData: PLCProjectData): PLCProjectData =>
   return processedData
 }
 
-export { addPythonLocalVariables }
+export { addPythonLocalVariables, PYTHON_RUNTIME_INTERNAL_VARIABLES }

--- a/src/frontend/utils/python/block-interface.ts
+++ b/src/frontend/utils/python/block-interface.ts
@@ -1,0 +1,111 @@
+import type { PLCVariable, VariableClass } from '../../../middleware/shared/ports/types'
+import { PYTHON_RUNTIME_INTERNAL_VARIABLES } from './addPythonLocalVariables'
+
+/**
+ * Which of a Python block's variables cross each way through shared memory.
+ *
+ * A Python block is a separate process, so unlike a C++ block it cannot be
+ * handed a pointer into the PLC's own storage. Every variable is marshalled: the
+ * stub packs one struct on the way in and unpacks another on the way out, and
+ * the Python driver decodes and re-encodes them by `struct` format string. Four
+ * emitters have to agree on the contents and the order of those two structs —
+ * the C stub's `shm_data_in_t` / `shm_data_out_t`, its copy loops, the format
+ * strings, and the driver's unpack/pack. A disagreement is not a caught error: a
+ * field one side omits shifts every later field's offset, so the corruption
+ * surfaces on unrelated variables. Hence one selection rule, here.
+ *
+ * The direction each class travels follows from what it means, not from what is
+ * convenient:
+ *
+ *   - `input` goes in only. The caller supplies it; the block reads it.
+ *   - `output` comes back only. The block produces it.
+ *   - `inOut` travels both ways, which is what VAR_IN_OUT is.
+ *   - `local` also travels both ways, though for a different reason: the PLC
+ *     owns the storage, so round-tripping is what makes a VAR survive as the
+ *     block's own state, stay visible to the debugger, and — once NODE-94 lands
+ *     — be retainable. A block that never assigns one sends back what it
+ *     received, unchanged.
+ *   - `external` travels both ways for the same reason as `local`; the stub
+ *     reads and writes it through the global's own lock.
+ *
+ * `temp` is absent deliberately: see `PYTHON_UNSUPPORTED_CLASSES`. `global` is
+ * absent for the reason it is absent from a POU at all — it is a
+ * configuration-level declaration, not a POU variable. So are the toolchain's
+ * own injected locals (`PYTHON_RUNTIME_INTERNAL_VARIABLES`): the first-run latch
+ * and the two mapped segment addresses are declared as `local`, and sweeping
+ * them into the structs would hand the block its own segment pointers to
+ * overwrite.
+ */
+const INBOUND_CLASSES: readonly VariableClass[] = ['input', 'inOut', 'local', 'external']
+
+/** Classes the block sends back to the PLC each cycle. */
+const OUTBOUND_CLASSES: readonly VariableClass[] = ['output', 'inOut', 'local', 'external']
+
+/**
+ * Classes a Python block cannot express, with the reason to show the user.
+ *
+ * VAR_TEMP means storage that does not survive the POU invocation. Python has
+ * no equivalent: the block's variables are module globals in a process that
+ * outlives every scan, so a value written to one would still be there on the
+ * next call. Marshalling it would not make it temporary, it would only make it a
+ * `local` wearing the wrong name — and the user would have written VAR to get
+ * that. Refusing says what is true.
+ */
+const PYTHON_UNSUPPORTED_CLASSES: Readonly<Record<string, string>> = {
+  temp: 'VAR_TEMP has no meaning in a Python block — its variables are module globals in a process that outlives the scan. Declare it under VAR instead.',
+}
+
+/**
+ * Select and order the variables travelling one direction.
+ *
+ * Ordering is by class, then by declaration order within a class. The order
+ * itself carries no meaning — it only has to be the same everywhere, because the
+ * struct layout and the format string are positional.
+ */
+const selectOrdered = (variables: readonly PLCVariable[], classes: readonly VariableClass[]): PLCVariable[] => {
+  const rankOf = new Map<VariableClass, number>(classes.map((cls, index) => [cls, index]))
+  const ranked: Array<{ variable: PLCVariable; rank: number; position: number }> = []
+
+  variables.forEach((variable, position) => {
+    if (PYTHON_RUNTIME_INTERNAL_VARIABLES.has(variable.name)) return
+    const rank = variable.class === undefined ? undefined : rankOf.get(variable.class)
+    if (rank === undefined) return
+    ranked.push({ variable, rank, position })
+  })
+
+  return ranked
+    .sort((a, b) => (a.rank !== b.rank ? a.rank - b.rank : a.position - b.position))
+    .map(({ variable }) => variable)
+}
+
+/** What the PLC packs into `shm_data_in_t` for the block to read. */
+const pythonInboundVariables = (variables: readonly PLCVariable[]): PLCVariable[] =>
+  selectOrdered(variables, INBOUND_CLASSES)
+
+/** What the block packs into `shm_data_out_t` for the PLC to read back. */
+const pythonOutboundVariables = (variables: readonly PLCVariable[]): PLCVariable[] =>
+  selectOrdered(variables, OUTBOUND_CLASSES)
+
+/** Every variable that crosses the boundary at all, in inbound order. */
+const pythonInterfaceVariables = (variables: readonly PLCVariable[]): PLCVariable[] => {
+  const inbound = pythonInboundVariables(variables)
+  const seen = new Set(inbound)
+  return [...inbound, ...pythonOutboundVariables(variables).filter((variable) => !seen.has(variable))]
+}
+
+/** The variables declared in a class a Python block cannot express. */
+const pythonRefusedVariables = (variables: readonly PLCVariable[]): Array<{ variable: PLCVariable; reason: string }> =>
+  variables.flatMap((variable) => {
+    const reason = variable.class === undefined ? undefined : PYTHON_UNSUPPORTED_CLASSES[variable.class]
+    return reason ? [{ variable, reason }] : []
+  })
+
+export {
+  INBOUND_CLASSES,
+  OUTBOUND_CLASSES,
+  PYTHON_UNSUPPORTED_CLASSES,
+  pythonInboundVariables,
+  pythonInterfaceVariables,
+  pythonOutboundVariables,
+  pythonRefusedVariables,
+}

--- a/src/frontend/utils/python/generatePythonLspPreamble.ts
+++ b/src/frontend/utils/python/generatePythonLspPreamble.ts
@@ -25,6 +25,7 @@
  */
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
 import { getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { pythonInterfaceVariables } from './block-interface'
 
 export interface PythonLspPreamble {
   /** Ready-to-prepend text, terminated by a newline (or empty). */
@@ -94,9 +95,12 @@ function defaultPythonLiteralFor(pythonType: string): string {
   if (pythonType === 'int') return '0'
   if (pythonType === 'float') return '0.0'
   if (pythonType === 'str') return "''"
-  // list[...] or any other compound — empty list is the safest no-op
-  // initial value Pyright accepts as compatible with the annotation.
-  if (pythonType.startsWith('list[')) return '[]'
+  // Unreachable in practice: `annotationFor` yields exactly these four scalar
+  // annotations or `list[...]`, and `initialValueFor` handles the list case
+  // before delegating here. Kept as a safety net rather than a throw, because a
+  // preamble is a convenience for the editor — a wrong literal costs a Pyright
+  // diagnostic, an exception would cost the user their type checking entirely.
+  /* istanbul ignore next -- defensive: annotationFor cannot produce another value */
   return 'None'
 }
 
@@ -155,7 +159,7 @@ function initialValueFor(variable: PLCVariable, annotation: string): string {
  * the lines are a synthetic Pyright nudge, not user code.
  */
 export function generatePythonLspPreamble(variables: PLCVariable[]): PythonLspPreamble {
-  const declarable = variables.filter((v) => v.class === 'input' || v.class === 'output')
+  const declarable = pythonInterfaceVariables(variables)
   if (declarable.length === 0) {
     return { text: '', lineCount: 0, variableNameByPreambleLine: new Map() }
   }

--- a/src/frontend/utils/python/generateSTCode.ts
+++ b/src/frontend/utils/python/generateSTCode.ts
@@ -1,5 +1,6 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
 import { getArrayStartIndex, getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { pythonInboundVariables, pythonOutboundVariables } from './block-interface'
 import { describeShmField, SHM_STRING_CHARS } from './shm-type-map'
 
 type STCodeGenerationParams = {
@@ -27,8 +28,7 @@ const fieldKind = (variable: PLCVariable): 'scalar' | 'string' | 'wstring' | nul
  * bridges between the wrapper (force-aware reads and writes on the IEC side)
  * and these raw fields at the boundary.
  */
-const shmFieldType = (variable: PLCVariable): string =>
-  describeShmField(variable)?.cType ?? 'uint8_t'
+const shmFieldType = (variable: PLCVariable): string => describeShmField(variable)?.cType ?? 'uint8_t'
 
 const generateStructField = (variable: PLCVariable): string => {
   const fieldType = shmFieldType(variable)
@@ -72,15 +72,49 @@ const generateCStructs = (inputVars: PLCVariable[], outputVars: PLCVariable[]): 
   return structs
 }
 
+/**
+ * How one variable is named in a copy statement, and what must wrap that
+ * statement.
+ *
+ * Every class but `external` is a plain member of the block's class, so the
+ * upper-cased name refers to it directly. A `VAR_EXTERNAL` is a
+ * `GlobalVar<V>*`: the value together with that global's own mutex. Naming it
+ * directly would compile — the pointer converts — and would copy from the wrong
+ * place while holding no lock at all.
+ *
+ * So an external's copy is wrapped in `with_lock`, which runs a callable with a
+ * `V*` while the lock is held. Each external is wrapped on its own rather than
+ * nested: this stub only copies values in and out, it does not run user code, so
+ * one lock at a time is enough — and that matches what an ST body does, with no
+ * lock ordering to reason about.
+ *
+ * The lambda's parameter is deduced, so nothing here names `V` — the compiler's
+ * layout stays the only statement of it. The dereference is bound to a reference
+ * on its own line rather than written inline as `(*p)`: this C++ sits inside an
+ * `{external}` block that the ST front end still scans, where `(*` opens a block
+ * comment and would swallow the rest of the POU.
+ */
+const accessorFor = (variable: PLCVariable): { open: string; name: string; close: string } => {
+  const upperName = variable.name.toUpperCase()
+  if (variable.class !== 'external') return { open: '', name: upperName, close: '' }
+
+  return {
+    open: `        ${upperName}->with_lock([&](auto* __g) {\n        auto& __r = *__g;\n`,
+    name: '__r',
+    close: '        });\n',
+  }
+}
+
 const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
   if (inputVars.length === 0) return ''
 
   let code = '        shm_data_in_t data_in;\n'
 
   inputVars.forEach((variable) => {
-    const upperName = variable.name.toUpperCase()
+    const { open, name: upperName, close } = accessorFor(variable)
     const fieldName = variable.name
     const kind = fieldKind(variable)
+    code += open
 
     if (isArrayVariable(variable)) {
       // Iterate IEC indices and pull each element through `.get()` so
@@ -114,6 +148,7 @@ const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
       // so a forced input is observed correctly.
       code += `        data_in.${fieldName} = ${upperName};\n`
     }
+    code += close
   })
 
   code += '        memcpy(shm_in_ptr, &data_in, sizeof(data_in));\n\n'
@@ -143,9 +178,10 @@ const generateOutputSeedCode = (outputVars: PLCVariable[]): string => {
   code += '        std::memset(&seed_out, 0, sizeof(seed_out));\n'
 
   outputVars.forEach((variable) => {
-    const upperName = variable.name.toUpperCase()
+    const { open, name: upperName, close } = accessorFor(variable)
     const fieldName = variable.name
     const kind = fieldKind(variable)
+    code += open
 
     if (isArrayVariable(variable)) {
       const totalElements = getArrayTotalElements(variable)
@@ -164,6 +200,7 @@ const generateOutputSeedCode = (outputVars: PLCVariable[]): string => {
     } else {
       code += `        seed_out.${fieldName} = ${upperName};\n`
     }
+    code += close
   })
 
   code += '        memcpy(shm_out_ptr, &seed_out, sizeof(seed_out));\n'
@@ -177,9 +214,10 @@ const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
   code += '        memcpy(&data_out, shm_out_ptr, sizeof(data_out));\n'
 
   outputVars.forEach((variable) => {
-    const upperName = variable.name.toUpperCase()
+    const { open, name: upperName, close } = accessorFor(variable)
     const fieldName = variable.name
     const kind = fieldKind(variable)
+    code += open
 
     if (isArrayVariable(variable)) {
       const totalElements = getArrayTotalElements(variable)
@@ -199,6 +237,7 @@ const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
       // Scalar — IECVar::operator=(T) → set(), force-respect.
       code += `        ${upperName} = data_out.${fieldName};\n`
     }
+    code += close
   })
 
   return code
@@ -207,8 +246,8 @@ const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
 const generateSTCode = (params: STCodeGenerationParams): string => {
   const { pouName, allVariables, processedPythonCode } = params
 
-  const inputVariables = allVariables.filter((v) => v.class === 'input')
-  const outputVariables = allVariables.filter((v) => v.class === 'output')
+  const inputVariables = pythonInboundVariables(allVariables)
+  const outputVariables = pythonOutboundVariables(allVariables)
 
   const cStructs = generateCStructs(inputVariables, outputVariables)
   const inputCopyCode = generateInputCopyCode(inputVariables)

--- a/src/frontend/utils/python/injectPythonCode.ts
+++ b/src/frontend/utils/python/injectPythonCode.ts
@@ -1,4 +1,5 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import { pythonInboundVariables, pythonOutboundVariables } from './block-interface'
 import { encodeCharactersFromVariable } from './encodeCharactersFromVariable'
 import { injectPythonRuntime } from './injectPythonRuntime'
 
@@ -12,8 +13,8 @@ type PythonPouData = {
 
 const injectPythonCode = (pythonPous: PythonPouData[]): string[] => {
   return pythonPous.map((pou) => {
-    const inputVariables = pou.variables.filter((v) => v.class === 'input')
-    const outputVariables = pou.variables.filter((v) => v.class === 'output')
+    const inputVariables = pythonInboundVariables(pou.variables)
+    const outputVariables = pythonOutboundVariables(pou.variables)
 
     const fmtIn = encodeCharactersFromVariable(inputVariables)
     const fmtOut = encodeCharactersFromVariable(outputVariables)


### PR DESCRIPTION
## What this is

Phase 5 of DOPE-584: a Python function block now sees the same Variables Table an ST block does — the same gap phase 4 closed for C++, across a harder boundary.

Before this, a Python block could see its inputs and its outputs. A `VAR`, a `VAR_IN_OUT` or a `VAR_EXTERNAL` declared in the same table did not cross, so the block's code referred to a name the editor had accepted and Python raised `NameError`.

## How each class travels

A Python block is a separate process, so nothing is passed by pointer — every variable is marshalled through two packed structs. The direction each class travels follows from what it means:

| Class | In | Out | Why |
|---|---|---|---|
| `input` | ✓ | | the caller supplies it |
| `output` | | ✓ | the block produces it |
| `inOut` | ✓ | ✓ | what VAR_IN_OUT is |
| `local` | ✓ | ✓ | the PLC owns the storage — round-tripping is what makes a VAR the block's own state, keeps it debuggable, and lets it be retained |
| `external` | ✓ | ✓ | same, read and written through the global's own lock |
| `temp` | — | — | **refused** |

`VAR_TEMP` means storage that does not survive the invocation, and Python has no such thing here: the block's variables are module globals in a process that outlives every scan. Marshalling it would not make it temporary, only a `VAR` wearing the wrong name. The refusal names the variable and says to declare it under `VAR` instead.

## One selection rule

Four emitters had been filtering by class independently — the two structs, the copy loops, the format strings, and the LSP preamble. That is worse here than it was for C++: a field one side omits does not go missing, it shifts every later field's offset, so the corruption surfaces on unrelated variables. The rule now lives in `block-interface` and all four read it.

Widening to `VAR` proved immediately why the exclusion list matters. `first_run`, `shm_in_ptr` and `shm_out_ptr` are injected as locals, and the first hardware run swept them into the structs and handed the block its own mapped segment addresses. Python died every cycle and the loader respawned it dozens of times. They are named and excluded now, as `hasBeenInitialized` is on the C++ side.

## Hardware verification

On slm-rp4, one block using all five classes. Over 195 Python cycles:

- the `VAR` accumulated to exactly `195 x 2`
- the `VAR_IN_OUT` reached 195 and round-tripped to the calling program
- the `VAR_EXTERNAL` reached `195 x 2`, with the configuration global agreeing

Sampled three times; every counter stayed exact. A `VAR_TEMP` is refused at compile time. The simulator path still stubs Python out and builds at 6% flash / 3% RAM.

## Coverage gaps closed on the way

- Phase 2 added the WSTRING pack and unpack paths without tests, dropping `injectPythonRuntime` from 100%. Both directions are pinned now, including the truncation that must land on a code-unit boundary.
- `generatePythonLspPreamble` had never covered STRING or an array of an unmappable element type, and the `list[` branch in its literal helper was dead code its own caller already owned. It is gone. This one predates the feature branch — `src/frontend/utils/` was already below its 100% threshold on `development`.

## Not in scope here

- **CONSTANT / RETAIN / NON_RETAIN** wait on NODE-94 (#1034), as for C++.
- **Structures, enumerations and function block instances** in a Python interface are still refused, by name and type. Phase 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaSZK4LqFWtZpERcqnZ8uQ