### PR TITLE
fix(DOPE-585): library C/C++/Python blocks build and compile (shared-surface mirror)

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -1,6 +1,6 @@
 {
   "strucpp": {
-    "version": "v0.6.3",
+    "version": "v0.6.4",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }

--- a/jest.config.json
+++ b/jest.config.json
@@ -20,7 +20,8 @@
     "src/frontend/utils/__tests__/notify-no-write-permission.test.ts",
     "src/frontend/services/__tests__/export-actions.test.ts",
     "src/frontend/services/__tests__/import-actions.test.ts",
-    "src/frontend/components/_organisms/modals/__tests__/confirm-plcopen-import-modal.test.tsx"
+    "src/frontend/components/_organisms/modals/__tests__/confirm-plcopen-import-modal.test.tsx",
+    "src/backend/shared/library/__tests__/build-pipeline-real-strucpp.test.ts"
   ],
   "transformIgnorePatterns": ["node_modules/(?!strucpp)"],
   "transform": {

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -25,7 +25,7 @@ type StrucppCompileError = import('strucpp').CompileError
 
 import { buildArduinoCliCompileArgs } from '@root/backend/shared/firmware/build-arduino-cli-args'
 import { runLibraryBuildPipeline } from '@root/backend/shared/library/library-build-orchestrator'
-import type { NativePouRef } from '@root/backend/shared/library/native-pou-list'
+import { parseNativePouRefs } from '@root/backend/shared/library/native-pou-list'
 import { buildKnownPous, emitCompileErrorEvents } from '@root/backend/shared/library/program-build-helpers'
 import { runProgramBuildPipeline } from '@root/backend/shared/library/program-build-pipeline'
 import { loadStrucpp } from '@root/backend/shared/library/strucpp-runtime'
@@ -3343,13 +3343,20 @@ class CompilerModule {
     // channel `preprocessPous` has already lowered every native body to
     // bridge ST and rewritten its language tag. An older renderer omits it,
     // which degrades to "this project has no native POUs".
-    const [projectPath, projectData, verifyProjectData, cleanBuild = false, nativePous = []] = args as [
+    const [projectPath, projectData, verifyProjectData, cleanBuild = false, rawNativePous] = args as [
       string,
       PLCProjectData,
       PLCProjectData,
       boolean | undefined,
-      NativePouRef[] | undefined,
+      unknown,
     ]
+
+    // Validated at the boundary rather than trusted: this crosses IPC, so it
+    // arrives as `unknown` whatever the renderer intended. A malformed entry
+    // would otherwise throw inside the pipeline's read loop, and this handler
+    // is invoked with `void` — the renderer would wait for a result that never
+    // arrives. `parseNativePouRefs` drops what it cannot read.
+    const nativePous = parseNativePouRefs(rawNativePous)
 
     // Bridge the orchestrator's structured port API onto the desktop
     // platform's existing helpers.  This is the only desktop-specific

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -25,6 +25,7 @@ type StrucppCompileError = import('strucpp').CompileError
 
 import { buildArduinoCliCompileArgs } from '@root/backend/shared/firmware/build-arduino-cli-args'
 import { runLibraryBuildPipeline } from '@root/backend/shared/library/library-build-orchestrator'
+import type { NativePouRef } from '@root/backend/shared/library/native-pou-list'
 import { buildKnownPous, emitCompileErrorEvents } from '@root/backend/shared/library/program-build-helpers'
 import { runProgramBuildPipeline } from '@root/backend/shared/library/program-build-pipeline'
 import { loadStrucpp } from '@root/backend/shared/library/strucpp-runtime'
@@ -3329,15 +3330,21 @@ class CompilerModule {
   ): Promise<void> {
     _mainProcessPort.start()
 
-    // The IPC args contract is preserved verbatim from the pre-
-    // refactor signature so the renderer-side adapter is unchanged:
+    // IPC args:
     //   [projectPath, projectData (build-pass), verifyProjectData,
-    //    cleanBuild?]
-    const [projectPath, projectData, verifyProjectData, cleanBuild = false] = args as [
+    //    cleanBuild?, nativePous?]
+    //
+    // `nativePous` is appended rather than derived here: it has to be read
+    // off the RAW project data, and by the time anything arrives over this
+    // channel `preprocessPous` has already lowered every native body to
+    // bridge ST and rewritten its language tag. An older renderer omits it,
+    // which degrades to "this project has no native POUs".
+    const [projectPath, projectData, verifyProjectData, cleanBuild = false, nativePous = []] = args as [
       string,
       PLCProjectData,
       PLCProjectData,
       boolean | undefined,
+      NativePouRef[] | undefined,
     ]
 
     // Bridge the orchestrator's structured port API onto the desktop
@@ -3358,6 +3365,7 @@ class CompilerModule {
         projectData,
         verifyProjectData,
         cleanBuild,
+        nativePous,
       },
       libraryPort,
       (event) => _mainProcessPort.postMessage({ logLevel: event.level, message: event.message }),

--- a/src/backend/shared/library/__tests__/build-pipeline-real-strucpp.test.ts
+++ b/src/backend/shared/library/__tests__/build-pipeline-real-strucpp.test.ts
@@ -1,0 +1,152 @@
+/**
+ * `libraryBuildFromTranspiledSt` against the REAL strucpp.
+ *
+ * The rest of `build-pipeline.test.ts` stubs `compileStlib` so the pipeline's
+ * own decisions can be asserted in isolation. That is the right default, but it
+ * cannot check the premise the design rests on: that strucpp accepts an
+ * ST-empty input set when native sources are present, and marks those blocks
+ * `implementation` in the manifest. Asserted against a stub, that premise is
+ * just a restatement of the stub.
+ *
+ * Requires the pinned strucpp (>= 0.6.4) in `node_modules`.
+ */
+
+import { libraryBuildFromTranspiledSt } from '../build-pipeline'
+import { __setStrucppRuntimeForTests } from '../strucpp-runtime'
+
+const manifest = { name: 'real_lib', version: '1.0.0', namespace: 'real_lib', extra: {} }
+
+const STUB_PROGRAM = 'PROGRAM main\n  VAR LocalVar : INT; END_VAR\n  LocalVar := 3;\nEND_PROGRAM\n'
+
+const CPP_FILE = `(* Scales an INT *)
+FUNCTION_BLOCK CPP_SCALE
+VAR_INPUT
+  RAW : INT;
+  GAIN : INT;
+END_VAR
+VAR_OUTPUT
+  SCALED : INT;
+END_VAR
+void setup() {}
+void loop() { SCALED = RAW * GAIN; }
+END_FUNCTION_BLOCK
+`
+
+const PY_FILE = `FUNCTION_BLOCK PY_OFFSET
+VAR_INPUT
+  IN_VAL : INT;
+  OFFSET : INT;
+END_VAR
+VAR_OUTPUT
+  OUT_VAL : INT;
+END_VAR
+def block_loop():
+    global OUT_VAL
+    OUT_VAL = IN_VAL + OFFSET
+END_FUNCTION_BLOCK
+`
+
+type Archive = {
+  formatVersion?: number
+  chunks?: Array<{ name: string }>
+  sources?: Array<{ fileName: string; source: string }>
+  manifest: { functionBlocks: Array<{ name: string; implementation?: string; sourceFile?: string }> }
+}
+
+beforeAll(() => {
+  // Explicitly the real runtime — no stub installed.
+  __setStrucppRuntimeForTests(null)
+})
+
+afterAll(() => {
+  __setStrucppRuntimeForTests(null)
+})
+
+describe('libraryBuildFromTranspiledSt against the real strucpp', () => {
+  const build = (nativeSources: Array<{ fileName: string; source: string }>, extraSt = '') => {
+    const knownPous = [
+      ...(extraSt ? [{ name: 'PlainSt', kind: 'FUNCTION_BLOCK' as const }] : []),
+      { name: 'main', kind: 'PROGRAM' as const },
+    ]
+    return libraryBuildFromTranspiledSt(`${extraSt}${STUB_PROGRAM}`, knownPous, manifest, { nativeSources })
+  }
+
+  it('builds an all-native library — strucpp tolerates an empty ST input set', () => {
+    const res = build([
+      { fileName: 'CPP_SCALE.cpp', source: CPP_FILE },
+      { fileName: 'PY_OFFSET.py', source: PY_FILE },
+    ])
+
+    expect(res.errors).toEqual([])
+    expect(res.success).toBe(true)
+
+    const archive = res.archive as Archive
+    expect(archive.formatVersion).toBe(1)
+    // Nothing was compiled, so no chunk was emitted for either block.
+    expect(archive.chunks).toEqual([])
+    expect(archive.manifest.functionBlocks.map((fb) => `${fb.name}:${fb.implementation}`).sort()).toEqual([
+      'CPP_SCALE:cpp',
+      'PY_OFFSET:python',
+    ])
+  })
+
+  it('carries the authored files byte for byte, not the generated bridge ST', () => {
+    const res = build([
+      { fileName: 'CPP_SCALE.cpp', source: CPP_FILE },
+      { fileName: 'PY_OFFSET.py', source: PY_FILE },
+    ])
+    const archive = res.archive as Archive
+
+    expect((archive.sources ?? []).map((s) => s.fileName).sort()).toEqual(['CPP_SCALE.cpp', 'PY_OFFSET.py'])
+    expect(archive.sources?.find((s) => s.fileName === 'PY_OFFSET.py')?.source).toBe(PY_FILE)
+    expect(archive.sources?.find((s) => s.fileName === 'CPP_SCALE.cpp')?.source).toBe(CPP_FILE)
+    // A `.st` entry here would mean a lowered bridge shipped instead.
+    expect((archive.sources ?? []).some((s) => s.fileName.endsWith('.st'))).toBe(false)
+  })
+
+  it('builds an all-Python library (AC3)', () => {
+    const res = build([{ fileName: 'PY_OFFSET.py', source: PY_FILE }])
+
+    expect(res.success).toBe(true)
+    const archive = res.archive as Archive
+    expect(archive.chunks).toEqual([])
+    expect(archive.manifest.functionBlocks).toHaveLength(1)
+    expect(archive.manifest.functionBlocks[0]).toMatchObject({
+      name: 'PY_OFFSET',
+      implementation: 'python',
+      sourceFile: 'PY_OFFSET.py',
+    })
+  })
+
+  it('compiles ST alongside native blocks, chunking only the ST', () => {
+    const plainSt =
+      'FUNCTION_BLOCK PlainSt\n  VAR_INPUT a : INT; END_VAR\n  VAR_OUTPUT q : INT; END_VAR\n  q := a;\nEND_FUNCTION_BLOCK\n\n'
+    const res = build([{ fileName: 'CPP_SCALE.cpp', source: CPP_FILE }], plainSt)
+
+    expect(res.success).toBe(true)
+    const archive = res.archive as Archive
+    expect(archive.chunks?.map((c) => c.name)).toEqual(['PLAINST'])
+
+    const byName = new Map(archive.manifest.functionBlocks.map((fb) => [fb.name, fb]))
+    expect(byName.get('PLAINST')?.implementation).toBeUndefined()
+    expect(byName.get('CPP_SCALE')?.implementation).toBe('cpp')
+  })
+
+  it('rejects a native block declared as a FUNCTION', () => {
+    const res = build([
+      {
+        fileName: 'BAD.cpp',
+        source: 'FUNCTION BAD : INT\nVAR_INPUT A : INT; END_VAR\nint f() { return 0; }\nEND_FUNCTION\n',
+      },
+    ])
+
+    expect(res.success).toBe(false)
+    expect(res.errors[0]?.message).toContain('FUNCTION_BLOCK')
+  })
+
+  // Duplicate names are strucpp's to reject and its own suite covers them.
+  // Not asserted from here: the native-block filter drops the same-named
+  // per-POU `.st` before `compileStlib` sees it, so the collision never
+  // reaches strucpp on this path — and a project cannot hold an ST POU and a
+  // native POU under one name anyway.
+})

--- a/src/backend/shared/library/__tests__/build-pipeline.test.ts
+++ b/src/backend/shared/library/__tests__/build-pipeline.test.ts
@@ -546,211 +546,114 @@ describe('libraryBuildFromTranspiledSt', () => {
     expect(archive.dependencies).toEqual([{ name: 'oscat', version: '3.3.0' }])
   })
 
-  it('filters C/C++ POUs from strucpp inputs and attaches them as `cppBlocks` on the archive', () => {
-    // The library has one ST FB (`Tank`) and one C/C++ FB (`SmartGate`).
-    // The user's `SmartGate` arrived here as an ST stub (preprocessPous
-    // converts C++ → ST stub + `originalCppPous` sidecar on the
-    // renderer side), so the splitter sees `SmartGate.st` in
-    // program.st.  The build pipeline must drop that source from the
-    // strucpp inputs (strucpp's library compiler has no
-    // `pouIncludes` to resolve the c_blocks.h externs the stub
-    // references) and stamp the original C++ onto the archive.
-    const archive: { manifest: { name: string }; dependencies: unknown[]; cppBlocks?: unknown[] } = {
-      manifest: { name: 'demo_lib' },
-      dependencies: [],
-    }
-    const compileStlib = jest.fn().mockReturnValue({ success: true, archive })
+  // Native (C/C++, Python) blocks: the editor hands strucpp the AUTHORED file
+  // and keeps the generated bridge ST out of the input. Shipping that stub
+  // would freeze this editor's `c_blocks.h` / `iec_python.h` ABI into the
+  // archive, so what reaches `compileStlib` is the contract worth asserting.
+  const nativeProgramSt =
+    'FUNCTION_BLOCK PlainSt\n  VAR y : INT; END_VAR\n  y := 1;\nEND_FUNCTION_BLOCK\n' +
+    '\n' +
+    'FUNCTION_BLOCK CppBlk\n  VAR x : BOOL; END_VAR\n  x := TRUE;\nEND_FUNCTION_BLOCK\n' +
+    '\n' +
+    'FUNCTION_BLOCK PyBlk\n  VAR z : INT; END_VAR\n  z := 2;\nEND_FUNCTION_BLOCK\n' +
+    '\n' +
+    'PROGRAM main\n  VAR LocalVar : INT; END_VAR\n  LocalVar := 3;\nEND_PROGRAM\n'
+
+  const nativeKnownPous = [
+    { name: 'PlainSt', kind: 'FUNCTION_BLOCK' as const },
+    { name: 'CppBlk', kind: 'FUNCTION_BLOCK' as const },
+    { name: 'PyBlk', kind: 'FUNCTION_BLOCK' as const },
+    { name: STUB.STUB_PROGRAM_NAME, kind: 'PROGRAM' as const },
+  ]
+
+  const CPP_FILE =
+    '(* doc *)\nFUNCTION_BLOCK CppBlk\nVAR_INPUT a : BOOL; END_VAR\nvoid setup() {}\nEND_FUNCTION_BLOCK\n'
+  const PY_FILE = 'FUNCTION_BLOCK PyBlk\nVAR_INPUT b : INT; END_VAR\ndef block_loop():\n    pass\nEND_FUNCTION_BLOCK\n'
+
+  const nativeAux = {
+    nativeSources: [
+      { fileName: 'CppBlk.cpp', source: CPP_FILE },
+      { fileName: 'PyBlk.py', source: PY_FILE },
+    ],
+  }
+
+  const runNativeBuild = (compileStlib: jest.Mock, libName = 'native_lib') => {
     __setStrucppRuntimeForTests(
       makeStrucppStub({ compileStlib: compileStlib as unknown as StrucppRuntime['compileStlib'] }),
     )
-
-    const programSt =
-      'FUNCTION_BLOCK Tank\n  VAR sp : INT; END_VAR\n  sp := 1;\nEND_FUNCTION_BLOCK\n' +
-      '\n' +
-      'FUNCTION_BLOCK SmartGate\n  VAR x : BOOL; END_VAR\n  x := TRUE;\nEND_FUNCTION_BLOCK\n' +
-      '\n' +
-      'PROGRAM main\n  VAR LocalVar : INT; END_VAR\n  LocalVar := 3;\nEND_PROGRAM\n'
-
-    libraryBuildFromTranspiledSt(
-      programSt,
-      [
-        { name: 'Tank', kind: 'FUNCTION_BLOCK' },
-        { name: 'SmartGate', kind: 'FUNCTION_BLOCK' },
-        { name: STUB.STUB_PROGRAM_NAME, kind: 'PROGRAM' },
-      ],
-      manifest,
-      {
-        cppBlocks: [
-          {
-            name: 'SmartGate',
-            code: 'void setup() {}\nvoid loop() {}',
-            variables: [{ name: 'x', class: 'input', type: { definition: 'base-type', value: 'BOOL' } }],
-          },
-        ],
-      },
+    return libraryBuildFromTranspiledSt(
+      nativeProgramSt,
+      nativeKnownPous,
+      { ...manifest, name: libName, namespace: libName },
+      nativeAux,
     )
+  }
 
-    // SmartGate.st must be filtered out of strucpp's input list.
-    const sources = compileStlib.mock.calls[0][0] as Array<{ fileName: string }>
-    const filenames = sources.map((s) => s.fileName)
-    expect(filenames).toContain('Tank.st')
-    expect(filenames).not.toContain('SmartGate.st')
-    expect(filenames).not.toContain(STUB.STUB_SPLIT_FILENAME)
-
-    // SmartGate rides through on `archive.cppBlocks` verbatim.
-    expect(archive.cppBlocks).toEqual([
-      {
-        name: 'SmartGate',
-        code: 'void setup() {}\nvoid loop() {}',
-        variables: [{ name: 'x', class: 'input', type: { definition: 'base-type', value: 'BOOL' } }],
-      },
-    ])
-  })
-
-  // Regression: a library whose POUs are ALL C/C++ (or all Python) leaves
-  // strucpp with an empty source list, and `compileStlib([])` hard-fails
-  // with "No source files provided" — which is what shipped.  The previous
-  // version of this test mocked `compileStlib` to return success, so the
-  // empty-array path it was named after was unreachable from the test.
-  //
-  // These assert on the pipeline's own decision instead: strucpp must not
-  // be called at all, and the synthesized archive must be shaped the way
-  // strucpp's own loader accepts on the way back in.
-  describe.each([
-    ['C/C++', 'cppBlocks' as const, 'void setup() {}\nvoid loop() {}'],
-    ['Python', 'pythonBlocks' as const, 'def loop():\n    pass'],
-  ])('a library that ships only %s blocks', (_label, field, code) => {
-    const buildNativeOnly = (compileStlib: jest.Mock) => {
-      __setStrucppRuntimeForTests(
-        makeStrucppStub({ compileStlib: compileStlib as unknown as StrucppRuntime['compileStlib'] }),
-      )
-
-      const programSt =
-        'FUNCTION_BLOCK NativeOnly\n  VAR x : BOOL; END_VAR\n  x := TRUE;\nEND_FUNCTION_BLOCK\n' +
-        '\n' +
-        'PROGRAM main\n  VAR LocalVar : INT; END_VAR\n  LocalVar := 3;\nEND_PROGRAM\n'
-
-      return libraryBuildFromTranspiledSt(
-        programSt,
-        [
-          { name: 'NativeOnly', kind: 'FUNCTION_BLOCK' },
-          { name: STUB.STUB_PROGRAM_NAME, kind: 'PROGRAM' },
-        ],
-        { ...manifest, name: 'native_only_lib', namespace: 'native_only_lib' },
-        { [field]: [{ name: 'NativeOnly', code, variables: [] }] },
-      )
-    }
-
-    it('builds without handing strucpp an empty source list', () => {
-      const compileStlib = jest.fn()
-      const res = buildNativeOnly(compileStlib)
-
-      expect(res.success).toBe(true)
-      // The whole point: strucpp has nothing to compile, so it is not asked.
-      expect(compileStlib).not.toHaveBeenCalled()
+  it('hands strucpp the authored native files, not their generated bridge ST', () => {
+    const compileStlib = jest.fn().mockReturnValue({
+      success: true,
+      archive: { manifest: { name: 'native_lib' }, dependencies: [] },
     })
+    const res = runNativeBuild(compileStlib)
+    expect(res.success).toBe(true)
 
-    it("produces an archive strucpp's own loader will accept", () => {
-      const res = buildNativeOnly(jest.fn())
-      const archive = res.archive as {
-        formatVersion?: number
-        manifest?: Record<string, unknown>
-        chunks?: unknown[]
-        dependencies?: unknown[]
-        sources?: unknown[]
-      }
+    const passed = compileStlib.mock.calls[0][0] as Array<{ fileName: string; source: string }>
+    const names = passed.map((p) => p.fileName)
 
-      // `loadStlibFromString` validates `formatVersion` and the manifest's
-      // array fields; an archive it rejects is no better than none.
-      expect(archive.formatVersion).toBe(1)
-      expect(archive.chunks).toEqual([])
-      expect(archive.sources).toEqual([])
-      expect(archive.manifest).toMatchObject({
-        name: 'native_only_lib',
-        namespace: 'native_only_lib',
-        functions: [],
-        functionBlocks: [],
-        types: [],
-        globals: [],
-        headers: [],
-        isBuiltin: false,
-        sourceFiles: [],
-      })
-    })
-
-    it('carries the block source through verbatim', () => {
-      const res = buildNativeOnly(jest.fn())
-      const archive = res.archive as Record<string, Array<{ name: string; code: string }>>
-
-      expect(archive[field]).toEqual([{ name: 'NativeOnly', code, variables: [] }])
-    })
-  })
-
-  it('keeps native blocks out of the strucpp source list when the library also has ST POUs', () => {
-    const archive = { manifest: { name: 'mixed_lib' }, dependencies: [] }
-    const compileStlib = jest.fn().mockReturnValue({ success: true, archive })
-    __setStrucppRuntimeForTests(
-      makeStrucppStub({ compileStlib: compileStlib as unknown as StrucppRuntime['compileStlib'] }),
-    )
-
-    const programSt =
-      'FUNCTION_BLOCK PlainSt\n  VAR y : INT; END_VAR\n  y := 1;\nEND_FUNCTION_BLOCK\n' +
-      '\n' +
-      'FUNCTION_BLOCK CppOnly\n  VAR x : BOOL; END_VAR\n  x := TRUE;\nEND_FUNCTION_BLOCK\n' +
-      '\n' +
-      'FUNCTION_BLOCK PyOnly\n  VAR z : INT; END_VAR\n  z := 2;\nEND_FUNCTION_BLOCK\n' +
-      '\n' +
-      'PROGRAM main\n  VAR LocalVar : INT; END_VAR\n  LocalVar := 3;\nEND_PROGRAM\n'
-
-    libraryBuildFromTranspiledSt(
-      programSt,
-      [
-        { name: 'PlainSt', kind: 'FUNCTION_BLOCK' },
-        { name: 'CppOnly', kind: 'FUNCTION_BLOCK' },
-        { name: 'PyOnly', kind: 'FUNCTION_BLOCK' },
-        { name: STUB.STUB_PROGRAM_NAME, kind: 'PROGRAM' },
-      ],
-      { ...manifest, name: 'mixed_lib', namespace: 'mixed_lib' },
-      {
-        cppBlocks: [{ name: 'CppOnly', code: 'void setup() {}', variables: [] }],
-        pythonBlocks: [{ name: 'PyOnly', code: 'pass', variables: [] }],
-      },
-    )
-
-    const sources = compileStlib.mock.calls[0][0] as Array<{ fileName: string }>
-    const names = sources.map((src) => src.fileName)
+    // The ST POU is compiled as usual.
     expect(names).toContain('PlainSt.st')
-    // Both native bodies are generated bridge stubs; shipping them would
-    // freeze this editor's C++/Python ABI into the archive.
-    expect(names).not.toContain('CppOnly.st')
-    expect(names).not.toContain('PyOnly.st')
+    // The bridge stubs are withheld…
+    expect(names).not.toContain('CppBlk.st')
+    expect(names).not.toContain('PyBlk.st')
+    // …and the authored files go instead, byte for byte.
+    expect(passed.find((p) => p.fileName === 'CppBlk.cpp')?.source).toBe(CPP_FILE)
+    expect(passed.find((p) => p.fileName === 'PyBlk.py')?.source).toBe(PY_FILE)
   })
 
-  it('attaches native sources regardless of any publish-without-sources option', () => {
-    const archive: Record<string, unknown> = { manifest: { name: 'mixed_lib' }, dependencies: [] }
-    const compileStlib = jest.fn().mockReturnValue({ success: true, archive })
+  it('builds a library whose POUs are ALL native, leaving strucpp only those files', () => {
+    const compileStlib = jest.fn().mockReturnValue({
+      success: true,
+      archive: { manifest: { name: 'native_only' }, dependencies: [] },
+    })
     __setStrucppRuntimeForTests(
       makeStrucppStub({ compileStlib: compileStlib as unknown as StrucppRuntime['compileStlib'] }),
     )
 
-    libraryBuildFromTranspiledSt(
-      'FUNCTION_BLOCK PlainSt\n  VAR y : INT; END_VAR\n  y := 1;\nEND_FUNCTION_BLOCK\n' +
+    const res = libraryBuildFromTranspiledSt(
+      'FUNCTION_BLOCK CppBlk\n  VAR x : BOOL; END_VAR\n  x := TRUE;\nEND_FUNCTION_BLOCK\n' +
         'PROGRAM main\n  VAR LocalVar : INT; END_VAR\n  LocalVar := 3;\nEND_PROGRAM\n',
       [
-        { name: 'PlainSt', kind: 'FUNCTION_BLOCK' },
+        { name: 'CppBlk', kind: 'FUNCTION_BLOCK' },
         { name: STUB.STUB_PROGRAM_NAME, kind: 'PROGRAM' },
       ],
-      { ...manifest, name: 'mixed_lib', namespace: 'mixed_lib' },
-      {
-        cppBlocks: [{ name: 'C', code: 'void setup() {}', variables: [] }],
-        pythonBlocks: [{ name: 'P', code: 'pass', variables: [] }],
-      },
+      { ...manifest, name: 'native_only', namespace: 'native_only' },
+      { nativeSources: [{ fileName: 'CppBlk.cpp', source: CPP_FILE }] },
     )
 
-    // A native block has no compiled chunk — its source IS the deliverable,
-    // so it can never be stripped the way ST sources legitimately can be.
-    expect(archive.cppBlocks).toEqual([{ name: 'C', code: 'void setup() {}', variables: [] }])
-    expect(archive.pythonBlocks).toEqual([{ name: 'P', code: 'pass', variables: [] }])
+    expect(res.success).toBe(true)
+    // strucpp is still called — it tolerates an ST-empty input set and
+    // recovers each native block's interface from its ST header. The editor
+    // no longer hand-builds an archive to work around a refusal here.
+    const passed = compileStlib.mock.calls[0][0] as Array<{ fileName: string }>
+    expect(passed.map((p) => p.fileName)).toEqual(['CppBlk.cpp'])
+  })
+
+  it('still refuses a library with neither ST nor native content', () => {
+    const compileStlib = jest.fn()
+    __setStrucppRuntimeForTests(
+      makeStrucppStub({ compileStlib: compileStlib as unknown as StrucppRuntime['compileStlib'] }),
+    )
+
+    const res = libraryBuildFromTranspiledSt(
+      'PROGRAM main\n  VAR LocalVar : INT; END_VAR\n  LocalVar := 3;\nEND_PROGRAM\n',
+      [{ name: STUB.STUB_PROGRAM_NAME, kind: 'PROGRAM' }],
+      { ...manifest, name: 'empty_lib', namespace: 'empty_lib' },
+      {},
+    )
+
+    expect(res.success).toBe(false)
+    expect(res.errors[0]?.message).toMatch(/no functions, function blocks, or data types/)
+    expect(compileStlib).not.toHaveBeenCalled()
   })
 
   it('matches POU docs case-insensitively (the transpiler upper-cases identifiers)', () => {

--- a/src/backend/shared/library/__tests__/build-pipeline.test.ts
+++ b/src/backend/shared/library/__tests__/build-pipeline.test.ts
@@ -607,34 +607,150 @@ describe('libraryBuildFromTranspiledSt', () => {
     ])
   })
 
-  it('accepts a library that ships only C/C++ blocks (no ST/IL POUs)', () => {
-    // Edge case: the library has one C++ FB and nothing else.  The
-    // ST/IL source list is empty after filtering, but `cppBlocks`
-    // is non-empty so the build still produces a valid archive.
-    const archive = { manifest: { name: 'cpp_only_lib' }, dependencies: [] }
+  // Regression: a library whose POUs are ALL C/C++ (or all Python) leaves
+  // strucpp with an empty source list, and `compileStlib([])` hard-fails
+  // with "No source files provided" — which is what shipped.  The previous
+  // version of this test mocked `compileStlib` to return success, so the
+  // empty-array path it was named after was unreachable from the test.
+  //
+  // These assert on the pipeline's own decision instead: strucpp must not
+  // be called at all, and the synthesized archive must be shaped the way
+  // strucpp's own loader accepts on the way back in.
+  describe.each([
+    ['C/C++', 'cppBlocks' as const, 'void setup() {}\nvoid loop() {}'],
+    ['Python', 'pythonBlocks' as const, 'def loop():\n    pass'],
+  ])('a library that ships only %s blocks', (_label, field, code) => {
+    const buildNativeOnly = (compileStlib: jest.Mock) => {
+      __setStrucppRuntimeForTests(
+        makeStrucppStub({ compileStlib: compileStlib as unknown as StrucppRuntime['compileStlib'] }),
+      )
+
+      const programSt =
+        'FUNCTION_BLOCK NativeOnly\n  VAR x : BOOL; END_VAR\n  x := TRUE;\nEND_FUNCTION_BLOCK\n' +
+        '\n' +
+        'PROGRAM main\n  VAR LocalVar : INT; END_VAR\n  LocalVar := 3;\nEND_PROGRAM\n'
+
+      return libraryBuildFromTranspiledSt(
+        programSt,
+        [
+          { name: 'NativeOnly', kind: 'FUNCTION_BLOCK' },
+          { name: STUB.STUB_PROGRAM_NAME, kind: 'PROGRAM' },
+        ],
+        { ...manifest, name: 'native_only_lib', namespace: 'native_only_lib' },
+        { [field]: [{ name: 'NativeOnly', code, variables: [] }] },
+      )
+    }
+
+    it('builds without handing strucpp an empty source list', () => {
+      const compileStlib = jest.fn()
+      const res = buildNativeOnly(compileStlib)
+
+      expect(res.success).toBe(true)
+      // The whole point: strucpp has nothing to compile, so it is not asked.
+      expect(compileStlib).not.toHaveBeenCalled()
+    })
+
+    it("produces an archive strucpp's own loader will accept", () => {
+      const res = buildNativeOnly(jest.fn())
+      const archive = res.archive as {
+        formatVersion?: number
+        manifest?: Record<string, unknown>
+        chunks?: unknown[]
+        dependencies?: unknown[]
+        sources?: unknown[]
+      }
+
+      // `loadStlibFromString` validates `formatVersion` and the manifest's
+      // array fields; an archive it rejects is no better than none.
+      expect(archive.formatVersion).toBe(1)
+      expect(archive.chunks).toEqual([])
+      expect(archive.sources).toEqual([])
+      expect(archive.manifest).toMatchObject({
+        name: 'native_only_lib',
+        namespace: 'native_only_lib',
+        functions: [],
+        functionBlocks: [],
+        types: [],
+        globals: [],
+        headers: [],
+        isBuiltin: false,
+        sourceFiles: [],
+      })
+    })
+
+    it('carries the block source through verbatim', () => {
+      const res = buildNativeOnly(jest.fn())
+      const archive = res.archive as Record<string, Array<{ name: string; code: string }>>
+
+      expect(archive[field]).toEqual([{ name: 'NativeOnly', code, variables: [] }])
+    })
+  })
+
+  it('keeps native blocks out of the strucpp source list when the library also has ST POUs', () => {
+    const archive = { manifest: { name: 'mixed_lib' }, dependencies: [] }
     const compileStlib = jest.fn().mockReturnValue({ success: true, archive })
     __setStrucppRuntimeForTests(
       makeStrucppStub({ compileStlib: compileStlib as unknown as StrucppRuntime['compileStlib'] }),
     )
 
     const programSt =
+      'FUNCTION_BLOCK PlainSt\n  VAR y : INT; END_VAR\n  y := 1;\nEND_FUNCTION_BLOCK\n' +
+      '\n' +
       'FUNCTION_BLOCK CppOnly\n  VAR x : BOOL; END_VAR\n  x := TRUE;\nEND_FUNCTION_BLOCK\n' +
+      '\n' +
+      'FUNCTION_BLOCK PyOnly\n  VAR z : INT; END_VAR\n  z := 2;\nEND_FUNCTION_BLOCK\n' +
       '\n' +
       'PROGRAM main\n  VAR LocalVar : INT; END_VAR\n  LocalVar := 3;\nEND_PROGRAM\n'
 
-    const res = libraryBuildFromTranspiledSt(
+    libraryBuildFromTranspiledSt(
       programSt,
       [
+        { name: 'PlainSt', kind: 'FUNCTION_BLOCK' },
         { name: 'CppOnly', kind: 'FUNCTION_BLOCK' },
+        { name: 'PyOnly', kind: 'FUNCTION_BLOCK' },
         { name: STUB.STUB_PROGRAM_NAME, kind: 'PROGRAM' },
       ],
-      { ...manifest, name: 'cpp_only_lib', namespace: 'cpp_only_lib' },
+      { ...manifest, name: 'mixed_lib', namespace: 'mixed_lib' },
       {
-        cppBlocks: [{ name: 'CppOnly', code: 'void setup() {}\nvoid loop() {}', variables: [] }],
+        cppBlocks: [{ name: 'CppOnly', code: 'void setup() {}', variables: [] }],
+        pythonBlocks: [{ name: 'PyOnly', code: 'pass', variables: [] }],
       },
     )
 
-    expect(res.success).toBe(true)
+    const sources = compileStlib.mock.calls[0][0] as Array<{ fileName: string }>
+    const names = sources.map((src) => src.fileName)
+    expect(names).toContain('PlainSt.st')
+    // Both native bodies are generated bridge stubs; shipping them would
+    // freeze this editor's C++/Python ABI into the archive.
+    expect(names).not.toContain('CppOnly.st')
+    expect(names).not.toContain('PyOnly.st')
+  })
+
+  it('attaches native sources regardless of any publish-without-sources option', () => {
+    const archive: Record<string, unknown> = { manifest: { name: 'mixed_lib' }, dependencies: [] }
+    const compileStlib = jest.fn().mockReturnValue({ success: true, archive })
+    __setStrucppRuntimeForTests(
+      makeStrucppStub({ compileStlib: compileStlib as unknown as StrucppRuntime['compileStlib'] }),
+    )
+
+    libraryBuildFromTranspiledSt(
+      'FUNCTION_BLOCK PlainSt\n  VAR y : INT; END_VAR\n  y := 1;\nEND_FUNCTION_BLOCK\n' +
+        'PROGRAM main\n  VAR LocalVar : INT; END_VAR\n  LocalVar := 3;\nEND_PROGRAM\n',
+      [
+        { name: 'PlainSt', kind: 'FUNCTION_BLOCK' },
+        { name: STUB.STUB_PROGRAM_NAME, kind: 'PROGRAM' },
+      ],
+      { ...manifest, name: 'mixed_lib', namespace: 'mixed_lib' },
+      {
+        cppBlocks: [{ name: 'C', code: 'void setup() {}', variables: [] }],
+        pythonBlocks: [{ name: 'P', code: 'pass', variables: [] }],
+      },
+    )
+
+    // A native block has no compiled chunk — its source IS the deliverable,
+    // so it can never be stripped the way ST sources legitimately can be.
+    expect(archive.cppBlocks).toEqual([{ name: 'C', code: 'void setup() {}', variables: [] }])
+    expect(archive.pythonBlocks).toEqual([{ name: 'P', code: 'pass', variables: [] }])
   })
 
   it('matches POU docs case-insensitively (the transpiler upper-cases identifiers)', () => {

--- a/src/backend/shared/library/__tests__/inject-library-blocks.test.ts
+++ b/src/backend/shared/library/__tests__/inject-library-blocks.test.ts
@@ -4,13 +4,37 @@ import { findLibrariesMissingNativeSources, injectLibraryBlocks, libraryBlockPou
 
 // -- helpers ------------------------------------------------------------------
 
-function project(overrides: {
-  libraries?: Array<{ name: string; version: string }>
-  pous?: Array<{ name: string }>
-}): PLCProjectData {
+/** A whole authored native POU file: ST header + native body. */
+const cppFile = (name: string, body = 'void setup() {}\nvoid loop() { SCALED = RAW * GAIN; }') => `(* Scales *)
+FUNCTION_BLOCK ${name}
+VAR_INPUT
+  RAW : INT;
+  GAIN : INT;
+END_VAR
+VAR_OUTPUT
+  SCALED : INT;
+END_VAR
+${body}
+END_FUNCTION_BLOCK
+`
+
+const pyFile = (name: string) => `FUNCTION_BLOCK ${name}
+VAR_INPUT
+  IN_VAL : INT;
+END_VAR
+VAR_OUTPUT
+  OUT_VAL : INT;
+END_VAR
+def block_loop():
+    global OUT_VAL
+    OUT_VAL = IN_VAL + 1
+END_FUNCTION_BLOCK
+`
+
+function project(overrides: { libraries?: Array<{ name: string; version: string }>; pous?: string[] }): PLCProjectData {
   return {
-    pous: (overrides.pous ?? []).map((p) => ({
-      name: p.name,
+    pous: (overrides.pous ?? []).map((name) => ({
+      name,
       pouType: 'program',
       interface: { variables: [] },
       body: { language: 'st', value: 'x := 1;' },
@@ -19,24 +43,37 @@ function project(overrides: {
   } as unknown as PLCProjectData
 }
 
-function archive(name: string, blocks: { cppBlocks?: unknown[]; pythonBlocks?: unknown[] } = {}): StlibArchiveDTO {
-  return {
-    manifest: { name, version: '1.0.0' },
-    ...blocks,
-  } as unknown as StlibArchiveDTO
+/** An archive shaped the way strucpp now emits one. */
+function archive(
+  name: string,
+  blocks: Array<{ name: string; language: 'cpp' | 'python'; file?: string; source?: string | null }> = [],
+  opts: { stBlocks?: string[] } = {},
+): StlibArchiveDTO {
+  const sources: Array<{ fileName: string; source: string }> = []
+  const functionBlocks: unknown[] = (opts.stBlocks ?? []).map((n) => ({
+    name: n,
+    inputs: [],
+    outputs: [],
+    inouts: [],
+  }))
+
+  for (const block of blocks) {
+    const fileName = block.file ?? `${block.name}.${block.language === 'cpp' ? 'cpp' : 'py'}`
+    const source =
+      block.source === undefined ? (block.language === 'cpp' ? cppFile(block.name) : pyFile(block.name)) : block.source
+    functionBlocks.push({
+      name: block.name,
+      inputs: [],
+      outputs: [],
+      inouts: [],
+      implementation: block.language,
+      sourceFile: fileName,
+    })
+    if (source !== null) sources.push({ fileName, source })
+  }
+
+  return { manifest: { name, version: '1.0.0', functionBlocks }, sources } as unknown as StlibArchiveDTO
 }
-
-const cppBlock = (name: string, code = 'void setup(){}\nvoid loop(){}') => ({
-  name,
-  code,
-  variables: [{ name: 'EN', class: 'input', type: { definition: 'base-type', value: 'BOOL' } }],
-})
-
-const pyBlock = (name: string, code = 'out = inp + 1') => ({
-  name,
-  code,
-  variables: [{ name: 'inp', class: 'input', type: { definition: 'base-type', value: 'INT' } }],
-})
 
 // -- tests --------------------------------------------------------------------
 
@@ -48,50 +85,64 @@ describe('libraryBlockPouName', () => {
 
 describe('injectLibraryBlocks', () => {
   it('returns the same object when the project enables no libraries', () => {
-    const data = project({ pous: [{ name: 'Main' }] })
-    expect(injectLibraryBlocks(data, [archive('lib', { cppBlocks: [cppBlock('X')] })])).toBe(data)
+    const data = project({ pous: ['main'] })
+    expect(injectLibraryBlocks(data, [archive('lib', [{ name: 'X', language: 'cpp' }])])).toBe(data)
   })
 
-  it('returns the same object when the project has an empty library list', () => {
-    const data = project({ pous: [{ name: 'Main' }], libraries: [] })
-    expect(injectLibraryBlocks(data, [archive('lib', { cppBlocks: [cppBlock('X')] })])).toBe(data)
+  it('returns the same object when the library list is empty', () => {
+    const data = project({ pous: ['main'], libraries: [] })
+    expect(injectLibraryBlocks(data, [archive('lib', [{ name: 'X', language: 'cpp' }])])).toBe(data)
   })
 
-  it('returns the same object when no enabled library ships native blocks', () => {
-    const data = project({ pous: [{ name: 'Main' }], libraries: [{ name: 'lib', version: '1.0.0' }] })
-    expect(injectLibraryBlocks(data, [archive('lib')])).toBe(data)
+  it('returns the same object for a library of only ST blocks', () => {
+    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
+    expect(injectLibraryBlocks(data, [archive('lib', [], { stBlocks: ['ST_ADD'] })])).toBe(data)
   })
 
-  it('grafts C++ blocks as cpp POUs under the prefixed name', () => {
-    const data = project({ pous: [{ name: 'Main' }], libraries: [{ name: 'network_tools', version: '1.0.0' }] })
-    const result = injectLibraryBlocks(data, [
-      archive('network_tools', { cppBlocks: [cppBlock('TCP_CLIENT'), cppBlock('UDP_SEND')] }),
-    ])
+  it('grafts a C++ block, parsing its interface and body from the authored file', () => {
+    const data = project({ pous: ['main'], libraries: [{ name: 'network_tools', version: '1.0.0' }] })
+    const result = injectLibraryBlocks(data, [archive('network_tools', [{ name: 'TCP_CLIENT', language: 'cpp' }])])
 
     expect(result).not.toBe(data)
-    expect(result.pous.map((p) => p.name)).toEqual(['Main', 'network_tools__TCP_CLIENT', 'network_tools__UDP_SEND'])
+    expect(result.pous.map((p) => p.name)).toEqual(['main', 'network_tools__TCP_CLIENT'])
 
     const grafted = result.pous[1]
     expect(grafted.pouType).toBe('function-block')
     expect(grafted.body.language).toBe('cpp')
-    expect(grafted.body.value).toBe('void setup(){}\nvoid loop(){}')
-    expect(grafted.interface?.variables).toEqual(cppBlock('TCP_CLIENT').variables)
+    // Interface recovered from the ST header, not from serialized metadata.
+    expect(grafted.interface?.variables.map((v) => `${v.name}:${v.class}`)).toEqual([
+      'RAW:input',
+      'GAIN:input',
+      'SCALED:output',
+    ])
+    // Body is the native code only — the ST header is stripped, exactly as it
+    // is for a POU read off disk.
+    expect(grafted.body.value).toContain('void loop()')
+    expect(grafted.body.value).not.toContain('VAR_INPUT')
+    expect(grafted.documentation).toBe('Scales')
   })
 
-  it('grafts Python blocks as python POUs', () => {
+  it('grafts a Python block as a python POU', () => {
     const data = project({ libraries: [{ name: 'pylib', version: '1.0.0' }] })
-    const result = injectLibraryBlocks(data, [archive('pylib', { pythonBlocks: [pyBlock('SCALE')] })])
+    const result = injectLibraryBlocks(data, [archive('pylib', [{ name: 'SCALE', language: 'python' }])])
 
     expect(result.pous).toHaveLength(1)
     expect(result.pous[0].name).toBe('pylib__SCALE')
     expect(result.pous[0].body.language).toBe('python')
-    expect(result.pous[0].body.value).toBe('out = inp + 1')
+    expect(result.pous[0].body.value).toContain('def block_loop()')
   })
 
-  it('grafts C++ and Python blocks from the same archive', () => {
+  it('grafts C++ and Python blocks from one archive, leaving ST blocks alone', () => {
     const data = project({ libraries: [{ name: 'mixed', version: '1.0.0' }] })
     const result = injectLibraryBlocks(data, [
-      archive('mixed', { cppBlocks: [cppBlock('C')], pythonBlocks: [pyBlock('P')] }),
+      archive(
+        'mixed',
+        [
+          { name: 'C', language: 'cpp' },
+          { name: 'P', language: 'python' },
+        ],
+        { stBlocks: ['S'] },
+      ),
     ])
 
     expect(result.pous.map((p) => `${p.name}:${p.body.language}`)).toEqual(['mixed__C:cpp', 'mixed__P:python'])
@@ -100,8 +151,8 @@ describe('injectLibraryBlocks', () => {
   it('ignores archives the project has not enabled', () => {
     const data = project({ libraries: [{ name: 'enabled', version: '1.0.0' }] })
     const result = injectLibraryBlocks(data, [
-      archive('enabled', { cppBlocks: [cppBlock('Yes')] }),
-      archive('disabled', { cppBlocks: [cppBlock('No')] }),
+      archive('enabled', [{ name: 'Yes', language: 'cpp' }]),
+      archive('disabled', [{ name: 'No', language: 'cpp' }]),
     ])
 
     expect(result.pous.map((p) => p.name)).toEqual(['enabled__Yes'])
@@ -109,88 +160,117 @@ describe('injectLibraryBlocks', () => {
 
   it('ignores an archive with no manifest name', () => {
     const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
-    const broken = { cppBlocks: [cppBlock('X')] } as unknown as StlibArchiveDTO
+    const broken = { sources: [] } as unknown as StlibArchiveDTO
     expect(injectLibraryBlocks(data, [broken])).toBe(data)
   })
 
-  it('carries documentation through, defaulting to empty', () => {
+  it('resolves the source by sourceFile, not by guessing from the block name', () => {
     const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
     const result = injectLibraryBlocks(data, [
-      archive('lib', {
-        cppBlocks: [{ ...cppBlock('Documented'), documentation: 'Does a thing.' }, cppBlock('Bare')],
-      }),
+      archive('lib', [{ name: 'Block', language: 'cpp', file: 'differently_named.cpp' }]),
     ])
+    expect(result.pous.map((p) => p.name)).toEqual(['lib__Block'])
+  })
 
-    expect(result.pous[0].documentation).toBe('Does a thing.')
-    expect(result.pous[1].documentation).toBe('')
+  it('skips a native block whose manifest entry names no source file', () => {
+    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
+    const noSourceFile = {
+      manifest: {
+        name: 'lib',
+        version: '1.0.0',
+        functionBlocks: [{ name: 'X', inputs: [], outputs: [], inouts: [], implementation: 'cpp' }],
+      },
+    } as unknown as StlibArchiveDTO
+    expect(injectLibraryBlocks(data, [noSourceFile]).pous).toEqual([])
+  })
+
+  it('tolerates an archive with no manifest.functionBlocks array', () => {
+    const data = project({ pous: ['main'], libraries: [{ name: 'lib', version: '1.0.0' }] })
+    const bare = { manifest: { name: 'lib', version: '1.0.0' } } as unknown as StlibArchiveDTO
+    expect(injectLibraryBlocks(data, [bare])).toBe(data)
+  })
+
+  it('skips a block whose source is missing from the archive', () => {
+    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
+    const result = injectLibraryBlocks(data, [archive('lib', [{ name: 'Gone', language: 'cpp', source: null }])])
+    expect(result.pous).toEqual([])
+  })
+
+  it('skips a block whose header the parser rejects, without aborting the graft', () => {
+    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
+    const result = injectLibraryBlocks(data, [
+      archive('lib', [
+        { name: 'Bad', language: 'cpp', source: 'this is not a POU at all' },
+        { name: 'Good', language: 'cpp' },
+      ]),
+    ])
+    expect(result.pous.map((p) => p.name)).toEqual(['lib__Good'])
+  })
+
+  it('returns the project untouched when every native block fails to parse', () => {
+    const data = project({ pous: ['main'], libraries: [{ name: 'lib', version: '1.0.0' }] })
+    const result = injectLibraryBlocks(data, [archive('lib', [{ name: 'Bad', language: 'cpp', source: 'not a POU' }])])
+    expect(result).toBe(data)
   })
 
   it('does not mutate the input project', () => {
-    const data = project({ pous: [{ name: 'Main' }], libraries: [{ name: 'lib', version: '1.0.0' }] })
-    const before = data.pous.length
-    injectLibraryBlocks(data, [archive('lib', { cppBlocks: [cppBlock('X')] })])
-    expect(data.pous).toHaveLength(before)
+    const data = project({ pous: ['main'], libraries: [{ name: 'lib', version: '1.0.0' }] })
+    injectLibraryBlocks(data, [archive('lib', [{ name: 'X', language: 'cpp' }])])
+    expect(data.pous).toHaveLength(1)
   })
 })
 
 describe('findLibrariesMissingNativeSources', () => {
   it('returns nothing when the project enables no libraries', () => {
     expect(
-      findLibrariesMissingNativeSources(project({}), [archive('lib', { cppBlocks: [cppBlock('X', '')] })]),
+      findLibrariesMissingNativeSources(project({}), [archive('lib', [{ name: 'X', language: 'cpp', source: null }])]),
     ).toEqual([])
-  })
-
-  it('returns nothing when the library list is empty', () => {
-    const data = project({ libraries: [] })
-    expect(findLibrariesMissingNativeSources(data, [archive('lib', { cppBlocks: [cppBlock('X', '')] })])).toEqual([])
-  })
-
-  it('returns nothing for libraries with no native blocks', () => {
-    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
-    expect(findLibrariesMissingNativeSources(data, [archive('lib')])).toEqual([])
   })
 
   it('returns nothing when every native block carries source', () => {
     const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
-    const archives = [archive('lib', { cppBlocks: [cppBlock('X')], pythonBlocks: [pyBlock('Y')] })]
+    const archives = [
+      archive('lib', [
+        { name: 'X', language: 'cpp' },
+        { name: 'Y', language: 'python' },
+      ]),
+    ]
     expect(findLibrariesMissingNativeSources(data, archives)).toEqual([])
   })
 
+  it('returns nothing for a library of only ST blocks', () => {
+    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
+    expect(findLibrariesMissingNativeSources(data, [archive('lib', [], { stBlocks: ['S'] })])).toEqual([])
+  })
+
   it.each([
-    ['an empty string', ''],
-    ['whitespace only', '   \n  '],
-  ])('flags a library whose C++ block source is %s', (_label, code) => {
+    ['absent from sources', null],
+    ['present but empty', ''],
+    ['whitespace only', '   \n '],
+  ])('flags a library whose native source is %s', (_label, source) => {
     const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
-    expect(findLibrariesMissingNativeSources(data, [archive('lib', { cppBlocks: [cppBlock('X', code)] })])).toEqual([
-      'lib',
-    ])
+    expect(findLibrariesMissingNativeSources(data, [archive('lib', [{ name: 'X', language: 'cpp', source }])])).toEqual(
+      ['lib'],
+    )
   })
 
-  it('flags a library whose Python block has no source', () => {
-    const data = project({ libraries: [{ name: 'pylib', version: '1.0.0' }] })
-    expect(findLibrariesMissingNativeSources(data, [archive('pylib', { pythonBlocks: [pyBlock('Y', '')] })])).toEqual([
-      'pylib',
-    ])
-  })
-
-  it('flags a library whose block source is not a string at all', () => {
+  it('reports each library once even with several sourceless blocks', () => {
     const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
-    const bad = archive('lib', { cppBlocks: [{ name: 'X', variables: [] }] })
-    expect(findLibrariesMissingNativeSources(data, [bad])).toEqual(['lib'])
+    const archives = [
+      archive('lib', [
+        { name: 'A', language: 'cpp', source: null },
+        { name: 'B', language: 'python', source: null },
+      ]),
+    ]
+    expect(findLibrariesMissingNativeSources(data, archives)).toEqual(['lib'])
   })
 
   it('ignores sourceless blocks in libraries the project has not enabled', () => {
     const data = project({ libraries: [{ name: 'enabled', version: '1.0.0' }] })
     const archives = [
-      archive('enabled', { cppBlocks: [cppBlock('Good')] }),
-      archive('disabled', { cppBlocks: [cppBlock('Bad', '')] }),
+      archive('enabled', [{ name: 'Good', language: 'cpp' }]),
+      archive('disabled', [{ name: 'Bad', language: 'cpp', source: null }]),
     ]
     expect(findLibrariesMissingNativeSources(data, archives)).toEqual([])
-  })
-
-  it('ignores an archive with no manifest name', () => {
-    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
-    const broken = { cppBlocks: [cppBlock('X', '')] } as unknown as StlibArchiveDTO
-    expect(findLibrariesMissingNativeSources(data, [broken])).toEqual([])
   })
 })

--- a/src/backend/shared/library/__tests__/inject-library-blocks.test.ts
+++ b/src/backend/shared/library/__tests__/inject-library-blocks.test.ts
@@ -1,0 +1,196 @@
+import type { StlibArchiveDTO } from '../../../../middleware/shared/ports/library-port'
+import type { PLCProjectData } from '../../../../middleware/shared/ports/types'
+import { findLibrariesMissingNativeSources, injectLibraryBlocks, libraryBlockPouName } from '../inject-library-blocks'
+
+// -- helpers ------------------------------------------------------------------
+
+function project(overrides: {
+  libraries?: Array<{ name: string; version: string }>
+  pous?: Array<{ name: string }>
+}): PLCProjectData {
+  return {
+    pous: (overrides.pous ?? []).map((p) => ({
+      name: p.name,
+      pouType: 'program',
+      interface: { variables: [] },
+      body: { language: 'st', value: 'x := 1;' },
+    })),
+    ...(overrides.libraries ? { libraries: overrides.libraries } : {}),
+  } as unknown as PLCProjectData
+}
+
+function archive(name: string, blocks: { cppBlocks?: unknown[]; pythonBlocks?: unknown[] } = {}): StlibArchiveDTO {
+  return {
+    manifest: { name, version: '1.0.0' },
+    ...blocks,
+  } as unknown as StlibArchiveDTO
+}
+
+const cppBlock = (name: string, code = 'void setup(){}\nvoid loop(){}') => ({
+  name,
+  code,
+  variables: [{ name: 'EN', class: 'input', type: { definition: 'base-type', value: 'BOOL' } }],
+})
+
+const pyBlock = (name: string, code = 'out = inp + 1') => ({
+  name,
+  code,
+  variables: [{ name: 'inp', class: 'input', type: { definition: 'base-type', value: 'INT' } }],
+})
+
+// -- tests --------------------------------------------------------------------
+
+describe('libraryBlockPouName', () => {
+  it('prefixes the block with its library, double-underscore separated', () => {
+    expect(libraryBlockPouName('network_tools', 'TCP_CLIENT')).toBe('network_tools__TCP_CLIENT')
+  })
+})
+
+describe('injectLibraryBlocks', () => {
+  it('returns the same object when the project enables no libraries', () => {
+    const data = project({ pous: [{ name: 'Main' }] })
+    expect(injectLibraryBlocks(data, [archive('lib', { cppBlocks: [cppBlock('X')] })])).toBe(data)
+  })
+
+  it('returns the same object when the project has an empty library list', () => {
+    const data = project({ pous: [{ name: 'Main' }], libraries: [] })
+    expect(injectLibraryBlocks(data, [archive('lib', { cppBlocks: [cppBlock('X')] })])).toBe(data)
+  })
+
+  it('returns the same object when no enabled library ships native blocks', () => {
+    const data = project({ pous: [{ name: 'Main' }], libraries: [{ name: 'lib', version: '1.0.0' }] })
+    expect(injectLibraryBlocks(data, [archive('lib')])).toBe(data)
+  })
+
+  it('grafts C++ blocks as cpp POUs under the prefixed name', () => {
+    const data = project({ pous: [{ name: 'Main' }], libraries: [{ name: 'network_tools', version: '1.0.0' }] })
+    const result = injectLibraryBlocks(data, [
+      archive('network_tools', { cppBlocks: [cppBlock('TCP_CLIENT'), cppBlock('UDP_SEND')] }),
+    ])
+
+    expect(result).not.toBe(data)
+    expect(result.pous.map((p) => p.name)).toEqual(['Main', 'network_tools__TCP_CLIENT', 'network_tools__UDP_SEND'])
+
+    const grafted = result.pous[1]
+    expect(grafted.pouType).toBe('function-block')
+    expect(grafted.body.language).toBe('cpp')
+    expect(grafted.body.value).toBe('void setup(){}\nvoid loop(){}')
+    expect(grafted.interface?.variables).toEqual(cppBlock('TCP_CLIENT').variables)
+  })
+
+  it('grafts Python blocks as python POUs', () => {
+    const data = project({ libraries: [{ name: 'pylib', version: '1.0.0' }] })
+    const result = injectLibraryBlocks(data, [archive('pylib', { pythonBlocks: [pyBlock('SCALE')] })])
+
+    expect(result.pous).toHaveLength(1)
+    expect(result.pous[0].name).toBe('pylib__SCALE')
+    expect(result.pous[0].body.language).toBe('python')
+    expect(result.pous[0].body.value).toBe('out = inp + 1')
+  })
+
+  it('grafts C++ and Python blocks from the same archive', () => {
+    const data = project({ libraries: [{ name: 'mixed', version: '1.0.0' }] })
+    const result = injectLibraryBlocks(data, [
+      archive('mixed', { cppBlocks: [cppBlock('C')], pythonBlocks: [pyBlock('P')] }),
+    ])
+
+    expect(result.pous.map((p) => `${p.name}:${p.body.language}`)).toEqual(['mixed__C:cpp', 'mixed__P:python'])
+  })
+
+  it('ignores archives the project has not enabled', () => {
+    const data = project({ libraries: [{ name: 'enabled', version: '1.0.0' }] })
+    const result = injectLibraryBlocks(data, [
+      archive('enabled', { cppBlocks: [cppBlock('Yes')] }),
+      archive('disabled', { cppBlocks: [cppBlock('No')] }),
+    ])
+
+    expect(result.pous.map((p) => p.name)).toEqual(['enabled__Yes'])
+  })
+
+  it('ignores an archive with no manifest name', () => {
+    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
+    const broken = { cppBlocks: [cppBlock('X')] } as unknown as StlibArchiveDTO
+    expect(injectLibraryBlocks(data, [broken])).toBe(data)
+  })
+
+  it('carries documentation through, defaulting to empty', () => {
+    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
+    const result = injectLibraryBlocks(data, [
+      archive('lib', {
+        cppBlocks: [{ ...cppBlock('Documented'), documentation: 'Does a thing.' }, cppBlock('Bare')],
+      }),
+    ])
+
+    expect(result.pous[0].documentation).toBe('Does a thing.')
+    expect(result.pous[1].documentation).toBe('')
+  })
+
+  it('does not mutate the input project', () => {
+    const data = project({ pous: [{ name: 'Main' }], libraries: [{ name: 'lib', version: '1.0.0' }] })
+    const before = data.pous.length
+    injectLibraryBlocks(data, [archive('lib', { cppBlocks: [cppBlock('X')] })])
+    expect(data.pous).toHaveLength(before)
+  })
+})
+
+describe('findLibrariesMissingNativeSources', () => {
+  it('returns nothing when the project enables no libraries', () => {
+    expect(
+      findLibrariesMissingNativeSources(project({}), [archive('lib', { cppBlocks: [cppBlock('X', '')] })]),
+    ).toEqual([])
+  })
+
+  it('returns nothing when the library list is empty', () => {
+    const data = project({ libraries: [] })
+    expect(findLibrariesMissingNativeSources(data, [archive('lib', { cppBlocks: [cppBlock('X', '')] })])).toEqual([])
+  })
+
+  it('returns nothing for libraries with no native blocks', () => {
+    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
+    expect(findLibrariesMissingNativeSources(data, [archive('lib')])).toEqual([])
+  })
+
+  it('returns nothing when every native block carries source', () => {
+    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
+    const archives = [archive('lib', { cppBlocks: [cppBlock('X')], pythonBlocks: [pyBlock('Y')] })]
+    expect(findLibrariesMissingNativeSources(data, archives)).toEqual([])
+  })
+
+  it.each([
+    ['an empty string', ''],
+    ['whitespace only', '   \n  '],
+  ])('flags a library whose C++ block source is %s', (_label, code) => {
+    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
+    expect(findLibrariesMissingNativeSources(data, [archive('lib', { cppBlocks: [cppBlock('X', code)] })])).toEqual([
+      'lib',
+    ])
+  })
+
+  it('flags a library whose Python block has no source', () => {
+    const data = project({ libraries: [{ name: 'pylib', version: '1.0.0' }] })
+    expect(findLibrariesMissingNativeSources(data, [archive('pylib', { pythonBlocks: [pyBlock('Y', '')] })])).toEqual([
+      'pylib',
+    ])
+  })
+
+  it('flags a library whose block source is not a string at all', () => {
+    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
+    const bad = archive('lib', { cppBlocks: [{ name: 'X', variables: [] }] })
+    expect(findLibrariesMissingNativeSources(data, [bad])).toEqual(['lib'])
+  })
+
+  it('ignores sourceless blocks in libraries the project has not enabled', () => {
+    const data = project({ libraries: [{ name: 'enabled', version: '1.0.0' }] })
+    const archives = [
+      archive('enabled', { cppBlocks: [cppBlock('Good')] }),
+      archive('disabled', { cppBlocks: [cppBlock('Bad', '')] }),
+    ]
+    expect(findLibrariesMissingNativeSources(data, archives)).toEqual([])
+  })
+
+  it('ignores an archive with no manifest name', () => {
+    const data = project({ libraries: [{ name: 'lib', version: '1.0.0' }] })
+    const broken = { cppBlocks: [cppBlock('X', '')] } as unknown as StlibArchiveDTO
+    expect(findLibrariesMissingNativeSources(data, [broken])).toEqual([])
+  })
+})

--- a/src/backend/shared/library/__tests__/library-build-orchestrator.test.ts
+++ b/src/backend/shared/library/__tests__/library-build-orchestrator.test.ts
@@ -427,7 +427,7 @@ describe('runLibraryBuildPipeline', () => {
     expect(events.some((e) => /\[main\.st:15\].*Undefined type 'TON'/.test(e.message))).toBe(true)
   })
 
-  it('threads pouDocs and cppBlocks through to libraryBuildFromTranspiledSt', async () => {
+  it('threads pouDocs through to libraryBuildFromTranspiledSt', async () => {
     const harness = makePort()
     const { emit } = captureEvents()
 
@@ -435,23 +435,74 @@ describe('runLibraryBuildPipeline', () => {
       ...projectDataEmpty(),
       pous: [{ type: 'function-block', data: { name: 'MyFb', documentation: 'A docstring' } }],
       dataTypes: [{ name: 'MyType', documentation: 'A type description' }],
-      originalCppPous: [{ name: 'MyCppFb', code: 'void setup() {}', variables: [] }],
     } as unknown as PLCProjectData
 
     await runLibraryBuildPipeline(
-      {
-        projectPath: '/project',
-        projectData,
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
-      },
+      { projectPath: '/project', projectData, verifyProjectData: projectDataEmpty(), cleanBuild: false },
       harness.port,
       emit,
     )
 
     const [, , , aux] = mockLibraryBuild.mock.calls[0]
     expect(aux.pouDocs).toEqual({ MyFb: 'A docstring', MyType: 'A type description' })
-    expect(aux.cppBlocks).toEqual([{ name: 'MyCppFb', code: 'void setup() {}', variables: [] }])
+  })
+
+  // The archive must carry what the AUTHOR wrote, so the native sources are
+  // read off disk rather than taken from the project data — by this point
+  // `preprocessPous` has already replaced those bodies with generated bridge
+  // ST, and shipping that would freeze this editor's bridge ABI.
+  it('reads authored C/C++ and Python POU files off disk and passes them verbatim', async () => {
+    const harness = makePort()
+    const { emit } = captureEvents()
+
+    const CPP = '(* doc *)\nFUNCTION_BLOCK MyCppFb\nVAR_INPUT a : BOOL; END_VAR\nvoid setup() {}\nEND_FUNCTION_BLOCK\n'
+    const PY = 'FUNCTION_BLOCK MyPyFb\nVAR_INPUT b : INT; END_VAR\ndef block_loop():\n    pass\nEND_FUNCTION_BLOCK\n'
+    harness.files.set('pous/function-blocks/MyCppFb.cpp', CPP)
+    harness.files.set('pous/function-blocks/MyPyFb.py', PY)
+
+    const projectData = {
+      ...projectDataEmpty(),
+      pous: [
+        // Bodies here are already lowered — proof the values below came from
+        // disk and not from the project data.
+        { type: 'function-block', data: { name: 'MyCppFb', body: { language: 'cpp' } } },
+        { type: 'function-block', data: { name: 'MyPyFb', body: { language: 'python' } } },
+        { type: 'function-block', data: { name: 'PlainSt', body: { language: 'st' } } },
+      ],
+    } as unknown as PLCProjectData
+
+    await runLibraryBuildPipeline(
+      { projectPath: '/project', projectData, verifyProjectData: projectDataEmpty(), cleanBuild: false },
+      harness.port,
+      emit,
+    )
+
+    const [, , , aux] = mockLibraryBuild.mock.calls[0]
+    expect(aux.nativeSources).toEqual([
+      { fileName: 'MyCppFb.cpp', source: CPP },
+      { fileName: 'MyPyFb.py', source: PY },
+    ])
+  })
+
+  it('fails naming the block when its authored source is missing from disk', async () => {
+    const harness = makePort()
+    const { emit } = captureEvents()
+
+    const projectData = {
+      ...projectDataEmpty(),
+      pous: [{ type: 'function-block', data: { name: 'Gone', body: { language: 'cpp' } } }],
+    } as unknown as PLCProjectData
+
+    const result = await runLibraryBuildPipeline(
+      { projectPath: '/project', projectData, verifyProjectData: projectDataEmpty(), cleanBuild: false },
+      harness.port,
+      emit,
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Gone')
+    expect(result.error).toContain('pous/function-blocks/Gone.cpp')
+    expect(mockLibraryBuild).not.toHaveBeenCalled()
   })
 
   it('returns the manifest validation error verbatim without proceeding', async () => {

--- a/src/backend/shared/library/__tests__/library-build-orchestrator.test.ts
+++ b/src/backend/shared/library/__tests__/library-build-orchestrator.test.ts
@@ -484,6 +484,32 @@ describe('runLibraryBuildPipeline', () => {
     ])
   })
 
+  // A hand-authored project may put a native file under `pous/functions/`.
+  // The read has to follow the POU type, or the build dies on a path we guessed
+  // wrong instead of letting strucpp explain that a native block cannot be a
+  // FUNCTION.
+  it('reads a native POU from the directory its type implies', async () => {
+    const harness = makePort()
+    const { emit } = captureEvents()
+
+    const FN = 'FUNCTION CPP_ADD : INT\nVAR_INPUT A : INT; END_VAR\nint add(){}\nEND_FUNCTION\n'
+    harness.files.set('pous/functions/CPP_ADD.cpp', FN)
+
+    const projectData = {
+      ...projectDataEmpty(),
+      pous: [{ type: 'function', data: { name: 'CPP_ADD', body: { language: 'cpp' } } }],
+    } as unknown as PLCProjectData
+
+    await runLibraryBuildPipeline(
+      { projectPath: '/project', projectData, verifyProjectData: projectDataEmpty(), cleanBuild: false },
+      harness.port,
+      emit,
+    )
+
+    const [, , , aux] = mockLibraryBuild.mock.calls[0]
+    expect(aux.nativeSources).toEqual([{ fileName: 'CPP_ADD.cpp', source: FN }])
+  })
+
   it('fails naming the block when its authored source is missing from disk', async () => {
     const harness = makePort()
     const { emit } = captureEvents()

--- a/src/backend/shared/library/__tests__/library-build-orchestrator.test.ts
+++ b/src/backend/shared/library/__tests__/library-build-orchestrator.test.ts
@@ -455,10 +455,12 @@ describe('runLibraryBuildPipeline', () => {
     expect(aux.pouDocs).toEqual({ MyFb: 'A docstring', MyType: 'A type description' })
   })
 
-  // The archive must carry what the AUTHOR wrote, so the native sources are
-  // read off disk rather than taken from the project data — by this point
-  // `preprocessPous` has already replaced those bodies with generated bridge
-  // ST, and shipping that would freeze this editor's bridge ABI.
+  // The archive must carry what the AUTHOR wrote. `nativePous` is supplied by
+  // the adapter from the RAW project data, because by the time the pipeline
+  // runs `preprocessPous` has lowered every native body to bridge ST AND
+  // rewritten its language tag — so the POU list here says `st` for all of
+  // them. Seeding `language: 'cpp'` in these args would test a state that
+  // cannot occur.
   it('reads authored C/C++ and Python POU files off disk and passes them verbatim', async () => {
     const harness = makePort()
     const { emit } = captureEvents()
@@ -470,17 +472,25 @@ describe('runLibraryBuildPipeline', () => {
 
     const projectData = {
       ...projectDataEmpty(),
+      // Lowered, exactly as the pipeline really receives them.
       pous: [
-        // Bodies here are already lowered — proof the values below came from
-        // disk and not from the project data.
-        { type: 'function-block', data: { name: 'MyCppFb', body: { language: 'cpp' } } },
-        { type: 'function-block', data: { name: 'MyPyFb', body: { language: 'python' } } },
+        { type: 'function-block', data: { name: 'MyCppFb', body: { language: 'st' } } },
+        { type: 'function-block', data: { name: 'MyPyFb', body: { language: 'st' } } },
         { type: 'function-block', data: { name: 'PlainSt', body: { language: 'st' } } },
       ],
     } as unknown as PLCProjectData
 
     await runLibraryBuildPipeline(
-      { projectPath: '/project', projectData, verifyProjectData: projectDataEmpty(), cleanBuild: false },
+      {
+        projectPath: '/project',
+        projectData,
+        verifyProjectData: projectDataEmpty(),
+        cleanBuild: false,
+        nativePous: [
+          { name: 'MyCppFb', language: 'cpp', relPath: 'pous/function-blocks/MyCppFb.cpp' },
+          { name: 'MyPyFb', language: 'python', relPath: 'pous/function-blocks/MyPyFb.py' },
+        ],
+      },
       harness.port,
       emit,
     )
@@ -493,10 +503,10 @@ describe('runLibraryBuildPipeline', () => {
   })
 
   // A hand-authored project may put a native file under `pous/functions/`.
-  // The read has to follow the POU type, or the build dies on a path we guessed
-  // wrong instead of letting strucpp explain that a native block cannot be a
-  // FUNCTION.
-  it('reads a native POU from the directory its type implies', async () => {
+  // `collectNativePous` derives the path from the POU type so the build hands
+  // strucpp the file and lets it explain that a native block cannot be a
+  // FUNCTION, rather than dying on a path guessed wrong.
+  it('reads a native POU from the path the adapter resolved', async () => {
     const harness = makePort()
     const { emit } = captureEvents()
 
@@ -505,17 +515,51 @@ describe('runLibraryBuildPipeline', () => {
 
     const projectData = {
       ...projectDataEmpty(),
-      pous: [{ type: 'function', data: { name: 'CPP_ADD', body: { language: 'cpp' } } }],
+      pous: [{ type: 'function', data: { name: 'CPP_ADD', body: { language: 'st' } } }],
     } as unknown as PLCProjectData
 
     await runLibraryBuildPipeline(
-      { projectPath: '/project', projectData, verifyProjectData: projectDataEmpty(), cleanBuild: false },
+      {
+        projectPath: '/project',
+        projectData,
+        verifyProjectData: projectDataEmpty(),
+        cleanBuild: false,
+        nativePous: [{ name: 'CPP_ADD', language: 'cpp', relPath: 'pous/functions/CPP_ADD.cpp' }],
+      },
       harness.port,
       emit,
     )
 
     const [, , , aux] = mockLibraryBuild.mock.calls[0]
     expect(aux.nativeSources).toEqual([{ fileName: 'CPP_ADD.cpp', source: FN }])
+  })
+
+  // Regression: the pipeline used to infer the native list from
+  // `projectData.pous[].body.language`, which is always `st` by this point.
+  // It therefore found none, shipped the bridge ST in the archive instead of
+  // the authored source, and produced the frozen-ABI artifact this design
+  // exists to avoid.
+  it('passes no native sources when the adapter supplied none, whatever the POU list says', async () => {
+    const harness = makePort()
+    const { emit } = captureEvents()
+    harness.files.set(
+      'pous/function-blocks/Ghost.cpp',
+      'FUNCTION_BLOCK Ghost\nVAR_INPUT a : BOOL; END_VAR\nEND_FUNCTION_BLOCK\n',
+    )
+
+    await runLibraryBuildPipeline(
+      {
+        projectPath: '/project',
+        projectData: projectDataEmpty(),
+        verifyProjectData: projectDataEmpty(),
+        cleanBuild: false,
+      },
+      harness.port,
+      emit,
+    )
+
+    const [, , , aux] = mockLibraryBuild.mock.calls[0]
+    expect(aux.nativeSources).toEqual([])
   })
 
   it('fails naming the path when reading a native source throws', async () => {
@@ -525,13 +569,14 @@ describe('runLibraryBuildPipeline', () => {
     // `library.json` and never reach the native read.
     harness.throwOnRead.set('pous/function-blocks/Boom.cpp', new Error('EIO'))
 
-    const projectData = {
-      ...projectDataEmpty(),
-      pous: [{ type: 'function-block', data: { name: 'Boom', body: { language: 'cpp' } } }],
-    } as unknown as PLCProjectData
-
     const result = await runLibraryBuildPipeline(
-      { projectPath: '/project', projectData, verifyProjectData: projectDataEmpty(), cleanBuild: false },
+      {
+        projectPath: '/project',
+        projectData: projectDataEmpty(),
+        verifyProjectData: projectDataEmpty(),
+        cleanBuild: false,
+        nativePous: [{ name: 'Boom', language: 'cpp', relPath: 'pous/function-blocks/Boom.cpp' }],
+      },
       harness.port,
       emit,
     )
@@ -546,13 +591,14 @@ describe('runLibraryBuildPipeline', () => {
     const harness = makePort()
     const { emit } = captureEvents()
 
-    const projectData = {
-      ...projectDataEmpty(),
-      pous: [{ type: 'function-block', data: { name: 'Gone', body: { language: 'cpp' } } }],
-    } as unknown as PLCProjectData
-
     const result = await runLibraryBuildPipeline(
-      { projectPath: '/project', projectData, verifyProjectData: projectDataEmpty(), cleanBuild: false },
+      {
+        projectPath: '/project',
+        projectData: projectDataEmpty(),
+        verifyProjectData: projectDataEmpty(),
+        cleanBuild: false,
+        nativePous: [{ name: 'Gone', language: 'cpp', relPath: 'pous/function-blocks/Gone.cpp' }],
+      },
       harness.port,
       emit,
     )

--- a/src/backend/shared/library/__tests__/library-build-orchestrator.test.ts
+++ b/src/backend/shared/library/__tests__/library-build-orchestrator.test.ts
@@ -57,6 +57,11 @@ interface PortHarness {
   transpileCalls: TranspileToStArgs[]
   /** Programmable error for whichever method the test wants to fail. */
   throwOn: Partial<Record<keyof LibraryBuildPort, Error>>
+  /** Error raised by `readBuildFile` for one specific path only.
+   *  `throwOn.readBuildFile` fails every read, which means stage 0's
+   *  `library.json` aborts the build before any later read is attempted —
+   *  so a failure deeper in the pipeline needs to be scoped to its path. */
+  throwOnRead: Map<string, Error>
 }
 
 function makePort(): PortHarness {
@@ -68,6 +73,7 @@ function makePort(): PortHarness {
     missing: [],
     verifyResult: { success: true },
     verifyCalls: [],
+    throwOnRead: new Map<string, Error>(),
     transpileResult: { ok: true, programSt: FAKE_PROGRAM_ST },
     transpileCalls: [],
     throwOn: {},
@@ -88,6 +94,8 @@ function makePort(): PortHarness {
     },
     async readBuildFile(_projectPath: string, relPath: string) {
       if (harness.throwOn.readBuildFile) throw harness.throwOn.readBuildFile
+      const scoped = harness.throwOnRead.get(relPath)
+      if (scoped) throw scoped
       if (relPath === 'library.json') return harness.manifestContent
       return harness.files.get(relPath) ?? null
     },
@@ -508,6 +516,30 @@ describe('runLibraryBuildPipeline', () => {
 
     const [, , , aux] = mockLibraryBuild.mock.calls[0]
     expect(aux.nativeSources).toEqual([{ fileName: 'CPP_ADD.cpp', source: FN }])
+  })
+
+  it('fails naming the path when reading a native source throws', async () => {
+    const harness = makePort()
+    const { emit } = captureEvents()
+    // Scoped to this one path: a blanket read failure would abort at stage 0's
+    // `library.json` and never reach the native read.
+    harness.throwOnRead.set('pous/function-blocks/Boom.cpp', new Error('EIO'))
+
+    const projectData = {
+      ...projectDataEmpty(),
+      pous: [{ type: 'function-block', data: { name: 'Boom', body: { language: 'cpp' } } }],
+    } as unknown as PLCProjectData
+
+    const result = await runLibraryBuildPipeline(
+      { projectPath: '/project', projectData, verifyProjectData: projectDataEmpty(), cleanBuild: false },
+      harness.port,
+      emit,
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('pous/function-blocks/Boom.cpp')
+    expect(result.error).toContain('EIO')
+    expect(mockLibraryBuild).not.toHaveBeenCalled()
   })
 
   it('fails naming the block when its authored source is missing from disk', async () => {

--- a/src/backend/shared/library/__tests__/native-pou-list.test.ts
+++ b/src/backend/shared/library/__tests__/native-pou-list.test.ts
@@ -1,15 +1,21 @@
+import type { PLCBody, PLCPou, PouType } from '../../../../middleware/shared/ports/open-plc-types'
 import type { PLCProjectData } from '../../../../middleware/shared/ports/types'
-import { collectNativePous } from '../native-pou-list'
+import { collectNativePous, parseNativePouRefs } from '../native-pou-list'
 
-function project(pous: Array<{ name: string; pouType: string; language: string }>): PLCProjectData {
+/** A typed project fixture — only `pous` is read, the rest is a valid empty. */
+function project(pous: Array<{ name: string; pouType: PouType; language: PLCBody['language'] }>): PLCProjectData {
+  const built: PLCPou[] = pous.map((p) => ({
+    name: p.name,
+    pouType: p.pouType,
+    interface: { variables: [] },
+    body: { language: p.language, value: '' } as PLCBody,
+    documentation: '',
+  }))
   return {
-    pous: pous.map((p) => ({
-      name: p.name,
-      pouType: p.pouType,
-      interface: { variables: [] },
-      body: { language: p.language, value: '' },
-    })),
-  } as unknown as PLCProjectData
+    pous: built,
+    dataTypes: [],
+    configurations: { resource: { tasks: [], instances: [], globalVariables: [] } },
+  }
 }
 
 describe('collectNativePous', () => {
@@ -46,9 +52,23 @@ describe('collectNativePous', () => {
   })
 
   it('falls back to the function-block directory for an unrecognised POU type', () => {
-    expect(collectNativePous(project([{ name: 'Odd', pouType: 'weird', language: 'cpp' }]))[0].relPath).toBe(
-      'pous/function-blocks/Odd.cpp',
-    )
+    // `pouType` is a union, so an unknown value can only arrive from data the
+    // types do not describe — a hand-edited project.json. The fallback keeps
+    // the build pointed somewhere sensible instead of at `undefined/Odd.cpp`.
+    const odd: PLCProjectData = {
+      pous: [
+        {
+          name: 'Odd',
+          pouType: 'weird' as PouType,
+          interface: { variables: [] },
+          body: { language: 'cpp', value: '' } as PLCBody,
+          documentation: '',
+        },
+      ],
+      dataTypes: [],
+      configurations: { resource: { tasks: [], instances: [], globalVariables: [] } },
+    }
+    expect(collectNativePous(odd)[0].relPath).toBe('pous/function-blocks/Odd.cpp')
   })
 
   it('keeps declaration order and skips non-native POUs', () => {
@@ -72,7 +92,52 @@ describe('collectNativePous', () => {
   })
 
   it('tolerates a POU with no body', () => {
-    const data = { pous: [{ name: 'Broken', pouType: 'function-block' }] } as unknown as PLCProjectData
-    expect(collectNativePous(data)).toEqual([])
+    // Same provenance as above: only malformed on-disk data produces this.
+    const noBody: PLCProjectData = {
+      pous: [{ name: 'Broken', pouType: 'function-block', interface: { variables: [] }, documentation: '' } as PLCPou],
+      dataTypes: [],
+      configurations: { resource: { tasks: [], instances: [], globalVariables: [] } },
+    }
+    expect(collectNativePous(noBody)).toEqual([])
+  })
+})
+
+describe('parseNativePouRefs', () => {
+  const valid = { name: 'CPP_SCALE', language: 'cpp', relPath: 'pous/function-blocks/CPP_SCALE.cpp' }
+
+  it('accepts a well-formed list', () => {
+    expect(parseNativePouRefs([valid])).toEqual([valid])
+  })
+
+  // Arrives over IPC, so it is `unknown` whatever the renderer meant to send.
+  // Unreadable input degrades to "no native POUs" rather than throwing inside
+  // the pipeline, out of a handler invoked with `void`.
+  it.each([
+    ['undefined (older renderer)', undefined],
+    ['null', null],
+    ['a string', 'nope'],
+    ['an object', { name: 'x' }],
+  ])('returns an empty list for %s', (_label, value) => {
+    expect(parseNativePouRefs(value)).toEqual([])
+  })
+
+  it.each([
+    ['a null entry', null],
+    ['a non-object entry', 'CPP_SCALE'],
+    ['a missing name', { language: 'cpp', relPath: 'a/b.cpp' }],
+    ['an empty name', { name: '', language: 'cpp', relPath: 'a/b.cpp' }],
+    ['a missing relPath', { name: 'X', language: 'cpp' }],
+    ['an empty relPath', { name: 'X', language: 'cpp', relPath: '' }],
+    ['a non-string relPath', { name: 'X', language: 'cpp', relPath: 42 }],
+    ['an unknown language', { name: 'X', language: 'rust', relPath: 'a/b.rs' }],
+  ])('drops %s', (_label, entry) => {
+    expect(parseNativePouRefs([entry])).toEqual([])
+  })
+
+  it('keeps the good entries and drops only the bad ones', () => {
+    expect(parseNativePouRefs([valid, { name: 'Bad' }, null, { ...valid, name: 'PY', language: 'python' }])).toEqual([
+      valid,
+      { name: 'PY', language: 'python', relPath: valid.relPath },
+    ])
   })
 })

--- a/src/backend/shared/library/__tests__/native-pou-list.test.ts
+++ b/src/backend/shared/library/__tests__/native-pou-list.test.ts
@@ -1,0 +1,78 @@
+import type { PLCProjectData } from '../../../../middleware/shared/ports/types'
+import { collectNativePous } from '../native-pou-list'
+
+function project(pous: Array<{ name: string; pouType: string; language: string }>): PLCProjectData {
+  return {
+    pous: pous.map((p) => ({
+      name: p.name,
+      pouType: p.pouType,
+      interface: { variables: [] },
+      body: { language: p.language, value: '' },
+    })),
+  } as unknown as PLCProjectData
+}
+
+describe('collectNativePous', () => {
+  it('returns nothing for a project with no native POUs', () => {
+    expect(collectNativePous(project([{ name: 'main', pouType: 'program', language: 'st' }]))).toEqual([])
+  })
+
+  it('returns nothing for an empty project', () => {
+    expect(collectNativePous(project([]))).toEqual([])
+  })
+
+  it('maps a C++ function block to its authored .cpp path', () => {
+    expect(collectNativePous(project([{ name: 'TCP_CLIENT', pouType: 'function-block', language: 'cpp' }]))).toEqual([
+      { name: 'TCP_CLIENT', language: 'cpp', relPath: 'pous/function-blocks/TCP_CLIENT.cpp' },
+    ])
+  })
+
+  it('maps a Python function block to its authored .py path', () => {
+    expect(collectNativePous(project([{ name: 'SCALE', pouType: 'function-block', language: 'python' }]))).toEqual([
+      { name: 'SCALE', language: 'python', relPath: 'pous/function-blocks/SCALE.py' },
+    ])
+  })
+
+  // A hand-authored project may declare a native POU as a FUNCTION. The path
+  // has to follow the POU type so the build hands strucpp the file and lets it
+  // explain that a native block must be a FUNCTION_BLOCK, rather than failing
+  // on a path guessed wrong.
+  it.each([
+    ['function', 'pous/functions/CPP_ADD.cpp'],
+    ['program', 'pous/programs/CPP_ADD.cpp'],
+    ['function-block', 'pous/function-blocks/CPP_ADD.cpp'],
+  ])('resolves a %s POU under its own directory', (pouType, relPath) => {
+    expect(collectNativePous(project([{ name: 'CPP_ADD', pouType, language: 'cpp' }]))[0].relPath).toBe(relPath)
+  })
+
+  it('falls back to the function-block directory for an unrecognised POU type', () => {
+    expect(collectNativePous(project([{ name: 'Odd', pouType: 'weird', language: 'cpp' }]))[0].relPath).toBe(
+      'pous/function-blocks/Odd.cpp',
+    )
+  })
+
+  it('keeps declaration order and skips non-native POUs', () => {
+    const refs = collectNativePous(
+      project([
+        { name: 'main', pouType: 'program', language: 'st' },
+        { name: 'B', pouType: 'function-block', language: 'cpp' },
+        { name: 'Rungs', pouType: 'program', language: 'ld' },
+        { name: 'A', pouType: 'function-block', language: 'python' },
+      ]),
+    )
+    expect(refs.map((r) => `${r.name}:${r.language}`)).toEqual(['B:cpp', 'A:python'])
+  })
+
+  // The whole reason this helper exists: `preprocessPous` lowers native bodies
+  // to bridge ST and rewrites the language tag with them, so a list derived
+  // after that step finds nothing and the archive ships the bridge instead of
+  // the authored source.
+  it('finds nothing once the bodies have been lowered to ST', () => {
+    expect(collectNativePous(project([{ name: 'CPP_SCALE', pouType: 'function-block', language: 'st' }]))).toEqual([])
+  })
+
+  it('tolerates a POU with no body', () => {
+    const data = { pous: [{ name: 'Broken', pouType: 'function-block' }] } as unknown as PLCProjectData
+    expect(collectNativePous(data)).toEqual([])
+  })
+})

--- a/src/backend/shared/library/build-pipeline.ts
+++ b/src/backend/shared/library/build-pipeline.ts
@@ -333,6 +333,14 @@ export interface LibraryBuildAux {
    *  `cppBlocks` field after compileStlib returns.  See
    *  `LibraryCppBlock` for the per-entry shape. */
   cppBlocks?: LibraryCppBlock[]
+  /** Python POUs from the library's project.  Same contract as
+   *  `cppBlocks`: filtered OUT of strucpp's input set, stamped onto
+   *  the archive's `pythonBlocks` field, and re-lowered by the
+   *  consumer at compile time.  Python POUs used to be left in the
+   *  strucpp input set, which shipped the generated `{external}`
+   *  bridge — freezing the `iec_python.h` ABI of the editor that
+   *  built the library into the archive. */
+  pythonBlocks?: LibraryCppBlock[]
 }
 
 /**
@@ -375,23 +383,30 @@ export function libraryBuildFromTranspiledSt(
   //     anyway — they ship POUs + types for consumer projects to
   //     instantiate.
   //   - Every per-POU file whose source POU was originally a
-  //     C/C++ function block.  Those POUs' ST bodies are
-  //     `generateCppSTCode`-emitted stubs that reference
-  //     `c_blocks.h` externs strucpp's library compiler can't
-  //     resolve (no `pouIncludes` on `compileStlib`).  We
-  //     re-attach the verbatim C++ source on the archive's
-  //     `cppBlocks` field after `compileStlib` returns; the
-  //     consumer's program compile reads it back and routes it
-  //     through the existing user-C++-block path.
+  //     C/C++ or Python function block.  Those POUs' ST bodies are
+  //     generated bridge stubs (`generateCppSTCode` /
+  //     `generateSTCode`) whose `{external}` blocks call into
+  //     `c_blocks.h` / `iec_python.h`.  Strucpp would happily emit
+  //     them — it is a transpiler, and an `{external}` body is
+  //     copied through verbatim — but shipping them would freeze
+  //     the building editor's ABI into the archive, so that any
+  //     later change to the bridge breaks every library published
+  //     before it until each one is rebuilt.  Instead the verbatim
+  //     author source rides on `cppBlocks` / `pythonBlocks` and the
+  //     consumer re-derives the stub at compile time, with whatever
+  //     transformation that consumer implements.  See
+  //     `inject-library-blocks.ts` for the consuming half.
   //
   // Keep `_types.st` and `_globals.st`: they may carry user-defined
   // types and library-internal globals the POUs reference.
-  const cppBlockFilenames = new Set((aux?.cppBlocks ?? []).map((b) => `${b.name}.st`))
+  const nativeBlockFilenames = new Set(
+    [...(aux?.cppBlocks ?? []), ...(aux?.pythonBlocks ?? [])].map((b) => `${b.name}.st`),
+  )
   const sources: CompileStlibSource[] = []
   for (const [fileName, source] of split.files.entries()) {
     if (fileName === STUB_SPLIT_FILENAME) continue
     if (fileName === '_config.st') continue
-    if (cppBlockFilenames.has(fileName)) continue
+    if (nativeBlockFilenames.has(fileName)) continue
     sources.push({
       fileName,
       source,
@@ -411,8 +426,9 @@ export function libraryBuildFromTranspiledSt(
   // just `cppBlocks` riding through the archive for the consumer
   // to consume).
   const hasRealSources = sources.some((s) => s.fileName !== '_globals.st')
-  const hasCppBlocks = (aux?.cppBlocks?.length ?? 0) > 0
-  if (!hasRealSources && !hasCppBlocks) {
+  const nativeBlocks = [...(aux?.cppBlocks ?? []), ...(aux?.pythonBlocks ?? [])]
+  const hasNativeBlocks = nativeBlocks.length > 0
+  if (!hasRealSources && !hasNativeBlocks) {
     return {
       success: false,
       errors: [
@@ -422,6 +438,44 @@ export function libraryBuildFromTranspiledSt(
         },
       ],
     }
+  }
+
+  // A library whose POUs are ALL C/C++ or Python has nothing left for
+  // strucpp: every per-POU file was just filtered out, and there are no
+  // types or globals.  `compileStlib([])` hard-fails with "No source
+  // files provided", which is what a library like this used to die on —
+  // right after verification had reported success, so it read as an
+  // infrastructure fault rather than anything to do with the project.
+  //
+  // There is genuinely nothing to compile, so don't ask strucpp to.
+  // Synthesize the archive shell it would have produced for an empty
+  // symbol set and let `decorateArchive` attach the native blocks, which
+  // is where all of this library's content actually lives.  The shape
+  // must match strucpp's own output exactly — `loadStlibFromString`
+  // validates `formatVersion` and the manifest's array fields on the way
+  // back in, and a consumer that can't load the archive is no better off
+  // than one that never got it.
+  if (sources.length === 0) {
+    const archive = {
+      formatVersion: 1,
+      manifest: {
+        name: manifest.name,
+        version: manifest.version,
+        namespace: manifest.namespace,
+        functions: [],
+        functionBlocks: [],
+        types: [],
+        globals: [],
+        headers: [],
+        isBuiltin: false,
+        sourceFiles: [],
+      },
+      chunks: [],
+      dependencies: [],
+      sources: [],
+    }
+    decorateArchive(archive, manifest, aux)
+    return { success: true, archive, errors: [] }
   }
 
   const compileRes = compileStlib(sources, {
@@ -473,6 +527,7 @@ function decorateArchive(archive: unknown, manifest: LibraryBuildManifest, aux: 
     }
     dependencies?: Array<{ name: string; version: string }>
     cppBlocks?: LibraryCppBlock[]
+    pythonBlocks?: LibraryCppBlock[]
   }
   if (!arch.manifest) return
 
@@ -511,20 +566,33 @@ function decorateArchive(archive: unknown, manifest: LibraryBuildManifest, aux: 
     arch.dependencies = aux.dependencyRefs.map((ref) => ({ name: ref.name, version: ref.version }))
   }
 
-  // C/C++ blocks ride through the archive verbatim — strucpp has
-  // no notion of them, the consumer-side editor reads them back
-  // at program-compile time and grafts them into the project's
-  // own C++-POU pipeline.  JSON.stringify preserves the field, so
-  // attaching it on the in-memory archive is enough to round-trip
-  // to disk.
-  if (aux?.cppBlocks && aux.cppBlocks.length > 0) {
-    arch.cppBlocks = aux.cppBlocks.map((b) => ({
-      name: b.name,
-      code: b.code,
-      variables: b.variables,
-      ...(b.documentation && b.documentation.length > 0 ? { documentation: b.documentation } : {}),
-    }))
-  }
+  // C/C++ and Python blocks ride through the archive verbatim —
+  // strucpp has no notion of them; the consumer-side editor reads
+  // them back at program-compile time and grafts them into the
+  // project's own native-POU pipeline.  JSON.stringify preserves the
+  // fields, so attaching them on the in-memory archive is enough to
+  // round-trip to disk.
+  //
+  // Deliberately unconditional with respect to any "publish without
+  // sources" option: strucpp's `noSource` may drop the ST `sources`
+  // array because those symbols are already compiled into `chunks`,
+  // but a native block has no chunk.  Its source IS the deliverable,
+  // and an archive that omitted it would be unbuildable by every
+  // consumer.  See `findLibrariesMissingNativeSources`.
+  const attachNative = (blocks: LibraryCppBlock[] | undefined): LibraryCppBlock[] | undefined =>
+    blocks && blocks.length > 0
+      ? blocks.map((b) => ({
+          name: b.name,
+          code: b.code,
+          variables: b.variables,
+          ...(b.documentation && b.documentation.length > 0 ? { documentation: b.documentation } : {}),
+        }))
+      : undefined
+
+  const cpp = attachNative(aux?.cppBlocks)
+  if (cpp) arch.cppBlocks = cpp
+  const python = attachNative(aux?.pythonBlocks)
+  if (python) arch.pythonBlocks = python
 }
 
 /**

--- a/src/backend/shared/library/build-pipeline.ts
+++ b/src/backend/shared/library/build-pipeline.ts
@@ -295,52 +295,38 @@ export interface LibraryBuildResult {
  *     transitive deps without re-reading every archive on disk.
  */
 /**
- * C/C++ function block carried verbatim through the `.stlib`.
- * Strucpp's library compiler is ST/IL-only, so the editor pulls
- * these out of the strucpp input set and re-attaches them on the
- * resulting archive as a separate field.  At consume time, the
- * editor reads them back, synthesizes user-POU-equivalent entries
- * into the consumer project (with a library-name prefix on the
- * POU name to avoid collisions), and feeds them through the
- * existing user-defined C/C++ block pipeline.  Strucpp never sees
- * them — same shape user-defined C++ POUs use today.
+ * One native (C/C++, Python) library source, exactly as the author wrote it.
+ *
+ * Handed straight to `compileStlib` alongside the ST sources. Strucpp routes
+ * by extension: it recovers the interface from the file's ST header, emits no
+ * chunk, and carries the file verbatim in the archive. The consumer re-derives
+ * the native bridge at its own build time, which is what keeps a published
+ * library working across bridge revisions — see
+ * `backend/shared/library/inject-library-blocks.ts`.
+ *
+ * The editor's own lowering of these POUs (the `generateCppSTCode` /
+ * Python-bridge ST that `preprocessPous` produces) is deliberately kept OUT of
+ * the archive: shipping it would freeze the building editor's bridge ABI into
+ * every library built with it.
  */
-export interface LibraryCppBlock {
-  /** FB name as the library author wrote it.  The consumer-side
-   *  injection renames this to `<library_name>__<name>` before
-   *  feeding to `preprocessPous`, so collisions with the
-   *  consumer's own POUs are impossible by construction. */
-  name: string
-  /** Raw user-authored C++ source.  Same shape `originalCppPous`
-   *  carries today (the body of `void setup()` / `void loop()`
-   *  plus any helpers). */
-  code: string
-  /** Variable declarations on the FB (inputs / outputs / etc.).
-   *  Same shape `PLCVariable` uses elsewhere; carried opaquely
-   *  here so this module stays free of the variable-schema
-   *  import. */
-  variables: unknown[]
-  /** Optional documentation surfaced in the library tree picker. */
-  documentation?: string
+export interface LibraryNativeSource {
+  /** File name as authored, e.g. `TCP_CLIENT.cpp`. The extension is how
+   *  strucpp decides the block's language, so it must be preserved. */
+  fileName: string
+  /** The whole authored file: ST header (`FUNCTION_BLOCK` + `VAR_*` blocks)
+   *  followed by the native body. */
+  source: string
 }
 
 export interface LibraryBuildAux {
   pouDocs?: Record<string, string>
   dependencyArchives?: unknown[]
   dependencyRefs?: Array<{ name: string; version: string }>
-  /** C/C++ POUs from the library's project.  Filtered OUT of
-   *  strucpp's input set and stamped onto the archive's
-   *  `cppBlocks` field after compileStlib returns.  See
-   *  `LibraryCppBlock` for the per-entry shape. */
-  cppBlocks?: LibraryCppBlock[]
-  /** Python POUs from the library's project.  Same contract as
-   *  `cppBlocks`: filtered OUT of strucpp's input set, stamped onto
-   *  the archive's `pythonBlocks` field, and re-lowered by the
-   *  consumer at compile time.  Python POUs used to be left in the
-   *  strucpp input set, which shipped the generated `{external}`
-   *  bridge — freezing the `iec_python.h` ABI of the editor that
-   *  built the library into the archive. */
-  pythonBlocks?: LibraryCppBlock[]
+  /** Verbatim C/C++ and Python sources from the library's project,
+   *  passed through to `compileStlib` next to the ST. Their lowered
+   *  bridge ST is filtered out of the strucpp input in exchange —
+   *  see `LibraryNativeSource`. */
+  nativeSources?: LibraryNativeSource[]
 }
 
 /**
@@ -382,31 +368,27 @@ export function libraryBuildFromTranspiledSt(
   //     diagnostics).  Libraries don't carry configurations
   //     anyway — they ship POUs + types for consumer projects to
   //     instantiate.
-  //   - Every per-POU file whose source POU was originally a
-  //     C/C++ or Python function block.  Those POUs' ST bodies are
-  //     generated bridge stubs (`generateCppSTCode` /
-  //     `generateSTCode`) whose `{external}` blocks call into
-  //     `c_blocks.h` / `iec_python.h`.  Strucpp would happily emit
-  //     them — it is a transpiler, and an `{external}` body is
-  //     copied through verbatim — but shipping them would freeze
-  //     the building editor's ABI into the archive, so that any
-  //     later change to the bridge breaks every library published
-  //     before it until each one is rebuilt.  Instead the verbatim
-  //     author source rides on `cppBlocks` / `pythonBlocks` and the
-  //     consumer re-derives the stub at compile time, with whatever
-  //     transformation that consumer implements.  See
-  //     `inject-library-blocks.ts` for the consuming half.
+  //   - Every per-POU file whose source POU was originally a C/C++ or
+  //     Python function block.  Those bodies are generated bridge stubs
+  //     against the current `c_blocks.h` / `iec_python.h` ABI; shipping
+  //     them would freeze this editor's bridge into the archive.  The
+  //     verbatim author source is handed to strucpp instead, which stores
+  //     it and lets the consumer re-derive the bridge at its own build
+  //     time.  See `inject-library-blocks.ts`.
   //
   // Keep `_types.st` and `_globals.st`: they may carry user-defined
   // types and library-internal globals the POUs reference.
-  const nativeBlockFilenames = new Set(
-    [...(aux?.cppBlocks ?? []), ...(aux?.pythonBlocks ?? [])].map((b) => `${b.name}.st`),
-  )
+  // Drop the per-POU file for every native block. `preprocessPous` replaced
+  // those POU bodies with generated bridge ST against the current
+  // `c_blocks.h` / `iec_python.h` ABI; shipping that would freeze this
+  // editor's bridge into the archive. The verbatim author source goes to
+  // strucpp instead, below.
+  const nativeStFilenames = new Set((aux?.nativeSources ?? []).map((n) => `${n.fileName.replace(/\.[^.]+$/, '')}.st`))
   const sources: CompileStlibSource[] = []
   for (const [fileName, source] of split.files.entries()) {
     if (fileName === STUB_SPLIT_FILENAME) continue
     if (fileName === '_config.st') continue
-    if (nativeBlockFilenames.has(fileName)) continue
+    if (nativeStFilenames.has(fileName)) continue
     sources.push({
       fileName,
       source,
@@ -414,21 +396,16 @@ export function libraryBuildFromTranspiledSt(
     })
   }
 
-  // No real POU files left?  That means the library has no
-  // functions / function-blocks / types — a degenerate case but a
-  // valid one (a library project may be opened fresh before the
-  // user has added any symbols).  Refuse with a clear message
-  // rather than producing an empty .stlib that strucpp would
-  // accept silently.
+  // Nothing to ship at all?  A library project may legitimately be opened
+  // fresh, before the user has added any symbols.  Refuse with a clear
+  // message rather than producing an empty `.stlib`.
   //
-  // C/C++ blocks count as "real content" — a library that ships
-  // only C/C++ FBs is still useful (no strucpp-compiled chunks,
-  // just `cppBlocks` riding through the archive for the consumer
-  // to consume).
+  // Native blocks count as real content: a library of nothing but C/C++ or
+  // Python FBs is useful, and strucpp handles an ST-empty input set — it
+  // recovers each block's interface from its ST header and emits no chunk.
   const hasRealSources = sources.some((s) => s.fileName !== '_globals.st')
-  const nativeBlocks = [...(aux?.cppBlocks ?? []), ...(aux?.pythonBlocks ?? [])]
-  const hasNativeBlocks = nativeBlocks.length > 0
-  if (!hasRealSources && !hasNativeBlocks) {
+  const nativeSources = aux?.nativeSources ?? []
+  if (!hasRealSources && nativeSources.length === 0) {
     return {
       success: false,
       errors: [
@@ -440,45 +417,9 @@ export function libraryBuildFromTranspiledSt(
     }
   }
 
-  // A library whose POUs are ALL C/C++ or Python has nothing left for
-  // strucpp: every per-POU file was just filtered out, and there are no
-  // types or globals.  `compileStlib([])` hard-fails with "No source
-  // files provided", which is what a library like this used to die on —
-  // right after verification had reported success, so it read as an
-  // infrastructure fault rather than anything to do with the project.
-  //
-  // There is genuinely nothing to compile, so don't ask strucpp to.
-  // Synthesize the archive shell it would have produced for an empty
-  // symbol set and let `decorateArchive` attach the native blocks, which
-  // is where all of this library's content actually lives.  The shape
-  // must match strucpp's own output exactly — `loadStlibFromString`
-  // validates `formatVersion` and the manifest's array fields on the way
-  // back in, and a consumer that can't load the archive is no better off
-  // than one that never got it.
-  if (sources.length === 0) {
-    const archive = {
-      formatVersion: 1,
-      manifest: {
-        name: manifest.name,
-        version: manifest.version,
-        namespace: manifest.namespace,
-        functions: [],
-        functionBlocks: [],
-        types: [],
-        globals: [],
-        headers: [],
-        isBuiltin: false,
-        sourceFiles: [],
-      },
-      chunks: [],
-      dependencies: [],
-      sources: [],
-    }
-    decorateArchive(archive, manifest, aux)
-    return { success: true, archive, errors: [] }
-  }
-
-  const compileRes = compileStlib(sources, {
+  // Native sources ride in the same input array; strucpp routes on the file
+  // extension.  Appended after the ST so `sourceFiles` ordering stays stable.
+  const compileRes = compileStlib([...sources, ...nativeSources.map((n) => ({ ...n }))], {
     name: manifest.name,
     version: manifest.version,
     namespace: manifest.namespace,
@@ -526,8 +467,6 @@ function decorateArchive(archive: unknown, manifest: LibraryBuildManifest, aux: 
       types?: Array<{ name: string; documentation?: string }>
     }
     dependencies?: Array<{ name: string; version: string }>
-    cppBlocks?: LibraryCppBlock[]
-    pythonBlocks?: LibraryCppBlock[]
   }
   if (!arch.manifest) return
 
@@ -565,34 +504,6 @@ function decorateArchive(archive: unknown, manifest: LibraryBuildManifest, aux: 
   if (aux?.dependencyRefs && aux.dependencyRefs.length > 0) {
     arch.dependencies = aux.dependencyRefs.map((ref) => ({ name: ref.name, version: ref.version }))
   }
-
-  // C/C++ and Python blocks ride through the archive verbatim —
-  // strucpp has no notion of them; the consumer-side editor reads
-  // them back at program-compile time and grafts them into the
-  // project's own native-POU pipeline.  JSON.stringify preserves the
-  // fields, so attaching them on the in-memory archive is enough to
-  // round-trip to disk.
-  //
-  // Deliberately unconditional with respect to any "publish without
-  // sources" option: strucpp's `noSource` may drop the ST `sources`
-  // array because those symbols are already compiled into `chunks`,
-  // but a native block has no chunk.  Its source IS the deliverable,
-  // and an archive that omitted it would be unbuildable by every
-  // consumer.  See `findLibrariesMissingNativeSources`.
-  const attachNative = (blocks: LibraryCppBlock[] | undefined): LibraryCppBlock[] | undefined =>
-    blocks && blocks.length > 0
-      ? blocks.map((b) => ({
-          name: b.name,
-          code: b.code,
-          variables: b.variables,
-          ...(b.documentation && b.documentation.length > 0 ? { documentation: b.documentation } : {}),
-        }))
-      : undefined
-
-  const cpp = attachNative(aux?.cppBlocks)
-  if (cpp) arch.cppBlocks = cpp
-  const python = attachNative(aux?.pythonBlocks)
-  if (python) arch.pythonBlocks = python
 }
 
 /**

--- a/src/backend/shared/library/build-pipeline.ts
+++ b/src/backend/shared/library/build-pipeline.ts
@@ -369,20 +369,12 @@ export function libraryBuildFromTranspiledSt(
   //     anyway — they ship POUs + types for consumer projects to
   //     instantiate.
   //   - Every per-POU file whose source POU was originally a C/C++ or
-  //     Python function block.  Those bodies are generated bridge stubs
-  //     against the current `c_blocks.h` / `iec_python.h` ABI; shipping
-  //     them would freeze this editor's bridge into the archive.  The
-  //     verbatim author source is handed to strucpp instead, which stores
-  //     it and lets the consumer re-derive the bridge at its own build
-  //     time.  See `inject-library-blocks.ts`.
+  //     Python function block.  See `LibraryNativeSource`.
   //
   // Keep `_types.st` and `_globals.st`: they may carry user-defined
   // types and library-internal globals the POUs reference.
-  // Drop the per-POU file for every native block. `preprocessPous` replaced
-  // those POU bodies with generated bridge ST against the current
-  // `c_blocks.h` / `iec_python.h` ABI; shipping that would freeze this
-  // editor's bridge into the archive. The verbatim author source goes to
-  // strucpp instead, below.
+  // Drop the per-POU file for every native block; the authored source goes
+  // to strucpp instead, below. See `LibraryNativeSource`.
   const nativeStFilenames = new Set((aux?.nativeSources ?? []).map((n) => `${n.fileName.replace(/\.[^.]+$/, '')}.st`))
   const sources: CompileStlibSource[] = []
   for (const [fileName, source] of split.files.entries()) {

--- a/src/backend/shared/library/inject-library-blocks.ts
+++ b/src/backend/shared/library/inject-library-blocks.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Graft library-supplied C/C++ and Python function blocks into a
+ * consumer project's POU list, immediately before `preprocessPous`
+ * runs.
+ *
+ * This module lives in `backend/shared/` and is therefore
+ * byte-identical between openplc-editor and openplc-web.  It used to
+ * exist only as a private helper inside the editor's compiler
+ * adapter, which meant web never performed the graft at all and
+ * library C/C++ blocks silently failed to compile there.  Nothing
+ * about the graft is platform-specific — only *reading* the archives
+ * is (IPC on desktop, HTTP on web) — so the archives arrive as an
+ * argument and the decision-making lives here, once.
+ *
+ * ## Why a graft rather than compiling the blocks into the archive
+ *
+ * Strucpp compiles ST/IL into the archive's `chunks`, and a consumer
+ * links those directly — that is how ordinary IEC library blocks
+ * work, and they need none of this.  C/C++ and Python blocks are
+ * different: strucpp never compiles them.  Their IEC-visible form is
+ * a generated ST stub that calls into `c_blocks.h` / `iec_python.h`
+ * externs, and *that stub encodes the current ABI* — the
+ * `<NAME>_VARS` struct layout, the `<name>_setup` / `<name>_loop`
+ * signatures, the pointer-assignment convention.
+ *
+ * So the archive carries the author's **original source, verbatim**,
+ * and the consuming editor re-derives the stub at compile time with
+ * whatever transformation that editor version implements.  A library
+ * published today keeps working when the C++/Python bridge changes,
+ * because the transformation is applied live rather than frozen into
+ * the archive.  Store the transformed ST instead and every previously
+ * published library breaks on the next ABI change until it is rebuilt
+ * — which is exactly the outcome this design exists to prevent.
+ *
+ * Because of that, a library archive that ships C/C++ or Python
+ * blocks *must* carry their sources; see `assertNativeSourcesPresent`.
+ *
+ * ## Renaming
+ *
+ * Each block's name is prefixed with the library's manifest name
+ * (`<library>__<block>`) so two libraries can both ship a `Foo`, and
+ * so a consumer's own POU may also be called `Foo`.  The library-tree
+ * picker surfaces the prefixed name, so the user authors their ST
+ * against it directly and no source rewriting is needed.
+ *
+ * Symbol-level renames inside the synthesized POU (the `<NAME>_VARS`
+ * struct, the `<name>_setup` / `<name>_loop` functions) follow
+ * automatically, because `generateCppSTCode`, `generateCBlocksHeader`
+ * and `generateCBlocksCode` all derive their names from `pou.name`.
+ */
+
+import type { StlibArchiveDTO } from '../../../middleware/shared/ports/library-port'
+import type { PLCPou, PLCProjectData, PLCVariable } from '../../../middleware/shared/ports/types'
+
+/** Separator between the library name and the block name. */
+const LIBRARY_BLOCK_SEPARATOR = '__'
+
+/** One native (non-strucpp) block as the archive carries it. */
+type ArchiveNativeBlock = {
+  name: string
+  code: string
+  variables: unknown[]
+  documentation?: string
+}
+
+/** Build the project-visible POU name for a library block. */
+export function libraryBlockPouName(libraryName: string, blockName: string): string {
+  return `${libraryName}${LIBRARY_BLOCK_SEPARATOR}${blockName}`
+}
+
+/**
+ * Every native block an archive ships, paired with the POU language
+ * the consumer should treat it as.  `cppBlocks` and `pythonBlocks`
+ * are structurally identical; only the language they lower through
+ * differs.
+ */
+function nativeBlocksOf(archive: StlibArchiveDTO): Array<{ block: ArchiveNativeBlock; language: 'cpp' | 'python' }> {
+  return [
+    ...(archive.cppBlocks ?? []).map((block) => ({ block, language: 'cpp' as const })),
+    ...(archive.pythonBlocks ?? []).map((block) => ({ block, language: 'python' as const })),
+  ]
+}
+
+/**
+ * Graft the native blocks of every *enabled* library into
+ * `projectData.pous`.
+ *
+ * Returns the input unchanged (same reference) when the project
+ * enables no libraries or none of them ship native blocks, so callers
+ * can apply this unconditionally on every compile path without paying
+ * a clone.
+ *
+ * Only archives whose manifest name appears in `projectData.libraries`
+ * contribute — an installed-but-not-enabled library must not leak its
+ * blocks into the build.
+ */
+export function injectLibraryBlocks(projectData: PLCProjectData, archives: StlibArchiveDTO[]): PLCProjectData {
+  if (!projectData.libraries || projectData.libraries.length === 0) return projectData
+
+  const enabledNames = new Set(projectData.libraries.map((ref) => ref.name))
+  const synthesized: PLCPou[] = []
+
+  for (const archive of archives) {
+    const libraryName = archive.manifest?.name
+    if (!libraryName || !enabledNames.has(libraryName)) continue
+
+    for (const { block, language } of nativeBlocksOf(archive)) {
+      synthesized.push({
+        name: libraryBlockPouName(libraryName, block.name),
+        pouType: 'function-block',
+        // `variables` rides through the archive as `unknown[]` by design —
+        // the manifest layer doesn't know our PLCVariable shape.  The
+        // archives are produced by this same editor's build pipeline from
+        // the same PLCVariable type, so the narrowing matches reality.
+        interface: { variables: block.variables as PLCVariable[] },
+        body: { language, value: block.code },
+        documentation: block.documentation ?? '',
+      })
+    }
+  }
+
+  if (synthesized.length === 0) return projectData
+
+  return { ...projectData, pous: [...projectData.pous, ...synthesized] }
+}
+
+/**
+ * Names of enabled libraries that declare native blocks in their
+ * manifest but ship no source for them.
+ *
+ * A `.stlib` may legitimately omit ST/IL sources (the "don't publish
+ * sources" option) because strucpp already compiled those into
+ * `chunks`.  C/C++ and Python blocks have no chunks — their source
+ * *is* the deliverable, and an archive without it is unbuildable by
+ * any consumer.  Callers surface this as a build error naming the
+ * library, rather than letting the compile fail later with an
+ * undefined-symbol diagnostic that points nowhere useful.
+ */
+export function findLibrariesMissingNativeSources(projectData: PLCProjectData, archives: StlibArchiveDTO[]): string[] {
+  if (!projectData.libraries || projectData.libraries.length === 0) return []
+
+  const enabledNames = new Set(projectData.libraries.map((ref) => ref.name))
+  const missing: string[] = []
+
+  for (const archive of archives) {
+    const libraryName = archive.manifest?.name
+    if (!libraryName || !enabledNames.has(libraryName)) continue
+
+    const blocks = nativeBlocksOf(archive)
+    if (blocks.length === 0) continue
+    if (blocks.some(({ block }) => typeof block.code !== 'string' || block.code.trim() === '')) {
+      missing.push(libraryName)
+    }
+  }
+
+  return missing
+}

--- a/src/backend/shared/library/inject-library-blocks.ts
+++ b/src/backend/shared/library/inject-library-blocks.ts
@@ -1,159 +1,169 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Autonomy / OpenPLC Project
 /**
- * Graft library-supplied C/C++ and Python function blocks into a
- * consumer project's POU list, immediately before `preprocessPous`
- * runs.
+ * Graft library-supplied C/C++ and Python function blocks into a consumer
+ * project's POU list, immediately before `preprocessPous` runs.
  *
- * This module lives in `backend/shared/` and is therefore
- * byte-identical between openplc-editor and openplc-web.  It used to
- * exist only as a private helper inside the editor's compiler
- * adapter, which meant web never performed the graft at all and
- * library C/C++ blocks silently failed to compile there.  Nothing
- * about the graft is platform-specific — only *reading* the archives
- * is (IPC on desktop, HTTP on web) — so the archives arrive as an
- * argument and the decision-making lives here, once.
+ * This module lives in `backend/shared/` and is therefore byte-identical
+ * between openplc-editor and openplc-web.  The graft used to exist only as a
+ * private helper inside the editor's compiler adapter, which meant web never
+ * performed it and library C/C++ blocks silently failed to compile there.
+ * Nothing about it is platform-specific — only *reading* the archives is (IPC
+ * on desktop, HTTP on web) — so the archives arrive as an argument and the
+ * decision-making lives here, once.
  *
- * ## Why a graft rather than compiling the blocks into the archive
+ * ## Why a graft rather than linking a compiled chunk
  *
- * Strucpp compiles ST/IL into the archive's `chunks`, and a consumer
- * links those directly — that is how ordinary IEC library blocks
- * work, and they need none of this.  C/C++ and Python blocks are
- * different: strucpp never compiles them.  Their IEC-visible form is
- * a generated ST stub that calls into `c_blocks.h` / `iec_python.h`
- * externs, and *that stub encodes the current ABI* — the
- * `<NAME>_VARS` struct layout, the `<name>_setup` / `<name>_loop`
- * signatures, the pointer-assignment convention.
+ * Strucpp compiles ST/IL into the archive's `chunks`, and a consumer links
+ * those directly — that is how ordinary IEC library blocks work, and they need
+ * none of this.  C/C++ and Python blocks are different: strucpp deliberately
+ * does not compile them.  It recovers their interface from the ST header every
+ * such file carries, marks the manifest entry `implementation: 'cpp' |
+ * 'python'`, emits no chunk, and ships the authored file verbatim in
+ * `archive.sources`.
  *
- * So the archive carries the author's **original source, verbatim**,
- * and the consuming editor re-derives the stub at compile time with
- * whatever transformation that editor version implements.  A library
- * published today keeps working when the C++/Python bridge changes,
- * because the transformation is applied live rather than frozen into
- * the archive.  Store the transformed ST instead and every previously
- * published library breaks on the next ABI change until it is rebuilt
- * — which is exactly the outcome this design exists to prevent.
- *
- * Because of that, a library archive that ships C/C++ or Python
- * blocks *must* carry their sources; see `assertNativeSourcesPresent`.
+ * The consumer therefore re-derives the native bridge at *its* build time,
+ * with whatever transformation that editor version implements.  A library
+ * published today keeps working when the C++/Python bridge changes, because
+ * the transformation is applied live rather than frozen into the archive.
+ * Were the lowered ST stored instead, every previously published library would
+ * break on the next bridge change until rebuilt.
  *
  * ## Renaming
  *
  * Each block's name is prefixed with the library's manifest name
- * (`<library>__<block>`) so two libraries can both ship a `Foo`, and
- * so a consumer's own POU may also be called `Foo`.  The library-tree
- * picker surfaces the prefixed name, so the user authors their ST
- * against it directly and no source rewriting is needed.
+ * (`<library>__<block>`) so two libraries can both ship a `Foo`, and so a
+ * consumer's own POU may also be called `Foo`.  The library-tree picker
+ * surfaces the prefixed name, so the user authors their ST against it directly
+ * and no source rewriting is needed.
  *
- * Symbol-level renames inside the synthesized POU (the `<NAME>_VARS`
- * struct, the `<name>_setup` / `<name>_loop` functions) follow
- * automatically, because `generateCppSTCode`, `generateCBlocksHeader`
- * and `generateCBlocksCode` all derive their names from `pou.name`.
+ * Symbol-level renames inside the synthesized POU (the `<NAME>_VARS` struct,
+ * the `<name>_setup` / `<name>_loop` functions) follow automatically, because
+ * `generateCppSTCode`, `generateCBlocksHeader` and `generateCBlocksCode` all
+ * derive their names from `pou.name`.
  */
 
+import { parseHybridPouFromString } from '../../../frontend/utils/PLC/pou-text-parser'
 import type { StlibArchiveDTO } from '../../../middleware/shared/ports/library-port'
-import type { PLCPou, PLCProjectData, PLCVariable } from '../../../middleware/shared/ports/types'
+import type { PLCPou, PLCProjectData } from '../../../middleware/shared/ports/types'
 
 /** Separator between the library name and the block name. */
 const LIBRARY_BLOCK_SEPARATOR = '__'
-
-/** One native (non-strucpp) block as the archive carries it. */
-type ArchiveNativeBlock = {
-  name: string
-  code: string
-  variables: unknown[]
-  documentation?: string
-}
 
 /** Build the project-visible POU name for a library block. */
 export function libraryBlockPouName(libraryName: string, blockName: string): string {
   return `${libraryName}${LIBRARY_BLOCK_SEPARATOR}${blockName}`
 }
 
+/** One native block an archive ships, resolved to its authored source. */
+type ResolvedNativeBlock = {
+  libraryName: string
+  blockName: string
+  language: 'cpp' | 'python'
+  /** The authored file, verbatim — ST header plus native body. */
+  source: string
+}
+
 /**
- * Every native block an archive ships, paired with the POU language
- * the consumer should treat it as.  `cppBlocks` and `pythonBlocks`
- * are structurally identical; only the language they lower through
- * differs.
+ * Every native block an *enabled* library ships, paired with its source.
+ *
+ * A manifest entry whose `sourceFile` is missing from `archive.sources` is
+ * skipped here and reported by `findLibrariesMissingNativeSources`, so the
+ * caller can fail the build naming the library rather than letting the compile
+ * die later on an undefined type.
  */
-function nativeBlocksOf(archive: StlibArchiveDTO): Array<{ block: ArchiveNativeBlock; language: 'cpp' | 'python' }> {
-  return [
-    ...(archive.cppBlocks ?? []).map((block) => ({ block, language: 'cpp' as const })),
-    ...(archive.pythonBlocks ?? []).map((block) => ({ block, language: 'python' as const })),
-  ]
+function resolveNativeBlocks(
+  projectData: PLCProjectData,
+  archives: StlibArchiveDTO[],
+): { blocks: ResolvedNativeBlock[]; librariesMissingSource: string[] } {
+  const blocks: ResolvedNativeBlock[] = []
+  const librariesMissingSource = new Set<string>()
+
+  if (!projectData.libraries || projectData.libraries.length === 0) {
+    return { blocks, librariesMissingSource: [] }
+  }
+  const enabledNames = new Set(projectData.libraries.map((ref) => ref.name))
+
+  for (const archive of archives) {
+    const libraryName = archive.manifest?.name
+    if (!libraryName || !enabledNames.has(libraryName)) continue
+
+    const sourceByFile = new Map((archive.sources ?? []).map((s) => [s.fileName, s.source]))
+
+    for (const entry of archive.manifest.functionBlocks ?? []) {
+      if (!entry.implementation) continue
+      const source = entry.sourceFile === undefined ? undefined : sourceByFile.get(entry.sourceFile)
+      if (source === undefined || source.trim() === '') {
+        librariesMissingSource.add(libraryName)
+        continue
+      }
+      blocks.push({
+        libraryName,
+        blockName: entry.name,
+        language: entry.implementation,
+        source,
+      })
+    }
+  }
+
+  return { blocks, librariesMissingSource: [...librariesMissingSource] }
 }
 
 /**
  * Graft the native blocks of every *enabled* library into
  * `projectData.pous`.
  *
- * Returns the input unchanged (same reference) when the project
- * enables no libraries or none of them ship native blocks, so callers
- * can apply this unconditionally on every compile path without paying
- * a clone.
+ * Returns the input unchanged (same reference) when the project enables no
+ * libraries or none of them ship native blocks, so callers can apply this
+ * unconditionally on every compile path without paying a clone.
  *
  * Only archives whose manifest name appears in `projectData.libraries`
- * contribute — an installed-but-not-enabled library must not leak its
- * blocks into the build.
+ * contribute — an installed-but-not-enabled library must not leak its blocks
+ * into the build.
+ *
+ * The authored file is parsed by `parseHybridPouFromString`, the same function
+ * that reads a native POU off disk.  Interface, body and documentation are
+ * therefore derived exactly as they are for a user-authored block: one parser,
+ * one representation, nothing for the archive to hold stale.
  */
 export function injectLibraryBlocks(projectData: PLCProjectData, archives: StlibArchiveDTO[]): PLCProjectData {
-  if (!projectData.libraries || projectData.libraries.length === 0) return projectData
+  const { blocks } = resolveNativeBlocks(projectData, archives)
+  if (blocks.length === 0) return projectData
 
-  const enabledNames = new Set(projectData.libraries.map((ref) => ref.name))
   const synthesized: PLCPou[] = []
-
-  for (const archive of archives) {
-    const libraryName = archive.manifest?.name
-    if (!libraryName || !enabledNames.has(libraryName)) continue
-
-    for (const { block, language } of nativeBlocksOf(archive)) {
-      synthesized.push({
-        name: libraryBlockPouName(libraryName, block.name),
-        pouType: 'function-block',
-        // `variables` rides through the archive as `unknown[]` by design —
-        // the manifest layer doesn't know our PLCVariable shape.  The
-        // archives are produced by this same editor's build pipeline from
-        // the same PLCVariable type, so the narrowing matches reality.
-        interface: { variables: block.variables as PLCVariable[] },
-        body: { language, value: block.code },
-        documentation: block.documentation ?? '',
-      })
+  for (const block of blocks) {
+    let parsed: PLCPou
+    try {
+      parsed = parseHybridPouFromString(block.source, block.language, 'function-block')
+    } catch {
+      // A block whose header the parser rejects is skipped rather than
+      // aborting the build: the consumer's compile then fails on the
+      // undefined type, which names the block the user actually referenced.
+      continue
     }
+    synthesized.push({
+      ...parsed,
+      name: libraryBlockPouName(block.libraryName, block.blockName),
+      pouType: 'function-block',
+    })
   }
 
   if (synthesized.length === 0) return projectData
-
   return { ...projectData, pous: [...projectData.pous, ...synthesized] }
 }
 
 /**
- * Names of enabled libraries that declare native blocks in their
- * manifest but ship no source for them.
+ * Names of enabled libraries that declare native blocks whose source is
+ * missing from the archive.
  *
- * A `.stlib` may legitimately omit ST/IL sources (the "don't publish
- * sources" option) because strucpp already compiled those into
- * `chunks`.  C/C++ and Python blocks have no chunks — their source
- * *is* the deliverable, and an archive without it is unbuildable by
- * any consumer.  Callers surface this as a build error naming the
- * library, rather than letting the compile fail later with an
- * undefined-symbol diagnostic that points nowhere useful.
+ * A `.stlib` may legitimately omit ST sources (published closed-source)
+ * because strucpp already compiled those into `chunks`.  Native blocks have no
+ * chunk — their source *is* the deliverable — so strucpp keeps them even under
+ * `--no-source`.  An archive that lacks them is malformed or was truncated in
+ * transit; callers surface this naming the library, rather than letting the
+ * compile fail later with an undefined-type diagnostic that points nowhere
+ * useful.
  */
 export function findLibrariesMissingNativeSources(projectData: PLCProjectData, archives: StlibArchiveDTO[]): string[] {
-  if (!projectData.libraries || projectData.libraries.length === 0) return []
-
-  const enabledNames = new Set(projectData.libraries.map((ref) => ref.name))
-  const missing: string[] = []
-
-  for (const archive of archives) {
-    const libraryName = archive.manifest?.name
-    if (!libraryName || !enabledNames.has(libraryName)) continue
-
-    const blocks = nativeBlocksOf(archive)
-    if (blocks.length === 0) continue
-    if (blocks.some(({ block }) => typeof block.code !== 'string' || block.code.trim() === '')) {
-      missing.push(libraryName)
-    }
-  }
-
-  return missing
+  return resolveNativeBlocks(projectData, archives).librariesMissingSource
 }

--- a/src/backend/shared/library/library-build-orchestrator.ts
+++ b/src/backend/shared/library/library-build-orchestrator.ts
@@ -45,6 +45,7 @@ import {
   type LibraryNativeSource,
   prepareXmlForLibraryBuild,
 } from './build-pipeline'
+import type { NativePouRef } from './native-pou-list'
 
 // ---------------------------------------------------------------------------
 // Public contract
@@ -68,6 +69,13 @@ export interface LibraryBuildArgs {
   verifyProjectData: PLCProjectData
   /** Skip the MD5 verification cache and force a fresh verify run. */
   cleanBuild: boolean
+  /** Native (C/C++, Python) POUs, collected from the project data BEFORE
+   *  `preprocessPous` ran — see `collectNativePous`. The pipeline cannot
+   *  derive this itself: by the time it sees `projectData`, every native body
+   *  has been lowered to bridge ST and the language tag rewritten with it, so
+   *  nothing identifies a native POU any more. Omitted or empty means the
+   *  project has none. */
+  nativePous?: NativePouRef[]
 }
 
 // Standard project-relative paths the orchestrator owns.  Centralised
@@ -85,18 +93,6 @@ export interface LibraryBuildArgs {
 const VERIFY_CACHE_REL_PATH = 'build/.verify-cache-library.json'
 const LIBRARY_MANIFEST_REL_PATH = 'library.json'
 const STLIB_OUT_DIR = 'build'
-/** Directory the editor persists each POU kind under. Native blocks are read
- *  back from here so the archive ships the author's bytes, not the lowered
- *  bridge ST that `preprocessPous` leaves on the project data. Keyed by POU
- *  type because a hand-authored project may put a C/C++ file under
- *  `pous/functions/` — strucpp rejects a native FUNCTION with a message that
- *  says why, and it can only do that if we hand it the file rather than
- *  failing here on a path we guessed wrong. */
-const POU_REL_DIR: Record<string, string> = {
-  program: 'pous/programs',
-  function: 'pous/functions',
-  'function-block': 'pous/function-blocks',
-}
 
 /**
  * Run the full library-build pipeline.  Pure with respect to its
@@ -113,7 +109,7 @@ export async function runLibraryBuildPipeline(
   port: LibraryBuildPort,
   emit: (event: LibraryBuildEvent) => void,
 ): Promise<CompileLibraryResult> {
-  const { projectPath, projectData, verifyProjectData, cleanBuild } = args
+  const { projectPath, projectData, verifyProjectData, cleanBuild, nativePous = [] } = args
 
   emit({ message: 'Starting library build...', level: 'info' })
 
@@ -300,22 +296,18 @@ export async function runLibraryBuildPipeline(
   // producing an archive whose manifest promises a block with no source.
   // -------------------------------------------------------------------------
   const nativeSources: LibraryNativeSource[] = []
-  for (const pou of projectData.pous) {
-    const language = pou.data.body?.language
-    if (language !== 'cpp' && language !== 'python') continue
-    const fileName = `${pou.data.name}.${language === 'cpp' ? 'cpp' : 'py'}`
-    const dir = POU_REL_DIR[pou.type] ?? POU_REL_DIR['function-block']
-    const relPath = `${dir}/${fileName}`
+  for (const ref of nativePous) {
+    const fileName = ref.relPath.split('/').pop() ?? ref.name
     let source: string | null
     try {
-      source = await port.readBuildFile(projectPath, relPath)
+      source = await port.readBuildFile(projectPath, ref.relPath)
     } catch (error) {
-      return fail(emit, `Could not read "${relPath}": ${formatError(error)}`, { libraryName: manifest.name })
+      return fail(emit, `Could not read "${ref.relPath}": ${formatError(error)}`, { libraryName: manifest.name })
     }
     if (source === null || source.trim() === '') {
       return fail(
         emit,
-        `Could not read the source for "${pou.data.name}" at ${relPath}. ` +
+        `Could not read the source for "${ref.name}" at ${ref.relPath}. ` +
           'C/C++ and Python blocks ship their source verbatim, so the file must be present.',
         { libraryName: manifest.name },
       )

--- a/src/backend/shared/library/library-build-orchestrator.ts
+++ b/src/backend/shared/library/library-build-orchestrator.ts
@@ -85,10 +85,18 @@ export interface LibraryBuildArgs {
 const VERIFY_CACHE_REL_PATH = 'build/.verify-cache-library.json'
 const LIBRARY_MANIFEST_REL_PATH = 'library.json'
 const STLIB_OUT_DIR = 'build'
-/** Where the editor persists function-block POU files. Native blocks are read
+/** Directory the editor persists each POU kind under. Native blocks are read
  *  back from here so the archive ships the author's bytes, not the lowered
- *  bridge ST that `preprocessPous` leaves on the project data. */
-const NATIVE_POU_REL_DIR = 'pous/function-blocks'
+ *  bridge ST that `preprocessPous` leaves on the project data. Keyed by POU
+ *  type because a hand-authored project may put a C/C++ file under
+ *  `pous/functions/` — strucpp rejects a native FUNCTION with a message that
+ *  says why, and it can only do that if we hand it the file rather than
+ *  failing here on a path we guessed wrong. */
+const POU_REL_DIR: Record<string, string> = {
+  program: 'pous/programs',
+  function: 'pous/functions',
+  'function-block': 'pous/function-blocks',
+}
 
 /**
  * Run the full library-build pipeline.  Pure with respect to its
@@ -296,7 +304,8 @@ export async function runLibraryBuildPipeline(
     const language = pou.data.body?.language
     if (language !== 'cpp' && language !== 'python') continue
     const fileName = `${pou.data.name}.${language === 'cpp' ? 'cpp' : 'py'}`
-    const relPath = `${NATIVE_POU_REL_DIR}/${fileName}`
+    const dir = POU_REL_DIR[pou.type] ?? POU_REL_DIR['function-block']
+    const relPath = `${dir}/${fileName}`
     let source: string | null
     try {
       source = await port.readBuildFile(projectPath, relPath)

--- a/src/backend/shared/library/library-build-orchestrator.ts
+++ b/src/backend/shared/library/library-build-orchestrator.ts
@@ -272,14 +272,35 @@ export async function runLibraryBuildPipeline(
       pouDocs[name] = doc
     }
   }
-  const cppBlocks: LibraryCppBlock[] = (
-    (projectData as { originalCppPous?: Array<{ name: string; code: string; variables: unknown[] }> })
-      .originalCppPous ?? []
-  ).map((b) => ({
-    name: b.name,
-    code: b.code,
-    variables: b.variables,
-  }))
+  // Native (non-strucpp) blocks ride the archive verbatim.  Both sidecars
+  // are captured by `preprocessPous` before lowering, so what ships is the
+  // author's original C++/Python, not the generated bridge stub — see
+  // `inject-library-blocks.ts` for why that distinction matters.
+  const nativeSidecars = projectData as {
+    originalCppPous?: Array<{ name: string; code: string; variables: unknown[] }>
+    originalPythonPous?: Array<{ name: string; code: string; variables: unknown[] }>
+  }
+  const toBlocks = (pous: Array<{ name: string; code: string; variables: unknown[] }> = []): LibraryCppBlock[] =>
+    pous.map((b) => ({
+      name: b.name,
+      code: b.code,
+      variables: b.variables,
+    }))
+  const cppBlocks = toBlocks(nativeSidecars.originalCppPous)
+  const pythonBlocks = toBlocks(nativeSidecars.originalPythonPous)
+
+  // A native block with no source is unbuildable by any consumer — its
+  // source is the whole deliverable.  Fail here, naming the block, rather
+  // than shipping an archive that dies later with an undefined-symbol
+  // diagnostic pointing at generated code.
+  const sourceless = [...cppBlocks, ...pythonBlocks].filter((b) => b.code.trim() === '').map((b) => b.name)
+  if (sourceless.length > 0) {
+    return fail(
+      emit,
+      `Library build aborted: C/C++ and Python blocks must ship their source, and these have none (${sourceless.join(', ')}).`,
+      { libraryName: manifest.name },
+    )
+  }
 
   // -------------------------------------------------------------------------
   // Stage 7: strucpp compileStlib
@@ -290,6 +311,7 @@ export async function runLibraryBuildPipeline(
     dependencyArchives: depArchives,
     dependencyRefs: enabledLibraryRefs,
     cppBlocks,
+    pythonBlocks,
   })
   if (!stage7.success) {
     for (const err of stage7.errors) {

--- a/src/backend/shared/library/library-build-orchestrator.ts
+++ b/src/backend/shared/library/library-build-orchestrator.ts
@@ -25,7 +25,8 @@
  *   4. Verification compile against the OpenPLC Simulator target
  *      via `LibraryBuildPort.verifyCompile`.  MD5 cache hit short-
  *      circuits.  Cache record persisted under `build/`.
- *   5. Gather `pouDocs` + `cppBlocks` from the project data.
+ *   5. Gather `pouDocs` from the project data, and read the authored
+ *      C/C++ / Python POU files off disk for strucpp to carry verbatim.
  *   6. strucpp compile via `libraryBuildFromTranspiledSt`.
  *   7. Write `.stlib` archive to `build/{name}.stlib`.
  *
@@ -41,7 +42,7 @@ import type { PLCProject, PLCProjectData } from '../types/PLC/open-plc'
 import {
   composeVerificationProject,
   libraryBuildFromTranspiledSt,
-  type LibraryCppBlock,
+  type LibraryNativeSource,
   prepareXmlForLibraryBuild,
 } from './build-pipeline'
 
@@ -84,6 +85,10 @@ export interface LibraryBuildArgs {
 const VERIFY_CACHE_REL_PATH = 'build/.verify-cache-library.json'
 const LIBRARY_MANIFEST_REL_PATH = 'library.json'
 const STLIB_OUT_DIR = 'build'
+/** Where the editor persists function-block POU files. Native blocks are read
+ *  back from here so the archive ships the author's bytes, not the lowered
+ *  bridge ST that `preprocessPous` leaves on the project data. */
+const NATIVE_POU_REL_DIR = 'pous/function-blocks'
 
 /**
  * Run the full library-build pipeline.  Pure with respect to its
@@ -257,7 +262,9 @@ export async function runLibraryBuildPipeline(
   // POUs contribute their editor "Description" field; data types
   // contribute their own optional documentation.  Both ride through
   // `libraryBuildFromTranspiledSt`'s aux block and get stamped onto
-  // the corresponding manifest entries via `decorateArchive`.
+  // the corresponding manifest entries via `decorateArchive`.  (Native
+  // blocks get their documentation from strucpp instead, which reads the
+  // leading ST comment out of the authored file.)
   // -------------------------------------------------------------------------
   const pouDocs: Record<string, string> = {}
   for (const pou of projectData.pous) {
@@ -272,34 +279,39 @@ export async function runLibraryBuildPipeline(
       pouDocs[name] = doc
     }
   }
-  // Native (non-strucpp) blocks ride the archive verbatim.  Both sidecars
-  // are captured by `preprocessPous` before lowering, so what ships is the
-  // author's original C++/Python, not the generated bridge stub — see
-  // `inject-library-blocks.ts` for why that distinction matters.
-  const nativeSidecars = projectData as {
-    originalCppPous?: Array<{ name: string; code: string; variables: unknown[] }>
-    originalPythonPous?: Array<{ name: string; code: string; variables: unknown[] }>
-  }
-  const toBlocks = (pous: Array<{ name: string; code: string; variables: unknown[] }> = []): LibraryCppBlock[] =>
-    pous.map((b) => ({
-      name: b.name,
-      code: b.code,
-      variables: b.variables,
-    }))
-  const cppBlocks = toBlocks(nativeSidecars.originalCppPous)
-  const pythonBlocks = toBlocks(nativeSidecars.originalPythonPous)
-
-  // A native block with no source is unbuildable by any consumer — its
-  // source is the whole deliverable.  Fail here, naming the block, rather
-  // than shipping an archive that dies later with an undefined-symbol
-  // diagnostic pointing at generated code.
-  const sourceless = [...cppBlocks, ...pythonBlocks].filter((b) => b.code.trim() === '').map((b) => b.name)
-  if (sourceless.length > 0) {
-    return fail(
-      emit,
-      `Library build aborted: C/C++ and Python blocks must ship their source, and these have none (${sourceless.join(', ')}).`,
-      { libraryName: manifest.name },
-    )
+  // -------------------------------------------------------------------------
+  // Stage 6b: read the authored C/C++ and Python POU files off the project
+  //
+  // Read from disk, NOT from the preprocessed project data: by this point
+  // `preprocessPous` has replaced every native body with generated bridge ST,
+  // and the archive must carry what the author wrote.  Strucpp stores these
+  // verbatim and the consumer re-derives the bridge at its own build time —
+  // that is what keeps a published library working when the bridge changes.
+  //
+  // A file that cannot be read fails the build naming the block, rather than
+  // producing an archive whose manifest promises a block with no source.
+  // -------------------------------------------------------------------------
+  const nativeSources: LibraryNativeSource[] = []
+  for (const pou of projectData.pous) {
+    const language = pou.data.body?.language
+    if (language !== 'cpp' && language !== 'python') continue
+    const fileName = `${pou.data.name}.${language === 'cpp' ? 'cpp' : 'py'}`
+    const relPath = `${NATIVE_POU_REL_DIR}/${fileName}`
+    let source: string | null
+    try {
+      source = await port.readBuildFile(projectPath, relPath)
+    } catch (error) {
+      return fail(emit, `Could not read "${relPath}": ${formatError(error)}`, { libraryName: manifest.name })
+    }
+    if (source === null || source.trim() === '') {
+      return fail(
+        emit,
+        `Could not read the source for "${pou.data.name}" at ${relPath}. ` +
+          'C/C++ and Python blocks ship their source verbatim, so the file must be present.',
+        { libraryName: manifest.name },
+      )
+    }
+    nativeSources.push({ fileName, source })
   }
 
   // -------------------------------------------------------------------------
@@ -310,8 +322,7 @@ export async function runLibraryBuildPipeline(
     pouDocs,
     dependencyArchives: depArchives,
     dependencyRefs: enabledLibraryRefs,
-    cppBlocks,
-    pythonBlocks,
+    nativeSources,
   })
   if (!stage7.success) {
     for (const err of stage7.errors) {

--- a/src/backend/shared/library/native-pou-list.ts
+++ b/src/backend/shared/library/native-pou-list.ts
@@ -58,3 +58,32 @@ export function collectNativePous(projectData: PLCProjectData): NativePouRef[] {
   }
   return refs
 }
+
+/**
+ * Narrow an untrusted value into `NativePouRef[]`.
+ *
+ * The desktop build sends this list across IPC, so it arrives as `unknown` no
+ * matter what the renderer meant to send: an older renderer omits it entirely,
+ * and a malformed entry would otherwise reach the read loop and throw on
+ * `relPath.split` — out of a handler invoked with `void`, so the renderer would
+ * sit waiting for a result that never comes.
+ *
+ * Unparseable input yields an empty list, which degrades to "this project has
+ * no native POUs": the library still builds, and a project that genuinely had
+ * native blocks fails later with strucpp's own diagnostic rather than a crash
+ * with no result at all. Individual malformed entries are dropped rather than
+ * failing the whole list, for the same reason.
+ */
+export function parseNativePouRefs(value: unknown): NativePouRef[] {
+  if (!Array.isArray(value)) return []
+  const refs: NativePouRef[] = []
+  for (const entry of value) {
+    if (typeof entry !== 'object' || entry === null) continue
+    const { name, language, relPath } = entry as Record<string, unknown>
+    if (typeof name !== 'string' || name === '') continue
+    if (typeof relPath !== 'string' || relPath === '') continue
+    if (language !== 'cpp' && language !== 'python') continue
+    refs.push({ name, language, relPath })
+  }
+  return refs
+}

--- a/src/backend/shared/library/native-pou-list.ts
+++ b/src/backend/shared/library/native-pou-list.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * The library build's inventory of native (C/C++, Python) POUs.
+ *
+ * Must be taken from the project data BEFORE `preprocessPous` runs. That step
+ * lowers every native body to its bridge ST and rewrites the language tag with
+ * it — `body: { language: 'st', value: <bridge ST> }` — so afterwards there is
+ * nothing left to identify a native POU by. A build that inferred the list
+ * post-lowering found none, shipped the generated bridge in the archive instead
+ * of the authored source, and produced exactly the frozen-ABI artifact the
+ * design exists to avoid.
+ *
+ * Both platforms compute this at their own adapter boundary, where the raw
+ * project data still exists, and pass it into `runLibraryBuildPipeline`.
+ */
+
+import type { PLCProjectData } from '../../../middleware/shared/ports/types'
+
+/** Directory the editor persists each POU kind under. */
+const POU_REL_DIR: Record<string, string> = {
+  program: 'pous/programs',
+  function: 'pous/functions',
+  'function-block': 'pous/function-blocks',
+}
+
+/** One native POU, enough to find its authored file and label its language. */
+export interface NativePouRef {
+  name: string
+  language: 'cpp' | 'python'
+  /** Project-relative path of the authored file, e.g.
+   *  `pous/function-blocks/TCP_CLIENT.cpp`. Derived from the POU type, because
+   *  a hand-authored project may declare a native POU as a FUNCTION — strucpp
+   *  rejects that with a message explaining why, and it can only do so if the
+   *  build hands it the file instead of failing on a path guessed wrong. */
+  relPath: string
+}
+
+/** File extension the editor writes a native POU of this language under. */
+function extensionFor(language: 'cpp' | 'python'): string {
+  return language === 'cpp' ? 'cpp' : 'py'
+}
+
+/**
+ * Native POUs in `projectData`, in declaration order.
+ *
+ * Call this on RAW project data — before `preprocessPous`. Returns an empty
+ * array for a project with no native POUs, which is the common case.
+ */
+export function collectNativePous(projectData: PLCProjectData): NativePouRef[] {
+  const refs: NativePouRef[] = []
+  for (const pou of projectData.pous) {
+    const language = pou.body?.language
+    if (language !== 'cpp' && language !== 'python') continue
+    const fileName = `${pou.name}.${extensionFor(language)}`
+    const dir = POU_REL_DIR[pou.pouType] ?? POU_REL_DIR['function-block']
+    refs.push({ name: pou.name, language, relPath: `${dir}/${fileName}` })
+  }
+  return refs
+}

--- a/src/backend/shared/utils/PLC/preprocess-pous.ts
+++ b/src/backend/shared/utils/PLC/preprocess-pous.ts
@@ -15,13 +15,6 @@ type CppPouData = {
 
 type ProjectDataWithCpp = PLCProjectData & {
   originalCppPous?: CppPouData[]
-  /** Verbatim Python POU sources, captured before lowering, in the same
-   *  shape `originalCppPous` uses.  The library build needs the author's
-   *  original Python to ship in the `.stlib` — the lowered ST embeds an
-   *  `{external}` bridge against the current `iec_python.h` ABI, which
-   *  must not be frozen into a published archive.  Program builds ignore
-   *  this field; only `library-build-orchestrator` reads it. */
-  originalPythonPous?: CppPouData[]
 }
 
 type LogFn = (level: 'info' | 'error', message: string) => void
@@ -61,18 +54,6 @@ function preprocessPous(projectData: PLCProjectData, isSimulator: boolean, log: 
     })
 
     log('info', `Processing ${pythonPous.length} Python POU(s)...`)
-
-    // Captured BEFORE lowering — once `generateSTCode` has run, the body is
-    // an ST bridge stub and the author's Python is gone.
-    const originalPythonPousData: CppPouData[] = pythonPous.map((pou) => ({
-      name: pou.name,
-      code:
-        /* istanbul ignore next -- defensive: filter above guarantees language === 'python' */
-        pou.body.language === 'python' ? (pou.body as { language: string; value: string }).value : '',
-      variables:
-        /* istanbul ignore next -- defensive: interface may be undefined */
-        pou.interface?.variables ?? [],
-    }))
 
     processedProjectData = addPythonLocalVariables(projectData)
 
@@ -127,8 +108,6 @@ function preprocessPous(projectData: PLCProjectData, isSimulator: boolean, log: 
     if (isSimulator) {
       log('info', `Compiled ${pythonPous.length} Python POU(s) as empty stubs for simulator`)
     }
-
-    ;(processedProjectData as ProjectDataWithCpp).originalPythonPous = originalPythonPousData
   }
 
   // --- C++ processing ---

--- a/src/backend/shared/utils/PLC/preprocess-pous.ts
+++ b/src/backend/shared/utils/PLC/preprocess-pous.ts
@@ -15,6 +15,13 @@ type CppPouData = {
 
 type ProjectDataWithCpp = PLCProjectData & {
   originalCppPous?: CppPouData[]
+  /** Verbatim Python POU sources, captured before lowering, in the same
+   *  shape `originalCppPous` uses.  The library build needs the author's
+   *  original Python to ship in the `.stlib` — the lowered ST embeds an
+   *  `{external}` bridge against the current `iec_python.h` ABI, which
+   *  must not be frozen into a published archive.  Program builds ignore
+   *  this field; only `library-build-orchestrator` reads it. */
+  originalPythonPous?: CppPouData[]
 }
 
 type LogFn = (level: 'info' | 'error', message: string) => void
@@ -54,6 +61,18 @@ function preprocessPous(projectData: PLCProjectData, isSimulator: boolean, log: 
     })
 
     log('info', `Processing ${pythonPous.length} Python POU(s)...`)
+
+    // Captured BEFORE lowering — once `generateSTCode` has run, the body is
+    // an ST bridge stub and the author's Python is gone.
+    const originalPythonPousData: CppPouData[] = pythonPous.map((pou) => ({
+      name: pou.name,
+      code:
+        /* istanbul ignore next -- defensive: filter above guarantees language === 'python' */
+        pou.body.language === 'python' ? (pou.body as { language: string; value: string }).value : '',
+      variables:
+        /* istanbul ignore next -- defensive: interface may be undefined */
+        pou.interface?.variables ?? [],
+    }))
 
     processedProjectData = addPythonLocalVariables(projectData)
 
@@ -108,6 +127,8 @@ function preprocessPous(projectData: PLCProjectData, isSimulator: boolean, log: 
     if (isSimulator) {
       log('info', `Compiled ${pythonPous.length} Python POU(s) as empty stubs for simulator`)
     }
+
+    ;(processedProjectData as ProjectDataWithCpp).originalPythonPous = originalPythonPousData
   }
 
   // --- C++ processing ---

--- a/src/frontend/utils/__tests__/stlib-to-system-library.test.ts
+++ b/src/frontend/utils/__tests__/stlib-to-system-library.test.ts
@@ -116,37 +116,44 @@ describe('stlibToSystemLibrary — function blocks', () => {
   })
 })
 
-describe('stlibToSystemLibrary — cppBlocks branch', () => {
-  it('surfaces each library cpp block under the prefixed name', () => {
-    const archive: StlibArchiveDTO = {
+describe('stlibToSystemLibrary — native (C/C++, Python) blocks', () => {
+  const nativeArchive = (
+    blocks: Array<{ name: string; implementation: 'cpp' | 'python'; sourceFile?: string; documentation?: string }>,
+    sources: Array<{ fileName: string; source: string }>,
+  ): StlibArchiveDTO =>
+    ({
       manifest: {
         name: 'mylib',
         version: '1.0.0',
         namespace: 'mylib',
         isBuiltin: false,
         functions: [],
-        functionBlocks: [],
+        functionBlocks: blocks.map((b) => ({
+          name: b.name,
+          inputs: [{ name: 'pin', type: 'INT' }],
+          outputs: [{ name: 'angle', type: 'INT' }],
+          inouts: [{ name: 'state', type: 'BOOL' }],
+          implementation: b.implementation,
+          sourceFile: b.sourceFile ?? `${b.name}.${b.implementation === 'cpp' ? 'cpp' : 'py'}`,
+          ...(b.documentation !== undefined ? { documentation: b.documentation } : {}),
+        })),
         types: [],
       },
-      cppBlocks: [
-        {
-          name: 'Servo',
-          code: 'void setup(){}void loop(){}',
-          variables: [
-            { name: 'pin', class: 'input', type: { value: 'INT' } },
-            { name: 'angle', class: 'output', type: { value: 'INT' } },
-            { name: 'state', class: 'inOut', type: { value: 'BOOL' } },
-            { name: 'local', class: 'local', type: { value: 'INT' } },
-          ],
-          documentation: 'A servo motor block',
-        },
-      ],
-    }
+      sources,
+    }) as unknown as StlibArchiveDTO
 
-    const lib = stlibToSystemLibrary(archive)
+  it('surfaces a C++ block under the prefixed name, with its authored source as the body', () => {
+    const lib = stlibToSystemLibrary(
+      nativeArchive(
+        [{ name: 'Servo', implementation: 'cpp', documentation: 'A servo motor block' }],
+        [{ fileName: 'Servo.cpp', source: 'void setup(){}void loop(){}' }],
+      ),
+    )
 
     expect(lib.pous).toHaveLength(1)
     const block = lib.pous[0]
+    // The prefix matters: the compile-time graft produces a POU with exactly
+    // this name, so the picker must show what the user has to type.
     expect(block.name).toBe('mylib__Servo')
     expect(block.type).toBe('function-block')
     expect(block.language).toBe('cpp')
@@ -155,48 +162,57 @@ describe('stlibToSystemLibrary — cppBlocks branch', () => {
     expect(block.variables.map((v) => v.class)).toEqual(['input', 'output', 'inOut'])
   })
 
-  it('falls back to BOOL when a cpp block variable omits its type', () => {
-    const archive: StlibArchiveDTO = {
-      manifest: {
-        name: 'mylib',
-        version: '1.0.0',
-        namespace: 'mylib',
-        isBuiltin: false,
-        functions: [],
-        functionBlocks: [],
-        types: [],
-      },
-      cppBlocks: [
-        {
-          name: 'Bare',
-          code: '',
-          variables: [{ name: 'x', class: 'input' }],
-        },
-      ],
-    }
-
-    const lib = stlibToSystemLibrary(archive)
-
-    expect(lib.pous[0].variables[0].type).toEqual({ definition: 'base-type', value: 'BOOL' })
+  it('surfaces a Python block as a python POU', () => {
+    const lib = stlibToSystemLibrary(
+      nativeArchive(
+        [{ name: 'Scale', implementation: 'python' }],
+        [{ fileName: 'Scale.py', source: 'def block_loop():\n    pass' }],
+      ),
+    )
+    expect(lib.pous[0].name).toBe('mylib__Scale')
+    expect(lib.pous[0].language).toBe('python')
+    expect(lib.pous[0].body).toBe('def block_loop():\n    pass')
   })
 
-  it('uses an empty documentation string when the cpp block omits one', () => {
-    const archive: StlibArchiveDTO = {
+  it('resolves the body via sourceFile rather than guessing from the block name', () => {
+    const lib = stlibToSystemLibrary(
+      nativeArchive(
+        [{ name: 'Block', implementation: 'cpp', sourceFile: 'renamed.cpp' }],
+        [{ fileName: 'renamed.cpp', source: 'void loop(){}' }],
+      ),
+    )
+    expect(lib.pous[0].body).toBe('void loop(){}')
+  })
+
+  it('leaves the body empty when the archive has no matching source', () => {
+    const lib = stlibToSystemLibrary(nativeArchive([{ name: 'Gone', implementation: 'cpp' }], []))
+    expect(lib.pous[0].body).toBe('')
+  })
+
+  it('uses an empty documentation string when the block omits one', () => {
+    const lib = stlibToSystemLibrary(
+      nativeArchive([{ name: 'Bare', implementation: 'cpp' }], [{ fileName: 'Bare.cpp', source: 'x' }]),
+    )
+    expect(lib.pous[0].documentation).toBe('')
+  })
+
+  it('leaves ordinary ST blocks unprefixed and marked st', () => {
+    const archive = {
       manifest: {
         name: 'mylib',
         version: '1.0.0',
         namespace: 'mylib',
         isBuiltin: false,
         functions: [],
-        functionBlocks: [],
+        functionBlocks: [{ name: 'ST_ADD', inputs: [], outputs: [], inouts: [] }],
         types: [],
       },
-      cppBlocks: [{ name: 'NoDoc', code: '', variables: [] }],
-    }
+    } as unknown as StlibArchiveDTO
 
     const lib = stlibToSystemLibrary(archive)
-
-    expect(lib.pous[0].documentation).toBe('')
+    expect(lib.pous[0].name).toBe('ST_ADD')
+    expect(lib.pous[0].language).toBe('st')
+    expect(lib.pous[0].body).toBe('')
   })
 })
 

--- a/src/frontend/utils/stlib-to-system-library.ts
+++ b/src/frontend/utils/stlib-to-system-library.ts
@@ -177,26 +177,33 @@ export function stlibToSystemLibrary(archive: StlibArchiveDTO): SystemLibrary {
     variables: CppBlockVar[]
     documentation?: string
   }
-  const archiveWithCppBlocks = archive as typeof archive & { cppBlocks?: CppBlockEntry[] }
-  for (const block of archiveWithCppBlocks.cppBlocks ?? []) {
-    const variables: SystemLibraryVariable[] = []
-    for (const v of block.variables) {
-      if (v.class !== 'input' && v.class !== 'output' && v.class !== 'inOut') continue
-      variables.push({
-        name: v.name,
-        class: v.class,
-        type: typeRef(v.type?.value ?? 'BOOL'),
+  const archiveWithNativeBlocks = archive as typeof archive & {
+    cppBlocks?: CppBlockEntry[]
+    pythonBlocks?: CppBlockEntry[]
+  }
+  const pushNativeBlocks = (blocks: CppBlockEntry[] | undefined, language: 'cpp' | 'python'): void => {
+    for (const block of blocks ?? []) {
+      const variables: SystemLibraryVariable[] = []
+      for (const v of block.variables) {
+        if (v.class !== 'input' && v.class !== 'output' && v.class !== 'inOut') continue
+        variables.push({
+          name: v.name,
+          class: v.class,
+          type: typeRef(v.type?.value ?? 'BOOL'),
+        })
+      }
+      pous.push({
+        name: `${m.name}__${block.name}`,
+        type: 'function-block',
+        language,
+        variables,
+        body: block.code,
+        documentation: block.documentation ?? '',
       })
     }
-    pous.push({
-      name: `${m.name}__${block.name}`,
-      type: 'function-block',
-      language: 'cpp',
-      variables,
-      body: block.code,
-      documentation: block.documentation ?? '',
-    })
   }
+  pushNativeBlocks(archiveWithNativeBlocks.cppBlocks, 'cpp')
+  pushNativeBlocks(archiveWithNativeBlocks.pythonBlocks, 'python')
 
   const result: SystemLibrary = {
     name: m.name,

--- a/src/frontend/utils/stlib-to-system-library.ts
+++ b/src/frontend/utils/stlib-to-system-library.ts
@@ -127,6 +127,10 @@ export function stlibToSystemLibrary(archive: StlibArchiveDTO): SystemLibrary {
     })
   }
 
+  // Native blocks carry their authored file in `archive.sources`, located via
+  // the manifest entry's `sourceFile`.
+  const sourceByFile = new Map((archive.sources ?? []).map((src) => [src.fileName, src.source]))
+
   for (const fb of m.functionBlocks) {
     const variables: SystemLibraryVariable[] = [
       ...fb.inputs.map((v) => ({
@@ -145,65 +149,21 @@ export function stlibToSystemLibrary(archive: StlibArchiveDTO): SystemLibrary {
         type: typeRef(v.type),
       })),
     ]
+    // A native (C/C++, Python) block is surfaced under the library-prefixed
+    // name (`<library>__<name>`) that the consumer's source must reference,
+    // because the compile-time graft produces a POU with exactly that name.
+    // The picker shows the prefix so the user types the right thing.
+    const nativeLanguage = fb.implementation
     pous.push({
-      name: fb.name,
+      name: nativeLanguage ? `${m.name}__${fb.name}` : fb.name,
       type: 'function-block',
-      language: 'st',
+      language: nativeLanguage ?? 'st',
       variables,
-      body: '',
+      body: nativeLanguage ? (sourceByFile.get(fb.sourceFile ?? '') ?? '') : '',
       documentation: fb.documentation ?? '',
       category: fb.category,
     })
   }
-
-  // C/C++ function blocks carried verbatim in `archive.cppBlocks`
-  // (strucpp doesn't compile these — the consumer's program build
-  // grafts them into its own C++-POU pipeline).  Each block is
-  // surfaced under the library-prefixed name (`<library>__<name>`)
-  // that the consumer's source code must reference, since the
-  // injection step at compile time uses the same prefix.  The
-  // picker shows the prefix so the user types the right name; the
-  // injection produces a POU with that exact name; everything
-  // resolves cleanly.
-  type CppBlockVar = {
-    name: string
-    class?: string
-    type?: { value?: string }
-    documentation?: string
-  }
-  type CppBlockEntry = {
-    name: string
-    code: string
-    variables: CppBlockVar[]
-    documentation?: string
-  }
-  const archiveWithNativeBlocks = archive as typeof archive & {
-    cppBlocks?: CppBlockEntry[]
-    pythonBlocks?: CppBlockEntry[]
-  }
-  const pushNativeBlocks = (blocks: CppBlockEntry[] | undefined, language: 'cpp' | 'python'): void => {
-    for (const block of blocks ?? []) {
-      const variables: SystemLibraryVariable[] = []
-      for (const v of block.variables) {
-        if (v.class !== 'input' && v.class !== 'output' && v.class !== 'inOut') continue
-        variables.push({
-          name: v.name,
-          class: v.class,
-          type: typeRef(v.type?.value ?? 'BOOL'),
-        })
-      }
-      pous.push({
-        name: `${m.name}__${block.name}`,
-        type: 'function-block',
-        language,
-        variables,
-        body: block.code,
-        documentation: block.documentation ?? '',
-      })
-    }
-  }
-  pushNativeBlocks(archiveWithNativeBlocks.cppBlocks, 'cpp')
-  pushNativeBlocks(archiveWithNativeBlocks.pythonBlocks, 'python')
 
   const result: SystemLibrary = {
     name: m.name,

--- a/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
@@ -773,9 +773,7 @@ describe('createEditorCompilerAdapter', () => {
       await promise
 
       const args = (window.bridge.runCompileLibrary as jest.Mock).mock.calls[0][0] as unknown[]
-      expect(args[4]).toEqual([
-        { name: 'CPP_SCALE', language: 'cpp', relPath: 'pous/function-blocks/CPP_SCALE.cpp' },
-      ])
+      expect(args[4]).toEqual([{ name: 'CPP_SCALE', language: 'cpp', relPath: 'pous/function-blocks/CPP_SCALE.cpp' }])
     })
 
     it('defaults non-error log levels to info when logLevel is missing', async () => {

--- a/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
@@ -527,88 +527,87 @@ describe('createEditorCompilerAdapter', () => {
     })
   })
 
-  describe('library-cpp-block injection', () => {
-    it("grafts each enabled library archive's cppBlocks into the project before preprocessing", async () => {
-      // Project enables a library called `motor_lib` that ships a
-      // C++ FB called `Driver`.  The bridge returns the archive with
-      // its cppBlocks; the adapter must inject a synthesized
-      // `motor_lib__Driver` POU into the project's POU list before
-      // it builds the IPC payload, so the program build's
-      // c_blocks.h/code.cpp generation picks up the C++ source.
+  describe('native library-block graft', () => {
+    /** An archive shaped the way strucpp emits one for a native block. */
+    const nativeArchive = (libraryName: string, blockName: string, language: 'cpp' | 'python') => {
+      const ext = language === 'cpp' ? 'cpp' : 'py'
+      const body = language === 'cpp' ? 'void setup() {}\nvoid loop() {}' : 'def block_loop():\n    pass'
+      return {
+        manifest: {
+          name: libraryName,
+          functionBlocks: [
+            {
+              name: blockName,
+              inputs: [],
+              outputs: [],
+              inouts: [],
+              implementation: language,
+              sourceFile: `${blockName}.${ext}`,
+            },
+          ],
+        },
+        sources: [
+          {
+            fileName: `${blockName}.${ext}`,
+            source: `FUNCTION_BLOCK ${blockName}\nVAR_INPUT pwm : INT; END_VAR\n${body}\nEND_FUNCTION_BLOCK\n`,
+          },
+        ],
+      }
+    }
+
+    const compileWith = async (projectData: PLCProjectData) => {
+      const promise = adapter.compileProgram({ projectData, boardTarget: 'Arduino Mega', projectPath: '/p' }, () => {})
+      await flushMicrotasks()
+      compileCallback!({ closePort: true })
+      await promise
+      const ipcArgs = (window.bridge.runCompileProgram as jest.Mock).mock.calls[0][0] as unknown[]
+      return ipcArgs[4] as {
+        pous: Array<{ data: { name: string } }>
+        originalCppPous?: Array<{ name: string }>
+      }
+    }
+
+    it("grafts an enabled library's C++ block into the project before preprocessing", async () => {
+      // The project enables `motor_lib`, which ships a C++ FB called `Driver`.
+      // The adapter must graft a `motor_lib__Driver` POU in before building the
+      // IPC payload, so the program build's c_blocks.h / code.cpp generation
+      // picks the C++ source up — exactly as it would for a user-authored block.
       const projectWithLib: PLCProjectData = {
         ...mockProjectData,
         libraries: [{ name: 'motor_lib', version: '1.0.0' }],
       }
-      ;(window.bridge.loadAllLibraries as jest.Mock).mockResolvedValue([
-        {
-          manifest: { name: 'motor_lib' },
-          cppBlocks: [
-            {
-              name: 'Driver',
-              code: 'void setup() {}\nvoid loop() {}',
-              variables: [
-                {
-                  name: 'pwm',
-                  class: 'input',
-                  type: { definition: 'base-type', value: 'INT' },
-                  location: '',
-                  documentation: '',
-                },
-              ],
-            },
-          ],
-        },
-      ])
+      ;(window.bridge.loadAllLibraries as jest.Mock).mockResolvedValue([nativeArchive('motor_lib', 'Driver', 'cpp')])
 
-      const promise = adapter.compileProgram(
-        { projectData: projectWithLib, boardTarget: 'Arduino Mega', projectPath: '/p' },
-        () => {},
-      )
-      await flushMicrotasks()
-      compileCallback!({ closePort: true })
-      await promise
-
-      // The IPC payload's POU list should contain the synthesized
-      // `motor_lib__Driver` POU AFTER preprocessing has turned its
-      // cpp body into an ST stub.  preprocessPous also stamps an
-      // `originalCppPous` entry alongside.
-      const ipcArgs = (window.bridge.runCompileProgram as jest.Mock).mock.calls[0][0] as unknown[]
-      const ipcProjectData = ipcArgs[4] as {
-        pous: Array<{ data: { name: string } }>
-        originalCppPous?: Array<{ name: string }>
-      }
-      const pouNames = ipcProjectData.pous.map((p) => p.data.name)
-      expect(pouNames).toContain('motor_lib__Driver')
+      const ipcProjectData = await compileWith(projectWithLib)
+      expect(ipcProjectData.pous.map((p) => p.data.name)).toContain('motor_lib__Driver')
+      // `preprocessPous` lowered the grafted body and stamped the sidecar,
+      // which is what proves it went through the user-POU path.
       expect(ipcProjectData.originalCppPous?.map((p) => p.name)).toContain('motor_lib__Driver')
     })
 
-    it("skips library cppBlocks that are not on the project's enabled list", async () => {
+    it("grafts an enabled library's Python block too", async () => {
+      const projectWithLib: PLCProjectData = {
+        ...mockProjectData,
+        libraries: [{ name: 'py_lib', version: '1.0.0' }],
+      }
+      ;(window.bridge.loadAllLibraries as jest.Mock).mockResolvedValue([nativeArchive('py_lib', 'Scale', 'python')])
+
+      const ipcProjectData = await compileWith(projectWithLib)
+      expect(ipcProjectData.pous.map((p) => p.data.name)).toContain('py_lib__Scale')
+    })
+
+    it("skips native blocks from libraries that are not on the project's enabled list", async () => {
       const projectWithLib: PLCProjectData = {
         ...mockProjectData,
         libraries: [{ name: 'enabled_lib', version: '1.0.0' }],
       }
       ;(window.bridge.loadAllLibraries as jest.Mock).mockResolvedValue([
-        {
-          manifest: { name: 'enabled_lib' },
-          cppBlocks: [{ name: 'OK', code: 'void setup(){}void loop(){}', variables: [] }],
-        },
-        {
-          // Not enabled — must not leak into the project.
-          manifest: { name: 'other_lib' },
-          cppBlocks: [{ name: 'Leak', code: 'void setup(){}void loop(){}', variables: [] }],
-        },
+        nativeArchive('enabled_lib', 'OK', 'cpp'),
+        // Installed but not enabled — must not leak into the build.
+        nativeArchive('other_lib', 'Leak', 'cpp'),
       ])
 
-      const promise = adapter.compileProgram(
-        { projectData: projectWithLib, boardTarget: 'Arduino Mega', projectPath: '/p' },
-        () => {},
-      )
-      await flushMicrotasks()
-      compileCallback!({ closePort: true })
-      await promise
-
-      const ipcArgs = (window.bridge.runCompileProgram as jest.Mock).mock.calls[0][0] as unknown[]
-      const ipcProjectData = ipcArgs[4] as { pous: Array<{ data: { name: string } }> }
+      const ipcProjectData = await compileWith(projectWithLib)
       const pouNames = ipcProjectData.pous.map((p) => p.data.name)
       expect(pouNames).toContain('enabled_lib__OK')
       expect(pouNames).not.toContain('other_lib__Leak')

--- a/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
@@ -636,12 +636,16 @@ describe('createEditorCompilerAdapter', () => {
       const result = await promise
 
       // Args: [projectPath, ipcDataForBuild, ipcDataForVerify, cleanBuild]
+      // 5th arg: the native-POU inventory, taken from the RAW project data
+      // before `preprocessPous` lowered every native body to bridge ST and
+      // rewrote its language tag. The main process cannot derive it.
       expect(window.bridge.runCompileLibrary).toHaveBeenCalledWith(
         [
           '/lib/project',
           expect.objectContaining({ pous: expect.any(Array) }),
           expect.objectContaining({ pous: expect.any(Array) }),
           false,
+          expect.any(Array),
         ],
         expect.any(Function),
       )
@@ -740,9 +744,38 @@ describe('createEditorCompilerAdapter', () => {
       await promise
 
       expect(window.bridge.runCompileLibrary).toHaveBeenCalledWith(
-        ['/lib/project', expect.any(Object), expect.any(Object), true],
+        ['/lib/project', expect.any(Object), expect.any(Object), true, expect.any(Array)],
         expect.any(Function),
       )
+    })
+
+    it('sends the native-POU inventory taken before preprocessing', async () => {
+      // Regression: the pipeline used to infer this from the POU list it
+      // received, which is always `st` by then — so it found none and the
+      // archive shipped the generated bridge instead of the authored source.
+      const withNative = {
+        ...mockProjectData,
+        pous: [
+          ...mockProjectData.pous,
+          {
+            name: 'CPP_SCALE',
+            pouType: 'function-block' as const,
+            body: { language: 'cpp' as const, value: 'void setup() {}\nvoid loop() {}' },
+            interface: { variables: [] },
+            documentation: '',
+          },
+        ],
+      }
+
+      const promise = adapter.compileLibrary!({ projectData: withNative, projectPath: '/lib/project' }, () => {})
+      await flushMicrotasks()
+      libraryCallback!({ closePort: true })
+      await promise
+
+      const args = (window.bridge.runCompileLibrary as jest.Mock).mock.calls[0][0] as unknown[]
+      expect(args[4]).toEqual([
+        { name: 'CPP_SCALE', language: 'cpp', relPath: 'pous/function-blocks/CPP_SCALE.cpp' },
+      ])
     })
 
     it('defaults non-error log levels to info when logLevel is missing', async () => {

--- a/src/middleware/adapters/editor/compile-program-flow.ts
+++ b/src/middleware/adapters/editor/compile-program-flow.ts
@@ -15,12 +15,16 @@
  * declares, whether a POU needs preprocessing, what shape the pipeline expects).
  */
 
+import {
+  findLibrariesMissingNativeSources,
+  injectLibraryBlocks,
+} from '../../../backend/shared/library/inject-library-blocks'
 import { preprocessPous } from '../../../backend/shared/utils/PLC/preprocess-pous'
 import type { CompileProgramArgs } from '../../shared/ports/compiler-port'
 import type { StlibArchiveDTO } from '../../shared/ports/library-port'
 import type { BoardInfo, CompileProgressEvent, CompileResult, StructuredCompileError } from '../../shared/ports/types'
 import type { IpcProjectData } from './compiler-adapter'
-import { decodeMessage, inferStage, injectLibraryCppBlocks, toIpcProjectData } from './compiler-adapter'
+import { decodeMessage, inferStage, toIpcProjectData } from './compiler-adapter'
 
 /**
  * The compile pipeline's argument list, by position.
@@ -86,14 +90,26 @@ export async function compileProgramFlow(
   const boardCore = boardInfo?.core ?? null
   const isSimulator = args.isSimulator ?? boardInfo?.compiler === 'simulator'
 
-  // Graft library-supplied C++ blocks into the project's POU
-  // list before preprocessing.  They behave like user-defined
-  // C++ POUs from this point on — same `preprocessPous` branch,
-  // same `c_blocks.h` / `c_blocks_code.cpp` generation
-  // downstream.  See `injectLibraryCppBlocks` for the renaming
-  // contract.
+  // Graft library-supplied C/C++ and Python blocks into the project's
+  // POU list before preprocessing.  They behave like user-defined
+  // native POUs from this point on — same `preprocessPous` branch,
+  // same `c_blocks.h` / `c_blocks_code.cpp` and Python-bridge
+  // generation downstream.  See `injectLibraryBlocks` for the renaming
+  // contract and for why the archive ships source rather than the
+  // already-lowered ST.
   const archives = await transport.loadAllLibraries()
-  const dataWithLibCpp = injectLibraryCppBlocks(args.projectData, archives)
+
+  // A native block with no source cannot be built by any consumer.
+  const missingSources = findLibrariesMissingNativeSources(args.projectData, archives)
+  if (missingSources.length > 0) {
+    const error =
+      `These libraries ship C/C++ or Python blocks without their source, so they cannot be built: ${missingSources.join(', ')}. ` +
+      'Reinstall them from a build that includes sources.'
+    onProgress({ stage: 'st', message: error, level: 'error' })
+    return { success: false, error }
+  }
+
+  const dataWithLibCpp = injectLibraryBlocks(args.projectData, archives)
 
   // Preprocess POUs (comment wrapping, Python->ST stubs, C++ validation/ST generation)
   const { projectData: processedData, validationFailed } = preprocessPous(

--- a/src/middleware/adapters/editor/compiler-adapter.ts
+++ b/src/middleware/adapters/editor/compiler-adapter.ts
@@ -15,6 +15,7 @@ import {
   findLibrariesMissingNativeSources,
   injectLibraryBlocks,
 } from '../../../backend/shared/library/inject-library-blocks'
+import { collectNativePous } from '../../../backend/shared/library/native-pou-list'
 import { preprocessPous } from '../../../backend/shared/utils/PLC/preprocess-pous'
 import type {
   CompileLibraryArgs,
@@ -255,6 +256,12 @@ export function createEditorCompilerAdapter(): CompilerPort {
       // The renderer-side `onProgress` log channel only sees the
       // build pass's preprocess output to avoid duplicate "Found
       // Python POU…" lines.
+      // Taken BEFORE preprocessing: that step lowers every native body to
+      // bridge ST and rewrites the language tag with it, leaving nothing to
+      // identify a native POU by.  Sent over IPC because the main process
+      // only ever sees the already-lowered data.
+      const nativePous = collectNativePous(args.projectData)
+
       const buildResult = preprocessPous(args.projectData, false, (level, message) => {
         onProgress({ stage: 'st', message, level })
       })
@@ -288,7 +295,13 @@ export function createEditorCompilerAdapter(): CompilerPort {
         //     `'close'` event — that's the sole "build done"
         //     signal the adapter resolves on.
         window.bridge.runCompileLibrary(
-          [args.projectPath, ipcDataForBuild as never, ipcDataForVerify as never, args.cleanBuild ?? false],
+          [
+            args.projectPath,
+            ipcDataForBuild as never,
+            ipcDataForVerify as never,
+            args.cleanBuild ?? false,
+            nativePous as never,
+          ],
           (data: Record<string, unknown>) => {
             if (data.libraryBuildResult) {
               finalResult = data.libraryBuildResult as CompileLibraryResult

--- a/src/middleware/adapters/editor/compiler-adapter.ts
+++ b/src/middleware/adapters/editor/compiler-adapter.ts
@@ -11,6 +11,10 @@
  *   - Port uses `configurations` (plural), IPC uses `configuration` (singular)
  */
 
+import {
+  findLibrariesMissingNativeSources,
+  injectLibraryBlocks,
+} from '../../../backend/shared/library/inject-library-blocks'
 import { preprocessPous } from '../../../backend/shared/utils/PLC/preprocess-pous'
 import type {
   CompileLibraryArgs,
@@ -27,7 +31,6 @@ import type {
   DebugCompileResult,
   PLCPou,
   PLCProjectData,
-  PLCVariable,
   Result,
 } from '../../shared/ports/types'
 import { compileProgramFlow } from './compile-program-flow'
@@ -112,63 +115,6 @@ function decodeMessage(raw: unknown): string {
   return String(raw)
 }
 
-/**
- * Graft any library-supplied C/C++ function blocks into the
- * project's POU list before the standard preprocessor runs.  Each
- * library archive's `cppBlocks` entry becomes a synthesized
- * `PLCPou` with `body.language: 'cpp'` — from there it flows
- * through `preprocessPous` exactly like a user-defined C++ POU
- * (ST stub generation, `originalCppPous` sidecar, downstream
- * `c_blocks.h` / `c_blocks_code.cpp` generation, link-time
- * resolution).  Strucpp never sees the C++ — it sees the
- * generated ST stub that calls into `c_blocks.h` externs.
- *
- * **Renaming**: each block's name is prefixed with the library's
- * manifest name (`${library_name}__${block_name}`) so two
- * different libraries can ship a block called `Foo` without
- * collision, and so a consumer's user-defined POU can also be
- * called `Foo` without colliding with a library's block.  The
- * editor's library-tree picker surfaces the prefixed name, so the
- * user authors their ST against that name directly — no parse +
- * rewrite of the user's source.
- *
- * Symbol-level renames inside the synthesized POU (the struct
- * `<NAME>_VARS`, the C functions `<name>_setup` /
- * `<name>_loop`) happen automatically because
- * `generateCppSTCode` / `generateCBlocksHeader` /
- * `generateCBlocksCode` all derive their names from
- * `pou.name`.
- */
-function injectLibraryCppBlocks(projectData: PLCProjectData, archives: StlibArchiveDTO[]): PLCProjectData {
-  if (!projectData.libraries || projectData.libraries.length === 0) return projectData
-
-  const enabledNames = new Set(projectData.libraries.map((ref) => ref.name))
-  const synthesized: PLCPou[] = []
-
-  for (const archive of archives) {
-    if (!archive.cppBlocks || archive.cppBlocks.length === 0) continue
-    if (!enabledNames.has(archive.manifest.name)) continue
-    for (const block of archive.cppBlocks) {
-      // `variables` rides through the StlibArchiveDTO as `unknown[]`
-      // by design — the manifest layer doesn't know our PLCVariable
-      // shape.  The on-disk archives are produced by THIS editor's
-      // own save pipeline using the same PLCVariable type, so the
-      // narrowing here matches reality at runtime.
-      synthesized.push({
-        name: `${archive.manifest.name}__${block.name}`,
-        pouType: 'function-block',
-        interface: { variables: block.variables as PLCVariable[] },
-        body: { language: 'cpp', value: block.code },
-        documentation: block.documentation ?? '',
-      })
-    }
-  }
-
-  if (synthesized.length === 0) return projectData
-
-  return { ...projectData, pous: [...projectData.pous, ...synthesized] }
-}
-
 /** Best-effort stage inference from compiler log messages. */
 function inferStage(message: string): CompileProgressEvent['stage'] {
   const lower = message.toLowerCase()
@@ -209,9 +155,20 @@ export function createEditorCompilerAdapter(): CompilerPort {
       args: DebugCompileArgs,
       onProgress: (event: CompileProgressEvent) => void,
     ): Promise<DebugCompileResult> {
-      // Same library-C++ injection as the program build path.
+      // Same graft as the program build path — a debug compile has to see
+      // the identical POU set or the debug map won't match the firmware.
       const archives = (await window.bridge.loadAllLibraries()) as StlibArchiveDTO[]
-      const dataWithLibCpp = injectLibraryCppBlocks(args.projectData, archives)
+
+      const missingSources = findLibrariesMissingNativeSources(args.projectData, archives)
+      if (missingSources.length > 0) {
+        const error =
+          `These libraries ship C/C++ or Python blocks without their source, so they cannot be built: ${missingSources.join(', ')}. ` +
+          'Reinstall them from a build that includes sources.'
+        onProgress({ stage: 'st', message: error, level: 'error' })
+        return { success: false, error }
+      }
+
+      const dataWithLibCpp = injectLibraryBlocks(args.projectData, archives)
 
       // Preprocess for debug compilation too
       const { projectData: processedData, validationFailed } = preprocessPous(
@@ -369,4 +326,4 @@ export function createEditorCompilerAdapter(): CompilerPort {
   }
 }
 
-export { decodeMessage, inferStage, injectLibraryCppBlocks, portPouToIpcPou, toIpcProjectData }
+export { decodeMessage, inferStage, portPouToIpcPou, toIpcProjectData }

--- a/src/middleware/shared/ports/library-port.ts
+++ b/src/middleware/shared/ports/library-port.ts
@@ -100,6 +100,20 @@ export interface StlibArchiveDTO {
     variables: unknown[]
     documentation?: string
   }>
+  /** Python function blocks the library ships, carried verbatim
+   *  through the archive.  Exactly the same contract as `cppBlocks`
+   *  — strucpp doesn't compile these either, and the consumer's
+   *  program build grafts them in and lowers them through the same
+   *  Python-POU pipeline a user-authored Python block uses.  Kept as
+   *  a separate field rather than a `language` tag on `cppBlocks` so
+   *  older editors, which only know `cppBlocks`, cannot mistake a
+   *  Python block for C++.  Absent on libraries that don't ship any. */
+  pythonBlocks?: Array<{
+    name: string
+    code: string
+    variables: unknown[]
+    documentation?: string
+  }>
 }
 
 export interface LibraryPort {

--- a/src/middleware/shared/ports/library-port.ts
+++ b/src/middleware/shared/ports/library-port.ts
@@ -75,6 +75,19 @@ export interface StlibArchiveDTO {
       inouts: Array<{ name: string; type: string }>
       documentation?: string
       category?: string
+      /** Body language, when strucpp did NOT compile this block.
+       *  Absent on ordinary ST/IL blocks (their C++ rides in the
+       *  archive's chunks).  Present on a C/C++ or Python block:
+       *  strucpp recovered the interface from the file's ST header,
+       *  emitted no chunk, and carried the authored file verbatim in
+       *  `sources`.  The consumer lowers that source itself at
+       *  compile time, which is what keeps a published library
+       *  working across native-bridge revisions. */
+      implementation?: 'cpp' | 'python'
+      /** Entry in `sources` holding this block's body.  Set with
+       *  `implementation`; the file name need not match the block
+       *  name, so it is carried explicitly rather than guessed. */
+      sourceFile?: string
     }>
     types: Array<{
       name: string
@@ -85,35 +98,14 @@ export interface StlibArchiveDTO {
     }>
   }
   globalConstants?: Record<string, number>
-  /** C/C++ function blocks the library ships, carried verbatim
-   *  through the archive.  Strucpp doesn't compile these — the
-   *  consumer's program build grafts them into the project's own
-   *  C++-POU pipeline (with a `<library_name>__<name>` rename for
-   *  collision avoidance) and routes them through the existing
-   *  `c_blocks.h` / `c_blocks_code.cpp` generation.  Absent on
-   *  libraries that don't ship any. */
-  cppBlocks?: Array<{
-    name: string
-    code: string
-    /** Opaque on this side — the editor maps to/from `PLCVariable`
-     *  on the renderer when grafting back into the project. */
-    variables: unknown[]
-    documentation?: string
-  }>
-  /** Python function blocks the library ships, carried verbatim
-   *  through the archive.  Exactly the same contract as `cppBlocks`
-   *  — strucpp doesn't compile these either, and the consumer's
-   *  program build grafts them in and lowers them through the same
-   *  Python-POU pipeline a user-authored Python block uses.  Kept as
-   *  a separate field rather than a `language` tag on `cppBlocks` so
-   *  older editors, which only know `cppBlocks`, cannot mistake a
-   *  Python block for C++.  Absent on libraries that don't ship any. */
-  pythonBlocks?: Array<{
-    name: string
-    code: string
-    variables: unknown[]
-    documentation?: string
-  }>
+  /** Authored source files the archive ships.
+   *
+   *  ST entries are present unless the library was published
+   *  closed-source (`--no-source`).  Native (C/C++, Python) entries
+   *  are ALWAYS present: they have no compiled chunk, so the source
+   *  is the deliverable and an archive without it is unbuildable.
+   *  Located via a function block's `sourceFile`. */
+  sources?: Array<{ fileName: string; source: string; category?: string }>
 }
 
 export interface LibraryPort {

--- a/src/middleware/shared/ports/library-types.ts
+++ b/src/middleware/shared/ports/library-types.ts
@@ -1,12 +1,11 @@
 export type LibraryPouType = 'function' | 'function-block'
 /** Body language as the library presents it to consumers.  `cpp` and
- *  `python` surface user-authored native function blocks the library
- *  ships via `archive.cppBlocks` / `archive.pythonBlocks` — strucpp
- *  doesn't compile those; the consumer's program build grafts them
- *  into the project's own native-POU pipeline (see
- *  `backend/shared/library/inject-library-blocks.ts`).
- *  ST/IL/LD/SFC/FBD libraries are strucpp-compiled and the chunks
- *  ride the manifest entries. */
+ *  `python` surface native function blocks: strucpp doesn't compile
+ *  those, it carries the authored source and the consumer's program
+ *  build grafts them into the project's own native-POU pipeline (see
+ *  `backend/shared/library/inject-library-blocks.ts`).  ST/IL/LD/SFC/FBD
+ *  libraries are strucpp-compiled and the chunks ride the manifest
+ *  entries. */
 export type LibraryLanguage = 'il' | 'st' | 'ld' | 'sfc' | 'fbd' | 'cpp' | 'python'
 
 export interface SystemLibraryVariable {

--- a/src/middleware/shared/ports/library-types.ts
+++ b/src/middleware/shared/ports/library-types.ts
@@ -1,11 +1,13 @@
 export type LibraryPouType = 'function' | 'function-block'
-/** Body language as the library presents it to consumers.  `cpp`
- *  surfaces user-authored C/C++ function blocks the library ships
- *  via `archive.cppBlocks` — strucpp doesn't compile them; the
- *  consumer's program build grafts them into the project's own
- *  C/C++-POU pipeline.  ST/IL/LD/SFC/FBD libraries are
- *  strucpp-compiled and the chunks ride the manifest entries. */
-export type LibraryLanguage = 'il' | 'st' | 'ld' | 'sfc' | 'fbd' | 'cpp'
+/** Body language as the library presents it to consumers.  `cpp` and
+ *  `python` surface user-authored native function blocks the library
+ *  ships via `archive.cppBlocks` / `archive.pythonBlocks` — strucpp
+ *  doesn't compile those; the consumer's program build grafts them
+ *  into the project's own native-POU pipeline (see
+ *  `backend/shared/library/inject-library-blocks.ts`).
+ *  ST/IL/LD/SFC/FBD libraries are strucpp-compiled and the chunks
+ *  ride the manifest entries. */
+export type LibraryLanguage = 'il' | 'st' | 'ld' | 'sfc' | 'fbd' | 'cpp' | 'python'
 
 export interface SystemLibraryVariable {
   name: string


### PR DESCRIPTION
Fixes [DOPE-585](https://autonomylogic.atlassian.net/browse/DOPE-585). Mirror of Autonomy-Logic/openplc-web#699 — the `backend/shared/`, `middleware/shared/` and `frontend/` files here are **byte-identical** to that PR's (verified with `cmp`).

The AI-chat half of DOPE-585 (scroll + context truncation) lives in `middleware/adapters/web/` and has no counterpart here; this PR carries only defect 3.

## 3. Libraries containing C/C++ or Python blocks

**This half now lives in STruCpp — see Autonomy-Logic/STruCpp#224.** This PR consumes it and deletes the editor-side workaround that preceded it.

An earlier revision of this branch fixed the problem editor-side: it hand-built the archive strucpp refused to produce, and stamped non-standard `cppBlocks` / `pythonBlocks` fields onto it afterwards. That was the wrong layer, for two reasons:

- The editor was duplicating strucpp's archive schema — `formatVersion`, the manifest field set, `chunks`, `sources` — making it the only thing holding an invariant it doesn't own. With web on strucpp 0.6.1 and editor on 0.6.3, that had to hold for two versions at once.
- Those fields were non-standard, and `loadStlibFromString` normalises unknown top-level fields away. They survived only because the install path happens to persist the archive *text* rather than the parsed object — a load-bearing accident nobody reading either file would notice.

strucpp now carries native blocks itself: it recovers the interface from the ST header every such file already has, marks the manifest entry `implementation: 'cpp' | 'python'`, emits no chunk, and ships the authored file verbatim in `sources`. Both of those are first-class fields, so they survive every round-trip by construction.

### What the editor deleted

- The synthesized `.stlib` (strucpp now tolerates an ST-empty input set).
- `decorateArchive`'s `cppBlocks` / `pythonBlocks` stamping, and those fields from `StlibArchiveDTO`.
- The `originalPythonPous` sidecar on `preprocessPous`.
- The `PLCVariable` projection the archive used to carry. That one mattered: serializing variables into the archive would have owed library variables a migration path forever — `parse-project-files` already carries `migrateLegacyVariables` because that schema changed once. Storing the authored file makes that class of drift impossible.

### What the editor still owns

Deciding which POUs are native and keeping their generated bridge ST out of strucpp's input — that needs project knowledge strucpp doesn't have. In exchange it passes the authored files, read off disk (`pous/function-blocks/<name>.<ext>`) rather than taken from the preprocessed project data, since by that point `preprocessPous` has already replaced those bodies with bridge ST.

On the consuming side, `injectLibraryBlocks` reads `manifest.functionBlocks[].implementation`, resolves the body through `sourceFile`, and parses it with `parseHybridPouFromString` — the same function that reads a native POU off disk. Interface, body and documentation are all derived by one parser from the authored bytes.

**strucpp dependency: satisfied.** This branch pins `binary-versions.json` at [v0.6.4](https://github.com/Autonomy-Logic/STruCpp/releases/tag/v0.6.4), which carries the native-block support (STruCpp#224, merged). Verified by running each repo's own download script and compiling an all-native library against the released build. On the previous pin the Python body reaches the ST parser and the build fails, so the bump is load-bearing rather than cosmetic.

### Also fixed

`readBuildFile` returned `null` unconditionally in dev-local mode, on the premise — stated in its own comment — that the orchestrator only used it for the verification cache. That stopped being true when stage 0 started reading `library.json` through it, so a library build under `dev:local` aborted before it began. Surfaced by driving the build from the UI. It now reads the bundled `public/dev-project.json` fixture, which `getInEnvelope` already knows how to address.

## Verified end-to-end, three ways

### 1. On real hardware, through the whole chain

`strucpp --compile-lib` → install through the editor's real install path → new project → instantiate its blocks → compile → upload → read values back. No step stubbed.

The library holds one C++ block and one Python block. The archive strucpp produced:

```
chunks   : []                                  <- nothing compiled
sources  : ['CPP_SCALE.cpp', 'PY_OFFSET.py']   <- authored files, verbatim
FB CPP_SCALE impl=cpp    src=CPP_SCALE.cpp
FB PY_OFFSET impl=python src=PY_OFFSET.py
```

Installed via `LibraryManagerModule.installFromFile` → `prepareStlibUpload` → `loadStlibFromString` → pool. This is the link where the blocks could have been lost, since the loader normalises unknown fields; they survive because manifest and `sources` are first-class:

```
install: {"success":true,"name":"nettest","version":"0.1.0","origin":"stlib"}
loadEnabledArchives(["nettest"]) -> native: CPP_SCALE:cpp, PY_OFFSET:python
injectLibraryBlocks -> nettest__CPP_SCALE [cpp] vars=RAW:input,GAIN:input,SCALED:output
                       nettest__PY_OFFSET [python] vars=IN_VAL:input,OFFSET:input,OUT_VAL:output
```

Interfaces parsed from the ST headers, not from serialized metadata. Then on `slm-rp4` (runtime v4.1.10, board `SLM-RP4`) the device compiled `pou_NETTEST__CPP_SCALE.cpp` and `pou_NETTEST__PY_OFFSET.cpp` and linked both into `new_libplc.so`.

| Variable | Expected | Device |
|---|---|---|
| `SCALER.SCALED` (library **C++**) | 42 | **42** ✅ |
| `RESULT_A` | 42 | **42** ✅ |
| `OFFSETTER.OUT_VAL` (library **Python**) | 142 | **142** ✅ |
| `RESULT_B` | 142 | **142** ✅ |

**Negative control** — inputs changed to `RAW := 6, GAIN := 7, OFFSET := 9`, rebuilt and re-uploaded: **42** and **51**, both correct. So the blocks compute on-device rather than returning anything stale.

### 2. From the openplc-web UI

`dev:local` with STruCpp#224's `dist` overlaid on `node_modules/strucpp`, library project loaded, **Build** clicked in the Build-options menu. The real flow, including the avr-gcc verification stage that an earlier revision of this PR had stubbed:

```
Manifest OK — building "nettest" v0.1.0.
Transpiling project to Structured Text
Verifying with OpenPLC Simulator (avr-gcc)...
[verify] Simulator firmware ready
Verification passed.
Compiling library archive...
Library built successfully: build/nettest.stlib
```

And the archive shape confirmed from inside the browser, using the web bundle's own strucpp: `chunks: ['ST_ADD']`, `CPP_SCALE:cpp`, `PY_OFFSET:python`, loader accepts.

### 3. A/B against `development`

Same project, same harness, reverting only the changed shared files:

| Library composition | `development` | this branch |
|---|---|---|
| All C++ | ❌ `No source files provided` | ✅ builds |
| C++ + Python | ⚠️ builds, but no `pythonBlocks` and `manifest FBs: ['PY_OFFSET']` — Python's bridge ST compiled **into** the archive, freezing the `iec_python.h` ABI | ✅ authored source carried, no chunk |

The all-C++ row is the exact production failure. The mixed row is worth noting because it fails **silently** today: the library builds fine and only breaks later, on an editor whose bridge has moved.

## Testing

- `inject-library-blocks.test.ts` — 21 new tests, 100 % stmts/lines/funcs
- `build-pipeline.test.ts` — the old test named "accepts a library that ships only C/C++ blocks" **mocked `compileStlib` to return success**, so the empty-array path it was named after was unreachable from it: the line was covered and still wrong. Rewritten to assert on the pipeline's own decision (strucpp not called, archive shape the loader accepts, source carried verbatim), parameterised over C++ and Python.
- `npx jest src/backend/shared/library src/backend/shared/utils/PLC` → 249 passed
- `npx jest src/middleware/adapters/editor` → 367 passed
- `tsc --noEmit` clean, `validate:arch` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qaJbNUTA9kMLL9Jr5FjUU

[DOPE-585]: https://autonomylogic.atlassian.net/browse/DOPE-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native library function blocks now support authored C/C++ and Python source files.
  * Library sources are automatically associated with declared function blocks, including names, documentation, interfaces, and implementation language.
  * Native blocks from enabled libraries are incorporated into builds while disabled-library blocks remain excluded.
* **Bug Fixes**
  * Builds now clearly report and stop when required native sources are missing, empty, or invalid.
  * Structured Text library blocks compile separately from native sources.
  * Source parsing and resolution now handle missing or malformed files more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




