### PR TITLE
task(DOPE-584): Python structures, enumerations, EN/ENO and editor stubs [phases 6-8]

### DIFF
--- a/src/backend/shared/utils/PLC/preprocess-pous.ts
+++ b/src/backend/shared/utils/PLC/preprocess-pous.ts
@@ -2,10 +2,10 @@ import { addCppLocalVariables } from '../../../../frontend/utils/cpp/addCppLocal
 import { generateSTCode as generateCppSTCode } from '../../../../frontend/utils/cpp/generateSTCode'
 import { validateCppCode } from '../../../../frontend/utils/cpp/validateCppCode'
 import { addPythonLocalVariables } from '../../../../frontend/utils/python/addPythonLocalVariables'
+import { pythonInterfaceVariables, pythonRefusedVariables } from '../../../../frontend/utils/python/block-interface'
 import { generateSTCode } from '../../../../frontend/utils/python/generateSTCode'
 import { injectPythonCode } from '../../../../frontend/utils/python/injectPythonCode'
-import { pythonInterfaceVariables, pythonRefusedVariables } from '../../../../frontend/utils/python/block-interface'
-import { describeShmField, describeVariableType } from '../../../../frontend/utils/python/shm-type-map'
+import { describeShmLeaves } from '../../../../frontend/utils/python/shm-leaves'
 import type { PLCPou, PLCProjectData, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { generateSoftMotionArtifacts } from '../../ethercat/generate-softmotion'
 
@@ -134,16 +134,19 @@ function preprocessPous(
     for (const pou of projectData.pous) {
       if (pou.body.language !== 'python') continue
       for (const variable of pythonInterfaceVariables(pou.interface?.variables ?? [])) {
-        if (describeShmField(variable) === null) {
-          unsupported.push(`"${pou.name}.${variable.name}" (${describeVariableType(variable)})`)
+        // The walk descends into structures, so the refusal names the member
+        // that cannot cross rather than the variable that contains it.
+        const walked = describeShmLeaves(variable, projectData.dataTypes ?? [])
+        if ('refusal' in walked) {
+          unsupported.push(`"${pou.name}.${walked.refusal.path.join('.')}": ${walked.refusal.reason}`)
         }
       }
     }
     if (unsupported.length > 0) {
       const message =
-        `Python function blocks cannot exchange these variable types yet: ${unsupported.join(', ')}. ` +
+        `Python function blocks cannot exchange these variables: ${unsupported.join('; ')}. ` +
         'Supported types are BOOL, the integer and bit-string types, REAL/LREAL, TIME/DATE/TOD/DT, ' +
-        'STRING, WSTRING, and arrays of those.'
+        'STRING, WSTRING, arrays of those, and structures and enumerations built from them.'
       log('error', message)
       return {
         projectData: processedProjectData as ProjectDataWithCpp,
@@ -181,7 +184,7 @@ function preprocessPous(
     } else {
       // Full pipeline for runtime targets
       const pythonData = extractPythonData(processedProjectData.pous)
-      const processedPythonCodes = injectPythonCode(pythonData)
+      const processedPythonCodes = injectPythonCode(pythonData, projectData.dataTypes ?? [])
 
       let pythonIndex = 0
       processedProjectData.pous = processedProjectData.pous.map((pou: PLCPou) => {
@@ -194,6 +197,7 @@ function preprocessPous(
                 /* istanbul ignore next -- defensive: interface may be undefined */
                 pou.interface?.variables ?? [],
               processedPythonCode: processedPythonCodes[pythonIndex],
+              dataTypes: projectData.dataTypes ?? [],
             })
 
             pythonIndex++

--- a/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
@@ -152,6 +152,7 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
       meta: { path: projectPath },
       data: {
         pous,
+        dataTypes,
         configurations: {
           resource: { globalVariables },
         },
@@ -342,8 +343,8 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
   useEffect(() => {
     if (!capabilities.hasPythonLSP) return
     if (language !== 'python') return
-    updatePythonLspContext(name, pouVariables)
-  }, [capabilities.hasPythonLSP, language, name, pouVariables])
+    updatePythonLspContext(name, pouVariables, dataTypes)
+  }, [capabilities.hasPythonLSP, language, name, pouVariables, dataTypes])
 
   useEffect(() => {
     return () => {
@@ -949,6 +950,9 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
           setupPythonLSPForEditor(editorInstance, {
             pouName: name,
             variables: pou.interface?.variables ?? [],
+            // The structures and enumerations the interface can name, so Pyright
+            // resolves `m.speed` to the same shape the runtime will build.
+            dataTypes,
           }),
         )
         .catch((err: unknown) => console.warn('[Python LSP]', err instanceof Error ? err.message : err))

--- a/src/frontend/components/_features/[workspace]/editor/monaco/python-lsp/index.ts
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/python-lsp/index.ts
@@ -26,7 +26,7 @@
  */
 
 import { type PythonLspService, startPythonLsp } from '@root/frontend/services/python-lsp'
-import type { PLCVariable } from '@root/middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '@root/middleware/shared/ports/types'
 import type { editor as MonacoEditor, IDisposable } from 'monaco-editor'
 import type * as monaco from 'monaco-editor'
 
@@ -89,7 +89,7 @@ export async function initPythonLSP(monacoModule: typeof monaco): Promise<void> 
  */
 export function setupPythonLSPForEditor(
   editor: MonacoEditor.IStandaloneCodeEditor,
-  ctx: { pouName: string; variables: PLCVariable[] },
+  ctx: { pouName: string; variables: PLCVariable[]; dataTypes?: readonly PLCDataType[] },
 ): void {
   if (!service) return
   const model = editor.getModel()
@@ -105,7 +105,7 @@ export function setupPythonLSPForEditor(
   // twice on every keystroke.
   wiringByUri.get(uri)?.contentSubscription.dispose()
 
-  service.attachPou(uri, ctx.pouName, ctx.variables, model.getValue())
+  service.attachPou(uri, ctx.pouName, ctx.variables, model.getValue(), ctx.dataTypes ?? [])
 
   const contentSubscription = model.onDidChangeContent(() => {
     service?.notifyBodyChange(uri, model.getValue())
@@ -120,13 +120,17 @@ export function setupPythonLSPForEditor(
  * document so Pyright sees the updated globals.  No-op if no editor
  * is currently attached for the POU.
  */
-export function updatePythonLspContext(pouName: string, variables: PLCVariable[]): void {
+export function updatePythonLspContext(
+  pouName: string,
+  variables: PLCVariable[],
+  dataTypes: readonly PLCDataType[] = [],
+): void {
   if (!service || !monacoApi) return
   for (const [uri, wiring] of wiringByUri.entries()) {
     if (wiring.pouName !== pouName) continue
     const model = monacoApi.editor.getModels().find((m) => m.uri.toString() === uri)
     if (!model) continue
-    service.notifyVariablesChange(uri, variables, model.getValue())
+    service.notifyVariablesChange(uri, variables, model.getValue(), dataTypes)
   }
 }
 

--- a/src/frontend/services/python-lsp/__tests__/index.test.ts
+++ b/src/frontend/services/python-lsp/__tests__/index.test.ts
@@ -181,8 +181,10 @@ describe('attachPou', () => {
     installMockSharedService()
 
     const service = startPythonLsp({ workerUrl: 'about:blank' })
-    // `local` vars don't get hoisted into module scope; preamble is empty.
-    service.attachPou(POU_URI, POU_NAME, [makeBoolVar('x', 'local')], 'pass\n')
+    // `temp` is the one class a Python block cannot express — it is refused at
+    // compile time and so never becomes a module global. Everything else,
+    // `local` included, is hoisted and does get a preamble line.
+    service.attachPou(POU_URI, POU_NAME, [makeBoolVar('x', 'temp')], 'pass\n')
 
     expect(setBodyLineOffset).toHaveBeenCalledWith(POU_LSP_URI, 0)
   })

--- a/src/frontend/services/python-lsp/index.ts
+++ b/src/frontend/services/python-lsp/index.ts
@@ -299,7 +299,7 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
   return {
     ready: sharedService.ready,
 
-    attachPou(uri, pouName, variables, bodyText) {
+    attachPou(uri, pouName, variables, bodyText, dataTypes = []) {
       // `uri` is the Monaco model URI the rest of the editor uses.
       // The LSP communication appends `.py` so basedpyright treats
       // the document as Python source.  Body-line offsets are
@@ -317,7 +317,7 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
       // notification, opened files sit in pyright's document
       // buffer but never enter the analysis queue.
       const lspUri = `${uri}.py`
-      const preamble = generatePythonLspPreamble(variables)
+      const preamble = generatePythonLspPreamble(variables, dataTypes)
       const iecVariableLineMap = getIecVariableLineMap(variables)
       entryByUri.set(uri, { pouName, lspUri, preamble, iecVariableLineMap })
       setBodyLineOffset(lspUri, preamble.lineCount)
@@ -330,7 +330,7 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
       sharedService.changeDocument(lspUri, augmentedDocument(uri, bodyText))
     },
 
-    notifyVariablesChange(uri, variables, bodyText) {
+    notifyVariablesChange(uri, variables, bodyText, dataTypes = []) {
       // Variables changed: regenerate the preamble + IEC line map
       // and update the offset registry BEFORE pushing the new
       // document so the diagnostics callback (which fires on the
@@ -340,7 +340,7 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
       // the URI we already opened with pyright.
       const existing = entryByUri.get(uri)
       const lspUri = existing?.lspUri ?? `${uri}.py`
-      const preamble = generatePythonLspPreamble(variables)
+      const preamble = generatePythonLspPreamble(variables, dataTypes)
       const iecVariableLineMap = getIecVariableLineMap(variables)
       entryByUri.set(uri, { pouName: existing?.pouName ?? '', lspUri, preamble, iecVariableLineMap })
       setBodyLineOffset(lspUri, preamble.lineCount)

--- a/src/frontend/services/python-lsp/types.ts
+++ b/src/frontend/services/python-lsp/types.ts
@@ -6,7 +6,7 @@
 
 import type * as monaco from 'monaco-editor'
 
-import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
 
 export interface PythonLspStartOptions {
   /**
@@ -53,7 +53,13 @@ export interface PythonLspService {
    * target lands in this URI.  Without it, the redirect can't open
    * the right POU tab.
    */
-  attachPou(uri: string, pouName: string, variables: PLCVariable[], bodyText: string): void
+  attachPou(
+    uri: string,
+    pouName: string,
+    variables: PLCVariable[],
+    bodyText: string,
+    dataTypes?: readonly PLCDataType[],
+  ): void
 
   /**
    * Push a new body version for an already-attached POU.  Preamble
@@ -66,7 +72,12 @@ export interface PythonLspService {
    * shared offset registry, and push the new augmented document.
    * Bumps the LSP document version.
    */
-  notifyVariablesChange(uri: string, variables: PLCVariable[], bodyText: string): void
+  notifyVariablesChange(
+    uri: string,
+    variables: PLCVariable[],
+    bodyText: string,
+    dataTypes?: readonly PLCDataType[],
+  ): void
 
   /** Send `textDocument/didClose` and drop the preamble entry. */
   detachPou(uri: string): void

--- a/src/frontend/utils/python/__tests__/encodeCharactersFromVariable.test.ts
+++ b/src/frontend/utils/python/__tests__/encodeCharactersFromVariable.test.ts
@@ -108,10 +108,15 @@ describe('encodeCharactersFromVariable', () => {
     expect(encodeCharactersFromVariable(vars)).toBe('=hfB')
   })
 
-  it('skips unknown scalar types and warns', () => {
+  it('describes nothing at all when one type cannot cross', () => {
+    // Emitting a format for the fields it *can* describe is the corruption this
+    // whole design exists to prevent: a dropped field does not go missing, it
+    // shifts every later field's offset. The compile path refuses such a POU
+    // before reaching here; a direct caller gets an empty layout rather than a
+    // half-formed one.
     const vars = [makeScalarVar('x', 'UNKNOWN_TYPE'), makeScalarVar('y', 'INT')]
-    const result = encodeCharactersFromVariable(vars)
-    expect(result).toBe('=h')
+
+    expect(encodeCharactersFromVariable(vars)).toBe('=')
   })
 
   it('encodes array variables with repeated format chars', () => {

--- a/src/frontend/utils/python/__tests__/generatePythonLspPreamble.test.ts
+++ b/src/frontend/utils/python/__tests__/generatePythonLspPreamble.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Autonomy / OpenPLC Project
-import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { generatePythonLspPreamble } from '../generatePythonLspPreamble'
 
 const makeScalar = (
@@ -209,19 +209,155 @@ describe('generatePythonLspPreamble', () => {
   })
 
   describe('user-data-type handling', () => {
-    it('skips user-data-type variables (structs / enums)', () => {
-      // `injectPythonRuntime` doesn't pack these into shared memory
-      // either; LSP stays in lockstep by not declaring them.
-      const structVar: PLCVariable = {
-        name: 'myStruct',
+    const structVar: PLCVariable = {
+      name: 'm',
+      class: 'input',
+      type: { definition: 'user-data-type', value: 'Motor' },
+      location: '',
+      documentation: '',
+      debug: false,
+    }
+
+    const MOTOR: PLCDataType = {
+      name: 'Motor',
+      derivation: 'structure',
+      variable: [
+        { name: 'speed', type: { definition: 'base-type', value: 'int' } },
+        { name: 'label', type: { definition: 'base-type', value: 'string' } },
+      ],
+    }
+
+    const MODE: PLCDataType = {
+      name: 'Mode',
+      derivation: 'enumerated',
+      values: [{ description: 'STOPPED' }, { description: 'RUNNING' }],
+    }
+
+    it('declares a structure as a class, so the editor resolves m.speed', () => {
+      const result = generatePythonLspPreamble([structVar], [MOTOR])
+
+      expect(result.text).toContain('class Motor:')
+      expect(result.text).toContain('    speed: int')
+      expect(result.text).toContain('    label: str')
+      expect(result.text).toContain('m: Motor = None')
+    })
+
+    it('declares an enumeration as an IntEnum with its members', () => {
+      const enumVar: PLCVariable = { ...structVar, name: 'md', type: { definition: 'user-data-type', value: 'Mode' } }
+      const result = generatePythonLspPreamble([enumVar], [MODE])
+
+      expect(result.text).toContain('from enum import IntEnum')
+      expect(result.text).toContain('class Mode(IntEnum):')
+      expect(result.text).toContain('    RUNNING = 1')
+    })
+
+    it('declares a nested structure before the one referencing it', () => {
+      const rig: PLCDataType = {
+        name: 'Rig',
+        derivation: 'structure',
+        variable: [{ name: 'drive', type: { definition: 'user-data-type', value: 'Motor' } }],
+      }
+      const rigVar: PLCVariable = { ...structVar, name: 'r', type: { definition: 'user-data-type', value: 'Rig' } }
+      const result = generatePythonLspPreamble([rigVar], [rig, MOTOR])
+
+      expect(result.text.indexOf('class Motor:')).toBeLessThan(result.text.indexOf('class Rig:'))
+      expect(result.text).toContain('    drive: Motor')
+    })
+
+    it('declares each type once however many variables use it', () => {
+      const b: PLCVariable = { ...structVar, name: 'b' }
+      const result = generatePythonLspPreamble([structVar, b], [MOTOR])
+
+      expect(result.text.match(/class Motor:/g)).toHaveLength(1)
+    })
+
+    it('still declares the variable when the project declares no data types', () => {
+      // The compile path refuses such a POU, but the editor should not silently
+      // drop a name the user can see in the Variables Table.
+      const result = generatePythonLspPreamble([structVar])
+
+      expect(result.text).toContain('m: Motor = None')
+      expect(result.text).not.toContain('class Motor:')
+    })
+
+    it('keeps the line map pointing past the type stubs', () => {
+      // The diagnostic line mapping depends on the declaration's absolute line,
+      // so stubs inserted above it have to shift it.
+      const withStubs = generatePythonLspPreamble([structVar], [MOTOR])
+      const withoutStubs = generatePythonLspPreamble([structVar])
+      const lineOf = (p: typeof withStubs) => [...p.variableNameByPreambleLine.entries()][0][0]
+
+      expect(lineOf(withStubs)).toBeGreaterThan(lineOf(withoutStubs))
+    })
+
+    it('annotates a member whose type has no Python equivalent as Any', () => {
+      // A function block instance inside a structure is refused at compile time,
+      // but the stub still has to name the attribute or Pyright reports every
+      // use of it as an error on code the user has not finished writing.
+      const rig: PLCDataType = {
+        name: 'Rig',
+        derivation: 'structure',
+        variable: [{ name: 'timer', type: { definition: 'base-type', value: 'float32' } }],
+      }
+      const rigVar: PLCVariable = { ...structVar, name: 'r', type: { definition: 'user-data-type', value: 'Rig' } }
+      const result = generatePythonLspPreamble([rigVar], [rig])
+
+      expect(result.text).toContain('    timer: Any')
+    })
+
+    it('declares neither the variable nor a stub for an array of structures', () => {
+      // It has no Python annotation and is refused at compile time, so the
+      // editor stays in lockstep with what the build will accept.
+      const bank: PLCVariable = {
+        name: 'bank',
         class: 'input',
-        type: { definition: 'user-data-type', value: 'MyStruct' },
+        type: {
+          definition: 'array',
+          value: 'ARRAY [0..1] OF Motor',
+          data: {
+            baseType: { definition: 'user-data-type', value: 'Motor' },
+            dimensions: [{ dimension: '0..1' }],
+          },
+        },
         location: '',
         documentation: '',
         debug: false,
       }
-      const result = generatePythonLspPreamble([structVar])
+      const result = generatePythonLspPreamble([bank], [MOTOR])
+
       expect(result.text).toBe('')
+    })
+
+    it('stops rather than recursing when a structure contains itself', () => {
+      const loop: PLCDataType = {
+        name: 'Loop',
+        derivation: 'structure',
+        variable: [{ name: 'inner', type: { definition: 'user-data-type', value: 'Loop' } }],
+      }
+      const loopVar: PLCVariable = { ...structVar, name: 'l', type: { definition: 'user-data-type', value: 'Loop' } }
+
+      expect(generatePythonLspPreamble([loopVar], [loop]).text).toContain('class Loop:')
+    })
+
+    it('declares a scalar alongside a structure without stubbing the scalar', () => {
+      const result = generatePythonLspPreamble([makeScalar('x', 'input', 'INT'), structVar], [MOTOR])
+
+      expect(result.text).toContain('x: int = 0')
+      expect(result.text).toContain('class Motor:')
+      expect(result.text).not.toContain('class int')
+    })
+
+    it('ignores a named ARRAY type, which has no class to declare', () => {
+      const named: PLCDataType = {
+        name: 'Bank',
+        derivation: 'array',
+        baseType: { definition: 'base-type', value: 'INT' },
+        dimensions: [{ dimension: '0..3' }],
+      }
+      const bankVar: PLCVariable = { ...structVar, name: 'b', type: { definition: 'user-data-type', value: 'Bank' } }
+      const result = generatePythonLspPreamble([bankVar], [named])
+
+      expect(result.text).not.toContain('class Bank')
     })
   })
 

--- a/src/frontend/utils/python/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/python/__tests__/generateSTCode.test.ts
@@ -1,4 +1,4 @@
-import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { generateSTCode } from '../generateSTCode'
 
 const makeScalarVar = (name: string, cls: 'input' | 'output', baseType: string): PLCVariable => ({
@@ -319,6 +319,81 @@ describe('generateSTCode (python)', () => {
     expect(result).toContain('const char *script_name = "controller.py";')
     expect(result).toContain('const char script_template[] =')
     expect(result).toContain('python_block_loader')
+  })
+
+  describe('structures and enumerations', () => {
+    const MOTOR: PLCDataType = {
+      name: 'Motor',
+      derivation: 'structure',
+      variable: [
+        { name: 'speed', type: { definition: 'base-type', value: 'int' } },
+        { name: 'label', type: { definition: 'base-type', value: 'string' } },
+      ],
+    }
+    const MODE: PLCDataType = {
+      name: 'Mode',
+      derivation: 'enumerated',
+      values: [{ description: 'STOPPED' }, { description: 'RUNNING' }],
+    }
+    const userTyped = (name: string, cls: PLCVariable['class'], typeName: string): PLCVariable => ({
+      name,
+      class: cls,
+      type: { definition: 'user-data-type', value: typeName },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+    const run = (variables: PLCVariable[], dataTypes: PLCDataType[]) =>
+      generateSTCode({ pouName: 'test', allVariables: variables, processedPythonCode: '', dataTypes })
+
+    it('flattens a structure into one field per member', () => {
+      const result = run([userTyped('m', 'input', 'Motor')], [MOTOR])
+
+      expect(result).toContain('int16_t m_speed;')
+      expect(result).toContain('shm_iec_string_t m_label;')
+    })
+
+    it('copies each member individually, by its name on the strucpp side', () => {
+      const result = run([userTyped('m', 'input', 'Motor')], [MOTOR])
+
+      expect(result).toContain('data_in.m_speed = M.SPEED;')
+      expect(result).toContain('auto __s = M.LABEL.get();')
+    })
+
+    it('reads an enumeration through both wrappers before casting to its integer', () => {
+      // `IEC_ENUM_Var::get()` yields an `IEC_ENUM_Value`, which converts to the
+      // scoped enum but not to an integer.
+      const result = run([userTyped('md', 'input', 'Mode')], [MODE])
+
+      expect(result).toContain('data_in.md = static_cast<int16_t>(MD.get().get());')
+    })
+
+    it('writes an enumeration back through set(), not operator=', () => {
+      // `operator=` would copy-assign a whole temporary wrapper and take its
+      // forced state along; `set()` leaves forcing where it was.
+      const result = run([userTyped('md', 'output', 'Mode')], [MODE])
+
+      expect(result).toContain('MD.set(static_cast<MODE>(data_out.md));')
+    })
+
+    it('writes a structure member back individually', () => {
+      const result = run([userTyped('m', 'output', 'Motor')], [MOTOR])
+
+      expect(result).toContain('M.SPEED = data_out.m_speed;')
+    })
+
+    it('seeds a structure output from what the PLC holds', () => {
+      const result = run([userTyped('m', 'output', 'Motor')], [MOTOR])
+
+      expect(result).toContain('seed_out.m_speed = M.SPEED;')
+    })
+
+    it('copies a structure member of an external under the global’s lock', () => {
+      const result = run([userTyped('g', 'external', 'Motor')], [MOTOR])
+
+      expect(result).toContain('G->with_lock([&](auto* __g) {')
+      expect(result).toContain('data_in.g_speed = __r.SPEED;')
+    })
   })
 
   describe('variable classes', () => {

--- a/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
+++ b/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
@@ -1,4 +1,4 @@
-import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { injectPythonRuntime } from '../injectPythonRuntime'
 
 const makeScalarVar = (name: string, cls: 'input' | 'output', baseType: string): PLCVariable => ({
@@ -42,6 +42,189 @@ const makeWStringVar = (name: string, cls: 'input' | 'output'): PLCVariable => (
   location: '',
   documentation: '',
   debug: false,
+})
+
+const userTyped = (name: string, cls: 'input' | 'output', typeName: string): PLCVariable => ({
+  name,
+  class: cls,
+  type: { definition: 'user-data-type', value: typeName },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const MOTOR: PLCDataType = {
+  name: 'Motor',
+  derivation: 'structure',
+  variable: [
+    { name: 'speed', type: { definition: 'base-type', value: 'int' } },
+    { name: 'label', type: { definition: 'base-type', value: 'string' } },
+  ],
+}
+
+const MODE: PLCDataType = {
+  name: 'Mode',
+  derivation: 'enumerated',
+  values: [{ description: 'STOPPED' }, { description: 'RUNNING' }],
+}
+
+describe('structures and enumerations', () => {
+  const run = (variables: PLCVariable[], dataTypes: PLCDataType[]) =>
+    injectPythonRuntime({
+      fmtIn: '=',
+      fmtOut: '=',
+      inputVariables: variables.filter((v) => v.class === 'input'),
+      outputVariables: variables.filter((v) => v.class === 'output'),
+      originalCode: '',
+      pouName: 'test',
+      dataTypes,
+    })
+
+  it('declares a structure as a slotted class, so the user writes m.speed', () => {
+    // The wire format is flat, but the block should read like ST. `__slots__`
+    // also makes an assignment to a name the structure lacks raise, rather than
+    // silently creating an attribute the PLC will never read back.
+    const result = run([userTyped('m', 'input', 'Motor')], [MOTOR])
+
+    expect(result).toContain('class Motor:')
+    expect(result).toContain("__slots__ = ('speed', 'label')")
+    expect(result).toContain('def __init__(self, speed=None, label=None):')
+  })
+
+  it('gives a one-member structure a trailing comma, so __slots__ is a tuple', () => {
+    // `('speed')` is the string, not a one-element tuple, and Python would then
+    // treat every character as a slot name.
+    const single: PLCDataType = {
+      name: 'One',
+      derivation: 'structure',
+      variable: [{ name: 'speed', type: { definition: 'base-type', value: 'int' } }],
+    }
+    const result = run([userTyped('o', 'input', 'One')], [single])
+
+    expect(result).toContain("__slots__ = ('speed',)")
+  })
+
+  it('declares an enumeration as an IntEnum, so mode == Mode.RUNNING reads naturally', () => {
+    const result = run([userTyped('md', 'input', 'Mode')], [MODE])
+
+    expect(result).toContain('from enum import IntEnum')
+    expect(result).toContain('class Mode(IntEnum):')
+    expect(result).toContain('    STOPPED = 0')
+    expect(result).toContain('    RUNNING = 1')
+  })
+
+  it('declares a nested structure before the one that constructs it', () => {
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [{ name: 'drive', type: { definition: 'user-data-type', value: 'Motor' } }],
+    }
+    const result = run([userTyped('r', 'input', 'Rig')], [rig, MOTOR])
+
+    expect(result.indexOf('class Motor:')).toBeLessThan(result.indexOf('class Rig:'))
+  })
+
+  it('declares each type once even when several variables use it', () => {
+    const result = run([userTyped('a', 'input', 'Motor'), userTyped('b', 'input', 'Motor')], [MOTOR])
+
+    expect(result.match(/class Motor:/g)).toHaveLength(1)
+  })
+
+  it('says so plainly when a block uses no composite type', () => {
+    const result = run([makeScalarVar('x', 'input', 'INT')], [MOTOR])
+
+    expect(result).toContain('# This block uses no structures or enumerations')
+    expect(result).not.toContain('class Motor:')
+  })
+
+  it('rebuilds a structure from its consecutive leaves', () => {
+    const result = run([userTyped('m', 'input', 'Motor')], [MOTOR])
+
+    expect(result).toContain('_m_speed = _vals[_idx]')
+    expect(result).toContain('m = Motor(speed=_m_speed, label=_m_label)')
+  })
+
+  it('rebuilds a nested structure innermost first', () => {
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [{ name: 'drive', type: { definition: 'user-data-type', value: 'Motor' } }],
+    }
+    const result = run([userTyped('r', 'input', 'Rig')], [rig, MOTOR])
+
+    expect(result).toContain('r = Rig(drive=Motor(speed=_r_drive_speed, label=_r_drive_label))')
+  })
+
+  it('wraps a structure member that is an enumeration', () => {
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [{ name: 'state', type: { definition: 'user-data-type', value: 'Mode' } }],
+    }
+    const result = run([userTyped('r', 'input', 'Rig')], [rig, MODE])
+
+    expect(result).toContain('r = Rig(state=Mode(_r_state))')
+  })
+
+  it('wraps a top-level enumeration in its IntEnum after decoding', () => {
+    const result = run([userTyped('md', 'input', 'Mode')], [MODE])
+
+    expect(result).toContain('md = Mode(md)')
+  })
+
+  it('packs a structure member by member, through the attribute path', () => {
+    const result = run([userTyped('m', 'output', 'Motor')], [MOTOR])
+
+    expect(result).toContain('_out.append(m.speed)')
+    expect(result).toContain("_body = m.label.encode('utf-8')[:126]")
+  })
+
+  it('packs an enumeration as its integer, explicitly', () => {
+    const result = run([userTyped('md', 'output', 'Mode')], [MODE])
+
+    expect(result).toContain('_out.append(int(md))')
+  })
+
+  it('ignores a named ARRAY type when declaring classes', () => {
+    // It cannot cross, and the build is refused upstream; there is no class to
+    // declare for it either way.
+    const named: PLCDataType = {
+      name: 'Bank',
+      derivation: 'array',
+      baseType: { definition: 'base-type', value: 'INT' },
+      dimensions: [{ dimension: '0..3' }],
+    }
+    const result = run([userTyped('b', 'input', 'Bank')], [named])
+
+    expect(result).toContain('# This block uses no structures or enumerations')
+  })
+
+  it('ignores a type the project does not declare', () => {
+    const result = run([userTyped('t', 'input', 'TON')], [MOTOR])
+
+    expect(result).toContain('# This block uses no structures or enumerations')
+  })
+
+  it('declares a structure reached through an array element type', () => {
+    const bank: PLCVariable = {
+      name: 'bank',
+      class: 'input',
+      type: {
+        definition: 'array',
+        value: 'ARRAY [0..1] OF Motor',
+        data: {
+          baseType: { definition: 'user-data-type', value: 'Motor' },
+          dimensions: [{ dimension: '0..1' }],
+        },
+      },
+      location: '',
+      documentation: '',
+      debug: false,
+    }
+    const result = run([bank], [MOTOR])
+
+    expect(result).toContain('class Motor:')
+  })
 })
 
 describe('WSTRING crosses as UTF-16, counted in code units', () => {

--- a/src/frontend/utils/python/__tests__/shm-leaves.test.ts
+++ b/src/frontend/utils/python/__tests__/shm-leaves.test.ts
@@ -1,0 +1,270 @@
+import type { PLCDataType, PLCVariable } from '../../../../middleware/shared/ports/types'
+import { describeShmLayout, describeShmLeaves } from '../shm-leaves'
+
+const scalar = (name: string, value: string): PLCVariable => ({
+  name,
+  class: 'input',
+  type: { definition: 'base-type', value },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const userTyped = (name: string, value: string): PLCVariable => ({
+  name,
+  class: 'input',
+  type: { definition: 'user-data-type', value },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const arrayOf = (name: string, baseType: string, dimension = '0..3'): PLCVariable => ({
+  name,
+  class: 'input',
+  type: {
+    definition: 'array',
+    value: `ARRAY [${dimension}] OF ${baseType}`,
+    data: { baseType: { definition: 'base-type', value: baseType }, dimensions: [{ dimension }] },
+  },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const MOTOR: PLCDataType = {
+  name: 'Motor',
+  derivation: 'structure',
+  variable: [
+    { name: 'speed', type: { definition: 'base-type', value: 'int' } },
+    { name: 'label', type: { definition: 'base-type', value: 'string' } },
+  ],
+}
+
+const MODE: PLCDataType = {
+  name: 'Mode',
+  derivation: 'enumerated',
+  values: [{ description: 'STOPPED' }, { description: 'RUNNING' }],
+}
+
+const leavesOf = (result: ReturnType<typeof describeShmLeaves>) => ('leaves' in result ? result.leaves : [])
+const refusalOf = (result: ReturnType<typeof describeShmLeaves>) => ('refusal' in result ? result.refusal : null)
+
+describe('describeShmLeaves', () => {
+  it('describes a scalar as one leaf reaching the member directly', () => {
+    const [leaf] = leavesOf(describeShmLeaves(scalar('x', 'INT')))
+
+    expect(leaf.field).toBe('x')
+    expect(leaf.path).toEqual(['x'])
+    expect(leaf.access).toBe('X')
+    expect(leaf.count).toBe(1)
+  })
+
+  it('describes an array as one leaf with its element count and lower bound', () => {
+    const [leaf] = leavesOf(describeShmLeaves(arrayOf('data', 'INT', '2..5')))
+
+    expect(leaf.count).toBe(4)
+    expect(leaf.startIndex).toBe(2)
+  })
+
+  it('flattens a structure into one leaf per member, in declaration order', () => {
+    const leaves = leavesOf(describeShmLeaves(userTyped('m', 'Motor'), [MOTOR]))
+
+    expect(leaves.map((l) => l.field)).toEqual(['m_speed', 'm_label'])
+    expect(leaves.map((l) => l.path)).toEqual([
+      ['m', 'speed'],
+      ['m', 'label'],
+    ])
+    expect(leaves.map((l) => l.access)).toEqual(['M.SPEED', 'M.LABEL'])
+  })
+
+  it('flattens rather than nesting, so neither side computes padding', () => {
+    // `#pragma pack` applies to the struct being defined, never to a member type
+    // already laid out — the trap that made WSTRING 254 bytes against Python's
+    // 253. Every leaf sits at the top level of one packed struct.
+    const leaves = leavesOf(describeShmLeaves(userTyped('m', 'Motor'), [MOTOR]))
+
+    expect(leaves.every((l) => !l.field.includes('.'))).toBe(true)
+  })
+
+  it('flattens a nested structure through both levels', () => {
+    const outer: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [{ name: 'drive', type: { definition: 'user-data-type', value: 'Motor' } }],
+    }
+    const leaves = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [outer, MOTOR]))
+
+    expect(leaves.map((l) => l.field)).toEqual(['r_drive_speed', 'r_drive_label'])
+    expect(leaves.map((l) => l.access)).toEqual(['R.DRIVE.SPEED', 'R.DRIVE.LABEL'])
+  })
+
+  it('describes an enumeration as its stored integer, naming the type for Python', () => {
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('md', 'Mode'), [MODE]))
+
+    expect(leaf.descriptor.cType).toBe('int16_t')
+    expect(leaf.enumTypeName).toBe('Mode')
+    // The access stays assignable; the emitter casts through the wrapper, since
+    // an IEC_ENUM_Var yields an IEC_ENUM_Value that converts to the scoped enum
+    // but not to an integer.
+    expect(leaf.access).toBe('MD')
+  })
+
+  it('mangles a member named after its own type, as the compiler does', () => {
+    // GCC rejects a member that changes the meaning of its type name inside the
+    // class, so STruC++ emits a trailing underscore. CODESYS allows
+    // `RunningLights : RunningLights` and real projects use it.
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [{ name: 'mode', type: { definition: 'user-data-type', value: 'Mode' } }],
+    }
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [rig, MODE]))
+
+    expect(leaf.access).toBe('R.MODE_')
+  })
+
+  it('does not mangle a member whose name merely matches an elementary type', () => {
+    // `Time : TIME` is an ordinary declaration the compiler emits unmangled;
+    // mangling it would name a `TIME_` member that does not exist.
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [{ name: 'time', type: { definition: 'base-type', value: 'TIME' } }],
+    }
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [rig]))
+
+    expect(leaf.access).toBe('R.TIME')
+  })
+
+  it('describes an array nested inside a structure', () => {
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [
+        {
+          name: 'trims',
+          type: {
+            definition: 'array',
+            value: 'ARRAY [1..3] OF INT',
+            data: { baseType: { definition: 'base-type', value: 'INT' }, dimensions: [{ dimension: '1..3' }] },
+          },
+        },
+      ],
+    }
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [rig]))
+
+    expect(leaf.count).toBe(3)
+    expect(leaf.startIndex).toBe(1)
+    expect(leaf.access).toBe('R.TRIMS')
+  })
+
+  it('reads an array member’s bounds even when its dimension text is malformed', () => {
+    // A dimension that cannot be parsed yields no lower bound rather than a
+    // guessed one; the element type still describes the field.
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [
+        {
+          name: 'trims',
+          type: {
+            definition: 'array',
+            value: 'ARRAY [?] OF INT',
+            data: { baseType: { definition: 'base-type', value: 'INT' }, dimensions: [{ dimension: 'nonsense' }] },
+          },
+        },
+      ],
+    }
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [rig]))
+
+    expect(leaf.startIndex).toBe(0)
+  })
+
+  it('refuses an array declaration carrying no dimension data rather than guessing', () => {
+    // Without `data` there is no element type and no count. Describing it as
+    // one scalar would put a single field where the C side may write many.
+    const bare: PLCVariable = {
+      name: 'data',
+      class: 'input',
+      type: { definition: 'array', value: 'ARRAY [0..3] OF INT' },
+      location: '',
+      documentation: '',
+      debug: false,
+    }
+
+    expect(refusalOf(describeShmLeaves(bare))?.reason).toContain('not a type Python can exchange')
+  })
+
+  describe('refusals', () => {
+    it('refuses a function block instance, naming why', () => {
+      const refusal = refusalOf(describeShmLeaves(userTyped('t', 'TON'), [MOTOR]))
+
+      expect(refusal?.reason).toContain('function block instance')
+      expect(refusal?.reason).toContain('its own process')
+    })
+
+    it('refuses an array of structures', () => {
+      const bank = arrayOf('bank', 'Motor')
+      bank.type.data!.baseType = { definition: 'user-data-type', value: 'Motor' }
+
+      expect(refusalOf(describeShmLeaves(bank, [MOTOR]))?.reason).toContain('array of structures')
+    })
+
+    it('refuses a named ARRAY type', () => {
+      const named: PLCDataType = {
+        name: 'Bank',
+        derivation: 'array',
+        baseType: { definition: 'base-type', value: 'INT' },
+        dimensions: [{ dimension: '0..3' }],
+      }
+
+      expect(refusalOf(describeShmLeaves(userTyped('b', 'Bank'), [named]))?.reason).toContain('named ARRAY type')
+    })
+
+    it('refuses an unsupported elementary type', () => {
+      expect(refusalOf(describeShmLeaves(scalar('x', 'float32')))?.reason).toContain('not a type Python can exchange')
+    })
+
+    it('names the member that cannot cross, not the variable containing it', () => {
+      const rig: PLCDataType = {
+        name: 'Rig',
+        derivation: 'structure',
+        variable: [{ name: 'timer', type: { definition: 'user-data-type', value: 'TON' } }],
+      }
+      const refusal = refusalOf(describeShmLeaves(userTyped('r', 'Rig'), [rig]))
+
+      expect(refusal?.path).toEqual(['r', 'timer'])
+    })
+
+    it('refuses a structure that contains itself rather than recursing forever', () => {
+      const loop: PLCDataType = {
+        name: 'Loop',
+        derivation: 'structure',
+        variable: [{ name: 'inner', type: { definition: 'user-data-type', value: 'Loop' } }],
+      }
+
+      expect(refusalOf(describeShmLeaves(userTyped('l', 'Loop'), [loop]))?.reason).toContain('refers to itself')
+    })
+  })
+})
+
+describe('describeShmLayout', () => {
+  it('concatenates every variable’s leaves in order', () => {
+    const result = describeShmLayout([scalar('a', 'INT'), userTyped('m', 'Motor')], [MOTOR])
+
+    expect(leavesOf(result).map((l) => l.field)).toEqual(['a', 'm_speed', 'm_label'])
+  })
+
+  it('reports the first refusal rather than a partial layout', () => {
+    // A partial layout is the corruption this design exists to prevent: a
+    // missing field shifts every later field's offset.
+    const result = describeShmLayout([scalar('a', 'INT'), userTyped('t', 'TON')], [MOTOR])
+
+    expect('refusal' in result).toBe(true)
+  })
+
+  it('is empty for no variables', () => {
+    expect(leavesOf(describeShmLayout([]))).toEqual([])
+  })
+})

--- a/src/frontend/utils/python/encodeCharactersFromVariable.ts
+++ b/src/frontend/utils/python/encodeCharactersFromVariable.ts
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Autonomy / OpenPLC Project
-import type { PLCVariable } from '../../../middleware/shared/ports/types'
-import { getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
-import { describeShmField } from './shm-type-map'
+import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
+import type { ShmLeaf } from './shm-leaves'
+import { describeShmLayout } from './shm-leaves'
 
 /**
  * Convert a POU's interface variables into the format string Python's
  * `struct.pack` / `struct.unpack` use for the shared-memory exchange.
  *
- * The per-type formats come from `shm-type-map.ts`, which the C-side struct
- * emitter reads as well — the two sides cannot drift because there is only one
- * table. This function's own job is just repetition and ordering.
+ * The format is built from the same leaf walk the C-side struct emitter uses, so
+ * the two descriptions of one layout cannot drift: a structure is flattened into
+ * the same fields, in the same order, on both sides.
  *
  * Unsupported types are refused upstream (`preprocessPous`) rather than skipped
  * here. Skipping was the original defect: a dropped field does not merely go
@@ -19,37 +19,36 @@ import { describeShmField } from './shm-type-map'
  * @returns a `struct` format string such as `'=hfb126s'`, native byte order and
  *   no alignment, matching the `#pragma pack(push, 1)` struct on the C side.
  */
-const encodeCharactersFromVariable = (variables: PLCVariable[]): string => {
+const encodeCharactersFromLeaves = (leaves: readonly ShmLeaf[]): string => {
+  const encoded = leaves.map((leaf) => {
+    if (leaf.count > 1) {
+      // A repeat count applies only to the FIRST character of a struct format,
+      // so `10b126s` is not ten strings. Multi-character formats are repeated
+      // whole.
+      if (leaf.descriptor.pyFormat.length > 1) {
+        return leaf.descriptor.pyFormat.repeat(leaf.count)
+      }
+      return `${leaf.count}${leaf.descriptor.pyFormat}`
+    }
+    return leaf.descriptor.pyFormat
+  })
+
+  return '=' + encoded.join('')
+}
+
+const encodeCharactersFromVariable = (variables: PLCVariable[], dataTypes: readonly PLCDataType[] = []): string => {
   if (!variables || variables.length === 0) {
     return '='
   }
 
-  const encodedChars = variables
-    .map((variable) => {
-      const descriptor = describeShmField(variable)
-      if (!descriptor) {
-        // Unreachable through the compile path — `preprocessPous` rejects an
-        // unsupported type before any of this runs. Kept as a total function so
-        // a direct caller cannot produce a half-formed layout.
-        return ''
-      }
+  const walked = describeShmLayout(variables, dataTypes)
+  // Unreachable through the compile path — `preprocessPous` refuses anything
+  // that cannot cross before any of this runs. Kept as a total function so a
+  // direct caller cannot produce a half-formed layout.
+  /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
+  if ('refusal' in walked) return '='
 
-      if (isArrayVariable(variable)) {
-        const totalElements = getArrayTotalElements(variable)
-        // A repeat count applies only to the FIRST character of a struct
-        // format, so `10b126s` is not ten strings. Multi-character formats are
-        // repeated whole.
-        if (descriptor.pyFormat.length > 1) {
-          return descriptor.pyFormat.repeat(totalElements)
-        }
-        return `${totalElements}${descriptor.pyFormat}`
-      }
-
-      return descriptor.pyFormat
-    })
-    .filter((char) => char !== '')
-
-  return '=' + encodedChars.join('')
+  return encodeCharactersFromLeaves(walked.leaves)
 }
 
-export { encodeCharactersFromVariable }
+export { encodeCharactersFromLeaves, encodeCharactersFromVariable }

--- a/src/frontend/utils/python/generatePythonLspPreamble.ts
+++ b/src/frontend/utils/python/generatePythonLspPreamble.ts
@@ -23,7 +23,7 @@
  * POU has no input/output variables — keeps the caller's prepend
  * logic uniform without a special case.
  */
-import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
 import { getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
 import { pythonInterfaceVariables } from './block-interface'
 
@@ -119,11 +119,15 @@ function annotationFor(variable: PLCVariable): string | null {
     if (!innerPython) return null
     return `list[${innerPython}]`
   }
-  if (variable.type.definition !== 'base-type') {
-    // user-data-type (struct / enum) — runtime injection doesn't
-    // pack these across shared memory today; skip silently.
-    return null
+  if (variable.type.definition === 'user-data-type') {
+    // A structure or an enumeration: the stub declared above carries its shape,
+    // so the annotation is simply the class name. A type the project does not
+    // declare — a function block instance — is refused at compile time and gets
+    // no declaration here either.
+    return variable.type.value
   }
+  /* istanbul ignore next -- defensive: only base-type remains */
+  if (variable.type.definition !== 'base-type') return null
   return mapIecBaseTypeToPython(variable.type.value)
 }
 
@@ -147,18 +151,80 @@ function initialValueFor(variable: PLCVariable, annotation: string): string {
 }
 
 /**
- * Generate the LSP-only preamble for a POU's variables.  Only
- * `input` and `output` IEC variables get a declaration — those are
- * the classes `injectPythonRuntime` wires through shared memory and
- * therefore the only ones the runtime will actually expose as
- * module-level globals.  Local / temp / inOut / external classes
- * are intentionally skipped so Pyright doesn't pretend symbols
- * exist that the runtime won't bind.
+ * Class stubs for the structures and enumerations a POU's interface uses.
+ *
+ * These mirror what `injectPythonRuntime` actually defines at runtime, so
+ * Pyright resolves `m.speed` and `Mode.RUNNING` to the same shapes the block
+ * will really see. Without them a structure variable has no type to be, and the
+ * editor either says nothing useful or reports an error on correct code.
+ *
+ * The stub bodies are `...` rather than the runtime's real `__init__`: Pyright
+ * only needs the attribute names and their types, and a shorter stub keeps the
+ * preamble's line count — which the diagnostic line mapping depends on — small.
+ */
+function typeStubsFor(variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string[] {
+  if (dataTypes.length === 0) return []
+  const byName = new Map(dataTypes.map((dataType) => [dataType.name.toUpperCase(), dataType]))
+  const emitted = new Set<string>()
+  const lines: string[] = []
+
+  // `emitted` is what breaks a cycle: a structure that contains itself is
+  // declared once and its member simply refers back to it, which is a legal
+  // Python annotation and exactly what Pyright should see.
+  const visit = (typeName: string): void => {
+    const key = typeName.toUpperCase()
+    if (emitted.has(key)) return
+    const dataType = byName.get(key)
+    if (!dataType || dataType.derivation === 'array') return
+    emitted.add(key)
+
+    if (dataType.derivation === 'enumerated') {
+      lines.push(`class ${dataType.name}(IntEnum):`)
+      dataType.values.forEach((value, index) => lines.push(`    ${value.description} = ${index}`))
+      return
+    }
+
+    // Members first, so a nested structure is named before it is referenced.
+    for (const member of dataType.variable) {
+      if (member.type.definition === 'user-data-type') visit(member.type.value)
+    }
+    lines.push(`class ${dataType.name}:`)
+    for (const member of dataType.variable) {
+      const annotation = annotationFor({
+        name: member.name,
+        type: member.type,
+        location: '',
+        documentation: '',
+      })
+      lines.push(`    ${member.name}: ${annotation ?? 'Any'}`)
+    }
+  }
+
+  // Only the variables that actually get a declaration below. An array of
+  // structures has no Python annotation and is refused at compile time, so it
+  // gets neither a declaration nor a stub — the editor stays in lockstep with
+  // what the build will accept.
+  for (const variable of variables) {
+    if (variable.type.definition === 'user-data-type') visit(variable.type.value)
+  }
+
+  return lines.length > 0 ? ['from enum import IntEnum', 'from typing import Any', ...lines, ''] : []
+}
+
+/**
+ * Generate the LSP-only preamble for a POU's variables.
+ *
+ * Every class `injectPythonRuntime` wires through shared memory gets a
+ * declaration, because those are exactly the names the runtime binds as module
+ * globals. `temp` is refused for a Python block and so is never one.
  *
  * The header comment makes it obvious in any debug snapshot that
  * the lines are a synthetic Pyright nudge, not user code.
  */
-export function generatePythonLspPreamble(variables: PLCVariable[]): PythonLspPreamble {
+export function generatePythonLspPreamble(
+  variables: PLCVariable[],
+  dataTypes: readonly PLCDataType[] = [],
+): PythonLspPreamble {
   const declarable = pythonInterfaceVariables(variables)
   if (declarable.length === 0) {
     return { text: '', lineCount: 0, variableNameByPreambleLine: new Map() }
@@ -171,6 +237,8 @@ export function generatePythonLspPreamble(variables: PLCVariable[]): PythonLspPr
     '# names as module-level globals at runtime (see injectPythonRuntime).',
     '# ===================================================================',
   ]
+  const declared = declarable.filter((variable) => annotationFor(variable) !== null)
+  const typeStubs = typeStubsFor(declared, dataTypes)
   const declLines: string[] = []
   const variableNameByPreambleLine = new Map<number, string>()
   // First declaration sits at line `header.length` (header occupies
@@ -178,7 +246,7 @@ export function generatePythonLspPreamble(variables: PLCVariable[]): PythonLspPr
   // by one line.  Variables whose type can't be mapped to Python
   // (TIME / DATE / TOD / DT / user types) are skipped — they don't
   // get a declaration line, so they don't take a slot in the map.
-  let preambleLine = header.length
+  let preambleLine = header.length + typeStubs.length
   for (const v of declarable) {
     const annotation = annotationFor(v)
     if (!annotation) continue
@@ -190,7 +258,7 @@ export function generatePythonLspPreamble(variables: PLCVariable[]): PythonLspPr
     return { text: '', lineCount: 0, variableNameByPreambleLine: new Map() }
   }
 
-  const body = [...header, ...declLines, '', '']
+  const body = [...header, ...typeStubs, ...declLines, '', '']
   const text = body.join('\n')
   // `lineCount` is the 0-indexed augmented-document line where the
   // user's first line begins.  Equivalently: the number of newline

--- a/src/frontend/utils/python/generateSTCode.ts
+++ b/src/frontend/utils/python/generateSTCode.ts
@@ -1,12 +1,15 @@
-import type { PLCVariable } from '../../../middleware/shared/ports/types'
-import { getArrayStartIndex, getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
+import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
 import { pythonInboundVariables, pythonOutboundVariables } from './block-interface'
-import { describeShmField, SHM_STRING_CHARS } from './shm-type-map'
+import type { ShmLeaf } from './shm-leaves'
+import { describeShmLayout, describeShmLeaves } from './shm-leaves'
+import { SHM_STRING_CHARS } from './shm-type-map'
 
 type STCodeGenerationParams = {
   pouName: string
   allVariables: PLCVariable[]
   processedPythonCode: string
+  /** The project's data types, so a structure or enumeration can be walked. */
+  dataTypes?: readonly PLCDataType[]
 }
 
 /**
@@ -15,144 +18,147 @@ type STCodeGenerationParams = {
  * `preprocessPous` refuses an unsupported type first — but the emitters stay
  * total so a direct caller cannot produce a half-formed struct.
  */
-const fieldKind = (variable: PLCVariable): 'scalar' | 'string' | 'wstring' | null =>
-  describeShmField(variable)?.kind ?? null
-
-/**
- * Raw C type for an SHM struct field.
- *
- * SHM is a packed binary protocol Python decodes with `struct.unpack`, so every
- * field must be a trivially-copyable C primitive. The strucpp `IEC_T` aliases
- * resolve to `IECVar<T>` wrappers with a non-trivial copy assignment, so
- * memcpy'ing into them is UB and gcc fires `-Wclass-memaccess`. The C stub
- * bridges between the wrapper (force-aware reads and writes on the IEC side)
- * and these raw fields at the boundary.
- */
-const shmFieldType = (variable: PLCVariable): string => describeShmField(variable)?.cType ?? 'uint8_t'
-
-const generateStructField = (variable: PLCVariable): string => {
-  const fieldType = shmFieldType(variable)
-  const name = variable.name
-  if (isArrayVariable(variable)) {
-    const totalElements = getArrayTotalElements(variable)
-    return `        ${fieldType} ${name}[${totalElements}];\n`
+const generateStructField = (leaf: ShmLeaf): string => {
+  const fieldType = leaf.descriptor.cType
+  if (leaf.count > 1) {
+    return `        ${fieldType} ${leaf.field}[${leaf.count}];\n`
   }
-  return `        ${fieldType} ${name};\n`
+  return `        ${fieldType} ${leaf.field};\n`
 }
 
-const generateCStructs = (inputVars: PLCVariable[], outputVars: PLCVariable[]): string => {
-  let structs = ''
-
-  // Input struct
-  structs += '    #pragma pack(push, 1)\n'
+const generateOneStruct = (leaves: ShmLeaf[], typeName: string): string => {
+  let structs = '    #pragma pack(push, 1)\n'
   structs += '    typedef struct {\n'
-  if (inputVars.length > 0) {
-    inputVars.forEach((variable) => {
-      structs += generateStructField(variable)
+  if (leaves.length > 0) {
+    leaves.forEach((leaf) => {
+      structs += generateStructField(leaf)
     })
   } else {
+    // An empty struct is not portable C, and its size would differ between the
+    // two sides. One byte nobody reads keeps the layouts agreeing.
     structs += '        uint8_t _padding;\n'
   }
-  structs += '    } shm_data_in_t;\n'
-  structs += '    #pragma pack(pop)\n\n'
-
-  // Output struct
-  structs += '    #pragma pack(push, 1)\n'
-  structs += '    typedef struct {\n'
-  if (outputVars.length > 0) {
-    outputVars.forEach((variable) => {
-      structs += generateStructField(variable)
-    })
-  } else {
-    structs += '        uint8_t _padding;\n'
-  }
-  structs += '    } shm_data_out_t;\n'
+  structs += `    } ${typeName};\n`
   structs += '    #pragma pack(pop)\n'
-
   return structs
 }
 
-/**
- * How one variable is named in a copy statement, and what must wrap that
- * statement.
- *
- * Every class but `external` is a plain member of the block's class, so the
- * upper-cased name refers to it directly. A `VAR_EXTERNAL` is a
- * `GlobalVar<V>*`: the value together with that global's own mutex. Naming it
- * directly would compile — the pointer converts — and would copy from the wrong
- * place while holding no lock at all.
- *
- * So an external's copy is wrapped in `with_lock`, which runs a callable with a
- * `V*` while the lock is held. Each external is wrapped on its own rather than
- * nested: this stub only copies values in and out, it does not run user code, so
- * one lock at a time is enough — and that matches what an ST body does, with no
- * lock ordering to reason about.
- *
- * The lambda's parameter is deduced, so nothing here names `V` — the compiler's
- * layout stays the only statement of it. The dereference is bound to a reference
- * on its own line rather than written inline as `(*p)`: this C++ sits inside an
- * `{external}` block that the ST front end still scans, where `(*` opens a block
- * comment and would swallow the rest of the POU.
- */
-const accessorFor = (variable: PLCVariable): { open: string; name: string; close: string } => {
-  const upperName = variable.name.toUpperCase()
-  if (variable.class !== 'external') return { open: '', name: upperName, close: '' }
+const generateCStructs = (inbound: ShmLeaf[], outbound: ShmLeaf[]): string =>
+  `${generateOneStruct(inbound, 'shm_data_in_t')}\n${generateOneStruct(outbound, 'shm_data_out_t')}`
 
-  return {
-    open: `        ${upperName}->with_lock([&](auto* __g) {\n        auto& __r = *__g;\n`,
-    name: '__r',
-    close: '        });\n',
+/**
+ * Copy one leaf between the strucpp side and a packed transport field.
+ *
+ * `toShm` picks the direction. Reads go through `.get()` (explicitly for arrays
+ * and strings, implicitly through `IECVar`'s conversion for scalars) so a forced
+ * value appears to Python exactly as it appears to the IEC program. Writes go
+ * through `IECVar::operator=`, which is a no-op while forced — a Python write to
+ * a forced variable is dropped on the IEC side, as it should be.
+ */
+const generateLeafCopy = (leaf: ShmLeaf, struct: string, toShm: boolean): string => {
+  const { field, access, descriptor, count, startIndex } = leaf
+  const shm = `${struct}.${field}`
+
+  if (count > 1) {
+    // Iterate IEC indices so a forced element crosses like any other.
+    return toShm
+      ? `        for (int __i = 0; __i < ${count}; __i++) ${shm}[__i] = ${access}[${startIndex} + __i].get();\n`
+      : `        for (int __i = 0; __i < ${count}; __i++) ${access}[${startIndex} + __i] = ${shm}[__i];\n`
   }
+
+  if (descriptor.kind === 'string' || descriptor.kind === 'wstring') {
+    const wide = descriptor.kind === 'wstring'
+    const unit = wide ? ' * sizeof(uint16_t)' : ''
+    if (toShm) {
+      // `get()` returns the string by value — bind it once so `c_str()` and
+      // `length()` refer to the same temporary. Copy only the characters that
+      // exist and zero the rest, so the body is deterministic rather than
+      // carrying whatever the wrapper's tail held.
+      let code = `        { auto __s = ${access}.get();\n`
+      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
+      code += `          ${shm}.len = __n;\n`
+      code += `          std::memset(${shm}.body, 0, STR_MAX_LEN${unit});\n`
+      code += `          std::memcpy(${shm}.body, __s.c_str(), (size_t)__n${unit}); }\n`
+      return code
+    }
+    // Reconstruct from the right unit width: a WSTRING body is char16_t, and
+    // reading it as `char*` would hand IECWString half a string.
+    const wrapper = wide ? 'IECWString' : 'IECString'
+    const pointer = wide ? 'const char16_t*' : 'const char*'
+    return `        ${access} = strucpp::${wrapper}<254>(reinterpret_cast<${pointer}>(${shm}.body), ${shm}.len);\n`
+  }
+
+  if (leaf.enumTypeName) {
+    // An `IEC_ENUM_Var` yields an `IEC_ENUM_Value`, which converts to the scoped
+    // enum but not to an integer, so the read goes through both and then casts.
+    // The write goes through `set()` rather than `operator=`, which would
+    // copy-assign a whole temporary wrapper and take the forced state with it.
+    const enumType = leaf.enumTypeName.toUpperCase()
+    return toShm
+      ? `        ${shm} = static_cast<${descriptor.cType}>(${access}.get().get());\n`
+      : `        ${access}.set(static_cast<${enumType}>(${shm}));\n`
+  }
+
+  // A plain scalar: `IECVar` converts to its value implicitly on the way out and
+  // assigns through `set()` on the way back.
+  if (toShm) return `        ${shm} = ${access};\n`
+  return `        ${access} = ${shm};\n`
 }
 
-const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
-  if (inputVars.length === 0) return ''
+/**
+ * Wrap a leaf's copy in its global's lock when the leaf belongs to a
+ * VAR_EXTERNAL.
+ *
+ * A `VAR_EXTERNAL` is a `GlobalVar<V>*` — the value together with that global's
+ * mutex. Naming it in a copy statement would compile, convert the pointer, and
+ * read the wrong memory holding no lock at all.
+ *
+ * Each external is wrapped on its own rather than nested: this stub only copies
+ * values, it runs no user code, so one lock at a time is enough and there is no
+ * ordering to reason about. The lambda parameter is deduced, so nothing here
+ * names `V`. The dereference is bound to a reference on its own line rather
+ * than written inline as `(*p)`: this C++ sits inside an `{external}` block
+ * that the ST front end still scans, where `(*` opens a block comment.
+ */
+const withExternalLock = (variable: PLCVariable, body: string): string => {
+  if (variable.class !== 'external') return body
+  const upperName = variable.name.toUpperCase()
+  return `        ${upperName}->with_lock([&](auto* __g) {\n        auto& __r = *__g;\n${body}        });\n`
+}
 
+/**
+ * Rewrite a leaf's access so it reaches through the locked reference instead of
+ * the class member, for a leaf belonging to a VAR_EXTERNAL.
+ */
+const throughLock = (variable: PLCVariable, leaf: ShmLeaf): ShmLeaf => {
+  if (variable.class !== 'external') return leaf
+  const upperName = variable.name.toUpperCase()
+  return { ...leaf, access: `__r${leaf.access.slice(upperName.length)}` }
+}
+
+/** Emit one direction's copies, grouping each external's leaves under its lock. */
+const generateCopies = (
+  variables: PLCVariable[],
+  dataTypes: readonly PLCDataType[],
+  struct: string,
+  toShm: boolean,
+): string => {
+  let code = ''
+  for (const variable of variables) {
+    const result = describeShmLeaves(variable, dataTypes)
+    /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
+    if ('refusal' in result) continue
+    const body = result.leaves.map((leaf) => generateLeafCopy(throughLock(variable, leaf), struct, toShm)).join('')
+    code += withExternalLock(variable, body)
+  }
+  return code
+}
+
+const generateInputCopyCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  if (variables.length === 0) return ''
   let code = '        shm_data_in_t data_in;\n'
-
-  inputVars.forEach((variable) => {
-    const { open, name: upperName, close } = accessorFor(variable)
-    const fieldName = variable.name
-    const kind = fieldKind(variable)
-    code += open
-
-    if (isArrayVariable(variable)) {
-      // Iterate IEC indices and pull each element through `.get()` so
-      // forced array elements appear in shared memory the same way they
-      // appear to the IEC program logic.
-      const totalElements = getArrayTotalElements(variable)
-      const startIdx = getArrayStartIndex(variable)
-      code += `        for (int __i = 0; __i < ${totalElements}; __i++) data_in.${fieldName}[__i] = ${upperName}[${startIdx} + __i].get();\n`
-    } else if (kind === 'string') {
-      // IECStringVar::get() returns IECString<N> by value — bind once to a
-      // local so c_str() / length() refer to the same temporary. Copy only the
-      // characters that exist and zero the rest, so the body is deterministic
-      // rather than carrying whatever the wrapper's tail held.
-      code += `        { auto __s = ${upperName}.get();\n`
-      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
-      code += `          data_in.${fieldName}.len = __n;\n`
-      code += `          std::memset(data_in.${fieldName}.body, 0, STR_MAX_LEN);\n`
-      code += `          std::memcpy(data_in.${fieldName}.body, __s.c_str(), (size_t)__n); }\n`
-    } else if (kind === 'wstring') {
-      // WSTRING is UTF-16: `length()` counts code units and `c_str()` yields
-      // `const char16_t*`, so the byte count is twice the length. The previous
-      // code copied STR_MAX_LEN *bytes* (63 code units) while writing a length
-      // in characters, which put the two sides permanently out of step.
-      code += `        { auto __s = ${upperName}.get();\n`
-      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
-      code += `          data_in.${fieldName}.len = __n;\n`
-      code += `          std::memset(data_in.${fieldName}.body, 0, STR_MAX_LEN * sizeof(uint16_t));\n`
-      code += `          std::memcpy(data_in.${fieldName}.body, __s.c_str(), (size_t)__n * sizeof(uint16_t)); }\n`
-    } else {
-      // Scalar — IECVar's implicit conversion to T routes through .get()
-      // so a forced input is observed correctly.
-      code += `        data_in.${fieldName} = ${upperName};\n`
-    }
-    code += close
-  })
-
+  code += generateCopies(variables, dataTypes, 'data_in', true)
   code += '        memcpy(shm_in_ptr, &data_in, sizeof(data_in));\n\n'
-
   return code
 }
 
@@ -160,99 +166,50 @@ const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
  * Publish the IEC-side output values into shared memory once, at startup.
  *
  * Without this the Python block seeds its output globals from the declaration
- * (`initialValue || 0`) and writes them back after its very first
- * `block_loop()`, before the user's code has assigned anything — so whatever
- * the IEC variable held is destroyed. Today that discards a declared initial
- * value; once a Python block can carry RETAIN it destroys the retained value on
- * every restart, which is the exact opposite of what retain is for.
+ * and writes them back after its very first `block_loop()`, before the user's
+ * code has assigned anything — so whatever the IEC variable held is destroyed.
+ * Today that discards a declared initial value; once a Python block can carry
+ * RETAIN it destroys the retained value on every restart, which is the exact
+ * opposite of what retain is for.
  *
  * Shared memory is created zeroed, so there is nothing for Python to seed from
- * unless the C side puts it there. This is the mirror of `generateOutputCopyCode`
- * — same fields, opposite direction — and runs in the `first_run` branch right
- * after the loader has mapped the segment.
+ * unless the C side puts it there.
  */
-const generateOutputSeedCode = (outputVars: PLCVariable[]): string => {
-  if (outputVars.length === 0) return ''
-
+const generateOutputSeedCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  if (variables.length === 0) return ''
   let code = '        shm_data_out_t seed_out;\n'
   code += '        std::memset(&seed_out, 0, sizeof(seed_out));\n'
-
-  outputVars.forEach((variable) => {
-    const { open, name: upperName, close } = accessorFor(variable)
-    const fieldName = variable.name
-    const kind = fieldKind(variable)
-    code += open
-
-    if (isArrayVariable(variable)) {
-      const totalElements = getArrayTotalElements(variable)
-      const startIdx = getArrayStartIndex(variable)
-      code += `        for (int __i = 0; __i < ${totalElements}; __i++) seed_out.${fieldName}[__i] = ${upperName}[${startIdx} + __i].get();\n`
-    } else if (kind === 'string') {
-      code += `        { auto __s = ${upperName}.get();\n`
-      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
-      code += `          seed_out.${fieldName}.len = __n;\n`
-      code += `          std::memcpy(seed_out.${fieldName}.body, __s.c_str(), (size_t)__n); }\n`
-    } else if (kind === 'wstring') {
-      code += `        { auto __s = ${upperName}.get();\n`
-      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
-      code += `          seed_out.${fieldName}.len = __n;\n`
-      code += `          std::memcpy(seed_out.${fieldName}.body, __s.c_str(), (size_t)__n * sizeof(uint16_t)); }\n`
-    } else {
-      code += `        seed_out.${fieldName} = ${upperName};\n`
-    }
-    code += close
-  })
-
+  code += generateCopies(variables, dataTypes, 'seed_out', true)
   code += '        memcpy(shm_out_ptr, &seed_out, sizeof(seed_out));\n'
   return code
 }
 
-const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
-  if (outputVars.length === 0) return ''
-
+const generateOutputCopyCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  if (variables.length === 0) return ''
   let code = '        shm_data_out_t data_out;\n'
   code += '        memcpy(&data_out, shm_out_ptr, sizeof(data_out));\n'
-
-  outputVars.forEach((variable) => {
-    const { open, name: upperName, close } = accessorFor(variable)
-    const fieldName = variable.name
-    const kind = fieldKind(variable)
-    code += open
-
-    if (isArrayVariable(variable)) {
-      const totalElements = getArrayTotalElements(variable)
-      const startIdx = getArrayStartIndex(variable)
-      // Element-wise assignment; IECVar::operator=(T) routes through
-      // .set(), which is a no-op when forced — Python user writes to a
-      // forced array element are silently dropped on the IEC side.
-      code += `        for (int __i = 0; __i < ${totalElements}; __i++) ${upperName}[${startIdx} + __i] = data_out.${fieldName}[__i];\n`
-    } else if (kind === 'string') {
-      code += `        ${upperName} = strucpp::IECString<254>(reinterpret_cast<const char*>(data_out.${fieldName}.body), data_out.${fieldName}.len);\n`
-    } else if (kind === 'wstring') {
-      // Reconstruct from char16_t units, not bytes — the mirror of the copy-in
-      // fix above. Reinterpreting the body as `char*` (what this did before)
-      // handed IECWString half a string.
-      code += `        ${upperName} = strucpp::IECWString<254>(reinterpret_cast<const char16_t*>(data_out.${fieldName}.body), data_out.${fieldName}.len);\n`
-    } else {
-      // Scalar — IECVar::operator=(T) → set(), force-respect.
-      code += `        ${upperName} = data_out.${fieldName};\n`
-    }
-    code += close
-  })
-
+  code += generateCopies(variables, dataTypes, 'data_out', false)
   return code
 }
 
 const generateSTCode = (params: STCodeGenerationParams): string => {
-  const { pouName, allVariables, processedPythonCode } = params
+  const { pouName, allVariables, processedPythonCode, dataTypes = [] } = params
 
   const inputVariables = pythonInboundVariables(allVariables)
   const outputVariables = pythonOutboundVariables(allVariables)
 
-  const cStructs = generateCStructs(inputVariables, outputVariables)
-  const inputCopyCode = generateInputCopyCode(inputVariables)
-  const outputCopyCode = generateOutputCopyCode(outputVariables)
-  const outputSeedCode = generateOutputSeedCode(outputVariables)
+  // The struct layout and the copy statements are generated from the same leaf
+  // walk, so a structure cannot be laid out one way and copied another.
+  const inboundLeaves = describeShmLayout(inputVariables, dataTypes)
+  const outboundLeaves = describeShmLayout(outputVariables, dataTypes)
+  /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
+  const cStructs = generateCStructs(
+    'leaves' in inboundLeaves ? inboundLeaves.leaves : [],
+    'leaves' in outboundLeaves ? outboundLeaves.leaves : [],
+  )
+  const inputCopyCode = generateInputCopyCode(inputVariables, dataTypes)
+  const outputCopyCode = generateOutputCopyCode(outputVariables, dataTypes)
+  const outputSeedCode = generateOutputSeedCode(outputVariables, dataTypes)
 
   const escapedPythonCode = processedPythonCode
     .replace(/\\/g, '\\\\')

--- a/src/frontend/utils/python/injectPythonCode.ts
+++ b/src/frontend/utils/python/injectPythonCode.ts
@@ -1,4 +1,4 @@
-import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
 import { pythonInboundVariables, pythonOutboundVariables } from './block-interface'
 import { encodeCharactersFromVariable } from './encodeCharactersFromVariable'
 import { injectPythonRuntime } from './injectPythonRuntime'
@@ -11,13 +11,13 @@ type PythonPouData = {
   variables: PLCVariable[]
 }
 
-const injectPythonCode = (pythonPous: PythonPouData[]): string[] => {
+const injectPythonCode = (pythonPous: PythonPouData[], dataTypes: readonly PLCDataType[] = []): string[] => {
   return pythonPous.map((pou) => {
     const inputVariables = pythonInboundVariables(pou.variables)
     const outputVariables = pythonOutboundVariables(pou.variables)
 
-    const fmtIn = encodeCharactersFromVariable(inputVariables)
-    const fmtOut = encodeCharactersFromVariable(outputVariables)
+    const fmtIn = encodeCharactersFromVariable(inputVariables, dataTypes)
+    const fmtOut = encodeCharactersFromVariable(outputVariables, dataTypes)
 
     const injectedCode = injectPythonRuntime({
       fmtIn,
@@ -26,6 +26,7 @@ const injectPythonCode = (pythonPous: PythonPouData[]): string[] => {
       outputVariables,
       originalCode: pou.code,
       pouName: pou.name,
+      dataTypes,
     })
 
     return injectedCode

--- a/src/frontend/utils/python/injectPythonRuntime.ts
+++ b/src/frontend/utils/python/injectPythonRuntime.ts
@@ -1,6 +1,7 @@
-import type { PLCVariable } from '../../../middleware/shared/ports/types'
-import { getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
-import { describeShmField, SHM_STRING_CHARS } from './shm-type-map'
+import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
+import type { ShmLeaf } from './shm-leaves'
+import { describeShmLeaves } from './shm-leaves'
+import { SHM_STRING_CHARS } from './shm-type-map'
 
 type PythonRuntimeInjectionParams = {
   fmtIn: string
@@ -9,11 +10,207 @@ type PythonRuntimeInjectionParams = {
   outputVariables: PLCVariable[]
   originalCode: string
   pouName: string
+  /** The project's data types, so a structure or enumeration can be rebuilt. */
+  dataTypes?: readonly PLCDataType[]
 }
 
-const generateInputUnpackCode = (inputVariables: PLCVariable[]): string => {
-  if (inputVariables.length === 0) return '    # No input variables to read'
-  return generateUnpackCode(inputVariables, {
+/**
+ * Python classes for the structures and enumerations a block's interface uses.
+ *
+ * The wire format is flat — one field per scalar leaf — but the user should
+ * write `m.speed`, not `m_speed`, exactly as they would in ST. So the driver
+ * rebuilds an object from consecutive leaves on the way in and reads it back
+ * apart on the way out, and these are the shapes it builds.
+ *
+ * A structure becomes a plain class with `__slots__`: cheap, and an assignment
+ * to a name the structure does not have raises rather than silently creating an
+ * attribute the PLC will never read back. An enumeration becomes an `IntEnum`,
+ * so `mode == Mode.RUNNING` reads naturally while the value crossing the
+ * boundary stays the plain integer the PLC stores.
+ */
+const generateTypeDeclarations = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  const referenced = collectReferencedTypes(variables, dataTypes)
+  if (referenced.length === 0) return '# This block uses no structures or enumerations'
+
+  let code = '# Structures and enumerations from the Variables Table\n'
+  for (const dataType of referenced) {
+    if (dataType.derivation === 'enumerated') {
+      code += `class ${dataType.name}(IntEnum):\n`
+      dataType.values.forEach((value, index) => {
+        code += `    ${value.description} = ${index}\n`
+      })
+      code += '\n'
+      continue
+    }
+    /* istanbul ignore else -- collectReferencedTypes yields only these two */
+    if (dataType.derivation === 'structure') {
+      const members = dataType.variable.map((member) => member.name)
+      code += `class ${dataType.name}:\n`
+      code += `    __slots__ = (${members.map((m) => `'${m}'`).join(', ')}${members.length === 1 ? ',' : ''})\n`
+      code += `    def __init__(self${members.map((m) => `, ${m}=None`).join('')}):\n`
+      for (const member of members) {
+        code += `        self.${member} = ${member}\n`
+      }
+      code += '\n'
+    }
+  }
+  return code
+}
+
+/**
+ * Every structure and enumeration a block's interface reaches, nested ones
+ * included, in an order where a type is declared before anything using it.
+ */
+const collectReferencedTypes = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): PLCDataType[] => {
+  const byName = new Map(dataTypes.map((dataType) => [dataType.name.toUpperCase(), dataType]))
+  const ordered: PLCDataType[] = []
+  const seen = new Set<string>()
+
+  const visit = (typeName: string, depth: number): void => {
+    /* istanbul ignore next -- defensive: describeShmLeaves refuses deeper nesting first */
+    if (depth > 16) return
+    const key = typeName.toUpperCase()
+    if (seen.has(key)) return
+    const dataType = byName.get(key)
+    if (!dataType || dataType.derivation === 'array') return
+    seen.add(key)
+    if (dataType.derivation === 'structure') {
+      // Members first, so a nested structure is defined before the class that
+      // constructs it.
+      for (const member of dataType.variable) {
+        if (member.type.definition === 'user-data-type') visit(member.type.value, depth + 1)
+      }
+    }
+    ordered.push(dataType)
+  }
+
+  for (const variable of variables) {
+    const base = variable.type.definition === 'array' ? variable.type.data?.baseType : variable.type
+    if (base?.definition === 'user-data-type') visit(base.value, 0)
+  }
+  return ordered
+}
+
+/**
+ * Emit the statements that decode one variable from consecutive leaves.
+ *
+ * A scalar binds straight to its name. A structure is constructed from its
+ * members, innermost first, so nesting rebuilds correctly. An enumeration is
+ * wrapped in its IntEnum.
+ */
+const generateVariableUnpack = (variable: PLCVariable, dataTypes: readonly PLCDataType[], indent: string): string => {
+  const walked = describeShmLeaves(variable, dataTypes)
+  /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
+  if ('refusal' in walked) return ''
+
+  let code = ''
+  const locals: string[] = []
+  for (const leaf of walked.leaves) {
+    // Each leaf decodes into a temporary named for its path, then the temporaries
+    // are assembled. A flat variable's path is just its own name, so the
+    // temporary *is* the variable and no assembly is needed.
+    const local = leaf.path.length === 1 ? variable.name : `_${leaf.field}`
+    locals.push(local)
+    code += decodeLeaf(leaf, local, indent)
+  }
+
+  if (walked.leaves.length === 1 && walked.leaves[0].path.length === 1) {
+    const only = walked.leaves[0]
+    return only.enumTypeName ? `${code}${indent}${variable.name} = ${only.enumTypeName}(${variable.name})\n` : code
+  }
+
+  code += `${indent}${variable.name} = ${buildValue(variable, dataTypes, [variable.name])}\n`
+  return code
+}
+
+/** Construct expression for a structure, recursing into nested members. */
+const buildValue = (variable: PLCVariable, dataTypes: readonly PLCDataType[], path: string[]): string => {
+  const byName = new Map(dataTypes.map((dataType) => [dataType.name.toUpperCase(), dataType]))
+  const base = variable.type.definition === 'array' ? variable.type.data?.baseType : variable.type
+
+  const buildFor = (typeName: string, fieldPath: string[]): string => {
+    const dataType = byName.get(typeName.toUpperCase())
+    /* istanbul ignore next -- defensive: only structures reach here */
+    if (!dataType || dataType.derivation !== 'structure') return `_${fieldPath.join('_')}`
+    const args = dataType.variable.map((member) => {
+      const memberPath = [...fieldPath, member.name]
+      if (member.type.definition === 'user-data-type') {
+        const nested = byName.get(member.type.value.toUpperCase())
+        if (nested?.derivation === 'structure') return `${member.name}=${buildFor(member.type.value, memberPath)}`
+        if (nested?.derivation === 'enumerated') {
+          return `${member.name}=${member.type.value}(_${memberPath.join('_')})`
+        }
+      }
+      return `${member.name}=_${memberPath.join('_')}`
+    })
+    return `${dataType.name}(${args.join(', ')})`
+  }
+
+  /* istanbul ignore next -- defensive: callers only assemble structures */
+  return base?.definition === 'user-data-type' ? buildFor(base.value, path) : `_${path.join('_')}`
+}
+
+/** Decode one leaf out of `_vals` into `local`. */
+const decodeLeaf = (leaf: ShmLeaf, local: string, indent: string): string => {
+  const { descriptor, count } = leaf
+  let code = ''
+
+  if (count > 1) {
+    code += `${indent}${local} = list(_vals[_idx:_idx+${count}])\n`
+    code += `${indent}_idx += ${count}\n`
+    return code
+  }
+
+  if (descriptor.kind === 'string' || descriptor.kind === 'wstring') {
+    code += `${indent}${local}_len = _vals[_idx]\n`
+    code += `${indent}_idx += 1\n`
+    code += `${indent}${local}_body = _vals[_idx]\n`
+    code += `${indent}_idx += 1\n`
+    // The C side clamps the length to the budget, but the prefix is a signed
+    // int8 and the buffer starts zeroed, so clamp on read too: a negative slice
+    // bound would silently truncate from the end instead of failing.
+    code += `${indent}${local}_len = max(0, min(${local}_len, ${SHM_STRING_CHARS}))\n`
+    if (descriptor.kind === 'wstring') {
+      // The length counts UTF-16 code units, so the byte slice is twice it.
+      code += `${indent}${local} = ${local}_body[:${local}_len * 2].decode('utf-16-le', errors='ignore')\n`
+    } else {
+      code += `${indent}${local} = ${local}_body[:${local}_len].decode('utf-8', errors='ignore')\n`
+    }
+    return code
+  }
+
+  code += `${indent}${local} = _vals[_idx]\n`
+  code += `${indent}_idx += 1\n`
+  return code
+}
+
+/**
+ * Emit the unpack sequence for a set of variables.
+ *
+ * Shared by the per-cycle input read and the one-time output seed: both decode
+ * the same packed layout, differing only in which buffer they read and at what
+ * indentation. Keeping one generator means the two cannot drift in how they
+ * interpret a field — the same reason the leaf walk is shared with the C side.
+ */
+const generateUnpackCode = (
+  variables: PLCVariable[],
+  dataTypes: readonly PLCDataType[],
+  opts: { header: string; buffer: string; fmt: string; size: string; indent: string },
+): string => {
+  const { header, buffer, fmt, size, indent } = opts
+
+  let code = `${header}\n`
+  code += `${indent}_vals = struct.unpack(${fmt}, ${buffer}.buf[:${size}])\n`
+  code += `${indent}_idx = 0\n`
+  for (const variable of variables) {
+    code += generateVariableUnpack(variable, dataTypes, indent)
+  }
+  return code
+}
+
+const generateInputUnpackCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  if (variables.length === 0) return '    # No input variables to read'
+  return generateUnpackCode(variables, dataTypes, {
     header: '    # Read input variables',
     buffer: 'shm_in',
     fmt: 'fmt_in',
@@ -26,18 +223,17 @@ const generateInputUnpackCode = (inputVariables: PLCVariable[]): string => {
  * Seed the output globals from what the PLC currently holds, before
  * `block_init()` runs.
  *
- * Previously the outputs were initialised from their declarations
- * (`initialValue || 0`) and written back after the first `block_loop()`, before
- * the user's code had assigned anything — so the IEC-side value was replaced by
- * a default on every start. With RETAIN that is destructive rather than merely
- * wrong. The C stub publishes the live values into shared memory when it maps
- * the segment (see `generateOutputSeedCode`), and this reads them back.
- *
- * A block that never assigns an output now leaves it exactly as the PLC had it.
+ * Previously the outputs were initialised from their declarations and written
+ * back after the first `block_loop()`, before the user's code had assigned
+ * anything — so the IEC-side value was replaced by a default on every start.
+ * With RETAIN that is destructive rather than merely wrong. The C stub publishes
+ * the live values into shared memory when it maps the segment, and this reads
+ * them back. A block that never assigns an output now leaves it exactly as the
+ * PLC had it.
  */
-const generateOutputSeedCode = (outputVariables: PLCVariable[]): string => {
-  if (outputVariables.length === 0) return '# No output variables to seed'
-  return generateUnpackCode(outputVariables, {
+const generateOutputSeedCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  if (variables.length === 0) return '# No output variables to seed'
+  return generateUnpackCode(variables, dataTypes, {
     header: '# Seed outputs from the values the PLC already holds',
     buffer: 'shm_out',
     fmt: 'fmt_out',
@@ -46,88 +242,56 @@ const generateOutputSeedCode = (outputVariables: PLCVariable[]): string => {
   })
 }
 
-/**
- * Emit the unpack sequence for a set of variables.
- *
- * Shared by the per-cycle input read and the one-time output seed: both decode
- * the same packed layout, differing only in which buffer they read and at what
- * indentation. Keeping one generator means the two cannot drift in how they
- * interpret a field — the same reason the type table is shared.
- */
-const generateUnpackCode = (
-  variables: PLCVariable[],
-  opts: { header: string; buffer: string; fmt: string; size: string; indent: string },
-): string => {
-  const { header, buffer, fmt, size, indent } = opts
+/** Encode one leaf, reading through the Python attribute path it came from. */
+const encodeLeaf = (leaf: ShmLeaf): string => {
+  const expr = leaf.path.join('.')
+  const { descriptor, count } = leaf
 
-  let code = `${header}\n`
-  code += `${indent}_vals = struct.unpack(${fmt}, ${buffer}.buf[:${size}])\n`
-  code += `${indent}_idx = 0\n`
+  if (count > 1) return `    _out.extend(${expr})\n`
 
-  variables.forEach((variable) => {
-    const kind = describeShmField(variable)?.kind
+  if (descriptor.kind === 'string') {
+    let code = `    _body = ${expr}.encode('utf-8')[:${SHM_STRING_CHARS}]\n`
+    code += `    _len = len(_body)\n`
+    code += `    _body = _body.ljust(${SHM_STRING_CHARS}, b'\\0')\n`
+    code += `    _out.append(_len)\n`
+    code += `    _out.append(_body)\n`
+    return code
+  }
 
-    if (isArrayVariable(variable)) {
-      const count = getArrayTotalElements(variable)
-      code += `${indent}${variable.name} = list(_vals[_idx:_idx+${count}])\n`
-      code += `${indent}_idx += ${count}\n`
-    } else if (kind === 'string' || kind === 'wstring') {
-      code += `${indent}${variable.name}_len = _vals[_idx]\n`
-      code += `${indent}_idx += 1\n`
-      code += `${indent}${variable.name}_body = _vals[_idx]\n`
-      code += `${indent}_idx += 1\n`
-      // The C side clamps the length to the budget, but the prefix is a signed
-      // int8 and the buffer starts zeroed, so clamp on read too: a negative
-      // slice bound would silently truncate from the end instead of failing.
-      code += `${indent}${variable.name}_len = max(0, min(${variable.name}_len, ${SHM_STRING_CHARS}))\n`
-      if (kind === 'wstring') {
-        // The length counts UTF-16 code units, so the byte slice is twice it.
-        code += `${indent}${variable.name} = ${variable.name}_body[:${variable.name}_len * 2].decode('utf-16-le', errors='ignore')\n`
-      } else {
-        code += `${indent}${variable.name} = ${variable.name}_body[:${variable.name}_len].decode('utf-8', errors='ignore')\n`
-      }
-    } else {
-      code += `${indent}${variable.name} = _vals[_idx]\n`
-      code += `${indent}_idx += 1\n`
-    }
-  })
+  if (descriptor.kind === 'wstring') {
+    // Truncate on a code-unit boundary, never mid-unit: encode, clip to the byte
+    // budget, then round down to an even length. `_len` is the code-unit count
+    // the C side expects, not the byte count.
+    let code = `    _body = ${expr}.encode('utf-16-le')[:${SHM_STRING_CHARS * 2}]\n`
+    code += `    _body = _body[: len(_body) - (len(_body) % 2)]\n`
+    code += `    _len = len(_body) // 2\n`
+    code += `    _body = _body.ljust(${SHM_STRING_CHARS * 2}, b'\\0')\n`
+    code += `    _out.append(_len)\n`
+    code += `    _out.append(_body)\n`
+    return code
+  }
 
-  return code
+  // An IntEnum packs as its integer already, but saying so keeps the generated
+  // code honest about what crosses — and survives a user assigning a plain int.
+  if (leaf.enumTypeName) return `    _out.append(int(${expr}))\n`
+
+  return `    _out.append(${expr})\n`
 }
 
 /**
  * Generate Python code that packs output variables into the flat struct format.
- * Arrays are flattened via extend(), scalars and string pairs via append().
  */
-const generateOutputPackCode = (outputVariables: PLCVariable[]): string => {
-  if (outputVariables.length === 0) return '    # No output variables to write'
+const generateOutputPackCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  if (variables.length === 0) return '    # No output variables to write'
 
   let code = '    # Write output variables\n'
   code += '    _out = []\n'
-
-  outputVariables.forEach((variable) => {
-    if (isArrayVariable(variable)) {
-      code += `    _out.extend(${variable.name})\n`
-    } else if (describeShmField(variable)?.kind === 'string') {
-      code += `    _body = ${variable.name}.encode('utf-8')[:${SHM_STRING_CHARS}]\n`
-      code += `    _len = len(_body)\n`
-      code += `    _body = _body.ljust(${SHM_STRING_CHARS}, b'\\0')\n`
-      code += `    _out.append(_len)\n`
-      code += `    _out.append(_body)\n`
-    } else if (describeShmField(variable)?.kind === 'wstring') {
-      // Truncate on a code-unit boundary, never mid-unit: encode, clip to the
-      // byte budget, then round down to an even length. `_len` is the code-unit
-      // count the C side expects, not the byte count.
-      code += `    _body = ${variable.name}.encode('utf-16-le')[:${SHM_STRING_CHARS * 2}]\n`
-      code += `    _body = _body[: len(_body) - (len(_body) % 2)]\n`
-      code += `    _len = len(_body) // 2\n`
-      code += `    _body = _body.ljust(${SHM_STRING_CHARS * 2}, b'\\0')\n`
-      code += `    _out.append(_len)\n`
-      code += `    _out.append(_body)\n`
-    } else {
-      code += `    _out.append(${variable.name})\n`
-    }
-  })
+  for (const variable of variables) {
+    const walked = describeShmLeaves(variable, dataTypes)
+    /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
+    if ('refusal' in walked) continue
+    for (const leaf of walked.leaves) code += encodeLeaf(leaf)
+  }
 
   code += '    packed = struct.pack(fmt_out, *_out)\n'
   code += '    shm_out.buf[:data_size_out] = packed'
@@ -136,13 +300,19 @@ const generateOutputPackCode = (outputVariables: PLCVariable[]): string => {
 }
 
 const injectPythonRuntime = (params: PythonRuntimeInjectionParams): string => {
-  const { fmtIn, fmtOut, inputVariables, outputVariables, originalCode, pouName } = params
+  const { fmtIn, fmtOut, inputVariables, outputVariables, originalCode, pouName, dataTypes = [] } = params
 
-  const outputSeeding = generateOutputSeedCode(outputVariables)
-  const readInputSection = generateInputUnpackCode(inputVariables)
-  const writeOutputSection = generateOutputPackCode(outputVariables)
+  const outputSeeding = generateOutputSeedCode(outputVariables, dataTypes)
+  const readInputSection = generateInputUnpackCode(inputVariables, dataTypes)
+  const writeOutputSection = generateOutputPackCode(outputVariables, dataTypes)
+  // Declared before the user's code, so a block_init() that constructs one of
+  // its own structures finds the class already defined.
+  const typeDeclarations = generateTypeDeclarations([...inputVariables, ...outputVariables], dataTypes)
 
   const injectedCode = `
+from enum import IntEnum
+
+${typeDeclarations}
 ${originalCode}
 
 plc_pid = %d

--- a/src/frontend/utils/python/shm-leaves.ts
+++ b/src/frontend/utils/python/shm-leaves.ts
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Flatten a Python block's interface variable into the scalar fields that
+ * actually cross shared memory.
+ *
+ * A structure or an enumeration cannot be memcpy'd across the boundary the way a
+ * scalar can: the PLC side holds `IECVar<T>` wrappers inside a strucpp struct,
+ * and the Python side holds an object. What both sides can agree on is the list
+ * of scalar leaves, in order — so that is what this produces, and every emitter
+ * works from it.
+ *
+ * Flattening rather than nesting is deliberate. The transport struct is ours to
+ * define, so nesting would buy nothing and would put `#pragma pack` inside
+ * `#pragma pack`, where an already-laid-out member type keeps its own padding —
+ * exactly the trap that made WSTRING 254 bytes against Python's 253. One field
+ * per leaf, all at the top level, is a layout both sides compute the same way.
+ *
+ * What a leaf carries is the two halves of the same field: `field`, the name in
+ * our packed struct and the position in the format string, and `access`, the
+ * expression that reaches the value on the strucpp side. They are separate
+ * because the second is not ours to choose — see `mangledMemberName`.
+ */
+
+import type {
+  PLCDataType,
+  PLCStructureVariable,
+  PLCVariable,
+  PLCVariableType,
+} from '../../../middleware/shared/ports/types'
+import { getArrayTotalElements } from '../PLC/array-codegen-helpers'
+import { parseDimensionRange } from '../PLC/dimension-range'
+import type { ShmFieldDescriptor } from './shm-type-map'
+import { describeShmField, SHM_SCALAR_TYPES } from './shm-type-map'
+
+/** One scalar field of the transport struct. */
+export interface ShmLeaf {
+  /** Field name in `shm_data_in_t` / `shm_data_out_t`, unique within the struct. */
+  field: string
+  /** Attribute path on the Python side, e.g. `['m', 'speed']`. */
+  path: string[]
+  /** Expression reaching the value on the strucpp side, e.g. `M.SPEED`. */
+  access: string
+  /** How the field is laid out and decoded. */
+  descriptor: ShmFieldDescriptor
+  /** Elements when the leaf is an array of scalars; 1 otherwise. */
+  count: number
+  /** Lowest IEC index, for an array leaf; 0 otherwise. */
+  startIndex: number
+  /**
+   * The enumeration this leaf came from, when it is one.
+   *
+   * The value crossing the boundary is the plain integer the PLC stores. The
+   * name tells the Python side which `IntEnum` to present it as, so the user
+   * writes `mode == Mode.RUNNING` rather than comparing against a bare number,
+   * and tells the C side which scoped enum to cast through: an `IEC_ENUM_Var`
+   * yields an `IEC_ENUM_Value`, which converts to the enum but not to an
+   * integer.
+   */
+  enumTypeName?: string
+}
+
+/** Why a variable cannot cross, phrased for the user. */
+export interface ShmRefusal {
+  path: string[]
+  reason: string
+}
+
+export type ShmWalkResult = { leaves: ShmLeaf[] } | { refusal: ShmRefusal }
+
+/**
+ * The member's C++ name, mirroring STruC++'s `member-mangling.ts`.
+ *
+ * A member whose name matches its own user-defined type is emitted with a
+ * trailing underscore, because GCC rejects a member that changes the meaning of
+ * its type name inside the class. CODESYS allows `RunningLights : RunningLights`
+ * and real projects use it, so the case is not hypothetical.
+ *
+ * This is a deliberate coupling to the compiler, and the only one in this file:
+ * everything else here describes a layout we define ourselves. It is restated
+ * rather than derived because the compiler exposes no way to ask, and the
+ * alternative — emitting a member name that does not exist — fails the build
+ * with an error that points at generated code the user never wrote.
+ *
+ * The interface-method collision that rule also covers cannot arise here: it
+ * applies to a function block implementing an interface, and only a STRUCT's
+ * members are walked.
+ */
+const mangledMemberName = (memberName: string, memberTypeName: string, userTypeNames: ReadonlySet<string>): string => {
+  const upper = memberName.toUpperCase()
+  return upper === memberTypeName.toUpperCase() && userTypeNames.has(upper) ? `${upper}_` : upper
+}
+
+/** Index the project's data types by upper-cased name. */
+const indexDataTypes = (dataTypes: readonly PLCDataType[]): Map<string, PLCDataType> =>
+  new Map(dataTypes.map((dataType) => [dataType.name.toUpperCase(), dataType]))
+
+/** IEC base type an enumeration is stored as. STruC++ defaults to INT. */
+const ENUM_BASE_DESCRIPTOR = SHM_SCALAR_TYPES.int
+
+const walk = (
+  name: string,
+  typeValue: string,
+  typeDefinition: PLCVariableType['definition'],
+  arrayInfo: { count: number; startIndex: number } | null,
+  path: string[],
+  field: string,
+  access: string,
+  types: Map<string, PLCDataType>,
+  userTypeNames: ReadonlySet<string>,
+  depth: number,
+): ShmWalkResult => {
+  // A structure that contains itself would otherwise recurse forever. The
+  // compiler rejects that too, but this walk runs first and must not hang.
+  if (depth > 16) {
+    return { refusal: { path, reason: 'the type nests too deeply, or refers to itself' } }
+  }
+
+  const dataType = typeDefinition === 'user-data-type' ? types.get(typeValue.toUpperCase()) : undefined
+
+  if (dataType?.derivation === 'structure') {
+    if (arrayInfo) {
+      return { refusal: { path, reason: 'an array of structures cannot cross into Python yet' } }
+    }
+    const leaves: ShmLeaf[] = []
+    for (const member of dataType.variable) {
+      // An array member is walked by its element type, exactly as a top-level
+      // array variable is: the count and lower bound travel separately, so the
+      // element is what has to be describable.
+      const element = elementTypeOf(member)
+      const result = walk(
+        member.name,
+        element.value,
+        element.definition,
+        arrayInfoFor(member),
+        [...path, member.name],
+        `${field}_${member.name}`,
+        `${access}.${mangledMemberName(member.name, member.type.value, userTypeNames)}`,
+        types,
+        userTypeNames,
+        depth + 1,
+      )
+      if ('refusal' in result) return result
+      leaves.push(...result.leaves)
+    }
+    return { leaves }
+  }
+
+  if (dataType?.derivation === 'enumerated') {
+    // An enumeration is stored as its base integer, which is what crosses. The
+    // Python side gets an IntEnum, so `mode == Mode.RUNNING` reads naturally
+    // while the wire format stays a plain int.
+    return {
+      leaves: [
+        {
+          field,
+          path,
+          access,
+          descriptor: ENUM_BASE_DESCRIPTOR,
+          count: arrayInfo?.count ?? 1,
+          startIndex: arrayInfo?.startIndex ?? 0,
+          enumTypeName: dataType.name,
+        },
+      ],
+    }
+  }
+
+  if (dataType?.derivation === 'array') {
+    return { refusal: { path, reason: 'a named ARRAY type cannot cross into Python yet' } }
+  }
+
+  if (typeDefinition === 'user-data-type') {
+    // Not in the project's data types: a function block instance. Python runs in
+    // its own process and cannot call one — the block would have to reach back
+    // into the scan it is not part of.
+    return {
+      refusal: {
+        path,
+        reason: `"${typeValue}" is a function block instance, which a Python block cannot hold — it runs in its own process and cannot call into the scan`,
+      },
+    }
+  }
+
+  const descriptor = describeShmField({
+    name,
+    type: { definition: typeDefinition, value: typeValue },
+    location: '',
+    documentation: '',
+  })
+  if (!descriptor) {
+    return { refusal: { path, reason: `${typeValue.toUpperCase()} is not a type Python can exchange` } }
+  }
+
+  return {
+    leaves: [
+      {
+        field,
+        path,
+        access,
+        descriptor,
+        count: arrayInfo?.count ?? 1,
+        startIndex: arrayInfo?.startIndex ?? 0,
+      },
+    ],
+  }
+}
+
+/**
+ * The type that actually describes a declaration's elements.
+ *
+ * For an array that is its element type; for anything else it is the type
+ * itself. An array's own `value` is the whole declaration text
+ * (`ARRAY [0..2] OF INT`), which names nothing describable — reading it as a
+ * type is what made an array member inside a structure refuse.
+ */
+const elementTypeOf = (declaration: PLCVariable | PLCStructureVariable): PLCVariableType => {
+  if (declaration.type.definition === 'array' && declaration.type.data) {
+    return { definition: declaration.type.data.baseType.definition, value: declaration.type.data.baseType.value }
+  }
+  return declaration.type
+}
+
+/** Element count and lower bound when a declaration is an array. */
+const arrayInfoFor = (
+  declaration: PLCVariable | PLCStructureVariable,
+): { count: number; startIndex: number } | null => {
+  if (declaration.type.definition !== 'array' || !declaration.type.data) return null
+  const dimensions = declaration.type.data.dimensions
+  const first = dimensions[0] ? parseDimensionRange(dimensions[0].dimension) : null
+  const asVariable: PLCVariable = {
+    name: declaration.name,
+    type: declaration.type,
+    location: '',
+    documentation: '',
+  }
+  return { count: getArrayTotalElements(asVariable), startIndex: first ? first.lower : 0 }
+}
+
+/**
+ * The scalar fields one interface variable contributes, in order — or the reason
+ * it cannot cross.
+ *
+ * A refusal is not a skip. A field the Python format string omits does not go
+ * missing: `struct.unpack` reads every later field from the wrong offset, so the
+ * failure lands on unrelated variables and reads as corrupted data. Refusing
+ * stops the build with the name of the variable that caused it.
+ */
+export const describeShmLeaves = (variable: PLCVariable, dataTypes: readonly PLCDataType[] = []): ShmWalkResult => {
+  const types = indexDataTypes(dataTypes)
+  const userTypeNames = new Set(dataTypes.map((dataType) => dataType.name.toUpperCase()))
+
+  const element = elementTypeOf(variable)
+
+  return walk(
+    variable.name,
+    element.value,
+    element.definition,
+    arrayInfoFor(variable),
+    [variable.name],
+    variable.name,
+    variable.name.toUpperCase(),
+    types,
+    userTypeNames,
+    0,
+  )
+}
+
+/** Every leaf of every variable, in order, or the first refusal encountered. */
+export const describeShmLayout = (
+  variables: readonly PLCVariable[],
+  dataTypes: readonly PLCDataType[] = [],
+): ShmWalkResult => {
+  const leaves: ShmLeaf[] = []
+  for (const variable of variables) {
+    const result = describeShmLeaves(variable, dataTypes)
+    if ('refusal' in result) return result
+    leaves.push(...result.leaves)
+  }
+  return { leaves }
+}


### PR DESCRIPTION
## What this is

Phases 6, 7 and 8 of DOPE-584 — the rest of the Python story, and the last type gap between a native block and an IEC one.

## Phase 6 — structures and enumerations

A Python block's interface was limited to elementary types and arrays of them. A structure or an enumeration, declared in the same project and usable from every other language, was refused.

A composite cannot be memcpy'd across this boundary: the PLC holds `IECVar<T>` wrappers inside a strucpp struct, Python holds an object. What both sides can agree on is the list of **scalar leaves, in order**, so `shm-leaves` walks a declaration into leaves once, and the transport struct, the copy statements, the format string and the driver's unpack/pack are all generated from that one walk.

Leaves are **flattened**, not nested. The transport struct is ours to define, so nesting buys nothing and would put `#pragma pack` inside `#pragma pack`, where an already-laid-out member keeps its own padding — exactly the trap that made WSTRING 254 bytes against Python's 253.

On the Python side the flat wire is rebuilt into an object, because the user should write `m.speed` as they would in ST. A structure becomes a slotted class (assigning a name it lacks raises, rather than silently creating an attribute the PLC will never read back); an enumeration becomes an `IntEnum`, so `mode == Mode.RUNNING` reads naturally while the integer is what crosses.

Two compiler facts had to be met exactly, and both were found by running the code:

- An enumeration's `get()` yields an `IEC_ENUM_Value`, which converts to the scoped enum but **not** to an integer. The read goes through both and casts; the write goes through `set()`, not `operator=`, which would copy-assign a whole temporary wrapper and take its forced state along.
- A member whose name matches its own user-defined type is emitted with a trailing underscore (GCC rejects a member that changes the meaning of its type name inside the class). That rule is **restated here deliberately**, in one place, with the reason written down — the compiler exposes no way to ask, and the alternative is naming a member that does not exist.

A function block instance stays refused, and now says why. Refusals name the *member* rather than the variable containing it.

## Phase 7 — EN/ENO: no implementation needed

The plan predicted EN/ENO would give Python blocks execution control with no compiler work. Verified rather than assumed: strucpp's call-site guard already gates a native block instance, including the `first_run` branch that spawns the Python process.

On slm-rp4, a gated instance next to a free-running one, with EN false for the first 50 scans:

| | sample 1 | sample 2 | sample 3 |
|---|---|---|---|
| Python: free − gated | 50 | 50 | 50 |
| C++: free − gated | 50 | 50 | — |

`ENO` mirrored the gate throughout. Nothing to build.

## Phase 8 — the editor knows the shapes

The Pyright preamble skipped anything with a user-defined type — correct while those could not cross, wrong the moment they could: `m.speed` was an error on code that compiles and runs. It now declares the structures and enumerations too, mirroring what the runtime really defines.

The two sides are kept in lockstep **by construction**: stubs are collected from the variables that actually get a declaration line, so a shape the compiler will refuse (an array of structures) gets neither. The editor never offers a name the build would reject, nor withholds one it would accept. `dataTypes` reaches the preamble the same way variables already did, and re-pushes on a data-type edit, so renaming a member updates the editor without a reopen.

## Hardware verification

On slm-rp4, a structure carrying a scalar, a STRING and a nested array, plus an enumeration input, all through a `VAR_IN_OUT` so every value round-trips to the calling program:

| | sample 1 | sample 2 |
|---|---|---|
| `mot.speed` (member written by Python) | 82 | 108 |
| `mot.trims[1]` (nested array, +2/cycle) | 164 | 216 |
| `mot.label` (STRING member) | `motor-82` | `motor-108` |
| reported length | 8 | 9 |
| enumeration input | RUNNING | RUNNING |

The simulator still stubs Python out and builds at 6% flash.

## Not in scope

**CONSTANT / RETAIN / NON_RETAIN** wait on NODE-94 (#1034), as for C++. Both interface builders are the single place they will need applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaSZK4LqFWtZpERcqnZ8uQ