### PR TITLE
task(DOPE-584): Python and C++ function blocks reach IEC parity

### DIFF
--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -1255,7 +1255,11 @@ class CompilerModule {
       variables: pou.variables,
     })) as CppPouDataHeader[]
 
-    const headerContent: string = generateCBlocksHeader(cppPous)
+    // The project's data-type names let the generator tell a structure or
+    // enumeration (which strucpp aliases as `IEC_<NAME>`) from a function block
+    // instance (a bare `class <NAME>`), which the variable alone cannot say.
+    const userTypeNames = (projectData.dataTypes ?? []).map((dataType) => dataType.name)
+    const headerContent: string = generateCBlocksHeader(cppPous, userTypeNames)
     const headerFilePath = join(sourceTargetFolderPath, 'c_blocks.h')
 
     try {

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -1292,7 +1292,10 @@ class CompilerModule {
     // -std=gnu++17. The static Baremetal/c_blocks_code.cpp baseline stays
     // strucpp-free and is compiled by arduino-cli in the core's native
     // standard.
-    const codeContent = generateCBlocksCode(cppPous)
+    // Every data type the project declares is aliased into the block's scope,
+    // including ones reachable only through a structure member.
+    const userTypeNames = (projectData.dataTypes ?? []).map((dataType) => dataType.name)
+    const codeContent = generateCBlocksCode(cppPous, userTypeNames)
     const codeFilePath = join(compilationPath, 'src', 'c_blocks_code.cpp')
 
     try {

--- a/src/backend/shared/compile/__tests__/compose-firmware-bundle.test.ts
+++ b/src/backend/shared/compile/__tests__/compose-firmware-bundle.test.ts
@@ -82,14 +82,23 @@ describe('composeFirmwareBundle — strucpp output', () => {
 })
 
 describe('composeFirmwareBundle — c_blocks_code.cpp overwrite semantics', () => {
-  it('OVERWRITES examples/Baremetal/c_blocks_code.cpp when cBlocks.code is non-null', () => {
+  it('puts the generated c_blocks_code.cpp under src/, on the pre-compiled side', () => {
+    // Not next to the sketch: there arduino-cli builds it at whatever standard
+    // the core ships, and this unit includes `generated.hpp`, which needs C++17.
+    // On an mbed core (gnu++14) that failed with `'is_arithmetic_v' is not a
+    // member of 'std'`; the AVR targets hid it by declaring -std=gnu++17 in
+    // their hals.json cxx_flags, which a VPP board such as Opta does not.
     const skeleton = { 'examples/Baremetal/c_blocks_code.cpp': '// static baseline\n' }
     const out = composeFirmwareBundle({
       ...baseInput,
       firmwareSkeleton: skeleton,
       cBlocks: { header: 'h', code: 'void blink_setup(void *) {}\n' },
     })
-    expect(out['examples/Baremetal/c_blocks_code.cpp']).toBe('void blink_setup(void *) {}\n')
+
+    expect(out['src/c_blocks_code.cpp']).toBe('void blink_setup(void *) {}\n')
+    // The skeleton's own baseline is left alone. It defines no symbols and pulls
+    // in no strucpp header, so it compiles at the core's standard regardless.
+    expect(out['examples/Baremetal/c_blocks_code.cpp']).toBe('// static baseline\n')
   })
 
   it('LEAVES examples/Baremetal/c_blocks_code.cpp untouched when cBlocks.code is null', () => {
@@ -134,7 +143,10 @@ describe('composeFirmwareBundle — full layout snapshot', () => {
 
     expect(out).toEqual({
       'examples/Baremetal/Baremetal.ino': 'BAREMETAL_INO',
-      'examples/Baremetal/c_blocks_code.cpp': 'CBLOCKS_CODE_WITH_USER',
+      // The skeleton's static baseline survives alongside the generated unit:
+      // it defines no symbols and pulls in no strucpp header.
+      'examples/Baremetal/c_blocks_code.cpp': 'STATIC_BASELINE',
+      'src/c_blocks_code.cpp': 'CBLOCKS_CODE_WITH_USER',
       'src/arduino.cpp': 'ARDUINO_HAL',
       'src/iec_std_lib.hpp': 'STRUCPP_RUNTIME_HEADER',
       'src/generated.cpp': 'GEN_CPP',

--- a/src/backend/shared/compile/pipeline.ts
+++ b/src/backend/shared/compile/pipeline.ts
@@ -541,7 +541,8 @@ async function runCompilePipelineInner(
     }
 
     emit({ stage: 'runtime-v4-bundle', message: 'Composing Runtime v4 upload bundle...', level: 'info' })
-    const cBlocks = buildCBlocksFromPous(originalCppPous as never, (projectData.dataTypes ?? []).map((dt) => dt.name))
+    const userTypeNames = (projectData.dataTypes ?? []).map((dataType) => dataType.name)
+    const cBlocks = buildCBlocksFromPous(originalCppPous as never, userTypeNames)
     const bundle = composeRuntimeV4Bundle({
       programSt,
       md5,
@@ -812,7 +813,8 @@ async function runCompilePipelineInner(
   // c_blocks header/code + defines.h + optional vpp_config.h).
   // Pure function.
   emit({ stage: 'firmware-bundle', message: 'Composing firmware bundle...', level: 'info' })
-  const cBlocks = buildCBlocksFromPous(originalCppPous as never, (projectData.dataTypes ?? []).map((dt) => dt.name))
+  const userTypeNames = (projectData.dataTypes ?? []).map((dataType) => dataType.name)
+  const cBlocks = buildCBlocksFromPous(originalCppPous as never, userTypeNames)
   const firmwareFiles = composeFirmwareBundle({
     strucppFiles: strucppFilesMap,
     cBlocks,

--- a/src/backend/shared/compile/pipeline.ts
+++ b/src/backend/shared/compile/pipeline.ts
@@ -541,7 +541,7 @@ async function runCompilePipelineInner(
     }
 
     emit({ stage: 'runtime-v4-bundle', message: 'Composing Runtime v4 upload bundle...', level: 'info' })
-    const cBlocks = buildCBlocksFromPous(originalCppPous as never)
+    const cBlocks = buildCBlocksFromPous(originalCppPous as never, (projectData.dataTypes ?? []).map((dt) => dt.name))
     const bundle = composeRuntimeV4Bundle({
       programSt,
       md5,
@@ -812,7 +812,7 @@ async function runCompilePipelineInner(
   // c_blocks header/code + defines.h + optional vpp_config.h).
   // Pure function.
   emit({ stage: 'firmware-bundle', message: 'Composing firmware bundle...', level: 'info' })
-  const cBlocks = buildCBlocksFromPous(originalCppPous as never)
+  const cBlocks = buildCBlocksFromPous(originalCppPous as never, (projectData.dataTypes ?? []).map((dt) => dt.name))
   const firmwareFiles = composeFirmwareBundle({
     strucppFiles: strucppFilesMap,
     cBlocks,

--- a/src/backend/shared/compile/steps/compose-firmware-bundle.ts
+++ b/src/backend/shared/compile/steps/compose-firmware-bundle.ts
@@ -110,7 +110,7 @@ export function buildCBlocksFromPous(
   }))
   return {
     header: generateCBlocksHeader(headers, userTypeNames),
-    code: generateCBlocksCode(originalCppPous),
+    code: generateCBlocksCode(originalCppPous, userTypeNames),
   }
 }
 

--- a/src/backend/shared/compile/steps/compose-firmware-bundle.ts
+++ b/src/backend/shared/compile/steps/compose-firmware-bundle.ts
@@ -119,7 +119,7 @@ export function buildCBlocksFromPous(
  *
  * Layout produced (paths relative to project root):
  *  - `examples/Baremetal/Baremetal.ino`              — from skeleton
- *  - `examples/Baremetal/c_blocks_code.cpp`          — overwritten when `cBlocks.code !== null`
+ *  - `src/c_blocks_code.cpp`                         — written when `cBlocks.code !== null`
  *  - `examples/Baremetal/modules/...`                — from skeleton (Arduino library helpers)
  *  - `src/arduino.cpp`                               — from skeleton (HAL adapter, simulator-specific)
  *  - `src/c_blocks.h`                                — written verbatim from `cBlocks.header`
@@ -157,13 +157,25 @@ export function composeFirmwareBundle(input: ComposeFirmwareBundleInput): Record
   // resolves which one wins.
   files['src/c_blocks.h'] = cBlocks.header
 
-  // C blocks code overwrites ONLY when the project has C/C++ POUs.
-  // For empty projects, the firmware skeleton's static
-  // `examples/Baremetal/c_blocks_code.cpp` baseline stays (it's
-  // a benign empty unit per the editor's emission, providing
-  // helpers the runtime expects regardless of user code).
+  // C blocks code goes under `src/`, not next to the sketch, so the
+  // pre-compile step picks it up and builds it at -std=gnu++17 with the rest of
+  // the generated code.
+  //
+  // It used to land in `examples/Baremetal/`, where arduino-cli compiles it at
+  // whatever standard the core ships. That was survivable while the unit only
+  // pulled in `iec_var.hpp` and `iec_string.hpp`, and stopped being survivable
+  // when it started including `generated.hpp` for the project's own types:
+  // `iec_ptr.hpp` uses `std::is_arithmetic_v`, so on an mbed core (gnu++14) a
+  // project with a C++ block failed with `'is_arithmetic_v' is not a member of
+  // 'std'`. The AVR targets hid it because `hals.json` declares
+  // `-std=gnu++17` in their `cxx_flags`; a VPP board such as Arduino Opta
+  // declares no such flag and does not.
+  //
+  // The skeleton's static `examples/Baremetal/c_blocks_code.cpp` stays where it
+  // is either way. It defines no symbols and pulls in no strucpp header, so it
+  // compiles at the core's standard and cannot collide with this one.
   if (cBlocks.code !== null) {
-    files['examples/Baremetal/c_blocks_code.cpp'] = cBlocks.code
+    files['src/c_blocks_code.cpp'] = cBlocks.code
   }
 
   // defines.h is the authored output of the shared

--- a/src/backend/shared/compile/steps/compose-firmware-bundle.ts
+++ b/src/backend/shared/compile/steps/compose-firmware-bundle.ts
@@ -94,7 +94,10 @@ export type CBlocksCodePou = CppPouDataCode
  * `cBlocks` input shape" case.  Caller can either use this or hand
  * the composer the pre-rendered strings directly.
  */
-export function buildCBlocksFromPous(originalCppPous: CppPouDataCode[]): ComposeFirmwareBundleInput['cBlocks'] {
+export function buildCBlocksFromPous(
+  originalCppPous: CppPouDataCode[],
+  userTypeNames: Iterable<string> = [],
+): ComposeFirmwareBundleInput['cBlocks'] {
   if (originalCppPous.length === 0) {
     // Editor's behaviour: leave the static `c_blocks.h` baseline
     // in place (`null` here means the composer skips the write).
@@ -106,7 +109,7 @@ export function buildCBlocksFromPous(originalCppPous: CppPouDataCode[]): Compose
     variables: pou.variables,
   }))
   return {
-    header: generateCBlocksHeader(headers),
+    header: generateCBlocksHeader(headers, userTypeNames),
     code: generateCBlocksCode(originalCppPous),
   }
 }

--- a/src/backend/shared/utils/PLC/__tests__/preprocess-pous.test.ts
+++ b/src/backend/shared/utils/PLC/__tests__/preprocess-pous.test.ts
@@ -286,6 +286,64 @@ describe('preprocessPous — C++', () => {
 // ---------------------------------------------------------------------------
 // Mixed scenarios
 // ---------------------------------------------------------------------------
+describe('preprocessPous — Python target support', () => {
+  it('rejects Python POUs when the target cannot run them', () => {
+    const project = makeProjectData([makePythonPou('PyBlock', 'def block_loop():\n    pass')])
+    const logs: Array<[string, string]> = []
+    const result = preprocessPous(project, false, (level, message) => logs.push([level, message]), {
+      supported: false,
+      targetLabel: 'Arduino Mega',
+    })
+
+    expect(result.validationFailed).toBe(true)
+    expect(result.validationError).toContain('Python function blocks are not supported on Arduino Mega')
+    expect(result.validationError).toContain('"PyBlock"')
+    expect(logs.some(([level]) => level === 'error')).toBe(true)
+  })
+
+  it('names every offending POU in the rejection', () => {
+    const project = makeProjectData([
+      makePythonPou('First', 'def block_loop():\n    pass'),
+      makePythonPou('Second', 'def block_loop():\n    pass'),
+    ])
+    const result = preprocessPous(project, false, () => {}, { supported: false, targetLabel: 'Arduino Uno' })
+
+    expect(result.validationError).toContain('"First", "Second"')
+  })
+
+  it('leaves the project untouched when it rejects', () => {
+    const project = makeProjectData([makePythonPou('PyBlock', 'def block_loop():\n    pass')])
+    const result = preprocessPous(project, false, () => {}, { supported: false, targetLabel: 'Arduino Mega' })
+
+    // No ST lowering, no injected runtime variables — the POU is as authored.
+    expect(result.projectData.pous[0].body.language).toBe('python')
+  })
+
+  it('does not reject a project with no Python POUs', () => {
+    const project = makeProjectData([makeStPou('Main', 'x := 1;')])
+    const result = preprocessPous(project, false, () => {}, { supported: false, targetLabel: 'Arduino Mega' })
+
+    expect(result.validationFailed).toBe(false)
+    expect(result.validationError).toBeUndefined()
+  })
+
+  it('processes Python normally when the target supports it', () => {
+    const project = makeProjectData([makePythonPou('PyBlock', 'def block_loop():\n    pass')])
+    const result = preprocessPous(project, false, () => {}, { supported: true, targetLabel: 'OpenPLC Runtime v4' })
+
+    expect(result.validationFailed).toBe(false)
+    expect(result.projectData.pous[0].body.language).toBe('st')
+  })
+
+  it('processes Python normally when no support hint is given (library builds)', () => {
+    const project = makeProjectData([makePythonPou('PyBlock', 'def block_loop():\n    pass')])
+    const result = preprocessPous(project, false, () => {})
+
+    expect(result.validationFailed).toBe(false)
+    expect(result.projectData.pous[0].body.language).toBe('st')
+  })
+})
+
 describe('preprocessPous — mixed', () => {
   it('handles a project with ST, Python, and C++ POUs', () => {
     const project = makeProjectData([

--- a/src/backend/shared/utils/PLC/__tests__/preprocess-pous.test.ts
+++ b/src/backend/shared/utils/PLC/__tests__/preprocess-pous.test.ts
@@ -436,3 +436,84 @@ describe('preprocessPous — mixed', () => {
     expect(main.interface!.variables.some((v) => v.name === 'X_Axis' && v.class === 'external')).toBe(true)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Python interface refusals (DOPE-584 AC 3 and AC 9)
+// ---------------------------------------------------------------------------
+describe('preprocessPous — Python interface refusals', () => {
+  // These two refusals had no test at all, which left AC 9 asserted only by the
+  // implementation. Both stop the build on purpose: a variable the two sides of
+  // the SHM boundary cannot describe identically does not merely go missing —
+  // `struct.unpack` reads every later field from the wrong offset, so the damage
+  // lands on an unrelated variable.
+
+  it('refuses `temp` on a Python POU and explains why (AC 9)', () => {
+    const project = makeProjectData([
+      makePythonPou('PyBlock', 'def block_loop():\n    pass', [
+        makeVariable('a', 'input'),
+        makeVariable('scratch', 'temp'),
+      ]),
+    ])
+    const logs: Array<[string, string]> = []
+    const result = preprocessPous(project, false, (level, message) => logs.push([level, message]))
+
+    expect(result.validationFailed).toBe(true)
+    expect(result.validationError).toContain('scratch')
+    expect(logs.some(([level]) => level === 'error')).toBe(true)
+  })
+
+  it('refuses a type the SHM boundary cannot describe, naming the variable', () => {
+    const project = makeProjectData([
+      makePythonPou('PyBlock', 'def block_loop():\n    pass', [
+        makeVariable('a', 'input'),
+        makeVariable('mystery', 'input', 'NotAType'),
+      ]),
+    ])
+    const result = preprocessPous(project, false, () => {})
+
+    expect(result.validationFailed).toBe(true)
+    expect(result.validationError).toContain('mystery')
+  })
+
+  it('refuses a multi-dimensional array on a Python POU (one dimension only)', () => {
+    const grid: PLCVariable = {
+      name: 'grid',
+      class: 'input',
+      type: {
+        definition: 'array',
+        value: 'ARRAY [0..1,0..2] OF INT',
+        data: {
+          baseType: { definition: 'base-type', value: 'INT' },
+          dimensions: [{ dimension: '0..1' }, { dimension: '0..2' }],
+        },
+      },
+      location: '',
+      documentation: '',
+      debug: false,
+    }
+    const project = makeProjectData([makePythonPou('PyBlock', 'def block_loop():\n    pass', [grid])])
+    const result = preprocessPous(project, false, () => {})
+
+    expect(result.validationFailed).toBe(true)
+    expect(result.validationError).toContain('one-dimensional arrays only')
+  })
+
+  it('accepts a one-dimensional array, so the rank refusal is not over-broad', () => {
+    const row: PLCVariable = {
+      name: 'row',
+      class: 'input',
+      type: {
+        definition: 'array',
+        value: 'ARRAY [0..3] OF INT',
+        data: { baseType: { definition: 'base-type', value: 'INT' }, dimensions: [{ dimension: '0..3' }] },
+      },
+      location: '',
+      documentation: '',
+      debug: false,
+    }
+    const project = makeProjectData([makePythonPou('PyBlock', 'def block_loop():\n    pass', [row])])
+    const result = preprocessPous(project, false, () => {})
+
+    expect(result.validationFailed).toBe(false)
+  })
+})

--- a/src/backend/shared/utils/PLC/preprocess-pous.ts
+++ b/src/backend/shared/utils/PLC/preprocess-pous.ts
@@ -1,6 +1,7 @@
 import { addCppLocalVariables } from '../../../../frontend/utils/cpp/addCppLocalVariables'
 import { generateSTCode as generateCppSTCode } from '../../../../frontend/utils/cpp/generateSTCode'
 import { validateCppCode } from '../../../../frontend/utils/cpp/validateCppCode'
+import type { LibraryFunctionBlockSource } from '../../../../frontend/utils/PLC/function-block-pins'
 import { addPythonLocalVariables } from '../../../../frontend/utils/python/addPythonLocalVariables'
 import { pythonInterfaceVariables, pythonRefusedVariables } from '../../../../frontend/utils/python/block-interface'
 import { generateSTCode } from '../../../../frontend/utils/python/generateSTCode'
@@ -76,6 +77,14 @@ function preprocessPous(
   isSimulator: boolean,
   log: LogFn,
   pythonSupport?: PythonTargetSupport,
+  /**
+   * Bundled libraries, needed only to resolve the pins of a function block
+   * instance a native block declares — `ton0 : TON` has to become a pin list
+   * before it can cross into Python. Passed in rather than read from the store,
+   * which this layer may not reach; omitted, only project-declared blocks
+   * resolve.
+   */
+  libraries: readonly LibraryFunctionBlockSource[] = [],
 ): PreprocessResult {
   let processedProjectData: PLCProjectData = projectData
 
@@ -136,7 +145,16 @@ function preprocessPous(
       for (const variable of pythonInterfaceVariables(pou.interface?.variables ?? [])) {
         // The walk descends into structures, so the refusal names the member
         // that cannot cross rather than the variable that contains it.
-        const walked = describeShmLeaves(variable, projectData.dataTypes ?? [])
+        // Refusals are direction-independent for every shape except a function
+        // block instance, and for that the inbound direction is the wider set —
+        // it carries the outputs too — so a pin that cannot cross is caught here
+        // whichever way it travels.
+        const walked = describeShmLeaves(variable, {
+          dataTypes: projectData.dataTypes ?? [],
+          pous: projectData.pous,
+          libraries,
+          direction: 'in',
+        })
         if ('refusal' in walked) {
           unsupported.push(`"${pou.name}.${walked.refusal.path.join('.')}": ${walked.refusal.reason}`)
         }
@@ -184,7 +202,12 @@ function preprocessPous(
     } else {
       // Full pipeline for runtime targets
       const pythonData = extractPythonData(processedProjectData.pous)
-      const processedPythonCodes = injectPythonCode(pythonData, projectData.dataTypes ?? [])
+      const processedPythonCodes = injectPythonCode(
+        pythonData,
+        projectData.dataTypes ?? [],
+        projectData.pous,
+        libraries,
+      )
 
       let pythonIndex = 0
       processedProjectData.pous = processedProjectData.pous.map((pou: PLCPou) => {
@@ -198,6 +221,8 @@ function preprocessPous(
                 pou.interface?.variables ?? [],
               processedPythonCode: processedPythonCodes[pythonIndex],
               dataTypes: projectData.dataTypes ?? [],
+              pous: projectData.pous,
+              libraries,
             })
 
             pythonIndex++

--- a/src/backend/shared/utils/PLC/preprocess-pous.ts
+++ b/src/backend/shared/utils/PLC/preprocess-pous.ts
@@ -2,10 +2,10 @@ import { addCppLocalVariables } from '../../../../frontend/utils/cpp/addCppLocal
 import { generateSTCode as generateCppSTCode } from '../../../../frontend/utils/cpp/generateSTCode'
 import { validateCppCode } from '../../../../frontend/utils/cpp/validateCppCode'
 import { addPythonLocalVariables } from '../../../../frontend/utils/python/addPythonLocalVariables'
+import { pythonInterfaceVariables, pythonRefusedVariables } from '../../../../frontend/utils/python/block-interface'
 import { generateSTCode } from '../../../../frontend/utils/python/generateSTCode'
 import { injectPythonCode } from '../../../../frontend/utils/python/injectPythonCode'
-import { pythonInterfaceVariables, pythonRefusedVariables } from '../../../../frontend/utils/python/block-interface'
-import { describeShmField, describeVariableType } from '../../../../frontend/utils/python/shm-type-map'
+import { describeShmLeaves } from '../../../../frontend/utils/python/shm-leaves'
 import type { PLCPou, PLCProjectData, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { generateSoftMotionArtifacts } from '../../ethercat/generate-softmotion'
 
@@ -134,16 +134,19 @@ function preprocessPous(
     for (const pou of projectData.pous) {
       if (pou.body.language !== 'python') continue
       for (const variable of pythonInterfaceVariables(pou.interface?.variables ?? [])) {
-        if (describeShmField(variable) === null) {
-          unsupported.push(`"${pou.name}.${variable.name}" (${describeVariableType(variable)})`)
+        // The walk descends into structures, so the refusal names the member
+        // that cannot cross rather than the variable that contains it.
+        const walked = describeShmLeaves(variable, projectData.dataTypes ?? [])
+        if ('refusal' in walked) {
+          unsupported.push(`"${pou.name}.${walked.refusal.path.join('.')}": ${walked.refusal.reason}`)
         }
       }
     }
     if (unsupported.length > 0) {
       const message =
-        `Python function blocks cannot exchange these variable types yet: ${unsupported.join(', ')}. ` +
+        `Python function blocks cannot exchange these variables: ${unsupported.join('; ')}. ` +
         'Supported types are BOOL, the integer and bit-string types, REAL/LREAL, TIME/DATE/TOD/DT, ' +
-        'STRING, WSTRING, and arrays of those.'
+        'STRING, WSTRING, arrays of those, and structures and enumerations built from them.'
       log('error', message)
       return {
         projectData: processedProjectData as ProjectDataWithCpp,
@@ -181,7 +184,7 @@ function preprocessPous(
     } else {
       // Full pipeline for runtime targets
       const pythonData = extractPythonData(processedProjectData.pous)
-      const processedPythonCodes = injectPythonCode(pythonData)
+      const processedPythonCodes = injectPythonCode(pythonData, projectData.dataTypes ?? [])
 
       let pythonIndex = 0
       processedProjectData.pous = processedProjectData.pous.map((pou: PLCPou) => {
@@ -194,6 +197,7 @@ function preprocessPous(
                 /* istanbul ignore next -- defensive: interface may be undefined */
                 pou.interface?.variables ?? [],
               processedPythonCode: processedPythonCodes[pythonIndex],
+              dataTypes: projectData.dataTypes ?? [],
             })
 
             pythonIndex++

--- a/src/backend/shared/utils/PLC/preprocess-pous.ts
+++ b/src/backend/shared/utils/PLC/preprocess-pous.ts
@@ -143,10 +143,10 @@ function preprocessPous(
       }
     }
     if (unsupported.length > 0) {
-      const message =
-        `Python function blocks cannot exchange these variables: ${unsupported.join('; ')}. ` +
-        'Supported types are BOOL, the integer and bit-string types, REAL/LREAL, TIME/DATE/TOD/DT, ' +
-        'STRING, WSTRING, arrays of those, and structures and enumerations built from them.'
+      // Each refusal explains itself — an unsupported type names the supported
+      // ones, a function block instance says why it cannot be held at all. A
+      // single trailing list would be wrong for half of them.
+      const message = `Python function blocks cannot exchange these variables: ${unsupported.join('; ')}.`
       log('error', message)
       return {
         projectData: processedProjectData as ProjectDataWithCpp,

--- a/src/backend/shared/utils/PLC/preprocess-pous.ts
+++ b/src/backend/shared/utils/PLC/preprocess-pous.ts
@@ -4,6 +4,7 @@ import { validateCppCode } from '../../../../frontend/utils/cpp/validateCppCode'
 import { addPythonLocalVariables } from '../../../../frontend/utils/python/addPythonLocalVariables'
 import { generateSTCode } from '../../../../frontend/utils/python/generateSTCode'
 import { injectPythonCode } from '../../../../frontend/utils/python/injectPythonCode'
+import { describeShmField, describeVariableType } from '../../../../frontend/utils/python/shm-type-map'
 import type { PLCPou, PLCProjectData, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { generateSoftMotionArtifacts } from '../../ethercat/generate-softmotion'
 
@@ -97,6 +98,38 @@ function preprocessPous(
       projectData: processedProjectData as ProjectDataWithCpp,
       validationFailed: true,
       validationError: message,
+    }
+  }
+
+  // A Python POU's interface can only carry types both sides of the shared
+  // memory boundary describe identically. Anything else is refused here rather
+  // than skipped during encoding: a field the Python format string omits does
+  // not go missing, it shifts every later field's offset, so the failure lands
+  // on unrelated variables and looks like corrupted data instead of an
+  // unsupported type. Structures, enumerations and function block instances
+  // arrive in later phases.
+  if (hasPythonCode) {
+    const unsupported: string[] = []
+    for (const pou of projectData.pous) {
+      if (pou.body.language !== 'python') continue
+      for (const variable of pou.interface?.variables ?? []) {
+        if (variable.class !== 'input' && variable.class !== 'output') continue
+        if (describeShmField(variable) === null) {
+          unsupported.push(`"${pou.name}.${variable.name}" (${describeVariableType(variable)})`)
+        }
+      }
+    }
+    if (unsupported.length > 0) {
+      const message =
+        `Python function blocks cannot exchange these variable types yet: ${unsupported.join(', ')}. ` +
+        'Supported types are BOOL, the integer and bit-string types, REAL/LREAL, TIME/DATE/TOD/DT, ' +
+        'STRING, WSTRING, and arrays of those.'
+      log('error', message)
+      return {
+        projectData: processedProjectData as ProjectDataWithCpp,
+        validationFailed: true,
+        validationError: message,
+      }
     }
   }
 

--- a/src/backend/shared/utils/PLC/preprocess-pous.ts
+++ b/src/backend/shared/utils/PLC/preprocess-pous.ts
@@ -4,6 +4,7 @@ import { validateCppCode } from '../../../../frontend/utils/cpp/validateCppCode'
 import { addPythonLocalVariables } from '../../../../frontend/utils/python/addPythonLocalVariables'
 import { generateSTCode } from '../../../../frontend/utils/python/generateSTCode'
 import { injectPythonCode } from '../../../../frontend/utils/python/injectPythonCode'
+import { pythonInterfaceVariables, pythonRefusedVariables } from '../../../../frontend/utils/python/block-interface'
 import { describeShmField, describeVariableType } from '../../../../frontend/utils/python/shm-type-map'
 import type { PLCPou, PLCProjectData, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { generateSoftMotionArtifacts } from '../../ethercat/generate-softmotion'
@@ -109,11 +110,30 @@ function preprocessPous(
   // unsupported type. Structures, enumerations and function block instances
   // arrive in later phases.
   if (hasPythonCode) {
+    // A class this side of the boundary cannot express is refused first, and on
+    // its own terms: telling a user their VAR_TEMP is an unsupported *type*
+    // would send them to change the type, which is not the problem.
+    const refusedClasses: string[] = []
+    for (const pou of projectData.pous) {
+      if (pou.body.language !== 'python') continue
+      for (const { variable, reason } of pythonRefusedVariables(pou.interface?.variables ?? [])) {
+        refusedClasses.push(`"${pou.name}.${variable.name}": ${reason}`)
+      }
+    }
+    if (refusedClasses.length > 0) {
+      const message = refusedClasses.join(' ')
+      log('error', message)
+      return {
+        projectData: processedProjectData as ProjectDataWithCpp,
+        validationFailed: true,
+        validationError: message,
+      }
+    }
+
     const unsupported: string[] = []
     for (const pou of projectData.pous) {
       if (pou.body.language !== 'python') continue
-      for (const variable of pou.interface?.variables ?? []) {
-        if (variable.class !== 'input' && variable.class !== 'output') continue
+      for (const variable of pythonInterfaceVariables(pou.interface?.variables ?? [])) {
         if (describeShmField(variable) === null) {
           unsupported.push(`"${pou.name}.${variable.name}" (${describeVariableType(variable)})`)
         }

--- a/src/backend/shared/utils/PLC/preprocess-pous.ts
+++ b/src/backend/shared/utils/PLC/preprocess-pous.ts
@@ -22,6 +22,35 @@ type LogFn = (level: 'info' | 'error', message: string) => void
 type PreprocessResult = {
   projectData: ProjectDataWithCpp
   validationFailed: boolean
+  /**
+   * Human-facing reason for `validationFailed`, when one is known.
+   *
+   * Callers used to hard-code the C/C++ setup()/loop() message, which was the
+   * only way validation could fail. Python-on-an-unsupported-target is a second
+   * way, and reporting it as a C/C++ problem would send the user looking in the
+   * wrong file. Absent → the caller's default message still applies.
+   */
+  validationError?: string
+}
+
+/**
+ * Whether the selected target can host Python function blocks, and what to call
+ * it when it cannot.
+ *
+ * Mirrors `TargetCapabilities.pythonFunctionBlocks`, which already states the
+ * contract: Runtime v3 / v4 run them natively, the Simulator compiles them as
+ * no-op stubs, and arduino-cli targets reject them at build time. The rejection
+ * half was never implemented — a Python block on an Arduino target took the
+ * full Linux pipeline and died inside avr-g++ with `'python_block_loader' was
+ * not declared in this scope`, which tells the user nothing.
+ *
+ * Optional so the library build paths, which have no board in hand, keep their
+ * existing behaviour.
+ */
+type PythonTargetSupport = {
+  supported: boolean
+  /** Board name as the user selected it, for the error message. */
+  targetLabel: string
 }
 
 const extractPythonData = (pous: PLCPou[]) => {
@@ -40,11 +69,36 @@ const extractPythonData = (pous: PLCPou[]) => {
     }))
 }
 
-function preprocessPous(projectData: PLCProjectData, isSimulator: boolean, log: LogFn): PreprocessResult {
+function preprocessPous(
+  projectData: PLCProjectData,
+  isSimulator: boolean,
+  log: LogFn,
+  pythonSupport?: PythonTargetSupport,
+): PreprocessResult {
   let processedProjectData: PLCProjectData = projectData
 
   // --- Python processing ---
   const hasPythonCode = projectData.pous.some((pou: PLCPou) => pou.body.language === 'python')
+
+  if (hasPythonCode && pythonSupport && !pythonSupport.supported) {
+    // Reject before any Python processing runs. Generating the shared-memory
+    // stub for a target that cannot load it only moves the failure into the
+    // board's C++ toolchain, where the message is about `python_block_loader`
+    // rather than about Python blocks being unsupported here.
+    const names = projectData.pous
+      .filter((pou: PLCPou) => pou.body.language === 'python')
+      .map((pou: PLCPou) => `"${pou.name}"`)
+      .join(', ')
+    const message =
+      `Python function blocks are not supported on ${pythonSupport.targetLabel} — ` +
+      `they require the OpenPLC Linux runtime. Remove or change ${names}, or select a Runtime target.`
+    log('error', message)
+    return {
+      projectData: processedProjectData as ProjectDataWithCpp,
+      validationFailed: true,
+      validationError: message,
+    }
+  }
 
   if (hasPythonCode) {
     const pythonPous = projectData.pous.filter((pou: PLCPou) => pou.body.language === 'python')
@@ -134,7 +188,11 @@ function preprocessPous(projectData: PLCProjectData, isSimulator: boolean, log: 
     }
 
     if (validationFailed) {
-      return { projectData: processedProjectData as ProjectDataWithCpp, validationFailed: true }
+      return {
+        projectData: processedProjectData as ProjectDataWithCpp,
+        validationFailed: true,
+        validationError: 'POU validation failed. Check C/C++ code for missing setup()/loop() functions.',
+      }
     }
 
     processedProjectData = addCppLocalVariables(processedProjectData)
@@ -186,4 +244,4 @@ function preprocessPous(projectData: PLCProjectData, isSimulator: boolean, log: 
   return { projectData: processedProjectData as ProjectDataWithCpp, validationFailed: false }
 }
 
-export { preprocessPous, type ProjectDataWithCpp }
+export { preprocessPous, type ProjectDataWithCpp, type PythonTargetSupport }

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
@@ -105,6 +105,24 @@ describe('generateCBlocksCode', () => {
     expect(result).toContain('#undef result')
   })
 
+  it('undefines Arduino’s abs macro, which breaks <chrono> on the mbed cores', () => {
+    // `<chrono>` calls `abs` with a template argument list the one-parameter
+    // macro cannot swallow: `macro "abs" passed 2 arguments, but takes just 1`,
+    // and the standard header then fails to parse. AVR never showed it — its
+    // libstdc++ is the vendored freestanding port and never reaches <chrono>.
+    const result = generateCBlocksCode([{ name: 'B', code: 'void setup() { }\nvoid loop() { }', variables: [] }])
+
+    expect(result).toContain('#undef abs')
+  })
+
+  it('leaves the Arduino macros that shadow nothing standard', () => {
+    // `constrain` and `sq` collide with no standard name, so user code keeps them.
+    const result = generateCBlocksCode([{ name: 'B', code: 'void setup() { }\nvoid loop() { }', variables: [] }])
+
+    expect(result).not.toContain('#undef constrain')
+    expect(result).not.toContain('#undef sq')
+  })
+
   it('generates array defines with direct struct dereference (no pointer deref)', () => {
     const variables: PLCVariable[] = [makeArrayVar('data', 'input', 'INT', '0..9')]
     const code = 'void setup() { }\nvoid loop() { }'
@@ -127,9 +145,9 @@ describe('generateCBlocksCode', () => {
     // No #define / #undef for variables (the only `#define`s in the
     // baseline now are the Arduino min/max macro guards).
     expect(result).not.toMatch(/^#define\s+\w+\s+\(/m)
-    // Strip the baseline's `#undef min` / `#undef max` (Arduino.h macro
-    // scrubbing — see baseline) before asserting no per-variable undefs.
-    const withoutArduinoUndefs = result.replace(/^#undef\s+(min|max)\s*$/gm, '')
+    // Strip the baseline's Arduino macro scrubbing (`#undef min` / `max` / `abs`
+    // — see baseline) before asserting no per-variable undefs.
+    const withoutArduinoUndefs = result.replace(/^#undef\s+(min|max|abs)\s*$/gm, '')
     expect(withoutArduinoUndefs).not.toMatch(/^#undef\s+\w+\s*$/m)
   })
 

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
@@ -166,17 +166,21 @@ describe('generateCBlocksCode', () => {
     expect(result).toContain('// comment about setup')
   })
 
-  it('filters variables by class (only input and output)', () => {
+  it('binds every class the user can declare, and nothing the toolchain injected', () => {
+    const byClass = (name: string, cls: PLCVariable['class'], type: string): PLCVariable => ({
+      name,
+      class: cls,
+      type: { definition: 'base-type', value: type },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
     const variables: PLCVariable[] = [
       makeScalarVar('inVar', 'input', 'INT'),
-      {
-        name: 'localVar',
-        class: 'local',
-        type: { definition: 'base-type', value: 'INT' },
-        location: '',
-        documentation: '',
-        debug: false,
-      },
+      byClass('localVar', 'local', 'INT'),
+      byClass('tempVar', 'temp', 'INT'),
+      byClass('ioVar', 'inOut', 'INT'),
+      byClass('hasBeenInitialized', 'local', 'BOOL'),
       makeScalarVar('outVar', 'output', 'INT'),
     ]
     const code = 'void setup() { }\nvoid loop() { }'
@@ -185,9 +189,16 @@ describe('generateCBlocksCode', () => {
 
     expect(result).toContain('#define inVar')
     expect(result).toContain('#define outVar')
-    expect(result).not.toContain('#define localVar')
+    expect(result).toContain('#define localVar')
+    expect(result).toContain('#define tempVar')
+    expect(result).toContain('#define ioVar')
+    // The setup() latch stays out of the user's reach — see the header tests.
+    expect(result).not.toContain('#define hasBeenInitialized')
     expect(result).toContain('#undef inVar')
     expect(result).toContain('#undef outVar')
-    expect(result).not.toContain('#undef localVar')
+    expect(result).toContain('#undef localVar')
+    expect(result).toContain('#undef tempVar')
+    expect(result).toContain('#undef ioVar')
+    expect(result).not.toContain('#undef hasBeenInitialized')
   })
 })

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
@@ -32,16 +32,14 @@ describe('generateCBlocksCode', () => {
     expect(result).toBe('')
   })
 
-  it('emits the c_blocks baseline (strucpp includes + raw IEC typedefs) before per-POU code', () => {
+  it('emits the c_blocks baseline (interface header + raw IEC typedefs) before per-POU code', () => {
     const variables: PLCVariable[] = [makeScalarVar('x', 'input', 'INT')]
     const code = 'void setup() { }\nvoid loop() { }'
     const result = generateCBlocksCode([{ name: 'B', code, variables }])
 
-    // Baseline: strucpp wrappers visible to the auto-generated struct
-    // — covers numeric AND STRING pins now (every pin field qualifies
-    // as `strucpp::IEC_*`).
-    expect(result).toContain('#include "iec_var.hpp"')
-    expect(result).toContain('#include "iec_string.hpp"')
+    // Baseline: the interface header, which defines the struct and carries the
+    // strucpp wrappers and the project's own types transitively.
+    expect(result).toContain('#include "c_blocks.h"')
     // Baseline: raw file-scope typedefs for user-local variables.
     expect(result).toContain('typedef int16_t   IEC_INT;')
     expect(result).toContain('typedef float    IEC_REAL;')
@@ -57,9 +55,9 @@ describe('generateCBlocksCode', () => {
 
   it("undefines Arduino.h's min/max macros before pulling in strucpp/std headers", () => {
     // Regression guard: Arduino.h defines `min` / `max` as preprocessor
-    // macros that wreck `<algorithm>` / `<limits>` (both transitively
-    // included via iec_string.hpp). Order must be:
-    //   include <Arduino.h>  ->  #undef min/max  ->  #include "iec_string.hpp"
+    // macros that wreck `<algorithm>` / `<limits>` (pulled in transitively by
+    // the strucpp headers behind c_blocks.h). Order must be:
+    //   include <Arduino.h>  ->  #undef min/max  ->  #include "c_blocks.h"
     const variables: PLCVariable[] = [makeScalarVar('x', 'input', 'INT')]
     const code = 'void setup() { }\nvoid loop() { }'
     const result = generateCBlocksCode([{ name: 'B', code, variables }])
@@ -67,13 +65,13 @@ describe('generateCBlocksCode', () => {
     const arduinoIdx = result.indexOf('#include <Arduino.h>')
     const undefMinIdx = result.indexOf('#undef min')
     const undefMaxIdx = result.indexOf('#undef max')
-    const iecStringIdx = result.indexOf('#include "iec_string.hpp"')
+    const strucppIdx = result.indexOf('#include "c_blocks.h"')
 
     expect(arduinoIdx).toBeGreaterThan(-1)
     expect(undefMinIdx).toBeGreaterThan(arduinoIdx)
     expect(undefMaxIdx).toBeGreaterThan(arduinoIdx)
-    expect(iecStringIdx).toBeGreaterThan(undefMinIdx)
-    expect(iecStringIdx).toBeGreaterThan(undefMaxIdx)
+    expect(strucppIdx).toBeGreaterThan(undefMinIdx)
+    expect(strucppIdx).toBeGreaterThan(undefMaxIdx)
   })
 
   it('generates struct, extern declarations, defines, code, and undefs for a pou', () => {
@@ -82,17 +80,15 @@ describe('generateCBlocksCode', () => {
 
     const result = generateCBlocksCode([{ name: 'MyBlock', code, variables }])
 
-    // Struct definition — fields are strucpp::IEC_* so user writes
-    // route through IECVar::operator= (force-respect).
-    expect(result).toContain('//definition of external blocks - MYBLOCK')
-    expect(result).toContain('typedef struct {')
-    expect(result).toContain('  strucpp::IEC_INT *SPEED;')
-    expect(result).toContain('  strucpp::IEC_REAL *RESULT;')
-    expect(result).toContain('} MYBLOCK_VARS;')
-
-    // Extern declarations
-    expect(result).toContain('extern "C" void myblock_setup(MYBLOCK_VARS *vars);')
-    expect(result).toContain('extern "C" void myblock_loop(MYBLOCK_VARS *vars);')
+    // The struct and the two entry-point declarations belong to c_blocks.h and
+    // must NOT be restated here. Two definitions of one typedef is what broke
+    // enumeration pins: the header spelled the field `strucpp::IEC_MODE` and
+    // this file spelled it `strucpp::MODE`, so the assignment in the POU glue
+    // failed to compile. Pin the absence so the duplication cannot come back.
+    expect(result).not.toContain('typedef struct {')
+    expect(result).not.toContain('} MYBLOCK_VARS;')
+    expect(result).not.toContain('strucpp::IEC_INT *SPEED;')
+    expect(result).not.toContain('extern "C" void myblock_setup(MYBLOCK_VARS *vars);')
 
     // Defines for input and output
     expect(result).toContain('#define speed (*(vars->SPEED))')
@@ -125,8 +121,9 @@ describe('generateCBlocksCode', () => {
 
     const result = generateCBlocksCode([{ name: 'empty', code, variables: [] }])
 
-    expect(result).toContain('typedef struct {')
-    expect(result).toContain('} EMPTY_VARS;')
+    // The struct lives in c_blocks.h — see the duplication regression above.
+    expect(result).not.toContain('typedef struct {')
+    expect(result).not.toContain('} EMPTY_VARS;')
     // No #define / #undef for variables (the only `#define`s in the
     // baseline now are the Arduino min/max macro guards).
     expect(result).not.toMatch(/^#define\s+\w+\s+\(/m)

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksCode.test.ts
@@ -166,6 +166,72 @@ describe('generateCBlocksCode', () => {
     expect(result).toContain('// comment about setup')
   })
 
+  describe('project type aliases', () => {
+    const code = 'void setup() { }\nvoid loop() { }'
+    const userVar = (name: string, typeName: string): PLCVariable => ({
+      name,
+      class: 'input',
+      type: { definition: 'user-data-type', value: typeName },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+
+    it('aliases every type the project declares, not only the ones a pin names', () => {
+      // A type reachable only through a structure member still has to be in
+      // scope: given `o : Outer` with a `State` member, the block writes
+      // `o.STATE_ = STATE::BUSY`, and walking pin types alone left STATE
+      // undeclared — which failed the build on hardware.
+      const result = generateCBlocksCode(
+        [{ name: 'B', code, variables: [userVar('o', 'Outer')] }],
+        ['Outer', 'Inner', 'State'],
+      )
+
+      expect(result).toContain('using OUTER = strucpp::OUTER;')
+      expect(result).toContain('using INNER = strucpp::INNER;')
+      expect(result).toContain('using STATE = strucpp::STATE;')
+    })
+
+    it('aliases a type named by a pin even when the project does not declare it', () => {
+      // A function block is a POU, not a data type, so it never appears among
+      // the project's dataTypes — but a block holding an instance may want to
+      // name the class.
+      const result = generateCBlocksCode([{ name: 'B', code, variables: [userVar('h', 'Helper')] }], [])
+
+      expect(result).toContain('using HELPER = strucpp::HELPER;')
+    })
+
+    it('emits each alias once when a type is both declared and named by a pin', () => {
+      const result = generateCBlocksCode([{ name: 'B', code, variables: [userVar('m', 'Motor')] }], ['Motor'])
+
+      expect(result.match(/using MOTOR = strucpp::MOTOR;/g)).toHaveLength(1)
+    })
+
+    it('aliases the element type of an array of a user type', () => {
+      const bank: PLCVariable = {
+        name: 'bank',
+        class: 'input',
+        type: {
+          definition: 'array',
+          value: 'ARRAY [0..3] OF Motor',
+          data: { baseType: { definition: 'user-data-type', value: 'Motor' }, dimensions: [{ dimension: '0..3' }] },
+        },
+        location: '',
+        documentation: '',
+        debug: false,
+      }
+      const result = generateCBlocksCode([{ name: 'B', code, variables: [bank] }], [])
+
+      expect(result).toContain('using MOTOR = strucpp::MOTOR;')
+    })
+
+    it('emits no alias block when the project has no user types at all', () => {
+      const result = generateCBlocksCode([{ name: 'B', code, variables: [makeScalarVar('x', 'input', 'INT')] }], [])
+
+      expect(result).not.toContain('using ')
+    })
+  })
+
   it('binds every class the user can declare, and nothing the toolchain injected', () => {
     const byClass = (name: string, cls: PLCVariable['class'], type: string): PLCVariable => ({
       name,

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
@@ -34,15 +34,82 @@ describe('generateCBlocksHeader', () => {
     expect(result).toContain('#endif // C_BLOCKS_H')
   })
 
-  it('pulls in the strucpp wrapper headers so `strucpp::IEC_*` qualifications resolve', () => {
-    // Every struct field this header emits is fully qualified as
-    // `strucpp::IEC_*` (numeric, bit-string, STRING, WSTRING). Without
-    // these includes, a TU that does `#include "c_blocks.h"` without
-    // first pulling in the strucpp runtime would fail with
-    // `'IEC_STRING' does not name a type`.
+  it('pulls in the generated declarations so every field type resolves', () => {
+    // Struct fields name strucpp types across the whole range the Variables
+    // Table can declare: `strucpp::IEC_*` wrappers for elementary pins, and the
+    // project's own structures, enumerations and function block classes for the
+    // rest. `generated.hpp` carries all of them (and the runtime wrappers
+    // transitively), so a TU that includes c_blocks.h without any other setup
+    // still compiles instead of failing with `'IEC_STRING' does not name a
+    // type` or `'MOTOR' does not name a type`.
     const result = generateCBlocksHeader([])
-    expect(result).toContain('#include "iec_var.hpp"')
-    expect(result).toContain('#include "iec_string.hpp"')
+    expect(result).toContain('#include "generated.hpp"')
+  })
+
+  describe('user-defined types', () => {
+    // strucpp spells the two shapes differently, and the variable alone cannot
+    // say which it is:
+    //
+    //   struct MOTOR { … };  using IEC_MOTOR = MOTOR;
+    //   enum class MODE { … }; using IEC_MODE = IEC_ENUM<MODE>;
+    //   class HELPER { … };                    // no alias at all
+    //
+    // A structure and an enumeration are both declared in the project's data
+    // types, so both get the `IEC_` alias. A function block instance is not,
+    // and taking `&instance` yields the bare class — spelling that field
+    // `IEC_HELPER` would name a type that does not exist.
+    const userVar = (name: string, cls: PLCVariable['class'], typeName: string): PLCVariable => ({
+      name,
+      class: cls,
+      type: { definition: 'user-data-type', value: typeName },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+
+    it('aliases a data type but leaves a function block instance bare', () => {
+      const variables: PLCVariable[] = [
+        userVar('m', 'input', 'Motor'),
+        userVar('md', 'input', 'Mode'),
+        userVar('h', 'input', 'Helper'),
+      ]
+
+      const result = generateCBlocksHeader([{ name: 'Blk', variables }], ['Motor', 'Mode'])
+
+      expect(result).toContain('  strucpp::IEC_MOTOR *M;')
+      expect(result).toContain('  strucpp::IEC_MODE *MD;')
+      expect(result).toContain('  strucpp::HELPER *H;')
+    })
+
+    it('spells an array of a data type through the same rule', () => {
+      const variables: PLCVariable[] = [
+        {
+          name: 'bank',
+          class: 'input',
+          type: {
+            definition: 'array',
+            value: 'ARRAY [0..3] OF Motor',
+            data: {
+              baseType: { definition: 'user-data-type', value: 'Motor' },
+              dimensions: [{ dimension: '0..3' }],
+            },
+          },
+          location: '',
+          documentation: '',
+          debug: false,
+        },
+      ]
+
+      const result = generateCBlocksHeader([{ name: 'Blk', variables }], ['Motor'])
+
+      expect(result).toContain('  strucpp::IEC_MOTOR *BANK;')
+    })
+
+    it('leaves every user type bare when the project declares no data types', () => {
+      const variables: PLCVariable[] = [userVar('h', 'input', 'Helper')]
+
+      expect(generateCBlocksHeader([{ name: 'Blk', variables }])).toContain('  strucpp::HELPER *H;')
+    })
   })
 
   it('generates struct and function declarations for a pou with scalar variables', () => {

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
@@ -174,13 +174,31 @@ describe('generateCBlocksHeader', () => {
     expect(generateCBlocksHeader([{ name: 'test', variables }])).not.toContain('HASBEENINITIALIZED')
   })
 
-  it('leaves out a VAR_EXTERNAL, which is not a plain member', () => {
-    // A `VAR_EXTERNAL` is a `GlobalVar<V>*` carrying the global's mutex, not a
-    // value member. Emitting a plain pointer to it would compile and silently
-    // drop the lock, so it is handled separately rather than folded in here.
+  it('gives a VAR_EXTERNAL an ordinary field, pointing at the global’s value', () => {
+    // From inside the block a global should read and write like any other
+    // variable, which is what it already does in ST. The difference is not in
+    // the field's type but in where the pointer comes from: the ST glue takes
+    // it under the global's own lock (see generateSTCode).
     const variables: PLCVariable[] = [makeScalarVar('inVar', 'input', 'INT'), byClass('gCounter', 'external', 'DINT')]
 
-    expect(generateCBlocksHeader([{ name: 'test', variables }])).not.toContain('GCOUNTER')
+    const result = generateCBlocksHeader([{ name: 'test', variables }])
+
+    expect(result).toContain('strucpp::IEC_DINT *GCOUNTER;')
+  })
+
+  it('places externals after the declared classes, in name order', () => {
+    // Name order is what makes the lock nesting identical in every block, so
+    // two blocks can never take the same pair of globals in opposite orders.
+    const variables: PLCVariable[] = [
+      byClass('gZulu', 'external', 'INT'),
+      makeScalarVar('inVar', 'input', 'INT'),
+      byClass('gAlpha', 'external', 'INT'),
+    ]
+
+    const result = generateCBlocksHeader([{ name: 'test', variables }])
+    const order = ['INVAR', 'GALPHA', 'GZULU'].map((n) => result.indexOf(`*${n};`))
+
+    expect(order).toEqual([...order].sort((a, b) => a - b))
   })
 
   it('generates declarations for multiple pous', () => {

--- a/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
+++ b/src/backend/shared/utils/cpp/__tests__/generateCBlocksHeader.test.ts
@@ -10,6 +10,16 @@ const makeScalarVar = (name: string, cls: 'input' | 'output', baseType: string):
   debug: false,
 })
 
+/** Same shape, for the classes beyond input/output that the struct now carries. */
+const byClass = (name: string, cls: PLCVariable['class'], baseType: string): PLCVariable => ({
+  name,
+  class: cls,
+  type: { definition: 'base-type', value: baseType },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
 const makeArrayVar = (name: string, cls: 'input' | 'output', baseType: string, dimension: string): PLCVariable => ({
   name,
   class: cls,
@@ -126,25 +136,51 @@ describe('generateCBlocksHeader', () => {
     expect(result).toContain('extern "C" void myblock_loop(MYBLOCK_VARS *vars);')
   })
 
-  it('includes only input and output variables in the struct', () => {
+  it('carries every class the user can declare, grouped in a stable order', () => {
+    // A native block should see its own Variables Table the way an ST block
+    // does. `inOut`, `local` and `temp` are all plain members on the strucpp
+    // side, so a pointer to each is exactly as valid as one to an input.
     const variables: PLCVariable[] = [
-      makeScalarVar('inVar', 'input', 'INT'),
-      {
-        name: 'localVar',
-        class: 'local',
-        type: { definition: 'base-type', value: 'BOOL' },
-        location: '',
-        documentation: '',
-        debug: false,
-      },
       makeScalarVar('outVar', 'output', 'BOOL'),
+      byClass('tempVar', 'temp', 'INT'),
+      makeScalarVar('inVar', 'input', 'INT'),
+      byClass('localVar', 'local', 'DINT'),
+      byClass('ioVar', 'inOut', 'REAL'),
     ]
 
     const result = generateCBlocksHeader([{ name: 'test', variables }])
 
     expect(result).toContain('strucpp::IEC_INT *INVAR;')
     expect(result).toContain('strucpp::IEC_BOOL *OUTVAR;')
-    expect(result).not.toContain('LOCALVAR')
+    expect(result).toContain('strucpp::IEC_REAL *IOVAR;')
+    expect(result).toContain('strucpp::IEC_DINT *LOCALVAR;')
+    expect(result).toContain('strucpp::IEC_INT *TEMPVAR;')
+
+    // Grouped by class regardless of declaration order, so the header stays
+    // readable and its diffs stay meaningful.
+    const order = ['INVAR', 'OUTVAR', 'IOVAR', 'LOCALVAR', 'TEMPVAR'].map((n) => result.indexOf(`*${n};`))
+    expect(order).toEqual([...order].sort((a, b) => a - b))
+  })
+
+  it('leaves out the latch the toolchain injects into every C++ block', () => {
+    // `hasBeenInitialized` drives the one-shot setup() call. It is machinery,
+    // not a declaration, and a block able to write it could re-run or skip its
+    // own initialisation.
+    const variables: PLCVariable[] = [
+      makeScalarVar('inVar', 'input', 'INT'),
+      byClass('hasBeenInitialized', 'local', 'BOOL'),
+    ]
+
+    expect(generateCBlocksHeader([{ name: 'test', variables }])).not.toContain('HASBEENINITIALIZED')
+  })
+
+  it('leaves out a VAR_EXTERNAL, which is not a plain member', () => {
+    // A `VAR_EXTERNAL` is a `GlobalVar<V>*` carrying the global's mutex, not a
+    // value member. Emitting a plain pointer to it would compile and silently
+    // drop the lock, so it is handled separately rather than folded in here.
+    const variables: PLCVariable[] = [makeScalarVar('inVar', 'input', 'INT'), byClass('gCounter', 'external', 'DINT')]
+
+    expect(generateCBlocksHeader([{ name: 'test', variables }])).not.toContain('GCOUNTER')
   })
 
   it('generates declarations for multiple pous', () => {

--- a/src/backend/shared/utils/cpp/generateCBlocksCode.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksCode.ts
@@ -138,9 +138,16 @@ const generateUndef = (variable: PLCVariable): string => {
  * is the structure itself and `strucpp::MODE` the enumeration, which is what a
  * user casts to. The `IEC_`-prefixed aliases stay reserved for pin types in the
  * generated struct.
+ *
+ * Every type the project declares is aliased, not only the ones a pin names
+ * directly. A type reachable through a structure member needs to be in scope
+ * too: given `o : Outer` where `Outer` has a `State` member, the block writes
+ * `o.STATE_ = STATE::BUSY`, and walking only pin types left `STATE` undeclared.
+ * Types named by a pin are added as well, which is what covers a function block
+ * instance — an FB is a POU, so it is not among the project's data types.
  */
-const generateUserTypeAliases = (cppPous: CppPouData[]): string => {
-  const referenced = new Set<string>()
+const generateUserTypeAliases = (cppPous: CppPouData[], userTypeNames: Iterable<string>): string => {
+  const referenced = new Set<string>(Array.from(userTypeNames, (name) => name.toUpperCase()))
   for (const pou of cppPous) {
     for (const variable of pou.variables) {
       if (variable.type.definition === 'user-data-type') {
@@ -203,11 +210,11 @@ const processUserCode = (pou: CppPouData): string => {
  * Returns an empty string when there are no C++ POUs so the caller can
  * skip writing the file.
  */
-const generateCBlocksCode = (cppPous: CppPouData[]): string => {
+const generateCBlocksCode = (cppPous: CppPouData[], userTypeNames: Iterable<string> = []): string => {
   if (cppPous.length === 0) return ''
 
   let codeContent = C_BLOCKS_BASELINE
-  codeContent += generateUserTypeAliases(cppPous)
+  codeContent += generateUserTypeAliases(cppPous, userTypeNames)
 
   cppPous.forEach((pou) => {
     codeContent += processUserCode(pou)

--- a/src/backend/shared/utils/cpp/generateCBlocksCode.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksCode.ts
@@ -1,4 +1,4 @@
-import { generateStructMember, isArrayVariable } from '../../../../frontend/utils/PLC/array-codegen-helpers'
+import { isArrayVariable } from '../../../../frontend/utils/PLC/array-codegen-helpers'
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 
 type CppPouData = {
@@ -8,32 +8,29 @@ type CppPouData = {
 }
 
 /**
- * Self-contained baseline for c_blocks_code.cpp. Carries:
+ * Baseline preamble for c_blocks_code.cpp. Carries:
  *
- *   - The strucpp runtime includes so the auto-generated POU struct
- *     fields (`strucpp::IEC_INT*` / `strucpp::IEC_STRING*` etc.,
- *     emitted by `generateStructMember`) resolve to IECVar /
- *     IECStringVar wrappers.  Force semantics flow through
- *     `IECVar::operator=` (and `IECStringVar::operator=`) on every
- *     user write — uniform across numeric, bit-string, and string
- *     pins.
+ *   - `c_blocks.h`, which defines the interface struct for every C++ POU in the
+ *     project and declares the two entry points this file goes on to define.
+ *     It is included rather than restated: the POU glue includes the same
+ *     header, so the two sides describe one struct and cannot drift apart.
+ *     Through it comes `generated.hpp` — the strucpp runtime wrappers plus this
+ *     project's own structures, enumerations and function block classes — so a
+ *     C block can name every type the Variables Table can declare, and force
+ *     semantics flow through `IECVar::operator=` on every user write.
  *
- *   - File-scope raw numeric typedefs (`IEC_BOOL` / `IEC_INT` /
- *     `IEC_REAL` / etc.) preserved from the MatIEC era.  These exist
- *     ONLY for the user's *local* variables inside `setup()` /
- *     `loop()` (e.g. `IEC_INT my_temp = 0;`).  They never collide
- *     with the auto-generated struct fields because the struct
- *     fully qualifies as `strucpp::IEC_*`.
+ *   - File-scope raw numeric typedefs (`IEC_BOOL` / `IEC_INT` / `IEC_REAL` /
+ *     etc.) preserved from the MatIEC era. These exist ONLY for the user's
+ *     *local* variables inside `setup()` / `loop()` (e.g. `IEC_INT my_temp =
+ *     0;`). They never collide with the struct fields because those fully
+ *     qualify as `strucpp::IEC_*`.
  *
- *   - No raw `IEC_STRING` / `IEC_WSTRING` typedef.  STRING pins now
- *     use the strucpp wrapper end-to-end (`strucpp::IEC_STRING =
- *     IECStringVar<254>`), so user code interacts with them via
- *     `name = "hello";` / `name.length()` / `name[i]` /
- *     `name.c_str()` / `name == "stop"` — the same surface every
- *     other pin already exposes.  Local STRING variables inside
- *     setup() / loop() can also be declared as
- *     `strucpp::IEC_STRING my_buf;` (or `using strucpp::IEC_STRING;`
- *     at the top of the user's POU body, opt-in).
+ *   - No raw `IEC_STRING` / `IEC_WSTRING` typedef. STRING pins use the strucpp
+ *     wrapper end-to-end (`strucpp::IEC_STRING = IECStringVar<254>`), so user
+ *     code interacts with them via `name = "hello";` / `name.length()` /
+ *     `name[i]` / `name.c_str()` / `name == "stop"` — the same surface every
+ *     other pin already exposes. A local STRING inside setup() / loop() can be
+ *     declared `strucpp::IEC_STRING my_buf;` too.
  */
 const C_BLOCKS_BASELINE = `#include <cstdint>
 #include <cstring>
@@ -51,13 +48,22 @@ const C_BLOCKS_BASELINE = `#include <cstdint>
 #undef max
 #endif
 
-// STruC++ runtime types — IECVar<T> / IECStringVar<N> wrappers under
-// namespace strucpp.  The auto-generated POU struct refers to them
-// as \`strucpp::IEC_*\` for every pin (numeric, bit-string, STRING,
-// WSTRING), keeping force-aware semantics on the user's writes via
-// the wrapper's operator=.
-#include "iec_var.hpp"
-#include "iec_string.hpp"
+// The C block interface — the \`<POU>_VARS\` struct for every C++ POU in this
+// project, and the \`extern "C"\` declarations of the setup/loop entry points
+// defined below.  Declared once, in c_blocks.h, and included rather than
+// restated here: the POU glue strucpp emits includes the same header, so the
+// two sides cannot describe the struct differently.
+//
+// It transitively carries \`generated.hpp\` — the strucpp runtime wrappers plus
+// this project's own structures, enumerations and function block classes — so a
+// C block can name every type the Variables Table can declare.
+//
+// This TU is pre-compiled with the board's toolchain at -std=gnu++17 into
+// libOpenPLCUserLib.a, on the same side of the isolation seam as the rest of
+// the generated code, so the header's C++17 surface is available here. The
+// arduino-cli pass compiles the core in its own (older) standard and never
+// sees this file.
+#include "c_blocks.h"
 
 /*********************/
 /*  IEC Types defs   */
@@ -107,6 +113,46 @@ const generateUndef = (variable: PLCVariable): string => {
   return `#undef ${variable.name}\n`
 }
 
+/**
+ * Bring the project's own type names into the C block's scope.
+ *
+ * The generated declarations live in `namespace strucpp`, so without this a
+ * user has to write `strucpp::Motor` / `(strucpp::Mode)` in their own block —
+ * the namespace is an implementation detail of the toolchain leaking into code
+ * that is supposed to look like ordinary C++ against the Variables Table.
+ *
+ * A blanket `using namespace strucpp;` is not an option: the baseline defines
+ * raw `IEC_BOOL` / `IEC_INT` / … typedefs at file scope for the user's local
+ * variables, and strucpp declares the same names as `IECVar<T>` wrappers, so
+ * every one of them would become ambiguous. Aliasing only the names this
+ * project actually defines keeps the natural spelling without that collision.
+ *
+ * The bare strucpp name is the right target for both shapes: `strucpp::MOTOR`
+ * is the structure itself and `strucpp::MODE` the enumeration, which is what a
+ * user casts to. The `IEC_`-prefixed aliases stay reserved for pin types in the
+ * generated struct.
+ */
+const generateUserTypeAliases = (cppPous: CppPouData[]): string => {
+  const referenced = new Set<string>()
+  for (const pou of cppPous) {
+    for (const variable of pou.variables) {
+      if (variable.type.definition === 'user-data-type') {
+        referenced.add(variable.type.value.toUpperCase())
+      }
+      if (variable.type.definition === 'array' && variable.type.data?.baseType.definition === 'user-data-type') {
+        referenced.add(variable.type.data.baseType.value.toUpperCase())
+      }
+    }
+  }
+  if (referenced.size === 0) return ''
+
+  let code = "// Project types, reachable without the toolchain's namespace\n"
+  for (const name of Array.from(referenced).sort()) {
+    code += `using ${name} = strucpp::${name};\n`
+  }
+  return code + '\n'
+}
+
 const processUserCode = (pou: CppPouData): string => {
   const structName = `${pou.name.toUpperCase()}_VARS`
   const setupFunctionName = `${pou.name.toLowerCase()}_setup`
@@ -115,21 +161,10 @@ const processUserCode = (pou: CppPouData): string => {
   const inputVariables = pou.variables.filter((v) => v.class === 'input')
   const outputVariables = pou.variables.filter((v) => v.class === 'output')
 
-  let processedCode = `//definition of external blocks - ${pou.name.toUpperCase()}\n`
-  processedCode += `typedef struct {\n`
-
-  inputVariables.forEach((variable) => {
-    processedCode += generateStructMember(variable)
-  })
-
-  outputVariables.forEach((variable) => {
-    processedCode += generateStructMember(variable)
-  })
-
-  processedCode += `} ${structName};\n\n`
-
-  processedCode += `extern "C" void ${setupFunctionName}(${structName} *vars);\n`
-  processedCode += `extern "C" void ${loopFunctionName}(${structName} *vars);\n\n`
+  // The struct and the two entry-point declarations come from c_blocks.h, which
+  // the baseline includes. Only the name-binding macros and the user's own body
+  // are emitted here.
+  let processedCode = `// ${pou.name.toUpperCase()} — Variables Table names bound to the interface struct\n`
 
   inputVariables.forEach((variable) => {
     processedCode += generateDefine(variable)
@@ -173,6 +208,7 @@ const generateCBlocksCode = (cppPous: CppPouData[]): string => {
   if (cppPous.length === 0) return ''
 
   let codeContent = C_BLOCKS_BASELINE
+  codeContent += generateUserTypeAliases(cppPous)
 
   cppPous.forEach((pou) => {
     codeContent += processUserCode(pou)

--- a/src/backend/shared/utils/cpp/generateCBlocksCode.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksCode.ts
@@ -38,15 +38,23 @@ const C_BLOCKS_BASELINE = `#include <cstdint>
 
 #ifdef ARDUINO
 #include <Arduino.h>
-// Arduino.h defines \`min\` and \`max\` as preprocessor macros, which
-// collide with the \`std::min\` / \`std::max\` function templates and
-// the \`numeric_limits<T>::min()\` / \`max()\` static members that
-// \`<algorithm>\` / \`<limits>\` declare (both pulled in transitively
-// via \`iec_string.hpp\` below). Undef'ing them here keeps the user's
-// c_blocks code free to call \`std::min\` / \`std::max\` and lets the
-// strucpp runtime headers compile cleanly on AVR.
+// Arduino declares several of its helpers as function-like preprocessor macros,
+// and every one of them collides with a standard-library name that the headers
+// below pull in: \`min\` / \`max\` with the \`std::min\` / \`std::max\` templates and
+// \`numeric_limits<T>::min()\` / \`max()\`, and \`abs\` with \`std::abs\` — which is
+// worse, because \`<chrono>\` (reached transitively on the mbed cores) calls
+// \`abs\` with a template argument list the one-parameter macro cannot swallow:
+// \`macro "abs" passed 2 arguments, but takes just 1\`, and the standard header
+// then fails to parse.
+//
+// The AVR targets never showed it, because their libstdc++ is the vendored
+// freestanding port and never reaches \`<chrono>\`. An mbed board does.
+//
+// \`constrain\` and \`sq\` are left alone: neither shadows a standard name, so
+// user code keeps them.
 #undef min
 #undef max
+#undef abs
 #endif
 
 // The C block interface — the \`<POU>_VARS\` struct for every C++ POU in this

--- a/src/backend/shared/utils/cpp/generateCBlocksCode.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksCode.ts
@@ -1,4 +1,4 @@
-import { cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
+import { cBlockExternalVariables, cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
 import { isArrayVariable } from '../../../../frontend/utils/PLC/array-codegen-helpers'
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 
@@ -159,7 +159,7 @@ const processUserCode = (pou: CppPouData): string => {
   const setupFunctionName = `${pou.name.toLowerCase()}_setup`
   const loopFunctionName = `${pou.name.toLowerCase()}_loop`
 
-  const interfaceVariables = cBlockInterfaceVariables(pou.variables)
+  const interfaceVariables = [...cBlockInterfaceVariables(pou.variables), ...cBlockExternalVariables(pou.variables)]
 
   // The struct and the two entry-point declarations come from c_blocks.h, which
   // the baseline includes. Only the name-binding macros and the user's own body

--- a/src/backend/shared/utils/cpp/generateCBlocksCode.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksCode.ts
@@ -1,3 +1,4 @@
+import { cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
 import { isArrayVariable } from '../../../../frontend/utils/PLC/array-codegen-helpers'
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 
@@ -158,19 +159,14 @@ const processUserCode = (pou: CppPouData): string => {
   const setupFunctionName = `${pou.name.toLowerCase()}_setup`
   const loopFunctionName = `${pou.name.toLowerCase()}_loop`
 
-  const inputVariables = pou.variables.filter((v) => v.class === 'input')
-  const outputVariables = pou.variables.filter((v) => v.class === 'output')
+  const interfaceVariables = cBlockInterfaceVariables(pou.variables)
 
   // The struct and the two entry-point declarations come from c_blocks.h, which
   // the baseline includes. Only the name-binding macros and the user's own body
   // are emitted here.
   let processedCode = `// ${pou.name.toUpperCase()} — Variables Table names bound to the interface struct\n`
 
-  inputVariables.forEach((variable) => {
-    processedCode += generateDefine(variable)
-  })
-
-  outputVariables.forEach((variable) => {
+  interfaceVariables.forEach((variable) => {
     processedCode += generateDefine(variable)
   })
 
@@ -188,10 +184,7 @@ const processUserCode = (pou: CppPouData): string => {
   processedCode += modifiedUserCode
   processedCode += '\n'
 
-  inputVariables.forEach((variable) => {
-    processedCode += generateUndef(variable)
-  })
-  outputVariables.forEach((variable) => {
+  interfaceVariables.forEach((variable) => {
     processedCode += generateUndef(variable)
   })
   processedCode += '\n'

--- a/src/backend/shared/utils/cpp/generateCBlocksCode.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksCode.ts
@@ -1,5 +1,5 @@
 import { cBlockExternalVariables, cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
-import { isArrayVariable } from '../../../../frontend/utils/PLC/array-codegen-helpers'
+import { isArrayVariable, multiDimensionalContainerType } from '../../../../frontend/utils/PLC/array-codegen-helpers'
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 
 type CppPouData = {
@@ -104,7 +104,13 @@ const generateDefine = (variable: PLCVariable): string => {
   const name = variable.name
   const upperName = name.toUpperCase()
 
-  if (isArrayVariable(variable)) {
+  // A one-dimensional array is a pointer to its first element offset by the
+  // lower bound, so the name binds to the pointer itself and `name[i]` indexes
+  // by the declared IEC range. Everything else — scalars, structures, function
+  // block instances, and multi-dimensional arrays, which are passed as the
+  // container — binds to the dereferenced pointer, so the user writes
+  // `name = 5`, `name.field`, `name()` or `name(i, j)` as the type allows.
+  if (isArrayVariable(variable) && !multiDimensionalContainerType(variable)) {
     return `#define ${name} (vars->${upperName})\n`
   }
   return `#define ${name} (*(vars->${upperName}))\n`

--- a/src/backend/shared/utils/cpp/generateCBlocksCode.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksCode.ts
@@ -150,7 +150,10 @@ const generateUserTypeAliases = (cppPous: CppPouData[], userTypeNames: Iterable<
   const referenced = new Set<string>(Array.from(userTypeNames, (name) => name.toUpperCase()))
   for (const pou of cppPous) {
     for (const variable of pou.variables) {
-      if (variable.type.definition === 'user-data-type') {
+      // `derived` is a function block instance, `user-data-type` a structure or
+      // enumeration. A block may name either — casting to an enumeration, or
+      // declaring a local of an FB class — so both belong in scope.
+      if (variable.type.definition === 'user-data-type' || variable.type.definition === 'derived') {
         referenced.add(variable.type.value.toUpperCase())
       }
       if (variable.type.definition === 'array' && variable.type.data?.baseType.definition === 'user-data-type') {

--- a/src/backend/shared/utils/cpp/generateCBlocksCode.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksCode.ts
@@ -132,9 +132,16 @@ const generateUndef = (variable: PLCVariable): string => {
  * Bring the project's own type names into the C block's scope.
  *
  * The generated declarations live in `namespace strucpp`, so without this a
- * user has to write `strucpp::Motor` / `(strucpp::Mode)` in their own block —
+ * user has to write `strucpp::MOTOR` / `(strucpp::MODE)` in their own block —
  * the namespace is an implementation detail of the toolchain leaking into code
  * that is supposed to look like ordinary C++ against the Variables Table.
+ *
+ * Upper-case throughout, and not a typo: strucpp's lexer upper-cases the whole
+ * ST source except string literals and `{external}` bodies, so a data type the
+ * user declared as `Motor` is `struct MOTOR` by the time `type-codegen` names
+ * it. The aliases below therefore match what the compiler actually emits; an
+ * earlier revision of this comment said `strucpp::Motor`, which would not
+ * resolve.
  *
  * A blanket `using namespace strucpp;` is not an option: the baseline defines
  * raw `IEC_BOOL` / `IEC_INT` / … typedefs at file scope for the user's local

--- a/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
@@ -1,4 +1,4 @@
-import { cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
+import { cBlockExternalVariables, cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
 import { generateStructMember } from '../../../../frontend/utils/PLC/array-codegen-helpers'
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 
@@ -55,6 +55,14 @@ const generateCBlocksHeader = (cppPous: CppPouData[], userTypeNames: Iterable<st
     headerContent += `typedef struct {\n`
 
     cBlockInterfaceVariables(pou.variables).forEach((variable) => {
+      headerContent += generateStructMember(variable, typeNames)
+    })
+
+    // A `VAR_EXTERNAL` field looks like any other: the pointer is to the
+    // global's value, so the block reads and writes it exactly as it does a
+    // local. What differs is that the ST glue takes that pointer under the
+    // global's lock — see `cBlockExternalVariables`.
+    cBlockExternalVariables(pou.variables).forEach((variable) => {
       headerContent += generateStructMember(variable, typeNames)
     })
 

--- a/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
@@ -1,3 +1,4 @@
+import { cBlockInterfaceVariables } from '../../../../frontend/utils/cpp/block-interface'
 import { generateStructMember } from '../../../../frontend/utils/PLC/array-codegen-helpers'
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
 
@@ -50,17 +51,10 @@ const generateCBlocksHeader = (cppPous: CppPouData[], userTypeNames: Iterable<st
     const setupFunctionName = `${pou.name.toLowerCase()}_setup`
     const loopFunctionName = `${pou.name.toLowerCase()}_loop`
 
-    const inputVariables = pou.variables.filter((v) => v.class === 'input')
-    const outputVariables = pou.variables.filter((v) => v.class === 'output')
-
     headerContent += `//definition of external blocks - ${pou.name.toUpperCase()}\n`
     headerContent += `typedef struct {\n`
 
-    inputVariables.forEach((variable) => {
-      headerContent += generateStructMember(variable, typeNames)
-    })
-
-    outputVariables.forEach((variable) => {
+    cBlockInterfaceVariables(pou.variables).forEach((variable) => {
       headerContent += generateStructMember(variable, typeNames)
     })
 

--- a/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
+++ b/src/backend/shared/utils/cpp/generateCBlocksHeader.ts
@@ -6,17 +6,42 @@ type CppPouData = {
   variables: PLCVariable[]
 }
 
-const generateCBlocksHeader = (cppPous: CppPouData[]): string => {
+/**
+ * The one place a C block's interface struct is written.
+ *
+ * `c_blocks_code.cpp` used to re-emit the same `<POU>_VARS` typedef from its own
+ * call into `generateStructMember`, so the project carried two independent
+ * spellings of one fact. They agreed only for as long as both call sites were
+ * edited together, and the moment a type needed more than a name lookup — an
+ * enumeration is `strucpp::IEC_MODE` in the struct but a structure is
+ * `strucpp::MOTOR` — they diverged, producing two conflicting definitions of the
+ * same typedef and a compile error at the assignment in the POU glue.
+ *
+ * Now the header is the definition and `c_blocks_code.cpp` includes it. Drift is
+ * not a bug that can be reintroduced: there is nothing left to disagree with.
+ */
+const generateCBlocksHeader = (cppPous: CppPouData[], userTypeNames: Iterable<string> = []): string => {
+  const typeNames: ReadonlySet<string> = new Set(Array.from(userTypeNames, (name) => name.toUpperCase()))
+
   let headerContent = `#ifndef C_BLOCKS_H
 #define C_BLOCKS_H
 
-// The user-visible struct fields are fully qualified as
-// \`strucpp::IEC_*\` (numeric, bit-string, STRING, WSTRING — every pin
-// is an \`IECVar<T>\` / \`IECStringVar<N>\` wrapper).  Pull the runtime
-// headers in here so any TU that includes this header gets the
-// wrappers in scope without depending on include order.
-#include "iec_var.hpp"
-#include "iec_string.hpp"
+// The project's own generated declarations. Every struct field below is a
+// strucpp type: an \`IECVar<T>\` / \`IECStringVar<N>\` wrapper for an elementary
+// pin, and for a user-defined type the structure, enumeration or function block
+// class the project declares. \`generated.hpp\` carries all of them, and pulls in
+// the runtime headers transitively, so any translation unit that includes this
+// header gets the whole surface regardless of include order.
+//
+// Every translation unit that includes this header is built at -std=gnu++17,
+// which is what \`generated.hpp\` needs. On a Runtime v4 or Arduino target the
+// POU glue and \`c_blocks_code.cpp\` are pre-compiled from
+// \`precompile/sources/\` with the board's toolchain at that standard; on the
+// baremetal/simulator path the flag is appended to the arduino-cli invocation
+// so the sketch-side copy of \`c_blocks_code.cpp\` compiles identically. Only
+// the core itself is left on whatever standard it ships with, and the core
+// never includes this header.
+#include "generated.hpp"
 
 `
 
@@ -32,18 +57,18 @@ const generateCBlocksHeader = (cppPous: CppPouData[]): string => {
     headerContent += `typedef struct {\n`
 
     inputVariables.forEach((variable) => {
-      headerContent += generateStructMember(variable)
+      headerContent += generateStructMember(variable, typeNames)
     })
 
     outputVariables.forEach((variable) => {
-      headerContent += generateStructMember(variable)
+      headerContent += generateStructMember(variable, typeNames)
     })
 
     headerContent += `} ${structName};\n`
-    // c_blocks_code.cpp defines these with `extern "C"` so the user's
-    // setup()/loop() bodies link unmangled. The header has to match —
-    // without `extern "C"` here, the per-POU call sites mangle the
-    // symbol and the dynamic loader fails with `undefined symbol:
+    // The user's setup()/loop() bodies are defined with `extern "C"` in
+    // c_blocks_code.cpp so they link unmangled. The declarations here have to
+    // match — without `extern "C"` the per-POU call sites mangle the symbol and
+    // the dynamic loader fails with `undefined symbol:
     // _Z<N><name>P<N><STRUCT>_VARS`.
     headerContent += `extern "C" void ${setupFunctionName}(${structName} *vars);\n`
     headerContent += `extern "C" void ${loopFunctionName}(${structName} *vars);\n\n`

--- a/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
@@ -152,6 +152,7 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
       meta: { path: projectPath },
       data: {
         pous,
+        dataTypes,
         configurations: {
           resource: { globalVariables },
         },
@@ -342,8 +343,8 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
   useEffect(() => {
     if (!capabilities.hasPythonLSP) return
     if (language !== 'python') return
-    updatePythonLspContext(name, pouVariables)
-  }, [capabilities.hasPythonLSP, language, name, pouVariables])
+    updatePythonLspContext(name, pouVariables, dataTypes)
+  }, [capabilities.hasPythonLSP, language, name, pouVariables, dataTypes])
 
   useEffect(() => {
     return () => {
@@ -949,6 +950,9 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
           setupPythonLSPForEditor(editorInstance, {
             pouName: name,
             variables: pou.interface?.variables ?? [],
+            // The structures and enumerations the interface can name, so Pyright
+            // resolves `m.speed` to the same shape the runtime will build.
+            dataTypes,
           }),
         )
         .catch((err: unknown) => console.warn('[Python LSP]', err instanceof Error ? err.message : err))

--- a/src/frontend/components/_features/[workspace]/editor/monaco/python-lsp/index.ts
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/python-lsp/index.ts
@@ -26,7 +26,7 @@
  */
 
 import { type PythonLspService, startPythonLsp } from '@root/frontend/services/python-lsp'
-import type { PLCVariable } from '@root/middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '@root/middleware/shared/ports/types'
 import type { editor as MonacoEditor, IDisposable } from 'monaco-editor'
 import type * as monaco from 'monaco-editor'
 
@@ -89,7 +89,7 @@ export async function initPythonLSP(monacoModule: typeof monaco): Promise<void> 
  */
 export function setupPythonLSPForEditor(
   editor: MonacoEditor.IStandaloneCodeEditor,
-  ctx: { pouName: string; variables: PLCVariable[] },
+  ctx: { pouName: string; variables: PLCVariable[]; dataTypes?: readonly PLCDataType[] },
 ): void {
   if (!service) return
   const model = editor.getModel()
@@ -105,7 +105,7 @@ export function setupPythonLSPForEditor(
   // twice on every keystroke.
   wiringByUri.get(uri)?.contentSubscription.dispose()
 
-  service.attachPou(uri, ctx.pouName, ctx.variables, model.getValue())
+  service.attachPou(uri, ctx.pouName, ctx.variables, model.getValue(), ctx.dataTypes ?? [])
 
   const contentSubscription = model.onDidChangeContent(() => {
     service?.notifyBodyChange(uri, model.getValue())
@@ -120,13 +120,17 @@ export function setupPythonLSPForEditor(
  * document so Pyright sees the updated globals.  No-op if no editor
  * is currently attached for the POU.
  */
-export function updatePythonLspContext(pouName: string, variables: PLCVariable[]): void {
+export function updatePythonLspContext(
+  pouName: string,
+  variables: PLCVariable[],
+  dataTypes: readonly PLCDataType[] = [],
+): void {
   if (!service || !monacoApi) return
   for (const [uri, wiring] of wiringByUri.entries()) {
     if (wiring.pouName !== pouName) continue
     const model = monacoApi.editor.getModels().find((m) => m.uri.toString() === uri)
     if (!model) continue
-    service.notifyVariablesChange(uri, variables, model.getValue())
+    service.notifyVariablesChange(uri, variables, model.getValue(), dataTypes)
   }
 }
 

--- a/src/frontend/services/lsp-shared/diagnostics.ts
+++ b/src/frontend/services/lsp-shared/diagnostics.ts
@@ -88,7 +88,19 @@ export function attachDiagnosticsBridge(
       monacoApi.editor.setModelMarkers(
         bodyModel,
         markerOwner,
-        params.diagnostics.map((d) => lspDiagnosticToMonaco(d, monacoApi, bodyOffset, defaultSource)),
+        params.diagnostics
+          .map((d) => lspDiagnosticToMonaco(d, monacoApi, bodyOffset, defaultSource))
+          // Drop what the preamble owns. The offset shifts worker-frame lines
+          // back to the body-only view, so anything the generated preamble
+          // produced lands at or below line 0 — and Monaco CLAMPS those to line
+          // 1 rather than discarding them, which this bridge used to assume it
+          // did. The user then got a red marker on their first line carrying a
+          // message about generated code they cannot see or fix: for Python,
+          // basedpyright's strict rules firing on the injected type stubs
+          // ("Instance variable \"speed\" is not initialized", "Type `Any` is
+          // not allowed"). Filtering here rather than muting individual rules
+          // keeps the user's own code checked exactly as strictly as before.
+          .filter((marker) => marker.startLineNumber >= 1),
       )
     }
 

--- a/src/frontend/services/python-lsp/__tests__/index.test.ts
+++ b/src/frontend/services/python-lsp/__tests__/index.test.ts
@@ -61,7 +61,7 @@ function installMockSharedService(): { service: MockLanguageService; sendNotific
   return { service, sendNotification }
 }
 
-function makeBoolVar(name: string, varClass: 'input' | 'output' | 'local' = 'input'): PLCVariable {
+function makeBoolVar(name: string, varClass: PLCVariable['class'] = 'input'): PLCVariable {
   return {
     id: name,
     name,

--- a/src/frontend/services/python-lsp/__tests__/index.test.ts
+++ b/src/frontend/services/python-lsp/__tests__/index.test.ts
@@ -181,8 +181,10 @@ describe('attachPou', () => {
     installMockSharedService()
 
     const service = startPythonLsp({ workerUrl: 'about:blank' })
-    // `local` vars don't get hoisted into module scope; preamble is empty.
-    service.attachPou(POU_URI, POU_NAME, [makeBoolVar('x', 'local')], 'pass\n')
+    // `temp` is the one class a Python block cannot express — it is refused at
+    // compile time and so never becomes a module global. Everything else,
+    // `local` included, is hoisted and does get a preamble line.
+    service.attachPou(POU_URI, POU_NAME, [makeBoolVar('x', 'temp')], 'pass\n')
 
     expect(setBodyLineOffset).toHaveBeenCalledWith(POU_LSP_URI, 0)
   })

--- a/src/frontend/services/python-lsp/index.ts
+++ b/src/frontend/services/python-lsp/index.ts
@@ -299,7 +299,7 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
   return {
     ready: sharedService.ready,
 
-    attachPou(uri, pouName, variables, bodyText) {
+    attachPou(uri, pouName, variables, bodyText, dataTypes = []) {
       // `uri` is the Monaco model URI the rest of the editor uses.
       // The LSP communication appends `.py` so basedpyright treats
       // the document as Python source.  Body-line offsets are
@@ -317,7 +317,7 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
       // notification, opened files sit in pyright's document
       // buffer but never enter the analysis queue.
       const lspUri = `${uri}.py`
-      const preamble = generatePythonLspPreamble(variables)
+      const preamble = generatePythonLspPreamble(variables, dataTypes)
       const iecVariableLineMap = getIecVariableLineMap(variables)
       entryByUri.set(uri, { pouName, lspUri, preamble, iecVariableLineMap })
       setBodyLineOffset(lspUri, preamble.lineCount)
@@ -330,7 +330,7 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
       sharedService.changeDocument(lspUri, augmentedDocument(uri, bodyText))
     },
 
-    notifyVariablesChange(uri, variables, bodyText) {
+    notifyVariablesChange(uri, variables, bodyText, dataTypes = []) {
       // Variables changed: regenerate the preamble + IEC line map
       // and update the offset registry BEFORE pushing the new
       // document so the diagnostics callback (which fires on the
@@ -340,7 +340,7 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
       // the URI we already opened with pyright.
       const existing = entryByUri.get(uri)
       const lspUri = existing?.lspUri ?? `${uri}.py`
-      const preamble = generatePythonLspPreamble(variables)
+      const preamble = generatePythonLspPreamble(variables, dataTypes)
       const iecVariableLineMap = getIecVariableLineMap(variables)
       entryByUri.set(uri, { pouName: existing?.pouName ?? '', lspUri, preamble, iecVariableLineMap })
       setBodyLineOffset(lspUri, preamble.lineCount)

--- a/src/frontend/services/python-lsp/types.ts
+++ b/src/frontend/services/python-lsp/types.ts
@@ -6,7 +6,7 @@
 
 import type * as monaco from 'monaco-editor'
 
-import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
 
 export interface PythonLspStartOptions {
   /**
@@ -53,7 +53,13 @@ export interface PythonLspService {
    * target lands in this URI.  Without it, the redirect can't open
    * the right POU tab.
    */
-  attachPou(uri: string, pouName: string, variables: PLCVariable[], bodyText: string): void
+  attachPou(
+    uri: string,
+    pouName: string,
+    variables: PLCVariable[],
+    bodyText: string,
+    dataTypes?: readonly PLCDataType[],
+  ): void
 
   /**
    * Push a new body version for an already-attached POU.  Preamble
@@ -66,7 +72,12 @@ export interface PythonLspService {
    * shared offset registry, and push the new augmented document.
    * Bumps the LSP document version.
    */
-  notifyVariablesChange(uri: string, variables: PLCVariable[], bodyText: string): void
+  notifyVariablesChange(
+    uri: string,
+    variables: PLCVariable[],
+    bodyText: string,
+    dataTypes?: readonly PLCDataType[],
+  ): void
 
   /** Send `textDocument/didClose` and drop the preamble entry. */
   detachPou(uri: string): void

--- a/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
+++ b/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
@@ -8,6 +8,7 @@ import {
   isArrayVariable,
   mapBaseTypeToIEC,
   mapUserTypeToIEC,
+  multiDimensionalContainerType,
 } from '../array-codegen-helpers'
 
 // ---------------------------------------------------------------------------
@@ -292,6 +293,87 @@ describe('mapUserTypeToIEC', () => {
 
   it('matches case-insensitively, since the set is uppercased by the caller', () => {
     expect(mapUserTypeToIEC('mOtOr', new Set(['MOTOR']))).toBe('IEC_MOTOR')
+  })
+})
+
+describe('multiDimensionalContainerType', () => {
+  const arrayOfRank = (dimensions: string[], baseType = 'INT'): PLCVariable => ({
+    name: 'grid',
+    class: 'input',
+    type: {
+      definition: 'array',
+      value: `ARRAY [${dimensions.join(', ')}] OF ${baseType}`,
+      data: {
+        baseType: { definition: 'base-type', value: baseType },
+        dimensions: dimensions.map((dimension) => ({ dimension })),
+      },
+    },
+    location: '',
+    documentation: '',
+    debug: false,
+  })
+
+  it('names the 2-D container with the user’s own bounds', () => {
+    expect(multiDimensionalContainerType(arrayOfRank(['1..2', '0..3']))).toBe('Array2D<strucpp::IEC_INT, 1, 2, 0, 3>')
+  })
+
+  it('names the 3-D container', () => {
+    expect(multiDimensionalContainerType(arrayOfRank(['0..1', '0..1', '0..1']))).toBe(
+      'Array3D<strucpp::IEC_INT, 0, 1, 0, 1, 0, 1>',
+    )
+  })
+
+  it('returns null for rank one, which is passed as an offset element pointer', () => {
+    // `arr[i]` with IEC indices is a better surface than `arr(i)`, and rank one
+    // is the only rank where the offset trick works.
+    expect(multiDimensionalContainerType(arrayOfRank(['0..9']))).toBeNull()
+  })
+
+  it('returns null past rank three, for which strucpp declares no alias', () => {
+    expect(multiDimensionalContainerType(arrayOfRank(['0..1', '0..1', '0..1', '0..1']))).toBeNull()
+  })
+
+  it('returns null when a bound cannot be read rather than guessing one', () => {
+    expect(multiDimensionalContainerType(arrayOfRank(['0..1', 'nonsense']))).toBeNull()
+  })
+
+  it('returns null for anything that is not an array', () => {
+    const scalar: PLCVariable = {
+      name: 'x',
+      class: 'input',
+      type: { definition: 'base-type', value: 'INT' },
+      location: '',
+      documentation: '',
+      debug: false,
+    }
+
+    expect(multiDimensionalContainerType(scalar)).toBeNull()
+  })
+
+  it('returns null for an array declaration carrying no dimension data', () => {
+    const bare: PLCVariable = {
+      name: 'grid',
+      class: 'input',
+      type: { definition: 'array', value: 'ARRAY [0..1, 0..1] OF INT' },
+      location: '',
+      documentation: '',
+      debug: false,
+    }
+
+    expect(multiDimensionalContainerType(bare)).toBeNull()
+  })
+
+  it('applies the user-defined type spelling to the element type', () => {
+    const v = arrayOfRank(['0..1', '0..1'], 'Motor')
+    v.type.data!.baseType = { definition: 'user-data-type', value: 'Motor' }
+
+    expect(multiDimensionalContainerType(v, new Set(['MOTOR']))).toBe('Array2D<strucpp::IEC_MOTOR, 0, 1, 0, 1>')
+  })
+
+  it('makes generateStructMember emit a pointer to the container', () => {
+    expect(generateStructMember(arrayOfRank(['1..2', '0..3']))).toBe(
+      '  strucpp::Array2D<strucpp::IEC_INT, 1, 2, 0, 3> *GRID;\n',
+    )
   })
 })
 

--- a/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
+++ b/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
@@ -1,4 +1,5 @@
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import { SHM_SCALAR_TYPES } from '../../python/shm-type-map'
 import {
   generateStructMember,
   getArrayBaseTypeValue,
@@ -271,6 +272,38 @@ describe('getArrayStartIndex', () => {
 // ---------------------------------------------------------------------------
 // generateStructMember
 // ---------------------------------------------------------------------------
+describe('the two native languages accept the same elementary types', () => {
+  // A type either crosses into both a C++ block and a Python block, or neither.
+  // They drifted once already: TIME / DATE / TOD / DT / WSTRING were in the
+  // Python shared-memory table but absent from the C++ map, so a C++ block
+  // declaring `TIME` emitted `strucpp::TIME` — a name that does not exist — and
+  // the build failed on generated code the user never wrote. Nothing catches
+  // that except a build, and nobody builds every type by hand.
+  const scalarOf = (value: string): PLCVariable => ({
+    name: 'v',
+    class: 'input',
+    type: { definition: 'base-type', value },
+    location: '',
+    documentation: '',
+    debug: false,
+  })
+
+  const pythonTypes = [...Object.keys(SHM_SCALAR_TYPES), 'string', 'wstring']
+
+  it.each(pythonTypes)('%s has a C++ spelling too', (type) => {
+    expect(mapBaseTypeToIEC(type)).toMatch(/^IEC_/)
+  })
+
+  it.each(pythonTypes)('%s resolves for a C++ struct member', (type) => {
+    expect(generateStructMember(scalarOf(type))).toMatch(/^ {2}strucpp::IEC_\w+ \*V;\n$/)
+  })
+
+  it('accepts the long spellings IEC 61131-3 allows for the calendar types', () => {
+    expect(mapBaseTypeToIEC('time_of_day')).toBe('IEC_TOD')
+    expect(mapBaseTypeToIEC('date_and_time')).toBe('IEC_DT')
+  })
+})
+
 describe('mapUserTypeToIEC', () => {
   // strucpp declares a structure or enumeration and then aliases it
   // (`using IEC_MOTOR = MOTOR`), but a function block class gets no alias. Only

--- a/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
+++ b/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
@@ -330,14 +330,18 @@ describe('mapUserTypeToIEC', () => {
 })
 
 describe('multiDimensionalContainerType', () => {
-  const arrayOfRank = (dimensions: string[], baseType = 'INT'): PLCVariable => ({
+  const arrayOfRank = (
+    dimensions: string[],
+    baseType = 'INT',
+    baseDefinition: 'base-type' | 'user-data-type' = 'base-type',
+  ): PLCVariable => ({
     name: 'grid',
     class: 'input',
     type: {
       definition: 'array',
       value: `ARRAY [${dimensions.join(', ')}] OF ${baseType}`,
       data: {
-        baseType: { definition: 'base-type', value: baseType },
+        baseType: { definition: baseDefinition, value: baseType },
         dimensions: dimensions.map((dimension) => ({ dimension })),
       },
     },
@@ -397,8 +401,10 @@ describe('multiDimensionalContainerType', () => {
   })
 
   it('applies the user-defined type spelling to the element type', () => {
-    const v = arrayOfRank(['0..1', '0..1'], 'Motor')
-    v.type.data!.baseType = { definition: 'user-data-type', value: 'Motor' }
+    // Built with the user-defined element type rather than mutated into one
+    // afterwards, so the fixture needs no non-null assertion to reach into
+    // `type.data`.
+    const v = arrayOfRank(['0..1', '0..1'], 'Motor', 'user-data-type')
 
     expect(multiDimensionalContainerType(v, new Set(['MOTOR']))).toBe('Array2D<strucpp::IEC_MOTOR, 0, 1, 0, 1>')
   })

--- a/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
+++ b/src/frontend/utils/PLC/__tests__/array-codegen-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   getVariableIECType,
   isArrayVariable,
   mapBaseTypeToIEC,
+  mapUserTypeToIEC,
 } from '../array-codegen-helpers'
 
 // ---------------------------------------------------------------------------
@@ -269,6 +270,31 @@ describe('getArrayStartIndex', () => {
 // ---------------------------------------------------------------------------
 // generateStructMember
 // ---------------------------------------------------------------------------
+describe('mapUserTypeToIEC', () => {
+  // strucpp declares a structure or enumeration and then aliases it
+  // (`using IEC_MOTOR = MOTOR`), but a function block class gets no alias. Only
+  // the project's declared data types carry the prefix; anything else — an FB
+  // instance — keeps the bare class name, because `IEC_HELPER` would name a
+  // type that was never declared.
+  it('prefixes a name the project declares as a data type', () => {
+    expect(mapUserTypeToIEC('Motor', new Set(['MOTOR']))).toBe('IEC_MOTOR')
+  })
+
+  it('leaves a name the project does not declare bare', () => {
+    expect(mapUserTypeToIEC('Helper', new Set(['MOTOR']))).toBe('HELPER')
+  })
+
+  it('leaves every name bare when no data-type set is supplied', () => {
+    // The set is optional so call sites that predate user types keep working;
+    // with nothing to match against, no name can be a data type.
+    expect(mapUserTypeToIEC('Motor')).toBe('MOTOR')
+  })
+
+  it('matches case-insensitively, since the set is uppercased by the caller', () => {
+    expect(mapUserTypeToIEC('mOtOr', new Set(['MOTOR']))).toBe('IEC_MOTOR')
+  })
+})
+
 describe('generateStructMember', () => {
   // Numeric/time/bit base types resolve to strucpp's IECVar wrapper —
   // the c_blocks_code.cpp baseline keeps file-scope raw typedefs for

--- a/src/frontend/utils/PLC/__tests__/function-block-pins.test.ts
+++ b/src/frontend/utils/PLC/__tests__/function-block-pins.test.ts
@@ -1,0 +1,162 @@
+import type { PLCPou } from '../../../../middleware/shared/ports/types'
+import { resolveFunctionBlockPins } from '../function-block-pins'
+
+const TON_LIB = {
+  functionBlocks: [
+    {
+      name: 'TON',
+      inputs: [
+        { name: 'IN', type: 'BOOL' },
+        { name: 'PT', type: 'TIME' },
+      ],
+      inouts: [{ name: 'IO', type: 'INT' }],
+      outputs: [
+        { name: 'Q', type: 'BOOL' },
+        { name: 'ET', type: 'TIME' },
+      ],
+    },
+  ],
+}
+
+const pou = (name: string, variables: NonNullable<PLCPou['interface']>['variables']): PLCPou => ({
+  name,
+  pouType: 'function-block',
+  interface: { variables },
+  body: { language: 'st', value: '' },
+})
+
+describe('resolveFunctionBlockPins', () => {
+  it('resolves a library block, grouping inputs then in-outs then outputs', () => {
+    // The same grouping the editor draws on the block, so the generated struct
+    // reads the way the block looks.
+    const pins = resolveFunctionBlockPins('TON', [], [TON_LIB])
+
+    expect(pins?.map((p) => [p.name, p.class])).toEqual([
+      ['IN', 'input'],
+      ['PT', 'input'],
+      ['IO', 'inOut'],
+      ['Q', 'output'],
+      ['ET', 'output'],
+    ])
+  })
+
+  it('maps an elementary pin type to a base type', () => {
+    const pins = resolveFunctionBlockPins('TON', [], [TON_LIB])
+
+    expect(pins?.[0].type).toEqual({ definition: 'base-type', value: 'BOOL' })
+  })
+
+  it('does not claim a generic pin is elementary', () => {
+    // `ANY_NUM` has no type until it is wired, so there is no width to marshal.
+    // Marking it a base type would invite a guess; the walkers refuse it instead.
+    const generic = {
+      functionBlocks: [{ name: 'ADD', inputs: [{ name: 'IN1', type: 'ANY_NUM' }], inouts: [], outputs: [] }],
+    }
+    const pins = resolveFunctionBlockPins('ADD', [], [generic])
+
+    expect(pins?.[0].type.definition).toBe('user-data-type')
+  })
+
+  it('matches the block name case-insensitively', () => {
+    expect(resolveFunctionBlockPins('ton', [], [TON_LIB])).not.toBeNull()
+  })
+
+  it('resolves a project block', () => {
+    const project = pou('Accum', [
+      {
+        name: 'step',
+        class: 'input',
+        type: { definition: 'base-type', value: 'INT' },
+        location: '',
+        documentation: '',
+      },
+      {
+        name: 'total',
+        class: 'output',
+        type: { definition: 'base-type', value: 'DINT' },
+        location: '',
+        documentation: '',
+      },
+    ])
+
+    expect(resolveFunctionBlockPins('Accum', [project], [])?.map((p) => p.name)).toEqual(['step', 'total'])
+  })
+
+  it('lets a project block shadow a library block of the same name', () => {
+    const project = pou('TON', [
+      {
+        name: 'mine',
+        class: 'input',
+        type: { definition: 'base-type', value: 'INT' },
+        location: '',
+        documentation: '',
+      },
+    ])
+
+    expect(resolveFunctionBlockPins('TON', [project], [TON_LIB])?.map((p) => p.name)).toEqual(['mine'])
+  })
+
+  it('keeps a project block’s internal locals, for the caller to filter', () => {
+    // The resolver reports what the block has; deciding what may cross is the
+    // marshaller's job, and it excludes locals.
+    const project = pou('Accum', [
+      {
+        name: 'step',
+        class: 'input',
+        type: { definition: 'base-type', value: 'INT' },
+        location: '',
+        documentation: '',
+      },
+      {
+        name: 'acc',
+        class: 'local',
+        type: { definition: 'base-type', value: 'DINT' },
+        location: '',
+        documentation: '',
+      },
+    ])
+
+    expect(resolveFunctionBlockPins('Accum', [project], [])?.map((p) => p.class)).toEqual(['input', 'local'])
+  })
+
+  it('drops a project variable in a class that is not a pin', () => {
+    const project = pou('Accum', [
+      {
+        name: 'step',
+        class: 'input',
+        type: { definition: 'base-type', value: 'INT' },
+        location: '',
+        documentation: '',
+      },
+      {
+        name: 'g',
+        class: 'external',
+        type: { definition: 'base-type', value: 'INT' },
+        location: '',
+        documentation: '',
+      },
+    ])
+
+    expect(resolveFunctionBlockPins('Accum', [project], [])?.map((p) => p.name)).toEqual(['step'])
+  })
+
+  it('returns null when nothing declares the block', () => {
+    expect(resolveFunctionBlockPins('Nowhere', [], [TON_LIB])).toBeNull()
+  })
+
+  it('ignores a project POU that is not a function block', () => {
+    const program: PLCPou = { name: 'TON', pouType: 'program', body: { language: 'st', value: '' } }
+
+    expect(resolveFunctionBlockPins('TON', [program], [])).toBeNull()
+  })
+
+  it('handles a function block POU with no interface at all', () => {
+    const bare: PLCPou = { name: 'Bare', pouType: 'function-block', body: { language: 'st', value: '' } }
+
+    expect(resolveFunctionBlockPins('Bare', [bare], [])).toEqual([])
+  })
+
+  it('returns nothing when given neither project nor libraries', () => {
+    expect(resolveFunctionBlockPins('TON')).toBeNull()
+  })
+})

--- a/src/frontend/utils/PLC/array-codegen-helpers.ts
+++ b/src/frontend/utils/PLC/array-codegen-helpers.ts
@@ -18,6 +18,20 @@ const BASE_TYPE_TO_IEC: Record<string, string> = {
   real: 'IEC_REAL',
   lreal: 'IEC_LREAL',
   string: 'IEC_STRING',
+  wstring: 'IEC_WSTRING',
+
+  // Duration and calendar types. Absent until DOPE-584's type sweep: a C++
+  // block declaring `TIME` emitted `strucpp::TIME`, which names nothing, and the
+  // build failed on generated code the user never wrote. The aliases these map
+  // to are the ones strucpp declares (`IEC_TIME = IECVar<TIME_t>`, and so on).
+  time: 'IEC_TIME',
+  date: 'IEC_DATE',
+  tod: 'IEC_TOD',
+  dt: 'IEC_DT',
+
+  // The long spellings IEC 61131-3 also allows for the same two types.
+  time_of_day: 'IEC_TOD',
+  date_and_time: 'IEC_DT',
 }
 
 /**

--- a/src/frontend/utils/PLC/array-codegen-helpers.ts
+++ b/src/frontend/utils/PLC/array-codegen-helpers.ts
@@ -114,6 +114,43 @@ const getArrayStartIndex = (variable: PLCVariable): number => {
 }
 
 /**
+ * strucpp container type for an array of rank two or three, or `null` for
+ * anything else.
+ *
+ * A one-dimensional array is passed as a pointer to its first element, offset by
+ * the lower bound, so the block writes `arr[i]` with the declared IEC indices
+ * and the element type is all the struct has to name. That trick does not extend
+ * past rank one: `IEC_ARRAY_2D` deliberately has no `operator[]` — a row
+ * subscript would have to return a view — and takes every index in one
+ * `operator()` call instead. So a multi-dimensional array is passed as a pointer
+ * to the container itself, and the block indexes it as `grid(i, j)`, which is
+ * the same accessor the compiler's own generated code uses.
+ *
+ * `Array2D` / `Array3D` are strucpp's documented public aliases, and the bounds
+ * handed to them come from the user's own declaration rather than from any
+ * assumption about how the container is laid out.
+ *
+ * Rank four and beyond returns `null`: strucpp declares no alias for it, so
+ * there is no type to name and no array to describe.
+ */
+const multiDimensionalContainerType = (variable: PLCVariable, userTypeNames?: ReadonlySet<string>): string | null => {
+  if (variable.type.definition !== 'array' || !variable.type.data) return null
+
+  const dimensions = variable.type.data.dimensions
+  if (dimensions.length < 2 || dimensions.length > 3) return null
+
+  const bounds: number[] = []
+  for (const dimension of dimensions) {
+    const range = parseDimensionRange(dimension.dimension)
+    if (!range) return null
+    bounds.push(range.lower, range.upper)
+  }
+
+  const elementType = mapBaseTypeToIEC(variable.type.data.baseType.value, userTypeNames)
+  return `Array${dimensions.length}D<strucpp::${elementType}, ${bounds.join(', ')}>`
+}
+
+/**
  * Generate a C struct member declaration for a variable.
  * Both scalars and arrays use pointers:
  * - Scalars: pointer to the single value
@@ -136,13 +173,17 @@ const getArrayStartIndex = (variable: PLCVariable): number => {
  * declarations inside `setup()` / `loop()`.
  */
 const generateStructMember = (variable: PLCVariable, userTypeNames?: ReadonlySet<string>): string => {
-  const iecType = getVariableIECType(variable, userTypeNames)
   const name = variable.name.toUpperCase()
+  const multiDimensional = multiDimensionalContainerType(variable, userTypeNames)
+  if (multiDimensional) return `  strucpp::${multiDimensional} *${name};\n`
+
+  const iecType = getVariableIECType(variable, userTypeNames)
   return `  strucpp::${iecType} *${name};\n`
 }
 
 export {
   generateStructMember,
+  multiDimensionalContainerType,
   mapUserTypeToIEC,
   getArrayBaseTypeValue,
   getArrayStartIndex,

--- a/src/frontend/utils/PLC/array-codegen-helpers.ts
+++ b/src/frontend/utils/PLC/array-codegen-helpers.ts
@@ -183,12 +183,12 @@ const generateStructMember = (variable: PLCVariable, userTypeNames?: ReadonlySet
 
 export {
   generateStructMember,
-  multiDimensionalContainerType,
-  mapUserTypeToIEC,
   getArrayBaseTypeValue,
   getArrayStartIndex,
   getArrayTotalElements,
   getVariableIECType,
   isArrayVariable,
   mapBaseTypeToIEC,
+  mapUserTypeToIEC,
+  multiDimensionalContainerType,
 }

--- a/src/frontend/utils/PLC/array-codegen-helpers.ts
+++ b/src/frontend/utils/PLC/array-codegen-helpers.ts
@@ -55,8 +55,35 @@ const getArrayBaseTypeValue = (variable: PLCVariable): string => {
  * Map a base type string to its IEC C type name.
  * Falls back to uppercasing the type value if not found.
  */
-const mapBaseTypeToIEC = (baseType: string): string => {
-  return BASE_TYPE_TO_IEC[baseType.toLowerCase()] || baseType.toUpperCase()
+/**
+ * Spell a user-defined type the way strucpp declares it.
+ *
+ * The compiler emits two different shapes and there is no single rule that
+ * covers both, so the caller has to say which names are data types:
+ *
+ *   - A data type gets an `IEC_`-prefixed alias — `struct MOTOR { … };
+ *     using IEC_MOTOR = MOTOR;` for a structure, and
+ *     `enum class MODE { … }; using IEC_MODE = IEC_ENUM<MODE>;` for an
+ *     enumeration. The alias is the one to use: for an enumeration the bare
+ *     name is the raw C++ `enum class`, while `IEC_MODE` is the force-aware
+ *     wrapper, and a pin must be the wrapper like every other pin.
+ *   - A function block instance is a plain `class HELPER;` with no alias, so
+ *     the bare name is the only spelling that exists.
+ *
+ * Without `userTypeNames` the bare name is returned, which is the correct
+ * answer for a function block and the historical behaviour for everything else.
+ */
+const mapUserTypeToIEC = (typeName: string, userTypeNames?: ReadonlySet<string>): string => {
+  const upper = typeName.toUpperCase()
+  return userTypeNames?.has(upper) ? `IEC_${upper}` : upper
+}
+
+const mapBaseTypeToIEC = (baseType: string, userTypeNames?: ReadonlySet<string>): string => {
+  const elementary = BASE_TYPE_TO_IEC[baseType.toLowerCase()]
+  if (elementary) return elementary
+  // Not elementary: an array of a user-defined type, or a type the map does not
+  // know. Both go through the same spelling rule as a scalar of that type.
+  return mapUserTypeToIEC(baseType, userTypeNames)
 }
 
 /**
@@ -64,14 +91,14 @@ const mapBaseTypeToIEC = (baseType: string): string => {
  * For arrays, returns the IEC type of the base element type.
  * For scalars, returns the IEC type of the variable's type.
  */
-const getVariableIECType = (variable: PLCVariable): string => {
+const getVariableIECType = (variable: PLCVariable, userTypeNames?: ReadonlySet<string>): string => {
   if (variable.type.definition === 'array' && variable.type.data) {
-    return mapBaseTypeToIEC(variable.type.data.baseType.value)
+    return mapBaseTypeToIEC(variable.type.data.baseType.value, userTypeNames)
   }
   if (variable.type.definition === 'base-type') {
-    return mapBaseTypeToIEC(variable.type.value)
+    return mapBaseTypeToIEC(variable.type.value, userTypeNames)
   }
-  return variable.type.value.toUpperCase()
+  return mapUserTypeToIEC(variable.type.value, userTypeNames)
 }
 
 /**
@@ -108,14 +135,15 @@ const getArrayStartIndex = (variable: PLCVariable): number => {
  * numeric raw typedefs that still cover the user's local-variable
  * declarations inside `setup()` / `loop()`.
  */
-const generateStructMember = (variable: PLCVariable): string => {
-  const iecType = getVariableIECType(variable)
+const generateStructMember = (variable: PLCVariable, userTypeNames?: ReadonlySet<string>): string => {
+  const iecType = getVariableIECType(variable, userTypeNames)
   const name = variable.name.toUpperCase()
   return `  strucpp::${iecType} *${name};\n`
 }
 
 export {
   generateStructMember,
+  mapUserTypeToIEC,
   getArrayBaseTypeValue,
   getArrayStartIndex,
   getArrayTotalElements,

--- a/src/frontend/utils/PLC/function-block-pins.ts
+++ b/src/frontend/utils/PLC/function-block-pins.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Resolve a function block type name to the pins an instance of it exposes.
+ *
+ * Two places declare a function block: the project itself, and a bundled system
+ * library (the IEC standard blocks, OSCAT, and anything else installed). Both
+ * carry the pin list, in slightly different shapes, and a caller that needs pins
+ * needs them from either source without caring which.
+ *
+ * The libraries are passed in rather than read from the store, for the reason
+ * `debug-tree-traversal` gives for doing the same: a `utils` module may not
+ * import `store`, and passing them keeps this a pure function.
+ */
+
+import type { PLCPou, PLCVariable, PLCVariableType } from '../../../middleware/shared/ports/types'
+
+/**
+ * The shape a library declares a function block in.
+ *
+ * Structurally what `StlibArchiveDTO.manifest.functionBlocks` provides, narrowed
+ * to the fields a pin walk needs, so this module depends on the shape rather
+ * than on the library port.
+ */
+export interface LibraryFunctionBlock {
+  name: string
+  inputs: ReadonlyArray<{ name: string; type: string }>
+  outputs: ReadonlyArray<{ name: string; type: string }>
+  inouts: ReadonlyArray<{ name: string; type: string }>
+}
+
+/** A library, as far as this module cares: a bag of function block declarations. */
+export interface LibraryFunctionBlockSource {
+  functionBlocks: ReadonlyArray<LibraryFunctionBlock>
+}
+
+/** One pin of a function block instance. */
+export interface FunctionBlockPin {
+  name: string
+  /** `local` covers FB-internal state; a caller decides whether to expose it. */
+  class: 'input' | 'output' | 'inOut' | 'local'
+  type: PLCVariableType
+}
+
+/** Normalise the library's POU-type spelling, which varies by source. */
+const isFunctionBlockType = (type: string): boolean => type.toLowerCase().replace(/[^a-z]/g, '') === 'functionblock'
+
+/**
+ * A library pin's type, which arrives as a bare IEC type name.
+ *
+ * An elementary name becomes a `base-type`, which the layout walkers describe.
+ * Anything else — a structure the library declares, or a generic like `ANY_NUM`
+ * that has no type until it is wired — becomes `user-data-type`, which the
+ * walkers either resolve or refuse with a reason. Guessing a width for a generic
+ * pin is the one thing that must not happen.
+ */
+const ELEMENTARY = new Set([
+  'BOOL',
+  'SINT',
+  'INT',
+  'DINT',
+  'LINT',
+  'USINT',
+  'UINT',
+  'UDINT',
+  'ULINT',
+  'BYTE',
+  'WORD',
+  'DWORD',
+  'LWORD',
+  'REAL',
+  'LREAL',
+  'TIME',
+  'DATE',
+  'TOD',
+  'DT',
+  'TIME_OF_DAY',
+  'DATE_AND_TIME',
+  'STRING',
+  'WSTRING',
+])
+
+const libraryPinType = (typeName: string): PLCVariableType =>
+  ELEMENTARY.has(typeName.toUpperCase())
+    ? { definition: 'base-type', value: typeName }
+    : { definition: 'user-data-type', value: typeName }
+
+/**
+ * The pins of `typeName`, or `null` when no function block by that name is
+ * declared in the project or in any supplied library.
+ *
+ * The project is searched first: a project POU shadows a library block of the
+ * same name, which is the same precedence the variables parser applies.
+ */
+export const resolveFunctionBlockPins = (
+  typeName: string,
+  pous: readonly PLCPou[] = [],
+  libraries: readonly LibraryFunctionBlockSource[] = [],
+): FunctionBlockPin[] | null => {
+  const wanted = typeName.toUpperCase()
+
+  const projectPou = pous.find((pou) => isFunctionBlockType(pou.pouType) && pou.name.toUpperCase() === wanted)
+  if (projectPou) {
+    return (projectPou.interface?.variables ?? [])
+      .filter(
+        (variable): variable is PLCVariable & { class: FunctionBlockPin['class'] } =>
+          variable.class === 'input' ||
+          variable.class === 'output' ||
+          variable.class === 'inOut' ||
+          variable.class === 'local',
+      )
+      .map((variable) => ({ name: variable.name, class: variable.class, type: variable.type }))
+  }
+
+  for (const library of libraries) {
+    const block = library.functionBlocks.find((entry) => entry.name.toUpperCase() === wanted)
+    if (block) {
+      // Declaration order within each group, inputs then in-outs then outputs —
+      // the same grouping the editor shows on the block, so the struct reads the
+      // way the block looks.
+      return [
+        ...block.inputs.map((pin) => ({ name: pin.name, class: 'input' as const, type: libraryPinType(pin.type) })),
+        ...block.inouts.map((pin) => ({ name: pin.name, class: 'inOut' as const, type: libraryPinType(pin.type) })),
+        ...block.outputs.map((pin) => ({ name: pin.name, class: 'output' as const, type: libraryPinType(pin.type) })),
+      ]
+    }
+  }
+
+  return null
+}

--- a/src/frontend/utils/PLC/function-block-pins.ts
+++ b/src/frontend/utils/PLC/function-block-pins.ts
@@ -14,6 +14,7 @@
  */
 
 import type { PLCPou, PLCVariable, PLCVariableType } from '../../../middleware/shared/ports/types'
+import { isBaseTypeName } from '../iec-types-registry'
 
 /**
  * The shape a library declares a function block in.
@@ -54,34 +55,16 @@ const isFunctionBlockType = (type: string): boolean => type.toLowerCase().replac
  * walkers either resolve or refuse with a reason. Guessing a width for a generic
  * pin is the one thing that must not happen.
  */
-const ELEMENTARY = new Set([
-  'BOOL',
-  'SINT',
-  'INT',
-  'DINT',
-  'LINT',
-  'USINT',
-  'UINT',
-  'UDINT',
-  'ULINT',
-  'BYTE',
-  'WORD',
-  'DWORD',
-  'LWORD',
-  'REAL',
-  'LREAL',
-  'TIME',
-  'DATE',
-  'TOD',
-  'DT',
-  'TIME_OF_DAY',
-  'DATE_AND_TIME',
-  'STRING',
-  'WSTRING',
-])
+// No local list of elementary names: `isBaseTypeName` reads
+// `strucpp/libs/iec-types.json`, so canonical spellings, aliases
+// (`TIME_OF_DAY`, `DATE_AND_TIME`), case and padding are all handled in one
+// place. The hand-written Set this replaces was a second copy of the compiler's
+// type list, which is exactly the drift the governing rule exists to prevent —
+// and a generic (`ANY_NUM`) is still not in the registry, so it still becomes a
+// `user-data-type` for the walkers to refuse rather than a guessed width.
 
 const libraryPinType = (typeName: string): PLCVariableType =>
-  ELEMENTARY.has(typeName.toUpperCase())
+  isBaseTypeName(typeName)
     ? { definition: 'base-type', value: typeName }
     : { definition: 'user-data-type', value: typeName }
 

--- a/src/frontend/utils/__tests__/generate-iec-string-to-variables.test.ts
+++ b/src/frontend/utils/__tests__/generate-iec-string-to-variables.test.ts
@@ -284,12 +284,49 @@ describe('parseIecStringToVariables', () => {
   })
 
   it('still accepts a comma-free non-array type the guard must not touch', () => {
-    // The guard keys on the comma alone, so bracketed non-array types such as a
-    // sized STRING keep parsing exactly as before.
-    const input = 'VAR\n  s : STRING[10];\nEND_VAR'
+    // The comma guard keys on the comma alone, so an ordinary user type keeps
+    // parsing exactly as before.
+    const input = 'VAR\n  m : Motor;\nEND_VAR'
     const result = parseIecStringToVariables(input)
 
-    expect(result[0].type).toEqual({ definition: 'user-data-type', value: 'STRING[10]' })
+    expect(result[0].type).toEqual({ definition: 'user-data-type', value: 'Motor' })
+  })
+
+  describe('a declared string length', () => {
+    // Legal IEC and legal CODESYS, and STruC++ does not accept it. Left alone it
+    // was not even recognised as a string: it became a user data type literally
+    // named "STRING[20]", emitted verbatim into the generated ST, where the
+    // compiler failed with `Expected Semicolon, found [` on a line the user
+    // never wrote.
+    it('is refused, naming the type and what to use instead', () => {
+      expect(() => parseIecStringToVariables('VAR\n  s : STRING[20];\nEND_VAR')).toThrow(
+        /A declared length is not supported on STRING — use plain STRING, which carries up to 126 characters/,
+      )
+    })
+
+    it('is refused for WSTRING too', () => {
+      expect(() => parseIecStringToVariables('VAR\n  s : WSTRING[8];\nEND_VAR')).toThrow(/not supported on WSTRING/)
+    })
+
+    it('is refused whatever the spacing and case', () => {
+      expect(() => parseIecStringToVariables('VAR\n  s : string [ 12 ];\nEND_VAR')).toThrow(/not supported on STRING/)
+    })
+
+    it('is refused when the length is empty, rather than becoming a stranger type', () => {
+      expect(() => parseIecStringToVariables('VAR\n  s : STRING[];\nEND_VAR')).toThrow(/not supported on STRING/)
+    })
+
+    it('still accepts a plain STRING', () => {
+      const result = parseIecStringToVariables('VAR\n  s : STRING;\nEND_VAR')
+
+      expect(result[0].type).toEqual({ definition: 'base-type', value: 'STRING' })
+    })
+
+    it('does not mistake an ARRAY OF STRING for a sized one', () => {
+      const result = parseIecStringToVariables('VAR\n  s : ARRAY[0..2] OF STRING;\nEND_VAR')
+
+      expect(result[0].type.definition).toBe('array')
+    })
   })
 
   it('still accepts a comma inside an initial value', () => {

--- a/src/frontend/utils/cpp/__tests__/block-interface.test.ts
+++ b/src/frontend/utils/cpp/__tests__/block-interface.test.ts
@@ -1,6 +1,6 @@
 import type { PLCVariable, VariableClass } from '../../../../middleware/shared/ports/types'
 import { CPP_RUNTIME_INTERNAL_VARIABLE } from '../addCppLocalVariables'
-import { cBlockInterfaceVariables, INTERFACE_CLASSES } from '../block-interface'
+import { cBlockExternalVariables, cBlockInterfaceVariables, INTERFACE_CLASSES } from '../block-interface'
 
 const variable = (name: string, cls?: VariableClass): PLCVariable => ({
   name,
@@ -41,9 +41,9 @@ describe('cBlockInterfaceVariables', () => {
     expect(names(result)).toEqual(['i1', 'i2', 'o1', 'o2', 't1', 't2'])
   })
 
-  it('leaves out a VAR_EXTERNAL, which is a GlobalVar pointer rather than a member', () => {
-    // Emitting a plain pointer to one would compile and silently drop the
-    // global's mutex, so externals are handled separately.
+  it('leaves out a VAR_EXTERNAL, which is collected separately', () => {
+    // An external reaches the same struct, but its pointer has to be taken
+    // under the global's lock, so the glue collects it on its own.
     expect(names(cBlockInterfaceVariables([variable('i', 'input'), variable('g', 'external')]))).toEqual(['i'])
   })
 
@@ -72,6 +72,45 @@ describe('cBlockInterfaceVariables', () => {
     cBlockInterfaceVariables(input)
 
     expect(names(input)).toEqual(['t', 'i'])
+  })
+
+  describe('cBlockExternalVariables', () => {
+    it('collects only the externals', () => {
+      const result = cBlockExternalVariables([
+        variable('i', 'input'),
+        variable('g', 'external'),
+        variable('l', 'local'),
+      ])
+
+      expect(names(result)).toEqual(['g'])
+    })
+
+    it('orders them by name, so the lock nesting is the same in every block', () => {
+      const result = cBlockExternalVariables([
+        variable('gZulu', 'external'),
+        variable('gAlpha', 'external'),
+        variable('gmike', 'external'),
+      ])
+
+      expect(names(result)).toEqual(['gAlpha', 'gmike', 'gZulu'])
+    })
+
+    it('orders case-insensitively, since the emitted names are uppercased', () => {
+      const result = cBlockExternalVariables([variable('gb', 'external'), variable('gA', 'external')])
+
+      expect(names(result)).toEqual(['gA', 'gb'])
+    })
+
+    it('does not reorder the caller’s array', () => {
+      const input = [variable('gZulu', 'external'), variable('gAlpha', 'external')]
+      cBlockExternalVariables(input)
+
+      expect(names(input)).toEqual(['gZulu', 'gAlpha'])
+    })
+
+    it('returns nothing when the block declares no externals', () => {
+      expect(cBlockExternalVariables([variable('i', 'input')])).toEqual([])
+    })
   })
 
   it('exposes the class order it applies', () => {

--- a/src/frontend/utils/cpp/__tests__/block-interface.test.ts
+++ b/src/frontend/utils/cpp/__tests__/block-interface.test.ts
@@ -1,0 +1,80 @@
+import type { PLCVariable, VariableClass } from '../../../../middleware/shared/ports/types'
+import { CPP_RUNTIME_INTERNAL_VARIABLE } from '../addCppLocalVariables'
+import { cBlockInterfaceVariables, INTERFACE_CLASSES } from '../block-interface'
+
+const variable = (name: string, cls?: VariableClass): PLCVariable => ({
+  name,
+  ...(cls ? { class: cls } : {}),
+  type: { definition: 'base-type', value: 'INT' },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const names = (variables: PLCVariable[]): string[] => variables.map((v) => v.name)
+
+describe('cBlockInterfaceVariables', () => {
+  it('carries every class a C++ block can reach as a plain member', () => {
+    const result = cBlockInterfaceVariables([
+      variable('i', 'input'),
+      variable('o', 'output'),
+      variable('io', 'inOut'),
+      variable('l', 'local'),
+      variable('t', 'temp'),
+    ])
+
+    expect(names(result)).toEqual(['i', 'o', 'io', 'l', 't'])
+  })
+
+  it('groups by class and keeps declaration order inside a class', () => {
+    // Grouping is cosmetic — the struct is filled by name — but a stable order
+    // keeps the generated header readable and its diffs meaningful.
+    const result = cBlockInterfaceVariables([
+      variable('t1', 'temp'),
+      variable('o1', 'output'),
+      variable('i1', 'input'),
+      variable('o2', 'output'),
+      variable('i2', 'input'),
+      variable('t2', 'temp'),
+    ])
+
+    expect(names(result)).toEqual(['i1', 'i2', 'o1', 'o2', 't1', 't2'])
+  })
+
+  it('leaves out a VAR_EXTERNAL, which is a GlobalVar pointer rather than a member', () => {
+    // Emitting a plain pointer to one would compile and silently drop the
+    // global's mutex, so externals are handled separately.
+    expect(names(cBlockInterfaceVariables([variable('i', 'input'), variable('g', 'external')]))).toEqual(['i'])
+  })
+
+  it('leaves out a configuration global, which is not a POU variable at all', () => {
+    expect(names(cBlockInterfaceVariables([variable('i', 'input'), variable('g', 'global')]))).toEqual(['i'])
+  })
+
+  it('leaves out the latch the toolchain injects into every C++ block', () => {
+    const result = cBlockInterfaceVariables([variable('i', 'input'), variable(CPP_RUNTIME_INTERNAL_VARIABLE, 'local')])
+
+    expect(names(result)).toEqual(['i'])
+  })
+
+  it('leaves out a variable with no class rather than guessing one', () => {
+    expect(names(cBlockInterfaceVariables([variable('i', 'input'), variable('mystery')]))).toEqual(['i'])
+  })
+
+  it('returns nothing for an empty interface', () => {
+    expect(cBlockInterfaceVariables([])).toEqual([])
+  })
+
+  it('does not mutate or alias the caller’s array', () => {
+    // The sort is on an internal copy: the emitters share one variable list and
+    // reordering it under them would be a very quiet bug.
+    const input = [variable('t', 'temp'), variable('i', 'input')]
+    cBlockInterfaceVariables(input)
+
+    expect(names(input)).toEqual(['t', 'i'])
+  })
+
+  it('exposes the class order it applies', () => {
+    expect(INTERFACE_CLASSES).toEqual(['input', 'output', 'inOut', 'local', 'temp'])
+  })
+})

--- a/src/frontend/utils/cpp/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/cpp/__tests__/generateSTCode.test.ts
@@ -153,21 +153,51 @@ describe('generateSTCode (cpp)', () => {
     expect(result).toContain('vars.D = &D[0] - 0;')
   })
 
-  it('filters out local variables', () => {
-    const localVar: PLCVariable = {
-      name: 'localVal',
-      class: 'local',
+  it('assigns a pointer for every class the struct carries', () => {
+    // The assignments and the struct must select the same variables: a field
+    // the assignments skip is a dangling pointer the user's first write
+    // follows. Both read `cBlockInterfaceVariables`, and this pins the result.
+    const byClass = (name: string, cls: PLCVariable['class']): PLCVariable => ({
+      name,
+      class: cls,
       type: { definition: 'base-type', value: 'INT' },
       location: '',
       documentation: '',
       debug: false,
-    }
+    })
 
     const result = generateSTCode({
       pouName: 'test',
-      allVariables: [makeScalarVar('x', 'input', 'INT'), localVar],
+      allVariables: [
+        makeScalarVar('x', 'input', 'INT'),
+        byClass('localVal', 'local'),
+        byClass('tempVal', 'temp'),
+        byClass('ioVal', 'inOut'),
+      ],
     })
 
-    expect(result).not.toContain('LOCALVAL')
+    expect(result).toContain('vars.X = &X;')
+    expect(result).toContain('vars.LOCALVAL = &LOCALVAL;')
+    expect(result).toContain('vars.TEMPVAL = &TEMPVAL;')
+    expect(result).toContain('vars.IOVAL = &IOVAL;')
+  })
+
+  it('does not assign the latch the toolchain injects', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [
+        makeScalarVar('x', 'input', 'INT'),
+        {
+          name: 'hasBeenInitialized',
+          class: 'local',
+          type: { definition: 'base-type', value: 'BOOL' },
+          location: '',
+          documentation: '',
+          debug: false,
+        },
+      ],
+    })
+
+    expect(result).not.toContain('vars.HASBEENINITIALIZED')
   })
 })

--- a/src/frontend/utils/cpp/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/cpp/__tests__/generateSTCode.test.ts
@@ -182,6 +182,103 @@ describe('generateSTCode (cpp)', () => {
     expect(result).toContain('vars.IOVAL = &IOVAL;')
   })
 
+  describe('VAR_EXTERNAL', () => {
+    const ext = (name: string): PLCVariable => ({
+      name,
+      class: 'external',
+      type: { definition: 'base-type', value: 'DINT' },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+
+    const extArray = (name: string, dimension: string): PLCVariable => ({
+      name,
+      class: 'external',
+      type: {
+        definition: 'array',
+        value: `ARRAY [${dimension}] OF INT`,
+        data: { baseType: { definition: 'base-type', value: 'INT' }, dimensions: [{ dimension }] },
+      },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+
+    it('takes each global’s pointer inside that global’s own lock', () => {
+      // strucpp holds a global as a `GlobalVar<V>` — value plus mutex — and
+      // hands out a `V*` only through `with_lock`. Filling the field anywhere
+      // else would compile and silently drop the lock.
+      const result = generateSTCode({ pouName: 'blk', allVariables: [ext('gCount')] })
+
+      expect(result).toContain('GCOUNT->with_lock([&](auto* g0) {')
+      expect(result).toContain('vars.GCOUNT = g0;')
+    })
+
+    it('deduces the pointer type instead of naming it', () => {
+      // `V` is IEC_DINT for a scalar, MOTOR for a structure, IEC_MODE for an
+      // enumeration and Array1D<IEC_INT, 0, 3> for an array. Writing any of
+      // those here would restate the compiler's layout, which has to stay
+      // stated in one place.
+      const result = generateSTCode({ pouName: 'blk', allVariables: [ext('gCount')] })
+
+      expect(result).toContain('auto* g0')
+      expect(result).not.toContain('GlobalVar<')
+    })
+
+    it('holds the lock across the call, not merely around the assignment', () => {
+      const result = generateSTCode({ pouName: 'blk', allVariables: [ext('gCount')] })
+      const openIdx = result.indexOf('GCOUNT->with_lock')
+      const callIdx = result.indexOf('blk_loop(&vars);')
+      const closeIdx = result.indexOf('});', callIdx)
+
+      expect(openIdx).toBeGreaterThan(-1)
+      expect(callIdx).toBeGreaterThan(openIdx)
+      expect(closeIdx).toBeGreaterThan(callIdx)
+    })
+
+    it('wraps setup as well as loop, since setup may touch a global too', () => {
+      const result = generateSTCode({ pouName: 'blk', allVariables: [ext('gCount')] })
+
+      expect(result.match(/GCOUNT->with_lock/g)).toHaveLength(2)
+    })
+
+    it('nests several globals in name order, identically in every block', () => {
+      // A fixed order is what stops two blocks taking the same pair of globals
+      // in opposite orders and deadlocking.
+      const result = generateSTCode({
+        pouName: 'blk',
+        allVariables: [ext('gZulu'), ext('gAlpha'), ext('gMike')],
+      })
+
+      const order = ['GALPHA', 'GMIKE', 'GZULU'].map((n) => result.indexOf(`${n}->with_lock`))
+      expect(order).toEqual([...order].sort((a, b) => a - b))
+    })
+
+    it('offsets an array global so it indexes by the declared IEC range', () => {
+      const result = generateSTCode({ pouName: 'blk', allVariables: [extArray('gArr', '2..5')] })
+
+      expect(result).toContain('vars.GARR = &g0_arr[2] - 2;')
+    })
+
+    it('binds the array dereference to a reference, never inline as `(*g)`', () => {
+      // This C++ sits inside an `{external}` block that the ST front end still
+      // scans, and `(*` opens a block comment there: inline would swallow the
+      // rest of the POU and fail as `Unclosed block comment`.
+      const result = generateSTCode({ pouName: 'blk', allVariables: [extArray('gArr', '0..3')] })
+
+      expect(result).toContain('auto& g0_arr = *g0;')
+      expect(result).not.toContain('(*g0)')
+    })
+
+    it('emits no wrapper at all when the block declares no externals', () => {
+      const result = generateSTCode({ pouName: 'blk', allVariables: [makeScalarVar('x', 'input', 'INT')] })
+
+      expect(result).not.toContain('with_lock')
+      expect(result).toContain('blk_loop(&vars);')
+    })
+  })
+
   it('does not assign the latch the toolchain injects', () => {
     const result = generateSTCode({
       pouName: 'test',

--- a/src/frontend/utils/cpp/addCppLocalVariables.ts
+++ b/src/frontend/utils/cpp/addCppLocalVariables.ts
@@ -1,8 +1,18 @@
 import type { PLCPou, PLCProjectData, PLCVariable } from '../../../middleware/shared/ports/types'
 
+/**
+ * Name of the latch this module injects into every C++ POU.
+ *
+ * Exported so the interface builder can leave it out of the block's struct:
+ * it is the toolchain's own machinery for calling `setup()` exactly once, not
+ * something the user declared, and a block that could write to it could
+ * re-run or skip its own initialisation.
+ */
+const CPP_RUNTIME_INTERNAL_VARIABLE = 'hasBeenInitialized'
+
 const createHasBeenInitializedVariable = (): PLCVariable => {
   return {
-    name: 'hasBeenInitialized',
+    name: CPP_RUNTIME_INTERNAL_VARIABLE,
     class: 'local',
     type: {
       definition: 'base-type',
@@ -34,4 +44,4 @@ const addCppLocalVariables = (projectData: PLCProjectData): PLCProjectData => {
   return processedData
 }
 
-export { addCppLocalVariables }
+export { addCppLocalVariables, CPP_RUNTIME_INTERNAL_VARIABLE }

--- a/src/frontend/utils/cpp/block-interface.ts
+++ b/src/frontend/utils/cpp/block-interface.ts
@@ -1,0 +1,65 @@
+import type { PLCVariable, VariableClass } from '../../../middleware/shared/ports/types'
+import { CPP_RUNTIME_INTERNAL_VARIABLE } from './addCppLocalVariables'
+
+/**
+ * Which of a C++ block's variables cross into its `<POU>_VARS` struct, and in
+ * what order.
+ *
+ * Three emitters have to describe the same interface: `generateCBlocksHeader`
+ * writes the struct, `generateSTCode` writes the pointer assignments that fill
+ * it, and `generateCBlocksCode` writes the macros that bind the user's names to
+ * it. If any one of them selects a different set, the mismatch is not a caught
+ * error — a field the assignments skip is a dangling pointer the user's first
+ * write follows. So the selection is made once, here, and all three read it.
+ *
+ * Selection rule: everything the user declared, minus what this toolchain
+ * injected. That is the whole point of the parity work — a native block should
+ * see its own Variables Table the way an ST block does, not a curated subset.
+ *
+ * `external` is deliberately absent. A `VAR_EXTERNAL` is not a plain member on
+ * the strucpp side but a `GlobalVar<V>*` carrying the global's mutex, so it
+ * needs a pointer of a different shape and an accessor that holds the lock —
+ * handled separately rather than folded in here, where it would silently lose
+ * the lock. `global` is absent for the same reason it is absent from a POU: it
+ * is a configuration-level declaration, not a POU variable.
+ */
+const INTERFACE_CLASSES: readonly VariableClass[] = ['input', 'output', 'inOut', 'local', 'temp']
+
+/**
+ * Rank used to group struct fields by class.
+ *
+ * Grouping is cosmetic — the struct is filled by name, so order changes nothing
+ * about correctness — but a stable order keeps the generated header readable and
+ * keeps its diffs meaningful when a user adds a variable. Declaration order is
+ * preserved inside each class.
+ */
+const CLASS_ORDER = new Map<VariableClass, number>(INTERFACE_CLASSES.map((cls, index) => [cls, index]))
+
+/**
+ * The variables that cross into the C block, grouped by class and stable within
+ * each group.
+ *
+ * `hasBeenInitialized` is filtered out: the toolchain adds it to every C++ POU
+ * to drive the one-shot `setup()` call, so it is machinery rather than something
+ * the user declared, and exposing it would both clutter the struct and let a
+ * block overwrite its own initialisation latch.
+ */
+const cBlockInterfaceVariables = (variables: readonly PLCVariable[]): PLCVariable[] => {
+  // The rank is captured while filtering rather than looked up again in the
+  // comparator: there it would need a fallback for a class that cannot occur,
+  // which is an unreachable branch and a lie about what the data can be.
+  const ranked: Array<{ variable: PLCVariable; rank: number; position: number }> = []
+
+  variables.forEach((variable, position) => {
+    if (variable.name === CPP_RUNTIME_INTERNAL_VARIABLE) return
+    const rank = variable.class === undefined ? undefined : CLASS_ORDER.get(variable.class)
+    if (rank === undefined) return
+    ranked.push({ variable, rank, position })
+  })
+
+  return ranked
+    .sort((a, b) => (a.rank !== b.rank ? a.rank - b.rank : a.position - b.position))
+    .map(({ variable }) => variable)
+}
+
+export { cBlockInterfaceVariables, INTERFACE_CLASSES }

--- a/src/frontend/utils/cpp/block-interface.ts
+++ b/src/frontend/utils/cpp/block-interface.ts
@@ -16,12 +16,11 @@ import { CPP_RUNTIME_INTERNAL_VARIABLE } from './addCppLocalVariables'
  * injected. That is the whole point of the parity work — a native block should
  * see its own Variables Table the way an ST block does, not a curated subset.
  *
- * `external` is deliberately absent. A `VAR_EXTERNAL` is not a plain member on
- * the strucpp side but a `GlobalVar<V>*` carrying the global's mutex, so it
- * needs a pointer of a different shape and an accessor that holds the lock —
- * handled separately rather than folded in here, where it would silently lose
- * the lock. `global` is absent for the same reason it is absent from a POU: it
- * is a configuration-level declaration, not a POU variable.
+ * `external` is absent here and handled by `cBlockExternalVariables` below: it
+ * reaches the same struct, but the pointer that fills the field has to be taken
+ * under the global's lock, so the two are collected separately. `global` is
+ * absent for the reason it is absent from a POU at all: it is a
+ * configuration-level declaration, not a POU variable.
  */
 const INTERFACE_CLASSES: readonly VariableClass[] = ['input', 'output', 'inOut', 'local', 'temp']
 
@@ -62,4 +61,33 @@ const cBlockInterfaceVariables = (variables: readonly PLCVariable[]): PLCVariabl
     .map(({ variable }) => variable)
 }
 
-export { cBlockInterfaceVariables, INTERFACE_CLASSES }
+/**
+ * The block's `VAR_EXTERNAL` declarations, in a fixed order.
+ *
+ * These end up in the same struct and are used by the same name as everything
+ * else — from inside the block, a global should read and write like any other
+ * variable, which is what it already does in ST. What differs is how the
+ * pointer is obtained.
+ *
+ * strucpp holds a global as a `GlobalVar<V>`: the value together with that
+ * global's own mutex, reached through `with_lock`, which runs a callable with a
+ * `V*` while holding the lock. The ST glue therefore wraps the block's entry
+ * points in one such callable per external and takes each pointer inside. The
+ * lambda's parameter is deduced, so nothing here has to name `V` — the
+ * compiler's own layout stays the only statement of it, arrays and structures
+ * included.
+ *
+ * The lock is held across the whole call rather than per access, which is
+ * stronger than what an ST body gets and is the right default for a block that
+ * may read a global, compute, and write it back. Ordering the externals by name
+ * makes the nesting order the same in every block, so two blocks holding two
+ * globals can never take them in opposite orders; an ST body never holds more
+ * than one lock at a time and so can never close a cycle either.
+ */
+const cBlockExternalVariables = (variables: readonly PLCVariable[]): PLCVariable[] =>
+  variables
+    .filter((variable) => variable.class === 'external')
+    .slice()
+    .sort((a, b) => a.name.toUpperCase().localeCompare(b.name.toUpperCase()))
+
+export { cBlockExternalVariables, cBlockInterfaceVariables, INTERFACE_CLASSES }

--- a/src/frontend/utils/cpp/generateSTCode.ts
+++ b/src/frontend/utils/cpp/generateSTCode.ts
@@ -1,6 +1,6 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
 import { getArrayStartIndex, isArrayVariable } from '../PLC/array-codegen-helpers'
-import { cBlockInterfaceVariables } from './block-interface'
+import { cBlockExternalVariables, cBlockInterfaceVariables } from './block-interface'
 
 type STCodeGenerationParams = {
   pouName: string
@@ -32,6 +32,56 @@ const generateVariableAssignment = (variable: PLCVariable): string => {
   return `vars.${name} = &${name};\n`
 }
 
+/**
+ * Wrap a call to the block so every `VAR_EXTERNAL` pointer is taken, and held,
+ * under its global's own lock.
+ *
+ * strucpp holds a global as a `GlobalVar<V>` — the value plus that global's
+ * mutex — and hands out access through `with_lock`, which runs a callable with a
+ * `V*` while the lock is held. So the call is nested inside one such callable
+ * per external, and each `vars` field is filled from the pointer that arrives.
+ *
+ * The lambda parameter is `auto*`, deduced. That matters beyond brevity: `V` is
+ * `IEC_DINT` for a scalar, `MOTOR` for a structure, `IEC_MODE` for an
+ * enumeration and `Array1D<IEC_INT, 0, 3>` for an array, and writing those out
+ * here would be this file restating the compiler's layout — the one thing that
+ * has to stay stated in exactly one place. Deduction keeps it there.
+ *
+ * An array is offset the same way a non-global one is, so the field stays a
+ * pointer to the element type and `name[i]` indexes by the declared IEC range.
+ * The dereference is bound to a reference on its own line rather than written
+ * inline as `(*g)[lo]`: this C++ sits inside an `{external}` block that the ST
+ * front end still scans, and `(*` opens a block comment there — inline would
+ * swallow the rest of the POU and fail as `Unclosed block comment`.
+ *
+ * Nesting is in name order (see `cBlockExternalVariables`), identical in every
+ * block, so no two blocks can take the same pair of globals in opposite orders.
+ * The lock is therefore held for the whole call rather than per access —
+ * stronger than an ST body gets, and the right default for code that may read a
+ * global, compute from it, and write it back.
+ */
+const wrapInGlobalLocks = (externals: PLCVariable[], call: string): string => {
+  if (externals.length === 0) return call
+
+  let open = ''
+  let close = ''
+  externals.forEach((variable, depth) => {
+    const name = variable.name.toUpperCase()
+    const held = `g${depth}`
+    open += `${name}->with_lock([&](auto* ${held}) {\n`
+    if (isArrayVariable(variable)) {
+      const startIndex = getArrayStartIndex(variable)
+      open += `auto& ${held}_arr = *${held};\n`
+      open += `vars.${name} = &${held}_arr[${startIndex}] - ${startIndex};\n`
+    } else {
+      open += `vars.${name} = ${held};\n`
+    }
+    close = `});\n` + close
+  })
+
+  return `${open}${call}\n${close}`.trimEnd()
+}
+
 const generateSTCode = (params: STCodeGenerationParams): string => {
   const { pouName, allVariables } = params
 
@@ -43,6 +93,10 @@ const generateSTCode = (params: STCodeGenerationParams): string => {
   for (const variable of cBlockInterfaceVariables(allVariables)) {
     variableAssignments += generateVariableAssignment(variable)
   }
+
+  // Externals are filled inside the lock wrapper instead, immediately before
+  // each call — their pointers are only valid while that lock is held.
+  const externals = cBlockExternalVariables(allVariables)
 
   // Header `{external}` block: declare the user-visible struct, fill
   // the pointer fields. STruC++ emits this body verbatim into the
@@ -56,12 +110,12 @@ ${structName} vars;
 ${variableAssignments}}
 if hasBeenInitialized = False then
 {external
-${setupFunctionName}(&vars);
+${wrapInGlobalLocks(externals, `${setupFunctionName}(&vars);`)}
 }
 hasBeenInitialized := True;
 end_if;
 {external
-${loopFunctionName}(&vars);
+${wrapInGlobalLocks(externals, `${loopFunctionName}(&vars);`)}
 }`
 }
 

--- a/src/frontend/utils/cpp/generateSTCode.ts
+++ b/src/frontend/utils/cpp/generateSTCode.ts
@@ -1,5 +1,5 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
-import { getArrayStartIndex, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { getArrayStartIndex, isArrayVariable, multiDimensionalContainerType } from '../PLC/array-codegen-helpers'
 import { cBlockExternalVariables, cBlockInterfaceVariables } from './block-interface'
 
 type STCodeGenerationParams = {
@@ -17,14 +17,23 @@ type STCodeGenerationParams = {
  *   `*name = 5` / `name = "hi"` routes through the wrapper's
  *   `operator=`, which respects forcing.
  *
- * - Base-type arrays: `vars.NAME = &NAME[lower] - lower`. `Array1D<T>`
+ * - One-dimensional arrays: `vars.NAME = &NAME[lower] - lower`. `Array1D<T>`
  *   stores `std::array<IECVar<T>, N>`; element 0 sits at `&NAME[lower]`.
  *   Subtracting `lower` shifts the pointer so `vars->NAME[iec_idx]`
  *   works for any IEC index in the declared range. Per-element forcing
  *   is preserved.
+ *
+ * - Multi-dimensional arrays: `vars.NAME = &NAME`. The offset trick does not
+ *   extend past rank one — `IEC_ARRAY_2D` has no `operator[]` and takes every
+ *   index in one `operator()` call — so the container itself is passed and the
+ *   block indexes it as `grid(i, j)`, the same accessor the compiler's own
+ *   generated code uses.
  */
 const generateVariableAssignment = (variable: PLCVariable): string => {
   const name = variable.name.toUpperCase()
+  if (multiDimensionalContainerType(variable)) {
+    return `vars.${name} = &${name};\n`
+  }
   if (isArrayVariable(variable)) {
     const startIndex = getArrayStartIndex(variable)
     return `vars.${name} = &${name}[${startIndex}] - ${startIndex};\n`
@@ -69,11 +78,13 @@ const wrapInGlobalLocks = (externals: PLCVariable[], call: string): string => {
     const name = variable.name.toUpperCase()
     const held = `g${depth}`
     open += `${name}->with_lock([&](auto* ${held}) {\n`
-    if (isArrayVariable(variable)) {
+    if (isArrayVariable(variable) && !multiDimensionalContainerType(variable)) {
       const startIndex = getArrayStartIndex(variable)
       open += `auto& ${held}_arr = *${held};\n`
       open += `vars.${name} = &${held}_arr[${startIndex}] - ${startIndex};\n`
     } else {
+      // Scalars, structures, function block instances and multi-dimensional
+      // arrays are all passed as the pointer `with_lock` already hands over.
       open += `vars.${name} = ${held};\n`
     }
     close = `});\n` + close

--- a/src/frontend/utils/cpp/generateSTCode.ts
+++ b/src/frontend/utils/cpp/generateSTCode.ts
@@ -1,5 +1,6 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
 import { getArrayStartIndex, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { cBlockInterfaceVariables } from './block-interface'
 
 type STCodeGenerationParams = {
   pouName: string
@@ -34,16 +35,14 @@ const generateVariableAssignment = (variable: PLCVariable): string => {
 const generateSTCode = (params: STCodeGenerationParams): string => {
   const { pouName, allVariables } = params
 
-  const inputVariables = allVariables.filter((v) => v.class === 'input')
-  const outputVariables = allVariables.filter((v) => v.class === 'output')
-
   const structName = `${pouName.toUpperCase()}_VARS`
   const setupFunctionName = `${pouName.toLowerCase()}_setup`
   const loopFunctionName = `${pouName.toLowerCase()}_loop`
 
   let variableAssignments = ''
-  for (const variable of inputVariables) variableAssignments += generateVariableAssignment(variable)
-  for (const variable of outputVariables) variableAssignments += generateVariableAssignment(variable)
+  for (const variable of cBlockInterfaceVariables(allVariables)) {
+    variableAssignments += generateVariableAssignment(variable)
+  }
 
   // Header `{external}` block: declare the user-visible struct, fill
   // the pointer fields. STruC++ emits this body verbatim into the

--- a/src/frontend/utils/generate-iec-string-to-variables.ts
+++ b/src/frontend/utils/generate-iec-string-to-variables.ts
@@ -1,6 +1,7 @@
 import type { LibraryState } from '../../middleware/shared/ports/library-types'
 import { baseTypeSchema } from '../../middleware/shared/ports/plc-schemas'
 import type { PLCDataType, PLCPou, PLCVariable } from '../../middleware/shared/ports/types'
+import { DEBUG_STRING_CAP } from './variable-sizes'
 
 const varBlockToClass: Record<string, PLCVariable['class']> = {
   VAR: 'local',
@@ -221,7 +222,7 @@ export const parseIecStringToVariables = (
     // `Expected Semicolon, found [` pointing at a line the user never wrote.
     //
     // Refusing here says what is true today. The transport carries a fixed
-    // 126-character budget, so a declared length would not be honoured even if
+    // DEBUG_STRING_CAP-character budget, so a declared length would not be honoured even if
     // it parsed; when the compiler grows the declaration, this guard is the one
     // place that has to change.
     const lengthQualifiedString = /^(W?STRING)\s*\[\s*[^\]]*\]$/i.exec(parsedType)
@@ -229,7 +230,7 @@ export const parseIecStringToVariables = (
       const keyword = lengthQualifiedString[1].toUpperCase()
       throw new Error(
         `Syntax error on line ${lineNumber}: "${line}". A declared length is not supported on ${keyword} — ` +
-          `use plain ${keyword}, which carries up to 126 characters.`,
+          `use plain ${keyword}, which carries up to ${DEBUG_STRING_CAP} characters.`,
       )
     }
 

--- a/src/frontend/utils/generate-iec-string-to-variables.ts
+++ b/src/frontend/utils/generate-iec-string-to-variables.ts
@@ -225,7 +225,16 @@ export const parseIecStringToVariables = (
     // DEBUG_STRING_CAP-character budget, so a declared length would not be honoured even if
     // it parsed; when the compiler grows the declaration, this guard is the one
     // place that has to change.
-    const lengthQualifiedString = /^(W?STRING)\s*\[\s*[^\]]*\]$/i.exec(parsedType)
+    // Both shapes it can take: on its own (`msg : STRING[20]`) and as an ARRAY's
+    // element type (`tags : ARRAY [0..3] OF STRING[20]`). The array form needs
+    // its own alternative because `parseArrayType` only accepts a bare
+    // identifier after `OF`, so a length-qualified element matches nothing and
+    // used to fall through every branch to the compiler — which then reported
+    // `Expected Semicolon, found [` at a column the user never wrote, plus two
+    // cascading errors on the FOLLOWING line, so even the line number misled.
+    const lengthQualifiedString =
+      /^(W?STRING)\s*\[\s*[^\]]*\]$/i.exec(parsedType) ??
+      /^ARRAY\s*\[[^\]]*\]\s+OF\s+(W?STRING)\s*\[\s*[^\]]*\]\s*$/i.exec(parsedType)
     if (lengthQualifiedString) {
       const keyword = lengthQualifiedString[1].toUpperCase()
       throw new Error(

--- a/src/frontend/utils/generate-iec-string-to-variables.ts
+++ b/src/frontend/utils/generate-iec-string-to-variables.ts
@@ -213,6 +213,26 @@ export const parseIecStringToVariables = (
       )
     }
 
+    // A length-qualified string (`STRING[20]`, `WSTRING[8]`) is legal IEC and
+    // legal CODESYS, and STruC++ does not accept it. Left alone it is not even
+    // recognised as a string: it becomes a user data type literally named
+    // "STRING[20]", which is persisted, shown in the type cell, and emitted
+    // verbatim into the generated ST — where the compiler fails with
+    // `Expected Semicolon, found [` pointing at a line the user never wrote.
+    //
+    // Refusing here says what is true today. The transport carries a fixed
+    // 126-character budget, so a declared length would not be honoured even if
+    // it parsed; when the compiler grows the declaration, this guard is the one
+    // place that has to change.
+    const lengthQualifiedString = /^(W?STRING)\s*\[\s*[^\]]*\]$/i.exec(parsedType)
+    if (lengthQualifiedString) {
+      const keyword = lengthQualifiedString[1].toUpperCase()
+      throw new Error(
+        `Syntax error on line ${lineNumber}: "${line}". A declared length is not supported on ${keyword} — ` +
+          `use plain ${keyword}, which carries up to 126 characters.`,
+      )
+    }
+
     const baseCheck = baseTypeSchema.safeParse(parsedType.toUpperCase())
 
     const isUserFunctionBlock = pous?.some(

--- a/src/frontend/utils/python/__tests__/block-interface.test.ts
+++ b/src/frontend/utils/python/__tests__/block-interface.test.ts
@@ -1,0 +1,121 @@
+import type { PLCVariable, VariableClass } from '../../../../middleware/shared/ports/types'
+import {
+  INBOUND_CLASSES,
+  OUTBOUND_CLASSES,
+  pythonInboundVariables,
+  pythonInterfaceVariables,
+  pythonOutboundVariables,
+  pythonRefusedVariables,
+} from '../block-interface'
+
+const variable = (name: string, cls?: VariableClass): PLCVariable => ({
+  name,
+  ...(cls ? { class: cls } : {}),
+  type: { definition: 'base-type', value: 'INT' },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const names = (variables: PLCVariable[]): string[] => variables.map((v) => v.name)
+
+describe('python block interface', () => {
+  const all = [
+    variable('i', 'input'),
+    variable('o', 'output'),
+    variable('io', 'inOut'),
+    variable('l', 'local'),
+    variable('g', 'external'),
+  ]
+
+  it('sends an input in only', () => {
+    expect(names(pythonInboundVariables(all))).toContain('i')
+    expect(names(pythonOutboundVariables(all))).not.toContain('i')
+  })
+
+  it('brings an output back only', () => {
+    expect(names(pythonOutboundVariables(all))).toContain('o')
+    expect(names(pythonInboundVariables(all))).not.toContain('o')
+  })
+
+  it.each(['io', 'l', 'g'])('carries %s both ways, so the PLC keeps owning the value', (name) => {
+    // A block that never assigns one sends back what it received. That is what
+    // makes a VAR the block's own state and keeps it visible to the debugger.
+    expect(names(pythonInboundVariables(all))).toContain(name)
+    expect(names(pythonOutboundVariables(all))).toContain(name)
+  })
+
+  it('orders both directions by class, then by declaration', () => {
+    // The order carries no meaning; it only has to be identical everywhere,
+    // because the struct layout and the format string are positional.
+    expect(names(pythonInboundVariables(all))).toEqual(['i', 'io', 'l', 'g'])
+    expect(names(pythonOutboundVariables(all))).toEqual(['o', 'io', 'l', 'g'])
+  })
+
+  it('keeps declaration order within one class', () => {
+    const vars = [variable('b', 'input'), variable('a', 'input')]
+    expect(names(pythonInboundVariables(vars))).toEqual(['b', 'a'])
+  })
+
+  it('carries no temp in either direction — it is refused instead', () => {
+    const vars = [variable('i', 'input'), variable('scratch', 'temp')]
+    expect(names(pythonInboundVariables(vars))).toEqual(['i'])
+    expect(names(pythonOutboundVariables(vars))).toEqual([])
+  })
+
+  it('carries no configuration global, which is not a POU variable', () => {
+    expect(names(pythonInboundVariables([variable('g', 'global')]))).toEqual([])
+  })
+
+  it('carries no variable that has no class rather than guessing one', () => {
+    expect(names(pythonInboundVariables([variable('mystery')]))).toEqual([])
+  })
+
+  it.each(['first_run', 'shm_in_ptr', 'shm_out_ptr'])('leaves the injected %s out of the structs', (name) => {
+    // These are declared `local` by the toolchain. Marshalling them would hand
+    // the block its own mapped segment addresses to overwrite.
+    const vars = [variable('i', 'input'), variable(name, 'local')]
+    expect(names(pythonInboundVariables(vars))).toEqual(['i'])
+    expect(names(pythonOutboundVariables(vars))).toEqual([])
+  })
+
+  it('does not reorder the caller’s array', () => {
+    const input = [variable('l', 'local'), variable('i', 'input')]
+    pythonInboundVariables(input)
+    expect(names(input)).toEqual(['l', 'i'])
+  })
+
+  describe('pythonInterfaceVariables', () => {
+    it('lists every variable that crosses at all, each exactly once', () => {
+      expect(names(pythonInterfaceVariables(all))).toEqual(['i', 'io', 'l', 'g', 'o'])
+    })
+
+    it('is empty when nothing crosses', () => {
+      expect(pythonInterfaceVariables([variable('scratch', 'temp')])).toEqual([])
+    })
+  })
+
+  describe('pythonRefusedVariables', () => {
+    it('refuses a temp, and says what to do instead', () => {
+      const refused = pythonRefusedVariables([variable('i', 'input'), variable('scratch', 'temp')])
+
+      expect(refused).toHaveLength(1)
+      expect(refused[0].variable.name).toBe('scratch')
+      expect(refused[0].reason).toContain('VAR_TEMP')
+      expect(refused[0].reason).toContain('Declare it under VAR instead')
+    })
+
+    it('refuses nothing a Python block can express', () => {
+      expect(pythonRefusedVariables(all)).toEqual([])
+    })
+
+    it('refuses nothing for a variable with no class', () => {
+      expect(pythonRefusedVariables([variable('mystery')])).toEqual([])
+    })
+  })
+
+  it('exposes the class order each direction applies', () => {
+    expect(INBOUND_CLASSES).toEqual(['input', 'inOut', 'local', 'external'])
+    expect(OUTBOUND_CLASSES).toEqual(['output', 'inOut', 'local', 'external'])
+  })
+})

--- a/src/frontend/utils/python/__tests__/encodeCharactersFromVariable.test.ts
+++ b/src/frontend/utils/python/__tests__/encodeCharactersFromVariable.test.ts
@@ -1,5 +1,9 @@
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import type { ShmWalkContext } from '../shm-leaves'
 import { encodeCharactersFromVariable } from '../encodeCharactersFromVariable'
+
+/** These tests describe layout, not direction. */
+const ctx: ShmWalkContext = { direction: 'in' }
 
 const makeScalarVar = (name: string, baseType: string): PLCVariable => ({
   name,
@@ -28,84 +32,84 @@ const makeArrayVar = (name: string, baseType: string, dimension: string): PLCVar
 
 describe('encodeCharactersFromVariable', () => {
   it('returns = for empty array', () => {
-    expect(encodeCharactersFromVariable([])).toBe('=')
+    expect(encodeCharactersFromVariable([], ctx)).toBe('=')
   })
 
   it('returns = for undefined input', () => {
-    expect(encodeCharactersFromVariable(undefined as unknown as PLCVariable[])).toBe('=')
+    expect(encodeCharactersFromVariable(undefined as unknown as PLCVariable[], ctx)).toBe('=')
   })
 
   it('returns = for null input', () => {
-    expect(encodeCharactersFromVariable(null as unknown as PLCVariable[])).toBe('=')
+    expect(encodeCharactersFromVariable(null as unknown as PLCVariable[], ctx)).toBe('=')
   })
 
   it('encodes BOOL as B', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'BOOL')])).toBe('=B')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'BOOL')], ctx)).toBe('=B')
   })
 
   it('encodes SINT as b', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'SINT')])).toBe('=b')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'SINT')], ctx)).toBe('=b')
   })
 
   it('encodes INT as h', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'INT')])).toBe('=h')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'INT')], ctx)).toBe('=h')
   })
 
   it('encodes DINT as i', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'DINT')])).toBe('=i')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'DINT')], ctx)).toBe('=i')
   })
 
   it('encodes LINT as q', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'LINT')])).toBe('=q')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'LINT')], ctx)).toBe('=q')
   })
 
   it('encodes USINT as B', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'USINT')])).toBe('=B')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'USINT')], ctx)).toBe('=B')
   })
 
   it('encodes UINT as H', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'UINT')])).toBe('=H')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'UINT')], ctx)).toBe('=H')
   })
 
   it('encodes UDINT as I', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'UDINT')])).toBe('=I')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'UDINT')], ctx)).toBe('=I')
   })
 
   it('encodes ULINT as Q', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'ULINT')])).toBe('=Q')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'ULINT')], ctx)).toBe('=Q')
   })
 
   it('encodes REAL as f', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'REAL')])).toBe('=f')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'REAL')], ctx)).toBe('=f')
   })
 
   it('encodes LREAL as d', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'LREAL')])).toBe('=d')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'LREAL')], ctx)).toBe('=d')
   })
 
   it('encodes BYTE as B', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'BYTE')])).toBe('=B')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'BYTE')], ctx)).toBe('=B')
   })
 
   it('encodes WORD as H', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'WORD')])).toBe('=H')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'WORD')], ctx)).toBe('=H')
   })
 
   it('encodes DWORD as I', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'DWORD')])).toBe('=I')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'DWORD')], ctx)).toBe('=I')
   })
 
   it('encodes LWORD as Q', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'LWORD')])).toBe('=Q')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'LWORD')], ctx)).toBe('=Q')
   })
 
   it('encodes STRING as b126s', () => {
-    expect(encodeCharactersFromVariable([makeScalarVar('x', 'STRING')])).toBe('=b126s')
+    expect(encodeCharactersFromVariable([makeScalarVar('x', 'STRING')], ctx)).toBe('=b126s')
   })
 
   it('encodes multiple variables in order', () => {
     const vars = [makeScalarVar('a', 'INT'), makeScalarVar('b', 'REAL'), makeScalarVar('c', 'BOOL')]
-    expect(encodeCharactersFromVariable(vars)).toBe('=hfB')
+    expect(encodeCharactersFromVariable(vars, ctx)).toBe('=hfB')
   })
 
   it('describes nothing at all when one type cannot cross', () => {
@@ -116,27 +120,27 @@ describe('encodeCharactersFromVariable', () => {
     // half-formed one.
     const vars = [makeScalarVar('x', 'UNKNOWN_TYPE'), makeScalarVar('y', 'INT')]
 
-    expect(encodeCharactersFromVariable(vars)).toBe('=')
+    expect(encodeCharactersFromVariable(vars, ctx)).toBe('=')
   })
 
   it('encodes array variables with repeated format chars', () => {
     const vars = [makeArrayVar('arr', 'INT', '0..4')]
-    expect(encodeCharactersFromVariable(vars)).toBe('=5h')
+    expect(encodeCharactersFromVariable(vars, ctx)).toBe('=5h')
   })
 
   it('encodes array of strings by repeating the full encoding string', () => {
     const vars = [makeArrayVar('arr', 'STRING', '0..2')]
-    expect(encodeCharactersFromVariable(vars)).toBe('=b126sb126sb126s')
+    expect(encodeCharactersFromVariable(vars, ctx)).toBe('=b126sb126sb126s')
   })
 
   it('skips array with unknown base type and warns', () => {
     const vars = [makeArrayVar('arr', 'UNKNOWN', '0..2')]
-    const result = encodeCharactersFromVariable(vars)
+    const result = encodeCharactersFromVariable(vars, ctx)
     expect(result).toBe('=')
   })
 
   it('encodes mixed scalar and array variables', () => {
     const vars = [makeScalarVar('a', 'INT'), makeArrayVar('b', 'REAL', '0..2'), makeScalarVar('c', 'BOOL')]
-    expect(encodeCharactersFromVariable(vars)).toBe('=h3fB')
+    expect(encodeCharactersFromVariable(vars, ctx)).toBe('=h3fB')
   })
 })

--- a/src/frontend/utils/python/__tests__/encodeCharactersFromVariable.test.ts
+++ b/src/frontend/utils/python/__tests__/encodeCharactersFromVariable.test.ts
@@ -108,10 +108,15 @@ describe('encodeCharactersFromVariable', () => {
     expect(encodeCharactersFromVariable(vars)).toBe('=hfB')
   })
 
-  it('skips unknown scalar types and warns', () => {
+  it('describes nothing at all when one type cannot cross', () => {
+    // Emitting a format for the fields it *can* describe is the corruption this
+    // whole design exists to prevent: a dropped field does not go missing, it
+    // shifts every later field's offset. The compile path refuses such a POU
+    // before reaching here; a direct caller gets an empty layout rather than a
+    // half-formed one.
     const vars = [makeScalarVar('x', 'UNKNOWN_TYPE'), makeScalarVar('y', 'INT')]
-    const result = encodeCharactersFromVariable(vars)
-    expect(result).toBe('=h')
+
+    expect(encodeCharactersFromVariable(vars)).toBe('=')
   })
 
   it('encodes array variables with repeated format chars', () => {

--- a/src/frontend/utils/python/__tests__/encodeCharactersFromVariable.test.ts
+++ b/src/frontend/utils/python/__tests__/encodeCharactersFromVariable.test.ts
@@ -36,11 +36,11 @@ describe('encodeCharactersFromVariable', () => {
   })
 
   it('returns = for undefined input', () => {
-    expect(encodeCharactersFromVariable(undefined as unknown as PLCVariable[], ctx)).toBe('=')
+    expect(encodeCharactersFromVariable(undefined, ctx)).toBe('=')
   })
 
   it('returns = for null input', () => {
-    expect(encodeCharactersFromVariable(null as unknown as PLCVariable[], ctx)).toBe('=')
+    expect(encodeCharactersFromVariable(null, ctx)).toBe('=')
   })
 
   it('encodes BOOL as B', () => {

--- a/src/frontend/utils/python/__tests__/encodeCharactersFromVariable.test.ts
+++ b/src/frontend/utils/python/__tests__/encodeCharactersFromVariable.test.ts
@@ -128,9 +128,15 @@ describe('encodeCharactersFromVariable', () => {
     expect(encodeCharactersFromVariable(vars, ctx)).toBe('=5h')
   })
 
-  it('encodes array of strings by repeating the full encoding string', () => {
+  it('emits nothing for an array of STRING, which the walk refuses', () => {
+    // This used to assert `'=b126sb126sb126s'` — the whole multi-item format
+    // repeated per element, which is 6 slots where the decoder consumed 3, so
+    // every variable declared after it read from the wrong offset. A repeat
+    // count applies only to the first item of a struct format, so an array of
+    // strings cannot be expressed as one leaf at all; the walk now refuses it
+    // and the caller reports that instead of emitting a misaligned format.
     const vars = [makeArrayVar('arr', 'STRING', '0..2')]
-    expect(encodeCharactersFromVariable(vars, ctx)).toBe('=b126sb126sb126s')
+    expect(encodeCharactersFromVariable(vars, ctx)).toBe('=')
   })
 
   it('skips array with unknown base type and warns', () => {

--- a/src/frontend/utils/python/__tests__/generatePythonLspPreamble.test.ts
+++ b/src/frontend/utils/python/__tests__/generatePythonLspPreamble.test.ts
@@ -42,17 +42,11 @@ describe('generatePythonLspPreamble', () => {
       expect(result.lineCount).toBe(0)
     })
 
-    it('returns empty text when no variables are input/output class', () => {
-      // The runtime injection only wires `input` and `output` through
-      // shared memory.  Local / temp / external would never become
-      // runtime globals — preamble must skip them so the LSP doesn't
-      // pretend they exist.
-      const vars = [
-        makeScalar('localOnly', 'local', 'INT'),
-        makeScalar('tempOnly', 'temp', 'BOOL'),
-        makeScalar('externOnly', 'external', 'REAL'),
-        makeScalar('ioOnly', 'inOut', 'INT'),
-      ]
+    it('returns empty text when no variable crosses the boundary', () => {
+      // The preamble declares exactly what the runtime injection makes a module
+      // global. A VAR_TEMP is refused outright for a Python block, so it never
+      // becomes one — declaring it would have the LSP pretend it exists.
+      const vars = [makeScalar('tempOnly', 'temp', 'BOOL')]
       const result = generatePythonLspPreamble(vars)
       expect(result.text).toBe('')
       expect(result.lineCount).toBe(0)
@@ -139,22 +133,78 @@ describe('generatePythonLspPreamble', () => {
   })
 
   describe('class filtering', () => {
-    it('includes only input + output, excludes local / temp / inOut / external', () => {
+    it('declares every class the runtime makes a module global, and no other', () => {
+      // The preamble has to match the injection exactly: anything it omits shows
+      // as an undefined name in the editor for a variable that does exist, and
+      // anything it adds is a name that will not be there at runtime.
       const vars = [
         makeScalar('inA', 'input', 'INT'),
         makeScalar('outB', 'output', 'REAL'),
         makeScalar('localC', 'local', 'BOOL'),
-        makeScalar('tempD', 'temp', 'INT'),
         makeScalar('ioE', 'inOut', 'INT'),
         makeScalar('extF', 'external', 'INT'),
+        makeScalar('tempD', 'temp', 'INT'),
       ]
       const result = generatePythonLspPreamble(vars)
       expect(result.text).toContain('inA: int = 0')
       expect(result.text).toContain('outB: float = 0.0')
-      expect(result.text).not.toContain('localC')
+      expect(result.text).toContain('localC: bool = False')
+      expect(result.text).toContain('ioE: int = 0')
+      expect(result.text).toContain('extF: int = 0')
+      // VAR_TEMP is refused for a Python block, so it is never a global.
       expect(result.text).not.toContain('tempD')
-      expect(result.text).not.toContain('ioE')
-      expect(result.text).not.toContain('extF')
+    })
+
+    it('declares a variable that travels both ways exactly once', () => {
+      const vars = [makeScalar('ioE', 'inOut', 'INT')]
+      const result = generatePythonLspPreamble(vars)
+
+      expect(result.text.match(/ioE: int = 0/g)).toHaveLength(1)
+    })
+  })
+
+  describe('types the annotation cannot map', () => {
+    it('declares a STRING as an empty str, not None', () => {
+      // Pyright needs a definite assignment compatible with the annotation, so
+      // the literal has to match the declared type rather than be a placeholder.
+      const result = generatePythonLspPreamble([makeScalar('label', 'input', 'STRING')])
+
+      expect(result.text).toContain("label: str = ''")
+    })
+
+    it('skips an array whose element type has no Python equivalent', () => {
+      // The runtime does not marshal one either, so declaring it would have the
+      // editor offer a name that will not exist at runtime.
+      const arrayOfStructs: PLCVariable = {
+        name: 'bank',
+        class: 'input',
+        type: {
+          definition: 'array',
+          value: 'ARRAY [0..3] OF Motor',
+          data: {
+            baseType: { definition: 'user-data-type', value: 'Motor' },
+            dimensions: [{ dimension: '0..3' }],
+          },
+        },
+        location: '',
+        documentation: '',
+        debug: false,
+      }
+
+      expect(generatePythonLspPreamble([arrayOfStructs]).text).toBe('')
+    })
+
+    it('skips an array whose declaration carries no element type', () => {
+      const malformed: PLCVariable = {
+        name: 'bank',
+        class: 'input',
+        type: { definition: 'array', value: 'ARRAY [0..3] OF INT' },
+        location: '',
+        documentation: '',
+        debug: false,
+      }
+
+      expect(generatePythonLspPreamble([malformed]).text).toBe('')
     })
   })
 
@@ -224,7 +274,9 @@ describe('generatePythonLspPreamble', () => {
   describe('variableNameByPreambleLine', () => {
     it('is empty when no variables produce declaration lines', () => {
       expect(generatePythonLspPreamble([]).variableNameByPreambleLine.size).toBe(0)
-      expect(generatePythonLspPreamble([makeScalar('x', 'local', 'BOOL')]).variableNameByPreambleLine.size).toBe(0)
+      // `temp` is the class a Python block cannot express, so it is the one that
+      // produces no declaration. A `local` does become a module global now.
+      expect(generatePythonLspPreamble([makeScalar('x', 'temp', 'BOOL')]).variableNameByPreambleLine.size).toBe(0)
     })
 
     it('maps each declaration line to the corresponding variable name in order', () => {

--- a/src/frontend/utils/python/__tests__/generatePythonLspPreamble.test.ts
+++ b/src/frontend/utils/python/__tests__/generatePythonLspPreamble.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Autonomy / OpenPLC Project
-import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { generatePythonLspPreamble } from '../generatePythonLspPreamble'
 
 const makeScalar = (
@@ -209,19 +209,155 @@ describe('generatePythonLspPreamble', () => {
   })
 
   describe('user-data-type handling', () => {
-    it('skips user-data-type variables (structs / enums)', () => {
-      // `injectPythonRuntime` doesn't pack these into shared memory
-      // either; LSP stays in lockstep by not declaring them.
-      const structVar: PLCVariable = {
-        name: 'myStruct',
+    const structVar: PLCVariable = {
+      name: 'm',
+      class: 'input',
+      type: { definition: 'user-data-type', value: 'Motor' },
+      location: '',
+      documentation: '',
+      debug: false,
+    }
+
+    const MOTOR: PLCDataType = {
+      name: 'Motor',
+      derivation: 'structure',
+      variable: [
+        { name: 'speed', type: { definition: 'base-type', value: 'int' } },
+        { name: 'label', type: { definition: 'base-type', value: 'string' } },
+      ],
+    }
+
+    const MODE: PLCDataType = {
+      name: 'Mode',
+      derivation: 'enumerated',
+      values: [{ description: 'STOPPED' }, { description: 'RUNNING' }],
+    }
+
+    it('declares a structure as a class, so the editor resolves m.speed', () => {
+      const result = generatePythonLspPreamble([structVar], [MOTOR])
+
+      expect(result.text).toContain('class Motor:')
+      expect(result.text).toContain('    speed: int')
+      expect(result.text).toContain('    label: str')
+      expect(result.text).toContain('m: Motor = None')
+    })
+
+    it('declares an enumeration as an IntEnum with its members', () => {
+      const enumVar: PLCVariable = { ...structVar, name: 'md', type: { definition: 'user-data-type', value: 'Mode' } }
+      const result = generatePythonLspPreamble([enumVar], [MODE])
+
+      expect(result.text).toContain('from enum import IntEnum')
+      expect(result.text).toContain('class Mode(IntEnum):')
+      expect(result.text).toContain('    RUNNING = 1')
+    })
+
+    it('declares a nested structure before the one referencing it', () => {
+      const rig: PLCDataType = {
+        name: 'Rig',
+        derivation: 'structure',
+        variable: [{ name: 'drive', type: { definition: 'user-data-type', value: 'Motor' } }],
+      }
+      const rigVar: PLCVariable = { ...structVar, name: 'r', type: { definition: 'user-data-type', value: 'Rig' } }
+      const result = generatePythonLspPreamble([rigVar], [rig, MOTOR])
+
+      expect(result.text.indexOf('class Motor:')).toBeLessThan(result.text.indexOf('class Rig:'))
+      expect(result.text).toContain('    drive: Motor')
+    })
+
+    it('declares each type once however many variables use it', () => {
+      const b: PLCVariable = { ...structVar, name: 'b' }
+      const result = generatePythonLspPreamble([structVar, b], [MOTOR])
+
+      expect(result.text.match(/class Motor:/g)).toHaveLength(1)
+    })
+
+    it('still declares the variable when the project declares no data types', () => {
+      // The compile path refuses such a POU, but the editor should not silently
+      // drop a name the user can see in the Variables Table.
+      const result = generatePythonLspPreamble([structVar])
+
+      expect(result.text).toContain('m: Motor = None')
+      expect(result.text).not.toContain('class Motor:')
+    })
+
+    it('keeps the line map pointing past the type stubs', () => {
+      // The diagnostic line mapping depends on the declaration's absolute line,
+      // so stubs inserted above it have to shift it.
+      const withStubs = generatePythonLspPreamble([structVar], [MOTOR])
+      const withoutStubs = generatePythonLspPreamble([structVar])
+      const lineOf = (p: typeof withStubs) => [...p.variableNameByPreambleLine.entries()][0][0]
+
+      expect(lineOf(withStubs)).toBeGreaterThan(lineOf(withoutStubs))
+    })
+
+    it('annotates a member whose type has no Python equivalent as Any', () => {
+      // A function block instance inside a structure is refused at compile time,
+      // but the stub still has to name the attribute or Pyright reports every
+      // use of it as an error on code the user has not finished writing.
+      const rig: PLCDataType = {
+        name: 'Rig',
+        derivation: 'structure',
+        variable: [{ name: 'timer', type: { definition: 'base-type', value: 'float32' } }],
+      }
+      const rigVar: PLCVariable = { ...structVar, name: 'r', type: { definition: 'user-data-type', value: 'Rig' } }
+      const result = generatePythonLspPreamble([rigVar], [rig])
+
+      expect(result.text).toContain('    timer: Any')
+    })
+
+    it('declares neither the variable nor a stub for an array of structures', () => {
+      // It has no Python annotation and is refused at compile time, so the
+      // editor stays in lockstep with what the build will accept.
+      const bank: PLCVariable = {
+        name: 'bank',
         class: 'input',
-        type: { definition: 'user-data-type', value: 'MyStruct' },
+        type: {
+          definition: 'array',
+          value: 'ARRAY [0..1] OF Motor',
+          data: {
+            baseType: { definition: 'user-data-type', value: 'Motor' },
+            dimensions: [{ dimension: '0..1' }],
+          },
+        },
         location: '',
         documentation: '',
         debug: false,
       }
-      const result = generatePythonLspPreamble([structVar])
+      const result = generatePythonLspPreamble([bank], [MOTOR])
+
       expect(result.text).toBe('')
+    })
+
+    it('stops rather than recursing when a structure contains itself', () => {
+      const loop: PLCDataType = {
+        name: 'Loop',
+        derivation: 'structure',
+        variable: [{ name: 'inner', type: { definition: 'user-data-type', value: 'Loop' } }],
+      }
+      const loopVar: PLCVariable = { ...structVar, name: 'l', type: { definition: 'user-data-type', value: 'Loop' } }
+
+      expect(generatePythonLspPreamble([loopVar], [loop]).text).toContain('class Loop:')
+    })
+
+    it('declares a scalar alongside a structure without stubbing the scalar', () => {
+      const result = generatePythonLspPreamble([makeScalar('x', 'input', 'INT'), structVar], [MOTOR])
+
+      expect(result.text).toContain('x: int = 0')
+      expect(result.text).toContain('class Motor:')
+      expect(result.text).not.toContain('class int')
+    })
+
+    it('ignores a named ARRAY type, which has no class to declare', () => {
+      const named: PLCDataType = {
+        name: 'Bank',
+        derivation: 'array',
+        baseType: { definition: 'base-type', value: 'INT' },
+        dimensions: [{ dimension: '0..3' }],
+      }
+      const bankVar: PLCVariable = { ...structVar, name: 'b', type: { definition: 'user-data-type', value: 'Bank' } }
+      const result = generatePythonLspPreamble([bankVar], [named])
+
+      expect(result.text).not.toContain('class Bank')
     })
   })
 

--- a/src/frontend/utils/python/__tests__/generatePythonLspPreamble.test.ts
+++ b/src/frontend/utils/python/__tests__/generatePythonLspPreamble.test.ts
@@ -239,7 +239,26 @@ describe('generatePythonLspPreamble', () => {
       expect(result.text).toContain('class Motor:')
       expect(result.text).toContain('    speed: int')
       expect(result.text).toContain('    label: str')
-      expect(result.text).toContain('m: Motor = None')
+      // Constructed, not `None`: the stub declares members and no `__init__`,
+      // so `Motor()` type-checks, where `= None` did not.
+      expect(result.text).toContain('m: Motor = Motor()')
+    })
+
+    it('annotates with the type’s own spelling, not the variable’s', () => {
+      // `m : MOTOR` against a type declared `Motor` used to annotate `MOTOR`,
+      // which names no class — Pyright reported `"MOTOR" is not defined`.
+      const shouty: PLCVariable = { ...structVar, type: { definition: 'user-data-type', value: 'MOTOR' } }
+      const result = generatePythonLspPreamble([shouty], [MOTOR])
+
+      expect(result.text).toContain('m: Motor = Motor()')
+      expect(result.text).not.toContain('m: MOTOR')
+    })
+
+    it('seeds an enumeration with its first member, which a class cannot be called for', () => {
+      const enumVar: PLCVariable = { ...structVar, name: 'md', type: { definition: 'user-data-type', value: 'Mode' } }
+      const result = generatePythonLspPreamble([enumVar], [MODE])
+
+      expect(result.text).toContain('md: Mode = Mode.STOPPED')
     })
 
     it('declares an enumeration as an IntEnum with its members', () => {
@@ -271,12 +290,14 @@ describe('generatePythonLspPreamble', () => {
       expect(result.text.match(/class Motor:/g)).toHaveLength(1)
     })
 
-    it('still declares the variable when the project declares no data types', () => {
+    it('annotates a type the project does not declare as Any', () => {
       // The compile path refuses such a POU, but the editor should not silently
-      // drop a name the user can see in the Variables Table.
+      // drop a name the user can see in the Variables Table — nor annotate it
+      // with a class that has no stub, which is what `m: Motor = None` did:
+      // Pyright reported `"Motor" is not defined` on a line the user cannot see.
       const result = generatePythonLspPreamble([structVar])
 
-      expect(result.text).toContain('m: Motor = None')
+      expect(result.text).toContain('m: Any = None')
       expect(result.text).not.toContain('class Motor:')
     })
 

--- a/src/frontend/utils/python/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/python/__tests__/generateSTCode.test.ts
@@ -223,7 +223,10 @@ describe('generateSTCode (python)', () => {
     // the field becomes 254 bytes where Python packs 253 — every later field
     // then decodes from the wrong offset. Only a real compile surfaced this.
     const preamble = result.slice(0, result.indexOf('shm_data_in_t'))
-    const packedRegion = preamble.slice(preamble.indexOf('#pragma pack(push, 1)'), preamble.indexOf('#pragma pack(pop)'))
+    const packedRegion = preamble.slice(
+      preamble.indexOf('#pragma pack(push, 1)'),
+      preamble.indexOf('#pragma pack(pop)'),
+    )
     expect(packedRegion).toContain('shm_iec_string_t')
     expect(packedRegion).toContain('shm_iec_wstring_t')
   })
@@ -318,24 +321,102 @@ describe('generateSTCode (python)', () => {
     expect(result).toContain('python_block_loader')
   })
 
-  it('skips locals — only input/output appear in SHM structs', () => {
-    const localVar: PLCVariable = {
-      name: 'localVal',
-      class: 'local',
-      type: { definition: 'base-type', value: 'INT' },
+  describe('variable classes', () => {
+    const byClass = (name: string, cls: PLCVariable['class'], type = 'INT'): PLCVariable => ({
+      name,
+      class: cls,
+      type: { definition: 'base-type', value: type },
       location: '',
       documentation: '',
       debug: false,
-    }
-
-    const result = generateSTCode({
-      pouName: 'test',
-      allVariables: [makeScalarVar('x', 'input', 'INT'), localVar, makeScalarVar('y', 'output', 'INT')],
-      processedPythonCode: '',
     })
 
-    expect(result).toContain('int16_t x;')
-    expect(result).toContain('int16_t y;')
-    expect(result).not.toContain('localVal')
+    const structs = (result: string) => {
+      const inStart = result.indexOf('typedef struct {')
+      const inEnd = result.indexOf('} shm_data_in_t;')
+      const outStart = result.indexOf('typedef struct {', inEnd)
+      const outEnd = result.indexOf('} shm_data_out_t;')
+      return { inbound: result.slice(inStart, inEnd), outbound: result.slice(outStart, outEnd) }
+    }
+
+    it('sends an input in only and an output back only', () => {
+      const result = generateSTCode({
+        pouName: 'test',
+        allVariables: [makeScalarVar('x', 'input', 'INT'), makeScalarVar('y', 'output', 'INT')],
+        processedPythonCode: '',
+      })
+      const { inbound, outbound } = structs(result)
+
+      expect(inbound).toContain('int16_t x;')
+      expect(inbound).not.toContain('int16_t y;')
+      expect(outbound).toContain('int16_t y;')
+      expect(outbound).not.toContain('int16_t x;')
+    })
+
+    it.each([
+      ['inOut', 'ioVal'],
+      ['local', 'localVal'],
+      ['external', 'gVal'],
+    ])('sends a %s both ways, so the PLC keeps owning the value', (cls, name) => {
+      // A block that never assigns one sends back what it received. That is what
+      // makes a VAR the block's own state, keeps it visible to the debugger, and
+      // lets it be retained.
+      const result = generateSTCode({
+        pouName: 'test',
+        allVariables: [makeScalarVar('x', 'input', 'INT'), byClass(name, cls as PLCVariable['class'])],
+        processedPythonCode: '',
+      })
+      const { inbound, outbound } = structs(result)
+
+      expect(inbound).toContain(`int16_t ${name};`)
+      expect(outbound).toContain(`int16_t ${name};`)
+    })
+
+    it('leaves a temp out entirely — it is refused before reaching here', () => {
+      const result = generateSTCode({
+        pouName: 'test',
+        allVariables: [makeScalarVar('x', 'input', 'INT'), byClass('scratch', 'temp')],
+        processedPythonCode: '',
+      })
+
+      expect(result).not.toContain('scratch')
+    })
+
+    it('copies an external under the global’s own lock', () => {
+      // A VAR_EXTERNAL is a `GlobalVar<V>*`, not a member. Naming it directly
+      // would compile and copy from the wrong place holding no lock at all.
+      const result = generateSTCode({
+        pouName: 'test',
+        allVariables: [byClass('gVal', 'external')],
+        processedPythonCode: '',
+      })
+
+      expect(result).toContain('GVAL->with_lock([&](auto* __g) {')
+      expect(result).toContain('auto& __r = *__g;')
+      expect(result).toContain('data_in.gVal = __r;')
+    })
+
+    it('never writes `(*` inside the external block, which the ST lexer reads as a comment', () => {
+      const result = generateSTCode({
+        pouName: 'test',
+        allVariables: [byClass('gVal', 'external')],
+        processedPythonCode: '',
+      })
+
+      expect(result).not.toContain('(*__g)')
+    })
+
+    it('locks each external on its own rather than nesting them', () => {
+      // The stub only copies values; it runs no user code, so one lock at a time
+      // is enough and there is no lock ordering to reason about.
+      const result = generateSTCode({
+        pouName: 'test',
+        allVariables: [byClass('gA', 'external'), byClass('gB', 'external')],
+        processedPythonCode: '',
+      })
+      const closeBeforeSecondOpen = result.indexOf('});') < result.indexOf('GB->with_lock')
+
+      expect(closeBeforeSecondOpen).toBe(true)
+    })
   })
 })

--- a/src/frontend/utils/python/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/python/__tests__/generateSTCode.test.ts
@@ -1,7 +1,7 @@
 import type { PLCDataType, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { generateSTCode } from '../generateSTCode'
 
-const makeScalarVar = (name: string, cls: 'input' | 'output', baseType: string): PLCVariable => ({
+const makeScalarVar = (name: string, cls: PLCVariable['class'], baseType: string): PLCVariable => ({
   name,
   class: cls,
   type: { definition: 'base-type', value: baseType },
@@ -10,7 +10,7 @@ const makeScalarVar = (name: string, cls: 'input' | 'output', baseType: string):
   debug: false,
 })
 
-const makeStringVar = (name: string, cls: 'input' | 'output'): PLCVariable => ({
+const makeStringVar = (name: string, cls: PLCVariable['class']): PLCVariable => ({
   name,
   class: cls,
   type: { definition: 'base-type', value: 'string' },
@@ -19,7 +19,7 @@ const makeStringVar = (name: string, cls: 'input' | 'output'): PLCVariable => ({
   debug: false,
 })
 
-const makeWStringVar = (name: string, cls: 'input' | 'output'): PLCVariable => ({
+const makeWStringVar = (name: string, cls: PLCVariable['class']): PLCVariable => ({
   name,
   class: cls,
   type: { definition: 'base-type', value: 'wstring' },
@@ -28,7 +28,7 @@ const makeWStringVar = (name: string, cls: 'input' | 'output'): PLCVariable => (
   debug: false,
 })
 
-const makeArrayVar = (name: string, cls: 'input' | 'output', baseType: string, dimension: string): PLCVariable => ({
+const makeArrayVar = (name: string, cls: PLCVariable['class'], baseType: string, dimension: string): PLCVariable => ({
   name,
   class: cls,
   type: {
@@ -286,6 +286,38 @@ describe('generateSTCode (python)', () => {
     expect(result).toContain(
       'MSG = strucpp::IECString<254>(reinterpret_cast<const char*>(data_out.msg.body), data_out.msg.len);',
     )
+  })
+
+  it('guards the STRING write-back so a value wider than the transport is not truncated', () => {
+    // The transport carries STR_MAX_LEN characters; an `IECStringVar` holds 254.
+    // An IEC string longer than the transport reaches Python already truncated,
+    // so writing Python's copy back would shorten the IEC variable permanently
+    // — with no user code having touched it. Reachable only since `local`,
+    // `inOut` and `external` began to round-trip.
+    // Every class that writes back gets the guard: an `external` reaches its
+    // global through the lock guard (`__r`) rather than by name, so the check is
+    // asserted on all four rather than on one spelling.
+    for (const cls of ['output', 'inOut', 'local', 'external'] as const) {
+      const result = generateSTCode({
+        pouName: 'test',
+        allVariables: [makeStringVar('msg', cls)],
+        processedPythonCode: '',
+      })
+      expect(result).toContain('if (__cur.length() <= STR_MAX_LEN)')
+      expect(result).toMatch(/auto __cur = (MSG|__r)\.get\(\);/)
+    }
+  })
+
+  it('guards the WSTRING write-back the same way', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [makeWStringVar('wmsg', 'output')],
+      processedPythonCode: '',
+    })
+
+    expect(result).toContain('auto __cur = WMSG.get();')
+    expect(result).toContain('if (__cur.length() <= STR_MAX_LEN)')
+    expect(result).toContain('strucpp::IECWString<254>(reinterpret_cast<const char16_t*>(data_out.wmsg.body)')
   })
 
   it('reads / writes the runtime SHM-pointer locals through their IECVars', () => {

--- a/src/frontend/utils/python/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/python/__tests__/generateSTCode.test.ts
@@ -1,4 +1,4 @@
-import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { generateSTCode } from '../generateSTCode'
 
 const makeScalarVar = (name: string, cls: 'input' | 'output', baseType: string): PLCVariable => ({
@@ -319,6 +319,81 @@ describe('generateSTCode (python)', () => {
     expect(result).toContain('const char *script_name = "controller.py";')
     expect(result).toContain('const char script_template[] =')
     expect(result).toContain('python_block_loader')
+  })
+
+  describe('structures and enumerations', () => {
+    const MOTOR: PLCDataType = {
+      name: 'Motor',
+      derivation: 'structure',
+      variable: [
+        { name: 'speed', type: { definition: 'base-type', value: 'int' } },
+        { name: 'label', type: { definition: 'base-type', value: 'string' } },
+      ],
+    }
+    const MODE: PLCDataType = {
+      name: 'Mode',
+      derivation: 'enumerated',
+      values: [{ description: 'STOPPED' }, { description: 'RUNNING' }],
+    }
+    const userTyped = (name: string, cls: PLCVariable['class'], typeName: string): PLCVariable => ({
+      name,
+      class: cls,
+      type: { definition: 'user-data-type', value: typeName },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+    const run = (variables: PLCVariable[], dataTypes: PLCDataType[]) =>
+      generateSTCode({ pouName: 'test', allVariables: variables, processedPythonCode: '', dataTypes })
+
+    it('flattens a structure into one field per member', () => {
+      const result = run([userTyped('m', 'input', 'Motor')], [MOTOR])
+
+      expect(result).toContain('int16_t m_speed;')
+      expect(result).toContain('shm_iec_string_t m_label;')
+    })
+
+    it('copies each member individually, by its name on the strucpp side', () => {
+      const result = run([userTyped('m', 'input', 'Motor')], [MOTOR])
+
+      expect(result).toContain('data_in.m_speed = M.SPEED;')
+      expect(result).toContain('auto __s = M.LABEL.get();')
+    })
+
+    it('reads an enumeration through both wrappers before casting to its integer', () => {
+      // `IEC_ENUM_Var::get()` yields an `IEC_ENUM_Value`, which converts to the
+      // scoped enum but not to an integer.
+      const result = run([userTyped('md', 'input', 'Mode')], [MODE])
+
+      expect(result).toContain('data_in.md = static_cast<int16_t>(MD.get().get());')
+    })
+
+    it('writes an enumeration back through set(), not operator=', () => {
+      // `operator=` would copy-assign a whole temporary wrapper and take its
+      // forced state along; `set()` leaves forcing where it was.
+      const result = run([userTyped('md', 'output', 'Mode')], [MODE])
+
+      expect(result).toContain('MD.set(static_cast<MODE>(data_out.md));')
+    })
+
+    it('writes a structure member back individually', () => {
+      const result = run([userTyped('m', 'output', 'Motor')], [MOTOR])
+
+      expect(result).toContain('M.SPEED = data_out.m_speed;')
+    })
+
+    it('seeds a structure output from what the PLC holds', () => {
+      const result = run([userTyped('m', 'output', 'Motor')], [MOTOR])
+
+      expect(result).toContain('seed_out.m_speed = M.SPEED;')
+    })
+
+    it('copies a structure member of an external under the global’s lock', () => {
+      const result = run([userTyped('g', 'external', 'Motor')], [MOTOR])
+
+      expect(result).toContain('G->with_lock([&](auto* __g) {')
+      expect(result).toContain('data_in.g_speed = __r.SPEED;')
+    })
   })
 
   describe('variable classes', () => {

--- a/src/frontend/utils/python/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/python/__tests__/generateSTCode.test.ts
@@ -396,6 +396,95 @@ describe('generateSTCode (python)', () => {
     })
   })
 
+  describe('function block instances', () => {
+    const TON_LIB = {
+      functionBlocks: [
+        {
+          name: 'TON',
+          inputs: [
+            { name: 'IN', type: 'BOOL' },
+            { name: 'PT', type: 'TIME' },
+          ],
+          inouts: [],
+          outputs: [
+            { name: 'Q', type: 'BOOL' },
+            { name: 'ET', type: 'TIME' },
+          ],
+        },
+      ],
+    }
+    const instance = (name: string): PLCVariable => ({
+      name,
+      class: 'local',
+      type: { definition: 'derived', value: 'TON' },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+    const run = (variables: PLCVariable[]) =>
+      generateSTCode({
+        pouName: 'blk',
+        allVariables: variables,
+        processedPythonCode: '',
+        dataTypes: [],
+        libraries: [TON_LIB],
+      })
+
+    it('calls the instance once per scan, as ST', () => {
+      // This is what makes an instance usable from Python at all: Python cannot
+      // call it, but the wrapper runs in the PLC process where it lives. Written
+      // as ST so the call goes through the same path a hand-written `ton0();`
+      // would, including the EN gate the compiler puts at every call site.
+      expect(run([instance('ton0')])).toContain('ton0();')
+    })
+
+    it('calls each instance, in declaration order', () => {
+      const result = run([instance('first'), instance('second')])
+
+      expect(result.indexOf('first();')).toBeLessThan(result.indexOf('second();'))
+    })
+
+    it('applies Python’s pin writes before the call and publishes after', () => {
+      // Otherwise setting `ton0.IN` would see `ton0.Q` answer a scan late for no
+      // reason. The exchange splits around the call.
+      const result = run([instance('ton0')])
+      const applied = result.indexOf('TON0.IN = data_out.ton0_IN;')
+      const called = result.indexOf('ton0();')
+      const published = result.indexOf('data_in.ton0_Q = TON0.Q;')
+
+      expect(applied).toBeGreaterThan(-1)
+      expect(called).toBeGreaterThan(applied)
+      expect(published).toBeGreaterThan(called)
+    })
+
+    it('puts every pin in the inbound struct and only drivable pins in the outbound one', () => {
+      const result = run([instance('ton0')])
+      const inStart = result.indexOf('typedef struct {', result.indexOf('#pragma pack(pop)'))
+      const inbound = result.slice(inStart, result.indexOf('} shm_data_in_t;'))
+      const outbound = result.slice(
+        result.indexOf('typedef struct {', result.indexOf('} shm_data_in_t;')),
+        result.indexOf('} shm_data_out_t;'),
+      )
+
+      expect(inbound).toContain('uint8_t ton0_Q;')
+      expect(inbound).toContain('int64_t ton0_ET;')
+      expect(outbound).toContain('uint8_t ton0_IN;')
+      expect(outbound).not.toContain('ton0_Q')
+    })
+
+    it('keeps the single-block exchange when there is no instance', () => {
+      // The split only earns its keep when something has to run between the two
+      // copies; without an instance the wrapper stays as it was.
+      const result = generateSTCode({
+        pouName: 'blk',
+        allVariables: [makeScalarVar('x', 'input', 'INT')],
+        processedPythonCode: '',
+      })
+
+      expect(result.match(/\{external/g)?.length).toBe(3)
+    })
+  })
+
   describe('variable classes', () => {
     const byClass = (name: string, cls: PLCVariable['class'], type = 'INT'): PLCVariable => ({
       name,

--- a/src/frontend/utils/python/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/python/__tests__/generateSTCode.test.ts
@@ -19,6 +19,15 @@ const makeStringVar = (name: string, cls: 'input' | 'output'): PLCVariable => ({
   debug: false,
 })
 
+const makeWStringVar = (name: string, cls: 'input' | 'output'): PLCVariable => ({
+  name,
+  class: cls,
+  type: { definition: 'base-type', value: 'wstring' },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
 const makeArrayVar = (name: string, cls: 'input' | 'output', baseType: string, dimension: string): PLCVariable => ({
   name,
   class: cls,
@@ -153,8 +162,74 @@ describe('generateSTCode (python)', () => {
     })
 
     expect(result).toContain('auto __s = MSG.get();')
-    expect(result).toContain('data_in.msg.len = (__strlen_t)__s.length();')
-    expect(result).toContain('std::memcpy(data_in.msg.body, __s.c_str(), STR_MAX_LEN);')
+    // The length is clamped to the transport budget and the body zero-filled
+    // before the copy, so a short string cannot carry the previous tail.
+    expect(result).toContain('data_in.msg.len = __n;')
+    expect(result).toContain('std::memset(data_in.msg.body, 0, STR_MAX_LEN);')
+    expect(result).toContain('std::memcpy(data_in.msg.body, __s.c_str(), (size_t)__n);')
+  })
+
+  it('packs the string typedefs themselves, not just the structs using them', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [makeWStringVar('wmsg', 'input')],
+      processedPythonCode: '',
+    })
+
+    // Regression: `#pragma pack` applies to the struct being defined, not to a
+    // member type already laid out elsewhere. Without its own packed region,
+    // shm_iec_wstring_t's uint16_t body forces a padding byte after `len` and
+    // the field becomes 254 bytes where Python packs 253 — every later field
+    // then decodes from the wrong offset. Only a real compile surfaced this.
+    const preamble = result.slice(0, result.indexOf('shm_data_in_t'))
+    const packedRegion = preamble.slice(preamble.indexOf('#pragma pack(push, 1)'), preamble.indexOf('#pragma pack(pop)'))
+    expect(packedRegion).toContain('shm_iec_string_t')
+    expect(packedRegion).toContain('shm_iec_wstring_t')
+  })
+
+  it('reads WSTRING inputs as UTF-16 code units, not bytes', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [makeWStringVar('wmsg', 'input')],
+      processedPythonCode: '',
+    })
+
+    // WSTRING gets its own struct shape; sharing STRING's meant copying
+    // STR_MAX_LEN *bytes* (half the characters) under a character count.
+    expect(result).toContain('shm_iec_wstring_t wmsg;')
+    expect(result).toContain('std::memcpy(data_in.wmsg.body, __s.c_str(), (size_t)__n * sizeof(uint16_t));')
+    expect(result).toContain('std::memset(data_in.wmsg.body, 0, STR_MAX_LEN * sizeof(uint16_t));')
+  })
+
+  it('writes WSTRING outputs back through char16_t, not a reinterpreted char*', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [makeWStringVar('wmsg', 'output')],
+      processedPythonCode: '',
+    })
+
+    expect(result).toContain('reinterpret_cast<const char16_t*>(data_out.wmsg.body)')
+    expect(result).toContain('strucpp::IECWString<254>')
+  })
+
+  it('emits int64 fields for the duration and calendar types', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [
+        makeScalarVar('t', 'input', 'time'),
+        makeScalarVar('d', 'input', 'date'),
+        makeScalarVar('td', 'input', 'tod'),
+        makeScalarVar('dt', 'input', 'dt'),
+      ],
+      processedPythonCode: '',
+    })
+
+    // Previously these reached the C struct as int64_t while the Python format
+    // string omitted them entirely, shifting every later field.
+    expect(result).toContain('int64_t t;')
+    expect(result).toContain('int64_t d;')
+    expect(result).toContain('int64_t td;')
+    expect(result).toContain('int64_t dt;')
   })
 
   it('writes STRING outputs back through IECStringVar (force-respect)', () => {

--- a/src/frontend/utils/python/__tests__/generateSTCode.test.ts
+++ b/src/frontend/utils/python/__tests__/generateSTCode.test.ts
@@ -169,6 +169,47 @@ describe('generateSTCode (python)', () => {
     expect(result).toContain('std::memcpy(data_in.msg.body, __s.c_str(), (size_t)__n);')
   })
 
+  it('publishes the live IEC output values into shared memory at startup', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [makeScalarVar('count', 'output', 'dint'), makeStringVar('msg', 'output')],
+      processedPythonCode: '',
+    })
+
+    // Shared memory is created zeroed, so without this the Python side has
+    // nothing to seed from and falls back to its declarations — overwriting
+    // the IEC value (a retained one included) on the first write-back.
+    expect(result).toContain('shm_data_out_t seed_out;')
+    expect(result).toContain('seed_out.count = COUNT;')
+    expect(result).toContain('seed_out.msg.len = __n;')
+    expect(result).toContain('memcpy(shm_out_ptr, &seed_out, sizeof(seed_out));')
+  })
+
+  it('publishes the seed inside the first_run branch, after the loader maps the segment', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [makeScalarVar('count', 'output', 'dint')],
+      processedPythonCode: '',
+    })
+
+    const loaderAt = result.indexOf('python_block_loader')
+    const seedAt = result.indexOf('memcpy(shm_out_ptr, &seed_out')
+    const firstRunSetAt = result.indexOf('first_run := true;')
+    expect(loaderAt).toBeGreaterThan(-1)
+    expect(seedAt).toBeGreaterThan(loaderAt)
+    expect(seedAt).toBeLessThan(firstRunSetAt)
+  })
+
+  it('emits no seed block when the POU has no outputs', () => {
+    const result = generateSTCode({
+      pouName: 'test',
+      allVariables: [makeScalarVar('v', 'input', 'int')],
+      processedPythonCode: '',
+    })
+
+    expect(result).not.toContain('seed_out')
+  })
+
   it('packs the string typedefs themselves, not just the structs using them', () => {
     const result = generateSTCode({
       pouName: 'test',

--- a/src/frontend/utils/python/__tests__/injectPythonCode.test.ts
+++ b/src/frontend/utils/python/__tests__/injectPythonCode.test.ts
@@ -62,26 +62,69 @@ describe('injectPythonCode', () => {
     expect(result).toHaveLength(0)
   })
 
-  it('separates variables by class for format encoding', () => {
+  it('separates variables by direction for format encoding', () => {
     const variables: PLCVariable[] = [
       makeScalarVar('a', 'input', 'INT'),
       makeScalarVar('b', 'input', 'REAL'),
       makeScalarVar('c', 'output', 'BOOL'),
-      {
-        name: 'local',
-        class: 'local',
-        type: { definition: 'base-type', value: 'INT' },
-        location: '',
-        documentation: '',
-        debug: false,
-      },
     ]
 
     const result = injectPythonCode([{ name: 'test', code: 'pass', type: 'function-block', variables }])
 
-    // Input format: =hf (INT + REAL)
+    // Inbound: =hf (INT + REAL). Outbound: =B (BOOL).
     expect(result[0]).toContain("fmt_in = ('=hf')")
-    // Output format: =B (BOOL)
     expect(result[0]).toContain("fmt_out = ('=B')")
+  })
+
+  it('puts a round-tripping class into both formats', () => {
+    // A VAR, a VAR_IN_OUT and a VAR_EXTERNAL all travel out and back, so each
+    // appears in both structs. The PLC keeps owning the value; a block that
+    // never assigns one sends back what it received.
+    const byClass = (name: string, cls: PLCVariable['class']): PLCVariable => ({
+      name,
+      class: cls,
+      type: { definition: 'base-type', value: 'INT' },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+    const variables: PLCVariable[] = [
+      makeScalarVar('a', 'input', 'INT'),
+      makeScalarVar('c', 'output', 'BOOL'),
+      byClass('io', 'inOut'),
+      byClass('keep', 'local'),
+      byClass('g', 'external'),
+    ]
+
+    const result = injectPythonCode([{ name: 'test', code: 'pass', type: 'function-block', variables }])
+
+    // Inbound: input then inOut, local, external — all INT (h).
+    expect(result[0]).toContain("fmt_in = ('=hhhh')")
+    // Outbound: output (B) then the same three.
+    expect(result[0]).toContain("fmt_out = ('=Bhhh')")
+  })
+
+  it('leaves the toolchain’s own injected locals out of both formats', () => {
+    // `first_run` and the two segment addresses are declared `local`. Sweeping
+    // them in would hand the block its own segment pointers to overwrite.
+    const internal = (name: string, type: string): PLCVariable => ({
+      name,
+      class: 'local',
+      type: { definition: 'base-type', value: type },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+    const variables: PLCVariable[] = [
+      makeScalarVar('a', 'input', 'INT'),
+      internal('first_run', 'BOOL'),
+      internal('shm_in_ptr', 'ULINT'),
+      internal('shm_out_ptr', 'ULINT'),
+    ]
+
+    const result = injectPythonCode([{ name: 'test', code: 'pass', type: 'function-block', variables }])
+
+    expect(result[0]).toContain("fmt_in = ('=h')")
+    expect(result[0]).toContain("fmt_out = ('=')")
   })
 })

--- a/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
+++ b/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
@@ -150,7 +150,7 @@ describe('injectPythonRuntime', () => {
     expect(result).toContain('_out.append(_body)')
   })
 
-  it('generates output initialization for scalar output variables', () => {
+  it('seeds scalar outputs from shared memory, not from the declaration', () => {
     const result = injectPythonRuntime({
       fmtIn: '=',
       fmtOut: '=h',
@@ -160,10 +160,15 @@ describe('injectPythonRuntime', () => {
       pouName: 'test',
     })
 
-    expect(result).toContain('count = 0')
+    // The old behaviour set `count = 0` from the declaration and wrote that
+    // back on the first cycle, destroying whatever the PLC held.
+    expect(result).toContain('# Seed outputs from the values the PLC already holds')
+    expect(result).toContain('_vals = struct.unpack(fmt_out, shm_out.buf[:data_size_out])')
+    expect(result).toContain('count = _vals[_idx]')
+    expect(result).not.toContain('count = 0')
   })
 
-  it('generates output initialization for array output variables', () => {
+  it('seeds array outputs from shared memory', () => {
     const result = injectPythonRuntime({
       fmtIn: '=',
       fmtOut: '=3h',
@@ -173,10 +178,11 @@ describe('injectPythonRuntime', () => {
       pouName: 'test',
     })
 
-    expect(result).toContain('arr = [0] * 3')
+    expect(result).toContain('arr = list(_vals[_idx:_idx+3])')
+    expect(result).not.toContain('arr = [0] * 3')
   })
 
-  it('generates output initialization for string output variables', () => {
+  it('seeds string outputs by decoding the shared-memory body', () => {
     const outputVar: PLCVariable = {
       name: 'msg',
       class: 'output',
@@ -195,10 +201,11 @@ describe('injectPythonRuntime', () => {
       pouName: 'test',
     })
 
-    expect(result).toContain('msg = ""')
+    expect(result).toContain("msg = msg_body[:msg_len].decode('utf-8', errors='ignore')")
+    expect(result).not.toContain('msg = ""')
   })
 
-  it('uses initialValue when present for scalar output initialization', () => {
+  it('ignores a declared initialValue on an output — the PLC value wins', () => {
     const outputVar: PLCVariable = {
       name: 'count',
       class: 'output',
@@ -218,10 +225,29 @@ describe('injectPythonRuntime', () => {
       pouName: 'test',
     })
 
-    expect(result).toContain('count = 42')
+    // The declaration's initial value is applied by the runtime on the IEC
+    // side and reaches Python through shared memory. Re-applying it here is
+    // what overwrote a retained value on restart.
+    expect(result).not.toContain('count = 42')
+    expect(result).toContain('count = _vals[_idx]')
   })
 
-  it('outputs comment for no output variables in initialization', () => {
+  it('seeds before block_init so the user sees real values in it', () => {
+    const result = injectPythonRuntime({
+      fmtIn: '=',
+      fmtOut: '=h',
+      inputVariables: [],
+      outputVariables: [makeScalarVar('count', 'output', 'INT')],
+      originalCode: '',
+      pouName: 'test',
+    })
+
+    expect(result.indexOf('# Seed outputs')).toBeLessThan(result.indexOf('block_init()'))
+    // calcsize has to precede the seed — the seed reads that many bytes.
+    expect(result.indexOf('data_size_out = struct.calcsize')).toBeLessThan(result.indexOf('# Seed outputs'))
+  })
+
+  it('says so plainly when there are no outputs to seed', () => {
     const result = injectPythonRuntime({
       fmtIn: '=',
       fmtOut: '=',
@@ -231,7 +257,7 @@ describe('injectPythonRuntime', () => {
       pouName: 'test',
     })
 
-    expect(result).toContain('# No output variables to initialize')
+    expect(result).toContain('# No output variables to seed')
   })
 
   it('outputs comment for no input variables', () => {

--- a/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
+++ b/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
@@ -1,4 +1,4 @@
-import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '../../../../middleware/shared/ports/types'
 import { injectPythonRuntime } from '../injectPythonRuntime'
 
 const makeScalarVar = (name: string, cls: 'input' | 'output', baseType: string): PLCVariable => ({
@@ -42,6 +42,189 @@ const makeWStringVar = (name: string, cls: 'input' | 'output'): PLCVariable => (
   location: '',
   documentation: '',
   debug: false,
+})
+
+const userTyped = (name: string, cls: 'input' | 'output', typeName: string): PLCVariable => ({
+  name,
+  class: cls,
+  type: { definition: 'user-data-type', value: typeName },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const MOTOR: PLCDataType = {
+  name: 'Motor',
+  derivation: 'structure',
+  variable: [
+    { name: 'speed', type: { definition: 'base-type', value: 'int' } },
+    { name: 'label', type: { definition: 'base-type', value: 'string' } },
+  ],
+}
+
+const MODE: PLCDataType = {
+  name: 'Mode',
+  derivation: 'enumerated',
+  values: [{ description: 'STOPPED' }, { description: 'RUNNING' }],
+}
+
+describe('structures and enumerations', () => {
+  const run = (variables: PLCVariable[], dataTypes: PLCDataType[]) =>
+    injectPythonRuntime({
+      fmtIn: '=',
+      fmtOut: '=',
+      inputVariables: variables.filter((v) => v.class === 'input'),
+      outputVariables: variables.filter((v) => v.class === 'output'),
+      originalCode: '',
+      pouName: 'test',
+      dataTypes,
+    })
+
+  it('declares a structure as a slotted class, so the user writes m.speed', () => {
+    // The wire format is flat, but the block should read like ST. `__slots__`
+    // also makes an assignment to a name the structure lacks raise, rather than
+    // silently creating an attribute the PLC will never read back.
+    const result = run([userTyped('m', 'input', 'Motor')], [MOTOR])
+
+    expect(result).toContain('class Motor:')
+    expect(result).toContain("__slots__ = ('speed', 'label')")
+    expect(result).toContain('def __init__(self, speed=None, label=None):')
+  })
+
+  it('gives a one-member structure a trailing comma, so __slots__ is a tuple', () => {
+    // `('speed')` is the string, not a one-element tuple, and Python would then
+    // treat every character as a slot name.
+    const single: PLCDataType = {
+      name: 'One',
+      derivation: 'structure',
+      variable: [{ name: 'speed', type: { definition: 'base-type', value: 'int' } }],
+    }
+    const result = run([userTyped('o', 'input', 'One')], [single])
+
+    expect(result).toContain("__slots__ = ('speed',)")
+  })
+
+  it('declares an enumeration as an IntEnum, so mode == Mode.RUNNING reads naturally', () => {
+    const result = run([userTyped('md', 'input', 'Mode')], [MODE])
+
+    expect(result).toContain('from enum import IntEnum')
+    expect(result).toContain('class Mode(IntEnum):')
+    expect(result).toContain('    STOPPED = 0')
+    expect(result).toContain('    RUNNING = 1')
+  })
+
+  it('declares a nested structure before the one that constructs it', () => {
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [{ name: 'drive', type: { definition: 'user-data-type', value: 'Motor' } }],
+    }
+    const result = run([userTyped('r', 'input', 'Rig')], [rig, MOTOR])
+
+    expect(result.indexOf('class Motor:')).toBeLessThan(result.indexOf('class Rig:'))
+  })
+
+  it('declares each type once even when several variables use it', () => {
+    const result = run([userTyped('a', 'input', 'Motor'), userTyped('b', 'input', 'Motor')], [MOTOR])
+
+    expect(result.match(/class Motor:/g)).toHaveLength(1)
+  })
+
+  it('says so plainly when a block uses no composite type', () => {
+    const result = run([makeScalarVar('x', 'input', 'INT')], [MOTOR])
+
+    expect(result).toContain('# This block uses no structures or enumerations')
+    expect(result).not.toContain('class Motor:')
+  })
+
+  it('rebuilds a structure from its consecutive leaves', () => {
+    const result = run([userTyped('m', 'input', 'Motor')], [MOTOR])
+
+    expect(result).toContain('_m_speed = _vals[_idx]')
+    expect(result).toContain('m = Motor(speed=_m_speed, label=_m_label)')
+  })
+
+  it('rebuilds a nested structure innermost first', () => {
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [{ name: 'drive', type: { definition: 'user-data-type', value: 'Motor' } }],
+    }
+    const result = run([userTyped('r', 'input', 'Rig')], [rig, MOTOR])
+
+    expect(result).toContain('r = Rig(drive=Motor(speed=_r_drive_speed, label=_r_drive_label))')
+  })
+
+  it('wraps a structure member that is an enumeration', () => {
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [{ name: 'state', type: { definition: 'user-data-type', value: 'Mode' } }],
+    }
+    const result = run([userTyped('r', 'input', 'Rig')], [rig, MODE])
+
+    expect(result).toContain('r = Rig(state=Mode(_r_state))')
+  })
+
+  it('wraps a top-level enumeration in its IntEnum after decoding', () => {
+    const result = run([userTyped('md', 'input', 'Mode')], [MODE])
+
+    expect(result).toContain('md = Mode(md)')
+  })
+
+  it('packs a structure member by member, through the attribute path', () => {
+    const result = run([userTyped('m', 'output', 'Motor')], [MOTOR])
+
+    expect(result).toContain('_out.append(m.speed)')
+    expect(result).toContain("_body = m.label.encode('utf-8')[:126]")
+  })
+
+  it('packs an enumeration as its integer, explicitly', () => {
+    const result = run([userTyped('md', 'output', 'Mode')], [MODE])
+
+    expect(result).toContain('_out.append(int(md))')
+  })
+
+  it('ignores a named ARRAY type when declaring classes', () => {
+    // It cannot cross, and the build is refused upstream; there is no class to
+    // declare for it either way.
+    const named: PLCDataType = {
+      name: 'Bank',
+      derivation: 'array',
+      baseType: { definition: 'base-type', value: 'INT' },
+      dimensions: [{ dimension: '0..3' }],
+    }
+    const result = run([userTyped('b', 'input', 'Bank')], [named])
+
+    expect(result).toContain('# This block uses no structures or enumerations')
+  })
+
+  it('ignores a type the project does not declare', () => {
+    const result = run([userTyped('t', 'input', 'TON')], [MOTOR])
+
+    expect(result).toContain('# This block uses no structures or enumerations')
+  })
+
+  it('declares a structure reached through an array element type', () => {
+    const bank: PLCVariable = {
+      name: 'bank',
+      class: 'input',
+      type: {
+        definition: 'array',
+        value: 'ARRAY [0..1] OF Motor',
+        data: {
+          baseType: { definition: 'user-data-type', value: 'Motor' },
+          dimensions: [{ dimension: '0..1' }],
+        },
+      },
+      location: '',
+      documentation: '',
+      debug: false,
+    }
+    const result = run([bank], [MOTOR])
+
+    expect(result).toContain('class Motor:')
+  })
 })
 
 describe('WSTRING crosses as UTF-16, counted in code units', () => {

--- a/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
+++ b/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
@@ -672,3 +672,80 @@ describe('injectPythonRuntime', () => {
     expect(result).toContain('# No output variables to write')
   })
 })
+
+describe('a function block pin that is itself composite', () => {
+  // The walk emits a temporary per LEAF, never one for the composite. A
+  // structure MEMBER already got that recursion; a pin did not, so the
+  // constructor named `_drv_CFG` — which the decode never assigns — and the
+  // module raised `NameError` before `block_init()`. Reproduced through
+  // openplc-cli before fixing.
+  const MOTOR: PLCDataType = {
+    name: 'Motor',
+    derivation: 'structure',
+    variable: [
+      { name: 'speed', type: { definition: 'base-type', value: 'int' } },
+      { name: 'label', type: { definition: 'base-type', value: 'string' } },
+    ],
+  }
+  const MODE: PLCDataType = {
+    name: 'Mode',
+    derivation: 'enumerated',
+    values: [{ description: 'STOPPED' }, { description: 'RUNNING' }],
+  }
+  /** A library block whose input pin is a structure and whose output is an enum. */
+  const DRIVE_LIB = {
+    functionBlocks: [
+      {
+        name: 'DRIVE',
+        inputs: [{ name: 'CFG', type: 'Motor' }],
+        inouts: [],
+        outputs: [{ name: 'STATE', type: 'Mode' }],
+      },
+    ],
+  }
+  const drv: PLCVariable = {
+    name: 'drv',
+    class: 'local',
+    type: { definition: 'derived', value: 'DRIVE' },
+    location: '',
+    documentation: '',
+    debug: false,
+  }
+  const run = () =>
+    injectPythonRuntime({
+      fmtIn: '=',
+      fmtOut: '=',
+      inputVariables: [drv],
+      outputVariables: [drv],
+      originalCode: '',
+      pouName: 'test',
+      inbound: { dataTypes: [MOTOR, MODE], libraries: [DRIVE_LIB], direction: 'in' },
+      outbound: { dataTypes: [MOTOR, MODE], libraries: [DRIVE_LIB], direction: 'out' },
+    })
+
+  it('builds a structure pin from the member temporaries the decode produced', () => {
+    expect(run()).toContain('CFG=Motor(speed=_drv_CFG_speed, label=_drv_CFG_label)')
+  })
+
+  it('never names a temporary for the composite itself', () => {
+    // `_drv_CFG` alone is the bug: assigned nowhere, referenced by the ctor.
+    expect(run()).not.toMatch(/CFG=_drv_CFG[,)]/)
+  })
+
+  it('wraps an enumeration pin back into its class', () => {
+    expect(run()).toContain('STATE=Mode(_drv_STATE)')
+  })
+
+  it('declares the classes reached only through a pin', () => {
+    // `collectReferencedTypes` stopped at the instance, so a structure used
+    // only as a pin type was never declared and the ctor named a missing class.
+    const result = run()
+    expect(result).toContain('class Motor:')
+    expect(result).toContain('class Mode(IntEnum):')
+  })
+
+  it('declares a pin type before the block class that constructs it', () => {
+    const result = run()
+    expect(result.indexOf('class Motor:')).toBeLessThan(result.indexOf('class DRIVE:'))
+  })
+})

--- a/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
+++ b/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
@@ -35,6 +35,71 @@ const makeArrayVar = (name: string, cls: 'input' | 'output', baseType: string, d
   debug: false,
 })
 
+const makeWStringVar = (name: string, cls: 'input' | 'output'): PLCVariable => ({
+  name,
+  class: cls,
+  type: { definition: 'base-type', value: 'wstring' },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+describe('WSTRING crosses as UTF-16, counted in code units', () => {
+  // WSTRING shared STRING's handling until DOPE-584 P2, which was wrong in both
+  // directions: the body is char16_t, so the byte count is twice the length, and
+  // the length the C side writes counts code units rather than bytes. These pin
+  // the distinction on both sides of the boundary.
+  const run = (variables: PLCVariable[]) =>
+    injectPythonRuntime({
+      fmtIn: '=b252s',
+      fmtOut: '=b252s',
+      inputVariables: variables.filter((v) => v.class === 'input'),
+      outputVariables: variables.filter((v) => v.class === 'output'),
+      originalCode: '',
+      pouName: 'test',
+    })
+
+  it('decodes an inbound WSTRING as utf-16-le over twice the length', () => {
+    const result = run([makeWStringVar('label', 'input')])
+
+    expect(result).toContain("label = label_body[:label_len * 2].decode('utf-16-le', errors='ignore')")
+  })
+
+  it('decodes an inbound STRING as utf-8 over the length itself', () => {
+    const result = run([makeStringVar('label', 'input')])
+
+    expect(result).toContain("label = label_body[:label_len].decode('utf-8', errors='ignore')")
+  })
+
+  it('encodes an outbound WSTRING to the doubled byte budget', () => {
+    const result = run([makeWStringVar('label', 'output')])
+
+    expect(result).toContain("_body = label.encode('utf-16-le')[:252]")
+    expect(result).toContain("_body = _body.ljust(252, b'\\0')")
+  })
+
+  it('truncates an outbound WSTRING on a code-unit boundary, never mid-unit', () => {
+    // Clipping to an odd byte count would split a UTF-16 unit and hand the C
+    // side half a character.
+    const result = run([makeWStringVar('label', 'output')])
+
+    expect(result).toContain('_body = _body[: len(_body) - (len(_body) % 2)]')
+  })
+
+  it('reports an outbound WSTRING length in code units, not bytes', () => {
+    const result = run([makeWStringVar('label', 'output')])
+
+    expect(result).toContain('_len = len(_body) // 2')
+  })
+
+  it('reports an outbound STRING length in bytes, which for utf-8 is what it is', () => {
+    const result = run([makeStringVar('label', 'output')])
+
+    expect(result).toContain('_len = len(_body)')
+    expect(result).not.toContain('_len = len(_body) // 2')
+  })
+})
+
 describe('injectPythonRuntime', () => {
   it('injects runtime wrapper around original code with no variables', () => {
     const result = injectPythonRuntime({

--- a/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
+++ b/src/frontend/utils/python/__tests__/injectPythonRuntime.test.ts
@@ -68,6 +68,109 @@ const MODE: PLCDataType = {
   values: [{ description: 'STOPPED' }, { description: 'RUNNING' }],
 }
 
+const TON_LIB = {
+  functionBlocks: [
+    {
+      name: 'TON',
+      inputs: [
+        { name: 'IN', type: 'BOOL' },
+        { name: 'PT', type: 'TIME' },
+      ],
+      inouts: [],
+      outputs: [
+        { name: 'Q', type: 'BOOL' },
+        { name: 'ET', type: 'TIME' },
+      ],
+    },
+  ],
+}
+
+describe('function block instances', () => {
+  const instance = (name: string): PLCVariable => ({
+    name,
+    class: 'local',
+    type: { definition: 'derived', value: 'TON' },
+    location: '',
+    documentation: '',
+    debug: false,
+  })
+  const run = (variables: PLCVariable[]) =>
+    injectPythonRuntime({
+      fmtIn: '=',
+      fmtOut: '=',
+      inputVariables: variables,
+      outputVariables: variables,
+      originalCode: '',
+      pouName: 'test',
+      inbound: { dataTypes: [], libraries: [TON_LIB], direction: 'in' },
+      outbound: { dataTypes: [], libraries: [TON_LIB], direction: 'out' },
+    })
+
+  it('declares a class carrying every pin, so one class serves both directions', () => {
+    const result = run([instance('ton0')])
+
+    expect(result).toContain('class TON:')
+    expect(result).toContain("__slots__ = ('IN', 'PT', 'Q', 'ET')")
+  })
+
+  it('says the instances are called by the PLC, not by the block', () => {
+    expect(run([instance('ton0')])).toContain('# Function block instances — called once per scan by the PLC')
+  })
+
+  it('declares each block type once however many instances use it', () => {
+    const result = run([instance('a'), instance('b')])
+
+    expect(result.match(/class TON:/g)).toHaveLength(1)
+  })
+
+  it('rebuilds the instance from every pin on the way in', () => {
+    const result = run([instance('ton0')])
+
+    expect(result).toContain('ton0 = TON(IN=_ton0_IN, PT=_ton0_PT, Q=_ton0_Q, ET=_ton0_ET)')
+  })
+
+  it('rebuilds it from only the drivable pins when seeding outputs', () => {
+    // The seed decodes the outbound layout, which has no output pins in it.
+    // Naming one here is what killed the block with `NameError: _ton0_Q`.
+    const result = run([instance('ton0')])
+    const seed = result.slice(result.indexOf('# Seed outputs'), result.indexOf('# Initialize block'))
+
+    expect(seed).toContain('ton0 = TON(IN=_ton0_IN, PT=_ton0_PT)')
+    expect(seed).not.toContain('_ton0_Q')
+  })
+
+  it('packs only the drivable pins back', () => {
+    const result = run([instance('ton0')])
+    const pack = result.slice(result.indexOf('# Write output variables'))
+
+    expect(pack).toContain('_out.append(ton0.IN)')
+    expect(pack).not.toContain('_out.append(ton0.Q)')
+  })
+
+  it('upper-cases a pin the project declared in lower case', () => {
+    // The compiler upper-cases members, and the Python attribute has to match
+    // the slot it was constructed with.
+    const lower = {
+      functionBlocks: [{ name: 'ACC', inputs: [{ name: 'step', type: 'INT' }], inouts: [], outputs: [] }],
+    }
+    const acc: PLCVariable = { ...instance('acc'), type: { definition: 'derived', value: 'ACC' } }
+    const result = injectPythonRuntime({
+      fmtIn: '=',
+      fmtOut: '=',
+      inputVariables: [acc],
+      outputVariables: [acc],
+      originalCode: '',
+      pouName: 'test',
+      inbound: { dataTypes: [], libraries: [lower], direction: 'in' },
+      outbound: { dataTypes: [], libraries: [lower], direction: 'out' },
+    })
+
+    expect(result).toContain("__slots__ = ('STEP',)")
+    expect(result).toContain('acc = ACC(STEP=_acc_STEP)')
+    expect(result).toContain('_out.append(acc.STEP)')
+  })
+})
+
 describe('structures and enumerations', () => {
   const run = (variables: PLCVariable[], dataTypes: PLCDataType[]) =>
     injectPythonRuntime({
@@ -77,7 +180,8 @@ describe('structures and enumerations', () => {
       outputVariables: variables.filter((v) => v.class === 'output'),
       originalCode: '',
       pouName: 'test',
-      dataTypes,
+      inbound: { dataTypes, direction: 'in' },
+      outbound: { dataTypes, direction: 'out' },
     })
 
   it('declares a structure as a slotted class, so the user writes m.speed', () => {
@@ -133,7 +237,7 @@ describe('structures and enumerations', () => {
   it('says so plainly when a block uses no composite type', () => {
     const result = run([makeScalarVar('x', 'input', 'INT')], [MOTOR])
 
-    expect(result).toContain('# This block uses no structures or enumerations')
+    expect(result).toContain('# This block uses no structures, enumerations or function block instances')
     expect(result).not.toContain('class Motor:')
   })
 
@@ -196,13 +300,15 @@ describe('structures and enumerations', () => {
     }
     const result = run([userTyped('b', 'input', 'Bank')], [named])
 
-    expect(result).toContain('# This block uses no structures or enumerations')
+    expect(result).toContain('# This block uses no structures, enumerations or function block instances')
   })
 
-  it('ignores a type the project does not declare', () => {
+  it('declares nothing for an instance whose block cannot be resolved', () => {
+    // With no library and no project POU there are no pins to expose. The build
+    // is refused upstream; here there is simply no class to emit.
     const result = run([userTyped('t', 'input', 'TON')], [MOTOR])
 
-    expect(result).toContain('# This block uses no structures or enumerations')
+    expect(result).not.toContain('class TON:')
   })
 
   it('declares a structure reached through an array element type', () => {
@@ -240,6 +346,8 @@ describe('WSTRING crosses as UTF-16, counted in code units', () => {
       outputVariables: variables.filter((v) => v.class === 'output'),
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
   it('decodes an inbound WSTRING as utf-16-le over twice the length', () => {
@@ -292,6 +400,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [],
       originalCode: 'def block_init():\n    pass\ndef block_loop():\n    pass',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     expect(result).toContain('def block_init():')
@@ -314,6 +424,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     expect(result).toContain('_vals = struct.unpack(fmt_in, shm_in.buf[:data_size_in])')
@@ -330,6 +442,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [makeScalarVar('result', 'output', 'INT'), makeScalarVar('flag', 'output', 'BOOL')],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     expect(result).toContain('_out = []')
@@ -347,6 +461,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     expect(result).toContain('data = list(_vals[_idx:_idx+5])')
@@ -361,6 +477,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [makeArrayVar('temps', 'output', 'REAL', '0..2')],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     expect(result).toContain('_out.extend(temps)')
@@ -374,6 +492,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     expect(result).toContain('msg_len = _vals[_idx]')
@@ -389,6 +509,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [makeStringVar('msg', 'output')],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     expect(result).toContain("_body = msg.encode('utf-8')[:126]")
@@ -406,6 +528,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [makeScalarVar('count', 'output', 'INT')],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     // The old behaviour set `count = 0` from the declaration and wrote that
@@ -424,6 +548,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [makeArrayVar('arr', 'output', 'INT', '0..2')],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     expect(result).toContain('arr = list(_vals[_idx:_idx+3])')
@@ -447,6 +573,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [outputVar],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     expect(result).toContain("msg = msg_body[:msg_len].decode('utf-8', errors='ignore')")
@@ -471,6 +599,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [outputVar],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     // The declaration's initial value is applied by the runtime on the IEC
@@ -488,6 +618,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [makeScalarVar('count', 'output', 'INT')],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     expect(result.indexOf('# Seed outputs')).toBeLessThan(result.indexOf('block_init()'))
@@ -503,6 +635,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     expect(result).toContain('# No output variables to seed')
@@ -516,6 +650,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     expect(result).toContain('# No input variables to read')
@@ -529,6 +665,8 @@ describe('injectPythonRuntime', () => {
       outputVariables: [],
       originalCode: '',
       pouName: 'test',
+      inbound: { direction: 'in' },
+      outbound: { direction: 'out' },
     })
 
     expect(result).toContain('# No output variables to write')

--- a/src/frontend/utils/python/__tests__/shm-leaves.test.ts
+++ b/src/frontend/utils/python/__tests__/shm-leaves.test.ts
@@ -193,7 +193,7 @@ describe('describeShmLeaves', () => {
       debug: false,
     }
 
-    expect(refusalOf(describeShmLeaves(bare))?.reason).toContain('not a type Python can exchange')
+    expect(refusalOf(describeShmLeaves(bare))?.reason).toContain('not a type a Python block can exchange')
   })
 
   describe('refusals', () => {
@@ -223,7 +223,12 @@ describe('describeShmLeaves', () => {
     })
 
     it('refuses an unsupported elementary type', () => {
-      expect(refusalOf(describeShmLeaves(scalar('x', 'float32')))?.reason).toContain('not a type Python can exchange')
+      const reason = refusalOf(describeShmLeaves(scalar('x', 'float32')))?.reason
+      // The reason lists what IS supported, so the message stands on its own —
+      // an FB-instance refusal needs a different explanation entirely, and a
+      // single trailing list would be wrong for one of them.
+      expect(reason).toContain('FLOAT32 is not a type a Python block can exchange')
+      expect(reason).toContain('STRING, WSTRING')
     })
 
     it('names the member that cannot cross, not the variable containing it', () => {

--- a/src/frontend/utils/python/__tests__/shm-leaves.test.ts
+++ b/src/frontend/utils/python/__tests__/shm-leaves.test.ts
@@ -33,6 +33,28 @@ const arrayOf = (name: string, baseType: string, dimension = '0..3'): PLCVariabl
   debug: false,
 })
 
+/** An array of arbitrary rank, for the one-dimension-only rule. */
+const arrayOfRank = (
+  name: string,
+  baseType: string,
+  dimensions: string[],
+  baseDefinition: 'base-type' | 'user-data-type' = 'base-type',
+): PLCVariable => ({
+  name,
+  class: 'input',
+  type: {
+    definition: 'array',
+    value: `ARRAY [${dimensions.join(',')}] OF ${baseType}`,
+    data: {
+      baseType: { definition: baseDefinition, value: baseType },
+      dimensions: dimensions.map((dimension) => ({ dimension })),
+    },
+  },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
 const MOTOR: PLCDataType = {
   name: 'Motor',
   derivation: 'structure',
@@ -185,9 +207,12 @@ describe('describeShmLeaves', () => {
     expect(leaf.access).toBe('R.TRIMS')
   })
 
-  it('reads an array member’s bounds even when its dimension text is malformed', () => {
-    // A dimension that cannot be parsed yields no lower bound rather than a
-    // guessed one; the element type still describes the field.
+  it('refuses an array member whose dimension text is malformed', () => {
+    // An unparsable range makes `getArrayTotalElements` return 0. That used to
+    // fall through to the scalar path — one field against an array member — and
+    // the old test asserted only `startIndex`, so it executed the bug without
+    // pinning it. The size of the field is unknown, so the only safe answer is
+    // to refuse.
     const rig: PLCDataType = {
       name: 'Rig',
       derivation: 'structure',
@@ -202,9 +227,9 @@ describe('describeShmLeaves', () => {
         },
       ],
     }
-    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), inbound([rig])))
-
-    expect(leaf.startIndex).toBe(0)
+    expect(refusalOf(describeShmLeaves(userTyped('r', 'Rig'), inbound([rig])))?.reason).toContain(
+      'array bounds cannot be read',
+    )
   })
 
   it('refuses an array declaration carrying no dimension data rather than guessing', () => {
@@ -311,6 +336,63 @@ describe('describeShmLeaves', () => {
       const leaves = leavesOf(describeShmLeaves(acc, { dataTypes: [], pous: [withLocal], direction: 'in' }))
 
       expect(leaves.map((l) => l.field)).toEqual(['acc_STEP', 'acc_TOTAL'])
+    })
+
+    it('accepts a library pin spelled with a registry alias (TIME_OF_DAY)', () => {
+      // The path the alias gap was actually reachable through: a `.stlib`
+      // manifest carries bare IEC type names, and TOD's alias is a legal
+      // spelling there. The hand-written table had only `tod`, so this refused
+      // the whole block; the registry knows both.
+      const aliasLib = {
+        functionBlocks: [
+          {
+            name: 'CLOCK',
+            inputs: [{ name: 'AT', type: 'TIME_OF_DAY' }],
+            inouts: [],
+            outputs: [{ name: 'STAMP', type: 'DATE_AND_TIME' }],
+          },
+        ],
+      }
+      const instance: PLCVariable = { ...ton('c'), type: { definition: 'derived', value: 'CLOCK' } }
+      const leaves = leavesOf(describeShmLeaves(instance, { dataTypes: [], libraries: [aliasLib], direction: 'in' }))
+
+      expect(leaves.map((l) => l.field)).toEqual(['c_AT', 'c_STAMP'])
+      // Both are 64-bit counts, taken from the registry's byteSize.
+      expect(leaves.every((l) => l.descriptor.size === 8)).toBe(true)
+    })
+
+    it('refuses an instance whose pin is a multi-dimensional array', () => {
+      // The rank rule applies to a block's pins too, not only to the variables
+      // the Python POU declares itself — an instance's pins cross the same
+      // boundary and are emitted by the same exchange.
+      const gridBlock = {
+        name: 'Grid',
+        pouType: 'function-block' as const,
+        interface: {
+          variables: [
+            {
+              name: 'cells',
+              class: 'input' as const,
+              type: {
+                definition: 'array' as const,
+                value: 'ARRAY [0..1,0..1] OF INT',
+                data: {
+                  baseType: { definition: 'base-type' as const, value: 'INT' },
+                  dimensions: [{ dimension: '0..1' }, { dimension: '0..1' }],
+                },
+              },
+              location: '',
+              documentation: '',
+            },
+          ],
+        },
+        body: { language: 'st' as const, value: '' },
+      }
+      const instance: PLCVariable = { ...ton('g'), type: { definition: 'derived', value: 'Grid' } }
+      const refusal = refusalOf(describeShmLeaves(instance, { dataTypes: [], pous: [gridBlock], direction: 'in' }))
+
+      expect(refusal?.reason).toContain('2-dimensional array cannot cross into Python')
+      expect(refusal?.path).toEqual(['g', 'CELLS'])
     })
 
     it('omits a library block’s pins that are not declared', () => {
@@ -492,5 +574,63 @@ describe('describeShmLayout', () => {
 
   it('is empty for no variables', () => {
     expect(leavesOf(describeShmLayout([], inbound()))).toEqual([])
+  })
+})
+
+describe('describeShmLeaves — array shapes the exchange cannot express', () => {
+  // Each of these used to be accepted and then mis-emitted. A refusal is the
+  // contract (AC 3): marshal correctly, or say why not. Silence was the one
+  // outcome ruled out, because a leaf the format string mis-sizes shifts every
+  // field after it and the corruption surfaces on an unrelated variable.
+
+  it('refuses a two-dimensional array, naming the rank and the way out', () => {
+    const refusal = refusalOf(describeShmLeaves(arrayOfRank('grid', 'INT', ['0..1', '0..2']), inbound()))
+    expect(refusal?.reason).toContain('2-dimensional array cannot cross into Python')
+    expect(refusal?.reason).toContain('one-dimensional arrays only')
+  })
+
+  it('refuses a three-dimensional array', () => {
+    const refusal = refusalOf(describeShmLeaves(arrayOfRank('cube', 'INT', ['0..1', '0..1', '0..1']), inbound()))
+    expect(refusal?.reason).toContain('3-dimensional array cannot cross into Python')
+  })
+
+  it('accepts a one-dimensional array, so the rank check is not over-broad', () => {
+    const [leaf] = leavesOf(describeShmLeaves(arrayOfRank('row', 'INT', ['0..3']), inbound()))
+    expect(leaf.isArray).toBe(true)
+    expect(leaf.count).toBe(4)
+  })
+
+  it('refuses an array of STRING', () => {
+    expect(refusalOf(describeShmLeaves(arrayOf('names', 'STRING'), inbound()))?.reason).toContain(
+      'an array of STRING cannot cross into Python yet',
+    )
+  })
+
+  it('refuses an array of WSTRING', () => {
+    expect(refusalOf(describeShmLeaves(arrayOf('names', 'WSTRING'), inbound()))?.reason).toContain(
+      'an array of WSTRING cannot cross into Python yet',
+    )
+  })
+
+  it('refuses an array of an enumeration', () => {
+    const modes = arrayOfRank('modes', 'Mode', ['0..2'], 'user-data-type')
+    const refusal = refusalOf(describeShmLeaves(modes, inbound([MODE])))
+    expect(refusal?.reason).toContain('an array of enumerations cannot cross into Python yet')
+  })
+
+  it('treats a single-element array as an array, not a scalar', () => {
+    // `ARRAY [0..0] OF INT` has count 1. Every emitter used to branch on
+    // `count > 1`, so this bound a plain int where the user declared an array —
+    // a scalar struct field against an array member on the C side.
+    const [leaf] = leavesOf(describeShmLeaves(arrayOf('one', 'INT', '0..0'), inbound()))
+    expect(leaf.isArray).toBe(true)
+    expect(leaf.count).toBe(1)
+    expect(leaf.startIndex).toBe(0)
+  })
+
+  it('carries isArray false for a genuine scalar', () => {
+    const [leaf] = leavesOf(describeShmLeaves(scalar('x', 'INT'), inbound()))
+    expect(leaf.isArray).toBe(false)
+    expect(leaf.count).toBe(1)
   })
 })

--- a/src/frontend/utils/python/__tests__/shm-leaves.test.ts
+++ b/src/frontend/utils/python/__tests__/shm-leaves.test.ts
@@ -1,0 +1,270 @@
+import type { PLCDataType, PLCVariable } from '../../../../middleware/shared/ports/types'
+import { describeShmLayout, describeShmLeaves } from '../shm-leaves'
+
+const scalar = (name: string, value: string): PLCVariable => ({
+  name,
+  class: 'input',
+  type: { definition: 'base-type', value },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const userTyped = (name: string, value: string): PLCVariable => ({
+  name,
+  class: 'input',
+  type: { definition: 'user-data-type', value },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const arrayOf = (name: string, baseType: string, dimension = '0..3'): PLCVariable => ({
+  name,
+  class: 'input',
+  type: {
+    definition: 'array',
+    value: `ARRAY [${dimension}] OF ${baseType}`,
+    data: { baseType: { definition: 'base-type', value: baseType }, dimensions: [{ dimension }] },
+  },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const MOTOR: PLCDataType = {
+  name: 'Motor',
+  derivation: 'structure',
+  variable: [
+    { name: 'speed', type: { definition: 'base-type', value: 'int' } },
+    { name: 'label', type: { definition: 'base-type', value: 'string' } },
+  ],
+}
+
+const MODE: PLCDataType = {
+  name: 'Mode',
+  derivation: 'enumerated',
+  values: [{ description: 'STOPPED' }, { description: 'RUNNING' }],
+}
+
+const leavesOf = (result: ReturnType<typeof describeShmLeaves>) => ('leaves' in result ? result.leaves : [])
+const refusalOf = (result: ReturnType<typeof describeShmLeaves>) => ('refusal' in result ? result.refusal : null)
+
+describe('describeShmLeaves', () => {
+  it('describes a scalar as one leaf reaching the member directly', () => {
+    const [leaf] = leavesOf(describeShmLeaves(scalar('x', 'INT')))
+
+    expect(leaf.field).toBe('x')
+    expect(leaf.path).toEqual(['x'])
+    expect(leaf.access).toBe('X')
+    expect(leaf.count).toBe(1)
+  })
+
+  it('describes an array as one leaf with its element count and lower bound', () => {
+    const [leaf] = leavesOf(describeShmLeaves(arrayOf('data', 'INT', '2..5')))
+
+    expect(leaf.count).toBe(4)
+    expect(leaf.startIndex).toBe(2)
+  })
+
+  it('flattens a structure into one leaf per member, in declaration order', () => {
+    const leaves = leavesOf(describeShmLeaves(userTyped('m', 'Motor'), [MOTOR]))
+
+    expect(leaves.map((l) => l.field)).toEqual(['m_speed', 'm_label'])
+    expect(leaves.map((l) => l.path)).toEqual([
+      ['m', 'speed'],
+      ['m', 'label'],
+    ])
+    expect(leaves.map((l) => l.access)).toEqual(['M.SPEED', 'M.LABEL'])
+  })
+
+  it('flattens rather than nesting, so neither side computes padding', () => {
+    // `#pragma pack` applies to the struct being defined, never to a member type
+    // already laid out — the trap that made WSTRING 254 bytes against Python's
+    // 253. Every leaf sits at the top level of one packed struct.
+    const leaves = leavesOf(describeShmLeaves(userTyped('m', 'Motor'), [MOTOR]))
+
+    expect(leaves.every((l) => !l.field.includes('.'))).toBe(true)
+  })
+
+  it('flattens a nested structure through both levels', () => {
+    const outer: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [{ name: 'drive', type: { definition: 'user-data-type', value: 'Motor' } }],
+    }
+    const leaves = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [outer, MOTOR]))
+
+    expect(leaves.map((l) => l.field)).toEqual(['r_drive_speed', 'r_drive_label'])
+    expect(leaves.map((l) => l.access)).toEqual(['R.DRIVE.SPEED', 'R.DRIVE.LABEL'])
+  })
+
+  it('describes an enumeration as its stored integer, naming the type for Python', () => {
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('md', 'Mode'), [MODE]))
+
+    expect(leaf.descriptor.cType).toBe('int16_t')
+    expect(leaf.enumTypeName).toBe('Mode')
+    // The access stays assignable; the emitter casts through the wrapper, since
+    // an IEC_ENUM_Var yields an IEC_ENUM_Value that converts to the scoped enum
+    // but not to an integer.
+    expect(leaf.access).toBe('MD')
+  })
+
+  it('mangles a member named after its own type, as the compiler does', () => {
+    // GCC rejects a member that changes the meaning of its type name inside the
+    // class, so STruC++ emits a trailing underscore. CODESYS allows
+    // `RunningLights : RunningLights` and real projects use it.
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [{ name: 'mode', type: { definition: 'user-data-type', value: 'Mode' } }],
+    }
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [rig, MODE]))
+
+    expect(leaf.access).toBe('R.MODE_')
+  })
+
+  it('does not mangle a member whose name merely matches an elementary type', () => {
+    // `Time : TIME` is an ordinary declaration the compiler emits unmangled;
+    // mangling it would name a `TIME_` member that does not exist.
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [{ name: 'time', type: { definition: 'base-type', value: 'TIME' } }],
+    }
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [rig]))
+
+    expect(leaf.access).toBe('R.TIME')
+  })
+
+  it('describes an array nested inside a structure', () => {
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [
+        {
+          name: 'trims',
+          type: {
+            definition: 'array',
+            value: 'ARRAY [1..3] OF INT',
+            data: { baseType: { definition: 'base-type', value: 'INT' }, dimensions: [{ dimension: '1..3' }] },
+          },
+        },
+      ],
+    }
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [rig]))
+
+    expect(leaf.count).toBe(3)
+    expect(leaf.startIndex).toBe(1)
+    expect(leaf.access).toBe('R.TRIMS')
+  })
+
+  it('reads an array member’s bounds even when its dimension text is malformed', () => {
+    // A dimension that cannot be parsed yields no lower bound rather than a
+    // guessed one; the element type still describes the field.
+    const rig: PLCDataType = {
+      name: 'Rig',
+      derivation: 'structure',
+      variable: [
+        {
+          name: 'trims',
+          type: {
+            definition: 'array',
+            value: 'ARRAY [?] OF INT',
+            data: { baseType: { definition: 'base-type', value: 'INT' }, dimensions: [{ dimension: 'nonsense' }] },
+          },
+        },
+      ],
+    }
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [rig]))
+
+    expect(leaf.startIndex).toBe(0)
+  })
+
+  it('refuses an array declaration carrying no dimension data rather than guessing', () => {
+    // Without `data` there is no element type and no count. Describing it as
+    // one scalar would put a single field where the C side may write many.
+    const bare: PLCVariable = {
+      name: 'data',
+      class: 'input',
+      type: { definition: 'array', value: 'ARRAY [0..3] OF INT' },
+      location: '',
+      documentation: '',
+      debug: false,
+    }
+
+    expect(refusalOf(describeShmLeaves(bare))?.reason).toContain('not a type Python can exchange')
+  })
+
+  describe('refusals', () => {
+    it('refuses a function block instance, naming why', () => {
+      const refusal = refusalOf(describeShmLeaves(userTyped('t', 'TON'), [MOTOR]))
+
+      expect(refusal?.reason).toContain('function block instance')
+      expect(refusal?.reason).toContain('its own process')
+    })
+
+    it('refuses an array of structures', () => {
+      const bank = arrayOf('bank', 'Motor')
+      bank.type.data!.baseType = { definition: 'user-data-type', value: 'Motor' }
+
+      expect(refusalOf(describeShmLeaves(bank, [MOTOR]))?.reason).toContain('array of structures')
+    })
+
+    it('refuses a named ARRAY type', () => {
+      const named: PLCDataType = {
+        name: 'Bank',
+        derivation: 'array',
+        baseType: { definition: 'base-type', value: 'INT' },
+        dimensions: [{ dimension: '0..3' }],
+      }
+
+      expect(refusalOf(describeShmLeaves(userTyped('b', 'Bank'), [named]))?.reason).toContain('named ARRAY type')
+    })
+
+    it('refuses an unsupported elementary type', () => {
+      expect(refusalOf(describeShmLeaves(scalar('x', 'float32')))?.reason).toContain('not a type Python can exchange')
+    })
+
+    it('names the member that cannot cross, not the variable containing it', () => {
+      const rig: PLCDataType = {
+        name: 'Rig',
+        derivation: 'structure',
+        variable: [{ name: 'timer', type: { definition: 'user-data-type', value: 'TON' } }],
+      }
+      const refusal = refusalOf(describeShmLeaves(userTyped('r', 'Rig'), [rig]))
+
+      expect(refusal?.path).toEqual(['r', 'timer'])
+    })
+
+    it('refuses a structure that contains itself rather than recursing forever', () => {
+      const loop: PLCDataType = {
+        name: 'Loop',
+        derivation: 'structure',
+        variable: [{ name: 'inner', type: { definition: 'user-data-type', value: 'Loop' } }],
+      }
+
+      expect(refusalOf(describeShmLeaves(userTyped('l', 'Loop'), [loop]))?.reason).toContain('refers to itself')
+    })
+  })
+})
+
+describe('describeShmLayout', () => {
+  it('concatenates every variable’s leaves in order', () => {
+    const result = describeShmLayout([scalar('a', 'INT'), userTyped('m', 'Motor')], [MOTOR])
+
+    expect(leavesOf(result).map((l) => l.field)).toEqual(['a', 'm_speed', 'm_label'])
+  })
+
+  it('reports the first refusal rather than a partial layout', () => {
+    // A partial layout is the corruption this design exists to prevent: a
+    // missing field shifts every later field's offset.
+    const result = describeShmLayout([scalar('a', 'INT'), userTyped('t', 'TON')], [MOTOR])
+
+    expect('refusal' in result).toBe(true)
+  })
+
+  it('is empty for no variables', () => {
+    expect(leavesOf(describeShmLayout([]))).toEqual([])
+  })
+})

--- a/src/frontend/utils/python/__tests__/shm-leaves.test.ts
+++ b/src/frontend/utils/python/__tests__/shm-leaves.test.ts
@@ -1,5 +1,6 @@
 import type { PLCDataType, PLCVariable } from '../../../../middleware/shared/ports/types'
-import { describeShmLayout, describeShmLeaves } from '../shm-leaves'
+import type { ShmWalkContext } from '../shm-leaves'
+import { describeShmLayout, describeShmLeaves, pythonFunctionBlockInstances } from '../shm-leaves'
 
 const scalar = (name: string, value: string): PLCVariable => ({
   name,
@@ -47,12 +48,37 @@ const MODE: PLCDataType = {
   values: [{ description: 'STOPPED' }, { description: 'RUNNING' }],
 }
 
+/**
+ * The inbound direction, which is the wider one — for a function block instance
+ * it carries the outputs as well as the inputs. Tests that care about direction
+ * pass their own.
+ */
+const inbound = (dataTypes: PLCDataType[] = []): ShmWalkContext => ({ dataTypes, direction: 'in' })
+
+/** A library declaring TON, in the shape a `.stlib` manifest provides. */
+const TON_LIB = {
+  functionBlocks: [
+    {
+      name: 'TON',
+      inputs: [
+        { name: 'IN', type: 'BOOL' },
+        { name: 'PT', type: 'TIME' },
+      ],
+      inouts: [],
+      outputs: [
+        { name: 'Q', type: 'BOOL' },
+        { name: 'ET', type: 'TIME' },
+      ],
+    },
+  ],
+}
+
 const leavesOf = (result: ReturnType<typeof describeShmLeaves>) => ('leaves' in result ? result.leaves : [])
 const refusalOf = (result: ReturnType<typeof describeShmLeaves>) => ('refusal' in result ? result.refusal : null)
 
 describe('describeShmLeaves', () => {
   it('describes a scalar as one leaf reaching the member directly', () => {
-    const [leaf] = leavesOf(describeShmLeaves(scalar('x', 'INT')))
+    const [leaf] = leavesOf(describeShmLeaves(scalar('x', 'INT'), inbound()))
 
     expect(leaf.field).toBe('x')
     expect(leaf.path).toEqual(['x'])
@@ -61,14 +87,14 @@ describe('describeShmLeaves', () => {
   })
 
   it('describes an array as one leaf with its element count and lower bound', () => {
-    const [leaf] = leavesOf(describeShmLeaves(arrayOf('data', 'INT', '2..5')))
+    const [leaf] = leavesOf(describeShmLeaves(arrayOf('data', 'INT', '2..5'), inbound()))
 
     expect(leaf.count).toBe(4)
     expect(leaf.startIndex).toBe(2)
   })
 
   it('flattens a structure into one leaf per member, in declaration order', () => {
-    const leaves = leavesOf(describeShmLeaves(userTyped('m', 'Motor'), [MOTOR]))
+    const leaves = leavesOf(describeShmLeaves(userTyped('m', 'Motor'), inbound([MOTOR])))
 
     expect(leaves.map((l) => l.field)).toEqual(['m_speed', 'm_label'])
     expect(leaves.map((l) => l.path)).toEqual([
@@ -82,7 +108,7 @@ describe('describeShmLeaves', () => {
     // `#pragma pack` applies to the struct being defined, never to a member type
     // already laid out — the trap that made WSTRING 254 bytes against Python's
     // 253. Every leaf sits at the top level of one packed struct.
-    const leaves = leavesOf(describeShmLeaves(userTyped('m', 'Motor'), [MOTOR]))
+    const leaves = leavesOf(describeShmLeaves(userTyped('m', 'Motor'), inbound([MOTOR])))
 
     expect(leaves.every((l) => !l.field.includes('.'))).toBe(true)
   })
@@ -93,14 +119,14 @@ describe('describeShmLeaves', () => {
       derivation: 'structure',
       variable: [{ name: 'drive', type: { definition: 'user-data-type', value: 'Motor' } }],
     }
-    const leaves = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [outer, MOTOR]))
+    const leaves = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), inbound([outer, MOTOR])))
 
     expect(leaves.map((l) => l.field)).toEqual(['r_drive_speed', 'r_drive_label'])
     expect(leaves.map((l) => l.access)).toEqual(['R.DRIVE.SPEED', 'R.DRIVE.LABEL'])
   })
 
   it('describes an enumeration as its stored integer, naming the type for Python', () => {
-    const [leaf] = leavesOf(describeShmLeaves(userTyped('md', 'Mode'), [MODE]))
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('md', 'Mode'), inbound([MODE])))
 
     expect(leaf.descriptor.cType).toBe('int16_t')
     expect(leaf.enumTypeName).toBe('Mode')
@@ -119,7 +145,7 @@ describe('describeShmLeaves', () => {
       derivation: 'structure',
       variable: [{ name: 'mode', type: { definition: 'user-data-type', value: 'Mode' } }],
     }
-    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [rig, MODE]))
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), inbound([rig, MODE])))
 
     expect(leaf.access).toBe('R.MODE_')
   })
@@ -132,7 +158,7 @@ describe('describeShmLeaves', () => {
       derivation: 'structure',
       variable: [{ name: 'time', type: { definition: 'base-type', value: 'TIME' } }],
     }
-    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [rig]))
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), inbound([rig])))
 
     expect(leaf.access).toBe('R.TIME')
   })
@@ -152,7 +178,7 @@ describe('describeShmLeaves', () => {
         },
       ],
     }
-    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [rig]))
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), inbound([rig])))
 
     expect(leaf.count).toBe(3)
     expect(leaf.startIndex).toBe(1)
@@ -176,7 +202,7 @@ describe('describeShmLeaves', () => {
         },
       ],
     }
-    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), [rig]))
+    const [leaf] = leavesOf(describeShmLeaves(userTyped('r', 'Rig'), inbound([rig])))
 
     expect(leaf.startIndex).toBe(0)
   })
@@ -193,22 +219,213 @@ describe('describeShmLeaves', () => {
       debug: false,
     }
 
-    expect(refusalOf(describeShmLeaves(bare))?.reason).toContain('not a type a Python block can exchange')
+    expect(refusalOf(describeShmLeaves(bare, inbound()))?.reason).toContain('not a type a Python block can exchange')
+  })
+
+  describe('function block instances', () => {
+    // Python cannot call an instance, but the generated ST wrapper does, once per
+    // scan, in the PLC process where the instance lives. So the pins cross like a
+    // structure's members — and which ones cross depends on the direction, because
+    // the block's inputs are the caller's to drive and its outputs are the
+    // instance's to produce.
+    const ton = (name: string): PLCVariable => ({
+      name,
+      class: 'local',
+      type: { definition: 'derived', value: 'TON' },
+      location: '',
+      documentation: '',
+      debug: false,
+    })
+    const ctx = (direction: 'in' | 'out'): ShmWalkContext => ({ dataTypes: [], libraries: [TON_LIB], direction })
+
+    it('carries every pin inbound, so Python can read what the instance produced', () => {
+      const leaves = leavesOf(describeShmLeaves(ton('ton0'), ctx('in')))
+
+      expect(leaves.map((l) => l.field)).toEqual(['ton0_IN', 'ton0_PT', 'ton0_Q', 'ton0_ET'])
+    })
+
+    it('carries only the drivable pins outbound, so Python cannot forge an output', () => {
+      const leaves = leavesOf(describeShmLeaves(ton('ton0'), ctx('out')))
+
+      expect(leaves.map((l) => l.field)).toEqual(['ton0_IN', 'ton0_PT'])
+    })
+
+    it('reaches each pin as an upper-cased member of the instance', () => {
+      const leaves = leavesOf(describeShmLeaves(ton('ton0'), ctx('in')))
+
+      expect(leaves.map((l) => l.access)).toEqual(['TON0.IN', 'TON0.PT', 'TON0.Q', 'TON0.ET'])
+    })
+
+    it('describes each pin with its own IEC type', () => {
+      const leaves = leavesOf(describeShmLeaves(ton('ton0'), ctx('in')))
+
+      expect(leaves.map((l) => l.descriptor.cType)).toEqual(['uint8_t', 'int64_t', 'uint8_t', 'int64_t'])
+    })
+
+    it('gives Python an attribute path per pin', () => {
+      const leaves = leavesOf(describeShmLeaves(ton('ton0'), ctx('in')))
+
+      expect(leaves.map((l) => l.path)).toEqual([
+        ['ton0', 'IN'],
+        ['ton0', 'PT'],
+        ['ton0', 'Q'],
+        ['ton0', 'ET'],
+      ])
+    })
+
+    it('leaves a project block’s internal state out entirely', () => {
+      // A block's own locals are its business; letting Python write them would
+      // corrupt the instance from outside. Only a project-declared block can
+      // have them — a library manifest lists pins only.
+      const withLocal = {
+        name: 'Accum',
+        pouType: 'function-block' as const,
+        interface: {
+          variables: [
+            {
+              name: 'step',
+              class: 'input' as const,
+              type: { definition: 'base-type' as const, value: 'INT' },
+              location: '',
+              documentation: '',
+            },
+            {
+              name: 'carry',
+              class: 'local' as const,
+              type: { definition: 'base-type' as const, value: 'DINT' },
+              location: '',
+              documentation: '',
+            },
+            {
+              name: 'total',
+              class: 'output' as const,
+              type: { definition: 'base-type' as const, value: 'DINT' },
+              location: '',
+              documentation: '',
+            },
+          ],
+        },
+        body: { language: 'st' as const, value: '' },
+      }
+      const acc: PLCVariable = { ...ton('acc'), type: { definition: 'derived', value: 'Accum' } }
+      const leaves = leavesOf(describeShmLeaves(acc, { dataTypes: [], pous: [withLocal], direction: 'in' }))
+
+      expect(leaves.map((l) => l.field)).toEqual(['acc_STEP', 'acc_TOTAL'])
+    })
+
+    it('omits a library block’s pins that are not declared', () => {
+      // A block's own locals are its business; letting Python write them would
+      // corrupt the instance from outside.
+      const withLocals = {
+        functionBlocks: [
+          {
+            name: 'ACC',
+            inputs: [{ name: 'STEP', type: 'INT' }],
+            inouts: [],
+            outputs: [{ name: 'TOTAL', type: 'DINT' }],
+          },
+        ],
+      }
+      const acc: PLCVariable = { ...ton('acc'), type: { definition: 'derived', value: 'ACC' } }
+      const leaves = leavesOf(describeShmLeaves(acc, { dataTypes: [], libraries: [withLocals], direction: 'in' }))
+
+      expect(leaves.map((l) => l.field)).toEqual(['acc_STEP', 'acc_TOTAL'])
+    })
+
+    it('resolves a project-declared block, which shadows a library of the same name', () => {
+      const projectPou = {
+        name: 'TON',
+        pouType: 'function-block' as const,
+        interface: {
+          variables: [
+            {
+              name: 'mine',
+              class: 'input' as const,
+              type: { definition: 'base-type' as const, value: 'INT' },
+              location: '',
+              documentation: '',
+            },
+          ],
+        },
+        body: { language: 'st' as const, value: '' },
+      }
+      const leaves = leavesOf(
+        describeShmLeaves(ton('t'), { dataTypes: [], pous: [projectPou], libraries: [TON_LIB], direction: 'in' }),
+      )
+
+      // Upper-cased even though the project declared it lowercase: the compiler
+      // upper-cases members, and the Python attribute has to match the slot.
+      expect(leaves.map((l) => l.field)).toEqual(['t_MINE'])
+    })
+  })
+
+  describe('pythonFunctionBlockInstances', () => {
+    it('finds the instances the wrapper has to call, in declaration order', () => {
+      const vars: PLCVariable[] = [
+        scalar('x', 'INT'),
+        { ...scalar('b', 'INT'), type: { definition: 'derived', value: 'TON' } },
+        userTyped('m', 'Motor'),
+        { ...scalar('a', 'INT'), type: { definition: 'derived', value: 'ACC' } },
+      ]
+
+      expect(pythonFunctionBlockInstances(vars, [MOTOR]).map((v) => v.name)).toEqual(['b', 'a'])
+    })
+
+    it('does not mistake a declared structure for an instance', () => {
+      expect(pythonFunctionBlockInstances([userTyped('m', 'Motor')], [MOTOR])).toEqual([])
+    })
+
+    it('treats a name the project does not declare as an instance', () => {
+      // The parser leaves it `user-data-type` when it resolved nothing; from here
+      // that is the same situation as `derived`.
+      expect(pythonFunctionBlockInstances([userTyped('t', 'TON')], [MOTOR]).map((v) => v.name)).toEqual(['t'])
+    })
   })
 
   describe('refusals', () => {
-    it('refuses a function block instance, naming why', () => {
-      const refusal = refusalOf(describeShmLeaves(userTyped('t', 'TON'), [MOTOR]))
+    it('refuses an instance whose block cannot be found anywhere', () => {
+      // No project POU and no library declares it, so there are no pins to walk.
+      // The reason says that rather than blaming the type.
+      const refusal = refusalOf(describeShmLeaves(userTyped('t', 'Nowhere'), inbound([MOTOR])))
 
-      expect(refusal?.reason).toContain('function block instance')
-      expect(refusal?.reason).toContain('its own process')
+      expect(refusal?.reason).toContain('no function block by that name was found')
+    })
+
+    it('refuses an array of function block instances', () => {
+      const bank: PLCVariable = {
+        name: 'bank',
+        class: 'local',
+        type: {
+          definition: 'array',
+          value: 'ARRAY [0..1] OF TON',
+          data: { baseType: { definition: 'user-data-type', value: 'TON' }, dimensions: [{ dimension: '0..1' }] },
+        },
+        location: '',
+        documentation: '',
+        debug: false,
+      }
+
+      expect(refusalOf(describeShmLeaves(bank, { ...inbound(), libraries: [TON_LIB] }))?.reason).toContain(
+        'array of function block instances',
+      )
+    })
+
+    it('refuses an instance whose pin type cannot cross, naming the pin', () => {
+      // A generic pin (`ANY_NUM`) has no type until it is wired, so there is no
+      // width to marshal.
+      const generic = {
+        functionBlocks: [{ name: 'ADD', inputs: [{ name: 'IN1', type: 'ANY_NUM' }], outputs: [], inouts: [] }],
+      }
+      const refusal = refusalOf(describeShmLeaves(userTyped('a', 'ADD'), { ...inbound(), libraries: [generic] }))
+
+      expect(refusal?.path).toEqual(['a', 'IN1'])
     })
 
     it('refuses an array of structures', () => {
       const bank = arrayOf('bank', 'Motor')
       bank.type.data!.baseType = { definition: 'user-data-type', value: 'Motor' }
 
-      expect(refusalOf(describeShmLeaves(bank, [MOTOR]))?.reason).toContain('array of structures')
+      expect(refusalOf(describeShmLeaves(bank, inbound([MOTOR])))?.reason).toContain('array of structures')
     })
 
     it('refuses a named ARRAY type', () => {
@@ -219,11 +436,13 @@ describe('describeShmLeaves', () => {
         dimensions: [{ dimension: '0..3' }],
       }
 
-      expect(refusalOf(describeShmLeaves(userTyped('b', 'Bank'), [named]))?.reason).toContain('named ARRAY type')
+      expect(refusalOf(describeShmLeaves(userTyped('b', 'Bank'), inbound([named])))?.reason).toContain(
+        'named ARRAY type',
+      )
     })
 
     it('refuses an unsupported elementary type', () => {
-      const reason = refusalOf(describeShmLeaves(scalar('x', 'float32')))?.reason
+      const reason = refusalOf(describeShmLeaves(scalar('x', 'float32'), inbound()))?.reason
       // The reason lists what IS supported, so the message stands on its own —
       // an FB-instance refusal needs a different explanation entirely, and a
       // single trailing list would be wrong for one of them.
@@ -237,7 +456,7 @@ describe('describeShmLeaves', () => {
         derivation: 'structure',
         variable: [{ name: 'timer', type: { definition: 'user-data-type', value: 'TON' } }],
       }
-      const refusal = refusalOf(describeShmLeaves(userTyped('r', 'Rig'), [rig]))
+      const refusal = refusalOf(describeShmLeaves(userTyped('r', 'Rig'), inbound([rig])))
 
       expect(refusal?.path).toEqual(['r', 'timer'])
     })
@@ -249,14 +468,16 @@ describe('describeShmLeaves', () => {
         variable: [{ name: 'inner', type: { definition: 'user-data-type', value: 'Loop' } }],
       }
 
-      expect(refusalOf(describeShmLeaves(userTyped('l', 'Loop'), [loop]))?.reason).toContain('refers to itself')
+      expect(refusalOf(describeShmLeaves(userTyped('l', 'Loop'), inbound([loop])))?.reason).toContain(
+        'refers to itself',
+      )
     })
   })
 })
 
 describe('describeShmLayout', () => {
   it('concatenates every variable’s leaves in order', () => {
-    const result = describeShmLayout([scalar('a', 'INT'), userTyped('m', 'Motor')], [MOTOR])
+    const result = describeShmLayout([scalar('a', 'INT'), userTyped('m', 'Motor')], inbound([MOTOR]))
 
     expect(leavesOf(result).map((l) => l.field)).toEqual(['a', 'm_speed', 'm_label'])
   })
@@ -264,12 +485,12 @@ describe('describeShmLayout', () => {
   it('reports the first refusal rather than a partial layout', () => {
     // A partial layout is the corruption this design exists to prevent: a
     // missing field shifts every later field's offset.
-    const result = describeShmLayout([scalar('a', 'INT'), userTyped('t', 'TON')], [MOTOR])
+    const result = describeShmLayout([scalar('a', 'INT'), userTyped('t', 'TON')], inbound([MOTOR]))
 
     expect('refusal' in result).toBe(true)
   })
 
   it('is empty for no variables', () => {
-    expect(leavesOf(describeShmLayout([]))).toEqual([])
+    expect(leavesOf(describeShmLayout([], inbound()))).toEqual([])
   })
 })

--- a/src/frontend/utils/python/__tests__/shm-type-map.test.ts
+++ b/src/frontend/utils/python/__tests__/shm-type-map.test.ts
@@ -1,7 +1,9 @@
 import { execFileSync } from 'node:child_process'
 
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import { IEC_BASE_TYPES } from '../../iec-types-registry'
 import {
+  describeShmBaseType,
   describeShmField,
   describeVariableType,
   SHM_SCALAR_TYPES,
@@ -149,5 +151,55 @@ describe('describeVariableType', () => {
 
   it('names a user-defined type', () => {
     expect(describeVariableType(userType('v', 'Motor'))).toBe('MOTOR')
+  })
+})
+
+describe('SHM_SCALAR_TYPES is derived from the compiler, not restated', () => {
+  // The governing rule on DOPE-584: the compiler is the single source of truth,
+  // and nothing downstream hard-codes a type fact. This table used to restate
+  // the size and C type of all 19 elementary types beside
+  // `strucpp/libs/iec-types.json`, and the two had already drifted — the aliases
+  // below were the observable symptom.
+
+  it('covers every user-declarable elementary type in the registry', () => {
+    const missing = IEC_BASE_TYPES.filter((type) => {
+      if (type.name.startsWith('__')) return false
+      return describeShmBaseType(type.name) === null
+    }).map((type) => type.name)
+
+    expect(missing).toEqual([])
+  })
+
+  it('takes each width from the registry rather than a local literal', () => {
+    for (const type of IEC_BASE_TYPES) {
+      if (type.name.startsWith('__')) continue
+      // STRING / WSTRING report byteSize 0 in the registry — their width is a
+      // length prefix plus a body, described by SHM_STRING / SHM_WSTRING.
+      if (type.byteSize === 0) continue
+      expect(describeShmBaseType(type.name)?.size).toBe(type.byteSize)
+    }
+  })
+
+  it('resolves TIME_OF_DAY exactly like TOD', () => {
+    // Reachable through PLCopen XML import and library FB manifests, both of
+    // which carry the alias spelling. The hand-written table had only `tod`, so
+    // a variable declared as TIME_OF_DAY made the whole block refuse.
+    expect(describeShmBaseType('TIME_OF_DAY')).toEqual(describeShmBaseType('TOD'))
+  })
+
+  it('resolves DATE_AND_TIME exactly like DT', () => {
+    expect(describeShmBaseType('DATE_AND_TIME')).toEqual(describeShmBaseType('DT'))
+  })
+
+  it('accepts any case and surrounding whitespace, as the registry does', () => {
+    // Legacy project files carry whitespace-padded and mixed-case type names;
+    // `lookupBaseType` trims and folds case, and routing through it means this
+    // file no longer re-implements that rule (badly).
+    expect(describeShmBaseType('  dInT  ')).toEqual(describeShmBaseType('DINT'))
+  })
+
+  it('still refuses a name that is not an elementary type', () => {
+    expect(describeShmBaseType('Motor')).toBeNull()
+    expect(describeShmBaseType('')).toBeNull()
   })
 })

--- a/src/frontend/utils/python/__tests__/shm-type-map.test.ts
+++ b/src/frontend/utils/python/__tests__/shm-type-map.test.ts
@@ -1,0 +1,153 @@
+import { execFileSync } from 'node:child_process'
+
+import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import {
+  describeShmField,
+  describeVariableType,
+  SHM_SCALAR_TYPES,
+  SHM_STRING,
+  SHM_STRING_CHARS,
+  SHM_WSTRING,
+} from '../shm-type-map'
+
+const scalar = (name: string, value: string): PLCVariable => ({
+  name,
+  class: 'input',
+  type: { definition: 'base-type', value },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const arrayOf = (name: string, baseType: string, dimension = '0..3'): PLCVariable => ({
+  name,
+  class: 'input',
+  type: {
+    definition: 'array',
+    value: `ARRAY [${dimension}] OF ${baseType}`,
+    data: { baseType: { definition: 'base-type', value: baseType }, dimensions: [{ dimension }] },
+  },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+const userType = (name: string, typeName: string): PLCVariable => ({
+  name,
+  class: 'input',
+  type: { definition: 'user-data-type', value: typeName },
+  location: '',
+  documentation: '',
+  debug: false,
+})
+
+/**
+ * Ask a real Python interpreter what a format string measures.
+ *
+ * The point of the descriptor table is that the C struct and the Python format
+ * describe the same bytes. Asserting the declared size against a hand-written
+ * constant would only restate the table; asking `struct.calcsize` measures the
+ * side that actually decodes the buffer at runtime.
+ */
+function pythonCalcsize(format: string): number {
+  const out = execFileSync('python3', ['-c', `import struct;print(struct.calcsize(${JSON.stringify(format)}))`], {
+    encoding: 'utf-8',
+  })
+  return Number.parseInt(out.trim(), 10)
+}
+
+describe('SHM type map — the C and Python sides describe the same bytes', () => {
+  const entries = Object.entries(SHM_SCALAR_TYPES)
+
+  it.each(entries)('%s: declared size matches struct.calcsize of its format', (_name, descriptor) => {
+    expect(pythonCalcsize(`=${descriptor.pyFormat}`)).toBe(descriptor.size)
+  })
+
+  it('STRING is a length byte plus its character budget', () => {
+    expect(pythonCalcsize(`=${SHM_STRING.pyFormat}`)).toBe(SHM_STRING.size)
+    expect(SHM_STRING.size).toBe(1 + SHM_STRING_CHARS)
+  })
+
+  it('WSTRING is a length byte plus two bytes per character', () => {
+    expect(pythonCalcsize(`=${SHM_WSTRING.pyFormat}`)).toBe(SHM_WSTRING.size)
+    expect(SHM_WSTRING.size).toBe(1 + SHM_STRING_CHARS * 2)
+  })
+
+  it('STRING and WSTRING match the sizes the debug map reports', () => {
+    // strucpp emits these for the same variables; the transport must agree with
+    // what the debugger already speaks.
+    expect(SHM_STRING.size).toBe(127)
+    expect(SHM_WSTRING.size).toBe(253)
+  })
+
+  it('every scalar has a distinct, non-empty C type and format', () => {
+    for (const [name, descriptor] of entries) {
+      expect(descriptor.cType).not.toBe('')
+      expect(descriptor.pyFormat).not.toBe('')
+      expect(descriptor.kind).toBe('scalar')
+      expect(descriptor.size).toBeGreaterThan(0)
+      expect(name).toBe(name.toLowerCase())
+    }
+  })
+})
+
+describe('describeShmField', () => {
+  it.each(['bool', 'sint', 'int', 'dint', 'lint', 'usint', 'uint', 'udint', 'ulint'])(
+    'resolves the integer type %s',
+    (t) => {
+      expect(describeShmField(scalar('v', t))).toBe(SHM_SCALAR_TYPES[t])
+    },
+  )
+
+  it.each(['time', 'date', 'tod', 'dt'])('resolves the duration/calendar type %s as int64', (t) => {
+    const descriptor = describeShmField(scalar('v', t))
+    expect(descriptor?.cType).toBe('int64_t')
+    expect(descriptor?.pyFormat).toBe('q')
+    expect(descriptor?.size).toBe(8)
+  })
+
+  it('is case-insensitive about the declared type name', () => {
+    expect(describeShmField(scalar('v', 'DINT'))).toBe(SHM_SCALAR_TYPES.dint)
+    expect(describeShmField(scalar('v', 'Real'))).toBe(SHM_SCALAR_TYPES.real)
+  })
+
+  it('resolves STRING and WSTRING to distinct descriptors', () => {
+    expect(describeShmField(scalar('v', 'string'))).toBe(SHM_STRING)
+    expect(describeShmField(scalar('v', 'wstring'))).toBe(SHM_WSTRING)
+    expect(SHM_STRING.cType).not.toBe(SHM_WSTRING.cType)
+    expect(SHM_STRING.size).not.toBe(SHM_WSTRING.size)
+  })
+
+  it('resolves an array through its element type', () => {
+    expect(describeShmField(arrayOf('v', 'INT'))).toBe(SHM_SCALAR_TYPES.int)
+    expect(describeShmField(arrayOf('v', 'TIME'))).toBe(SHM_SCALAR_TYPES.time)
+  })
+
+  it('refuses a user-defined type rather than describing it', () => {
+    expect(describeShmField(userType('v', 'Motor'))).toBeNull()
+  })
+
+  it('refuses an array of a user-defined type', () => {
+    const v = arrayOf('v', 'Motor')
+    v.type.data!.baseType = { definition: 'user-data-type', value: 'Motor' }
+    expect(describeShmField(v)).toBeNull()
+  })
+
+  it('refuses an unknown base type rather than guessing a width', () => {
+    expect(describeShmField(scalar('v', 'float32'))).toBeNull()
+  })
+})
+
+describe('describeVariableType', () => {
+  it('names a scalar type', () => {
+    expect(describeVariableType(scalar('v', 'dint'))).toBe('DINT')
+  })
+
+  it('names an array by its element type', () => {
+    expect(describeVariableType(arrayOf('v', 'INT'))).toBe('ARRAY OF INT')
+  })
+
+  it('names a user-defined type', () => {
+    expect(describeVariableType(userType('v', 'Motor'))).toBe('MOTOR')
+  })
+})

--- a/src/frontend/utils/python/addPythonLocalVariables.ts
+++ b/src/frontend/utils/python/addPythonLocalVariables.ts
@@ -1,5 +1,16 @@
 import type { PLCPou, PLCProjectData, PLCVariable } from '../../../middleware/shared/ports/types'
 
+/**
+ * Names this module injects into every Python POU.
+ *
+ * Exported so the interface builder can leave them out of the shared-memory
+ * structs: they are the toolchain's own machinery — the one-shot latch and the
+ * two mapped segment addresses — not variables the user declared. Marshalling
+ * them would hand the block its own segment pointers to overwrite, and would put
+ * three fields into a layout the user cannot see or account for.
+ */
+const PYTHON_RUNTIME_INTERNAL_VARIABLES: ReadonlySet<string> = new Set(['first_run', 'shm_in_ptr', 'shm_out_ptr'])
+
 const createRuntimeVariables = (): PLCVariable[] => {
   return [
     {
@@ -57,4 +68,4 @@ const addPythonLocalVariables = (projectData: PLCProjectData): PLCProjectData =>
   return processedData
 }
 
-export { addPythonLocalVariables }
+export { addPythonLocalVariables, PYTHON_RUNTIME_INTERNAL_VARIABLES }

--- a/src/frontend/utils/python/block-interface.ts
+++ b/src/frontend/utils/python/block-interface.ts
@@ -28,6 +28,23 @@ import { PYTHON_RUNTIME_INTERNAL_VARIABLES } from './addPythonLocalVariables'
  *   - `external` travels both ways for the same reason as `local`; the stub
  *     reads and writes it through the global's own lock.
  *
+ * One consequence of marshalling an `external` is worth stating plainly, because
+ * it differs from every other language a block can be written in. Each access is
+ * atomic — the stub takes the global's lock to read and again to write — but the
+ * read-modify-write as a whole is not, because the "modify" happens in another
+ * process a cycle later. So `g := g + 1` in a Python block loses updates that
+ * another task makes in between, where the same line in ST or C++ completes
+ * inside one scan under one lock.
+ *
+ * Measured on hardware: a Python block and a C++ block each adding 2 to the same
+ * global reached about 70% of the total both had added. With a single writer —
+ * the ordinary case — the count is exact.
+ *
+ * The alternative is holding the lock from the Python read to the Python write,
+ * which would stall every other task touching that global for a whole Python
+ * cycle. Lost updates under contention is the better trade, but it is a real
+ * difference and belongs in the user documentation.
+ *
  * `temp` is absent deliberately: see `PYTHON_UNSUPPORTED_CLASSES`. `global` is
  * absent for the reason it is absent from a POU at all — it is a
  * configuration-level declaration, not a POU variable. So are the toolchain's

--- a/src/frontend/utils/python/block-interface.ts
+++ b/src/frontend/utils/python/block-interface.ts
@@ -1,0 +1,111 @@
+import type { PLCVariable, VariableClass } from '../../../middleware/shared/ports/types'
+import { PYTHON_RUNTIME_INTERNAL_VARIABLES } from './addPythonLocalVariables'
+
+/**
+ * Which of a Python block's variables cross each way through shared memory.
+ *
+ * A Python block is a separate process, so unlike a C++ block it cannot be
+ * handed a pointer into the PLC's own storage. Every variable is marshalled: the
+ * stub packs one struct on the way in and unpacks another on the way out, and
+ * the Python driver decodes and re-encodes them by `struct` format string. Four
+ * emitters have to agree on the contents and the order of those two structs —
+ * the C stub's `shm_data_in_t` / `shm_data_out_t`, its copy loops, the format
+ * strings, and the driver's unpack/pack. A disagreement is not a caught error: a
+ * field one side omits shifts every later field's offset, so the corruption
+ * surfaces on unrelated variables. Hence one selection rule, here.
+ *
+ * The direction each class travels follows from what it means, not from what is
+ * convenient:
+ *
+ *   - `input` goes in only. The caller supplies it; the block reads it.
+ *   - `output` comes back only. The block produces it.
+ *   - `inOut` travels both ways, which is what VAR_IN_OUT is.
+ *   - `local` also travels both ways, though for a different reason: the PLC
+ *     owns the storage, so round-tripping is what makes a VAR survive as the
+ *     block's own state, stay visible to the debugger, and — once NODE-94 lands
+ *     — be retainable. A block that never assigns one sends back what it
+ *     received, unchanged.
+ *   - `external` travels both ways for the same reason as `local`; the stub
+ *     reads and writes it through the global's own lock.
+ *
+ * `temp` is absent deliberately: see `PYTHON_UNSUPPORTED_CLASSES`. `global` is
+ * absent for the reason it is absent from a POU at all — it is a
+ * configuration-level declaration, not a POU variable. So are the toolchain's
+ * own injected locals (`PYTHON_RUNTIME_INTERNAL_VARIABLES`): the first-run latch
+ * and the two mapped segment addresses are declared as `local`, and sweeping
+ * them into the structs would hand the block its own segment pointers to
+ * overwrite.
+ */
+const INBOUND_CLASSES: readonly VariableClass[] = ['input', 'inOut', 'local', 'external']
+
+/** Classes the block sends back to the PLC each cycle. */
+const OUTBOUND_CLASSES: readonly VariableClass[] = ['output', 'inOut', 'local', 'external']
+
+/**
+ * Classes a Python block cannot express, with the reason to show the user.
+ *
+ * VAR_TEMP means storage that does not survive the POU invocation. Python has
+ * no equivalent: the block's variables are module globals in a process that
+ * outlives every scan, so a value written to one would still be there on the
+ * next call. Marshalling it would not make it temporary, it would only make it a
+ * `local` wearing the wrong name — and the user would have written VAR to get
+ * that. Refusing says what is true.
+ */
+const PYTHON_UNSUPPORTED_CLASSES: Readonly<Record<string, string>> = {
+  temp: 'VAR_TEMP has no meaning in a Python block — its variables are module globals in a process that outlives the scan. Declare it under VAR instead.',
+}
+
+/**
+ * Select and order the variables travelling one direction.
+ *
+ * Ordering is by class, then by declaration order within a class. The order
+ * itself carries no meaning — it only has to be the same everywhere, because the
+ * struct layout and the format string are positional.
+ */
+const selectOrdered = (variables: readonly PLCVariable[], classes: readonly VariableClass[]): PLCVariable[] => {
+  const rankOf = new Map<VariableClass, number>(classes.map((cls, index) => [cls, index]))
+  const ranked: Array<{ variable: PLCVariable; rank: number; position: number }> = []
+
+  variables.forEach((variable, position) => {
+    if (PYTHON_RUNTIME_INTERNAL_VARIABLES.has(variable.name)) return
+    const rank = variable.class === undefined ? undefined : rankOf.get(variable.class)
+    if (rank === undefined) return
+    ranked.push({ variable, rank, position })
+  })
+
+  return ranked
+    .sort((a, b) => (a.rank !== b.rank ? a.rank - b.rank : a.position - b.position))
+    .map(({ variable }) => variable)
+}
+
+/** What the PLC packs into `shm_data_in_t` for the block to read. */
+const pythonInboundVariables = (variables: readonly PLCVariable[]): PLCVariable[] =>
+  selectOrdered(variables, INBOUND_CLASSES)
+
+/** What the block packs into `shm_data_out_t` for the PLC to read back. */
+const pythonOutboundVariables = (variables: readonly PLCVariable[]): PLCVariable[] =>
+  selectOrdered(variables, OUTBOUND_CLASSES)
+
+/** Every variable that crosses the boundary at all, in inbound order. */
+const pythonInterfaceVariables = (variables: readonly PLCVariable[]): PLCVariable[] => {
+  const inbound = pythonInboundVariables(variables)
+  const seen = new Set(inbound)
+  return [...inbound, ...pythonOutboundVariables(variables).filter((variable) => !seen.has(variable))]
+}
+
+/** The variables declared in a class a Python block cannot express. */
+const pythonRefusedVariables = (variables: readonly PLCVariable[]): Array<{ variable: PLCVariable; reason: string }> =>
+  variables.flatMap((variable) => {
+    const reason = variable.class === undefined ? undefined : PYTHON_UNSUPPORTED_CLASSES[variable.class]
+    return reason ? [{ variable, reason }] : []
+  })
+
+export {
+  INBOUND_CLASSES,
+  OUTBOUND_CLASSES,
+  PYTHON_UNSUPPORTED_CLASSES,
+  pythonInboundVariables,
+  pythonInterfaceVariables,
+  pythonOutboundVariables,
+  pythonRefusedVariables,
+}

--- a/src/frontend/utils/python/encodeCharactersFromVariable.ts
+++ b/src/frontend/utils/python/encodeCharactersFromVariable.ts
@@ -1,33 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
-import { getArrayBaseTypeValue, getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
-
-const TYPE_ENCODING_MAP: Record<string, string> = {
-  bool: 'B',
-  sint: 'b',
-  int: 'h',
-  dint: 'i',
-  lint: 'q',
-  usint: 'B',
-  uint: 'H',
-  udint: 'I',
-  ulint: 'Q',
-  real: 'f',
-  lreal: 'd',
-  byte: 'B',
-  word: 'H',
-  dword: 'I',
-  lword: 'Q',
-  string: 'b126s',
-}
+import { getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { describeShmField } from './shm-type-map'
 
 /**
- * Converts an array of PLC variables into a format string for Python's struct.pack/unpack.
- * For scalar variables, returns the corresponding format character.
- * For array variables, repeats the base type's format character N times (e.g., ARRAY[0..9] OF INT -> '10h').
- * @param variables Array of PLC variables
- * @returns String in the format '=hfb126sib126sH' for use with struct.pack/unpack
+ * Convert a POU's interface variables into the format string Python's
+ * `struct.pack` / `struct.unpack` use for the shared-memory exchange.
+ *
+ * The per-type formats come from `shm-type-map.ts`, which the C-side struct
+ * emitter reads as well — the two sides cannot drift because there is only one
+ * table. This function's own job is just repetition and ordering.
+ *
+ * Unsupported types are refused upstream (`preprocessPous`) rather than skipped
+ * here. Skipping was the original defect: a dropped field does not merely go
+ * missing, it shifts every later field's offset and silently corrupts them.
+ *
+ * @returns a `struct` format string such as `'=hfb126s'`, native byte order and
+ *   no alignment, matching the `#pragma pack(push, 1)` struct on the C side.
  */
-
 const encodeCharactersFromVariable = (variables: PLCVariable[]): string => {
   if (!variables || variables.length === 0) {
     return '='
@@ -35,32 +26,26 @@ const encodeCharactersFromVariable = (variables: PLCVariable[]): string => {
 
   const encodedChars = variables
     .map((variable) => {
-      if (isArrayVariable(variable)) {
-        const baseType = getArrayBaseTypeValue(variable).toLowerCase()
-        const encodingChar = TYPE_ENCODING_MAP[baseType]
-        if (!encodingChar) {
-          console.warn(`Warning: Unknown base type "${baseType}" for array variable "${variable.name}". Skipping.`)
-          return ''
-        }
-        const totalElements = getArrayTotalElements(variable)
-        // For multi-char encodings (e.g., 'b126s' for STRING), the repeat count
-        // only applies to the first char in Python struct format ('10b126s' != 10x'b126s').
-        // Repeat the full encoding string instead.
-        if (encodingChar.length > 1) {
-          return encodingChar.repeat(totalElements)
-        }
-        return `${totalElements}${encodingChar}`
-      }
-
-      const typeValue = variable.type.value.toLowerCase()
-      const encodingChar = TYPE_ENCODING_MAP[typeValue]
-
-      if (!encodingChar) {
-        console.warn(`Warning: Unknown type "${typeValue}" for variable "${variable.name}". Skipping.`)
+      const descriptor = describeShmField(variable)
+      if (!descriptor) {
+        // Unreachable through the compile path — `preprocessPous` rejects an
+        // unsupported type before any of this runs. Kept as a total function so
+        // a direct caller cannot produce a half-formed layout.
         return ''
       }
 
-      return encodingChar
+      if (isArrayVariable(variable)) {
+        const totalElements = getArrayTotalElements(variable)
+        // A repeat count applies only to the FIRST character of a struct
+        // format, so `10b126s` is not ten strings. Multi-character formats are
+        // repeated whole.
+        if (descriptor.pyFormat.length > 1) {
+          return descriptor.pyFormat.repeat(totalElements)
+        }
+        return `${totalElements}${descriptor.pyFormat}`
+      }
+
+      return descriptor.pyFormat
     })
     .filter((char) => char !== '')
 

--- a/src/frontend/utils/python/encodeCharactersFromVariable.ts
+++ b/src/frontend/utils/python/encodeCharactersFromVariable.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Autonomy / OpenPLC Project
-import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
-import type { ShmLeaf } from './shm-leaves'
+import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import type { ShmLeaf, ShmWalkContext } from './shm-leaves'
 import { describeShmLayout } from './shm-leaves'
 
 /**
@@ -36,12 +36,12 @@ const encodeCharactersFromLeaves = (leaves: readonly ShmLeaf[]): string => {
   return '=' + encoded.join('')
 }
 
-const encodeCharactersFromVariable = (variables: PLCVariable[], dataTypes: readonly PLCDataType[] = []): string => {
+const encodeCharactersFromVariable = (variables: PLCVariable[], context: ShmWalkContext): string => {
   if (!variables || variables.length === 0) {
     return '='
   }
 
-  const walked = describeShmLayout(variables, dataTypes)
+  const walked = describeShmLayout(variables, context)
   // Unreachable through the compile path — `preprocessPous` refuses anything
   // that cannot cross before any of this runs. Kept as a total function so a
   // direct caller cannot produce a half-formed layout.

--- a/src/frontend/utils/python/encodeCharactersFromVariable.ts
+++ b/src/frontend/utils/python/encodeCharactersFromVariable.ts
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Autonomy / OpenPLC Project
-import type { PLCVariable } from '../../../middleware/shared/ports/types'
-import { getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
-import { describeShmField } from './shm-type-map'
+import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
+import type { ShmLeaf } from './shm-leaves'
+import { describeShmLayout } from './shm-leaves'
 
 /**
  * Convert a POU's interface variables into the format string Python's
  * `struct.pack` / `struct.unpack` use for the shared-memory exchange.
  *
- * The per-type formats come from `shm-type-map.ts`, which the C-side struct
- * emitter reads as well — the two sides cannot drift because there is only one
- * table. This function's own job is just repetition and ordering.
+ * The format is built from the same leaf walk the C-side struct emitter uses, so
+ * the two descriptions of one layout cannot drift: a structure is flattened into
+ * the same fields, in the same order, on both sides.
  *
  * Unsupported types are refused upstream (`preprocessPous`) rather than skipped
  * here. Skipping was the original defect: a dropped field does not merely go
@@ -19,37 +19,36 @@ import { describeShmField } from './shm-type-map'
  * @returns a `struct` format string such as `'=hfb126s'`, native byte order and
  *   no alignment, matching the `#pragma pack(push, 1)` struct on the C side.
  */
-const encodeCharactersFromVariable = (variables: PLCVariable[]): string => {
+const encodeCharactersFromLeaves = (leaves: readonly ShmLeaf[]): string => {
+  const encoded = leaves.map((leaf) => {
+    if (leaf.count > 1) {
+      // A repeat count applies only to the FIRST character of a struct format,
+      // so `10b126s` is not ten strings. Multi-character formats are repeated
+      // whole.
+      if (leaf.descriptor.pyFormat.length > 1) {
+        return leaf.descriptor.pyFormat.repeat(leaf.count)
+      }
+      return `${leaf.count}${leaf.descriptor.pyFormat}`
+    }
+    return leaf.descriptor.pyFormat
+  })
+
+  return '=' + encoded.join('')
+}
+
+const encodeCharactersFromVariable = (variables: PLCVariable[], dataTypes: readonly PLCDataType[] = []): string => {
   if (!variables || variables.length === 0) {
     return '='
   }
 
-  const encodedChars = variables
-    .map((variable) => {
-      const descriptor = describeShmField(variable)
-      if (!descriptor) {
-        // Unreachable through the compile path — `preprocessPous` rejects an
-        // unsupported type before any of this runs. Kept as a total function so
-        // a direct caller cannot produce a half-formed layout.
-        return ''
-      }
+  const walked = describeShmLayout(variables, dataTypes)
+  // Unreachable through the compile path — `preprocessPous` refuses anything
+  // that cannot cross before any of this runs. Kept as a total function so a
+  // direct caller cannot produce a half-formed layout.
+  /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
+  if ('refusal' in walked) return '='
 
-      if (isArrayVariable(variable)) {
-        const totalElements = getArrayTotalElements(variable)
-        // A repeat count applies only to the FIRST character of a struct
-        // format, so `10b126s` is not ten strings. Multi-character formats are
-        // repeated whole.
-        if (descriptor.pyFormat.length > 1) {
-          return descriptor.pyFormat.repeat(totalElements)
-        }
-        return `${totalElements}${descriptor.pyFormat}`
-      }
-
-      return descriptor.pyFormat
-    })
-    .filter((char) => char !== '')
-
-  return '=' + encodedChars.join('')
+  return encodeCharactersFromLeaves(walked.leaves)
 }
 
-export { encodeCharactersFromVariable }
+export { encodeCharactersFromLeaves, encodeCharactersFromVariable }

--- a/src/frontend/utils/python/encodeCharactersFromVariable.ts
+++ b/src/frontend/utils/python/encodeCharactersFromVariable.ts
@@ -34,7 +34,14 @@ const encodeCharactersFromLeaves = (leaves: readonly ShmLeaf[]): string => {
   return '=' + encoded.join('')
 }
 
-const encodeCharactersFromVariable = (variables: PLCVariable[], context: ShmWalkContext): string => {
+/**
+ * `variables` is nullable on purpose. The guard below has always accepted a
+ * missing list — a POU with no interface at all reaches here as `undefined` from
+ * the older project shapes — but the signature claimed otherwise, so the tests
+ * covering that guard had to lie to the compiler with `as unknown as`. Stating
+ * it in the type removes the assertion instead of hiding it.
+ */
+const encodeCharactersFromVariable = (variables: PLCVariable[] | null | undefined, context: ShmWalkContext): string => {
   if (!variables || variables.length === 0) {
     return '='
   }

--- a/src/frontend/utils/python/encodeCharactersFromVariable.ts
+++ b/src/frontend/utils/python/encodeCharactersFromVariable.ts
@@ -21,13 +21,11 @@ import { describeShmLayout } from './shm-leaves'
  */
 const encodeCharactersFromLeaves = (leaves: readonly ShmLeaf[]): string => {
   const encoded = leaves.map((leaf) => {
-    if (leaf.count > 1) {
-      // A repeat count applies only to the FIRST character of a struct format,
-      // so `10b126s` is not ten strings. Multi-character formats are repeated
-      // whole.
-      if (leaf.descriptor.pyFormat.length > 1) {
-        return leaf.descriptor.pyFormat.repeat(leaf.count)
-      }
+    if (leaf.isArray) {
+      // A repeat count applies only to the FIRST item of a struct format, so
+      // `4b126s` is not four strings. Only single-item formats can carry one,
+      // which is why the walk refuses an array whose element needs more than
+      // one — an array leaf here is always a scalar element.
       return `${leaf.count}${leaf.descriptor.pyFormat}`
     }
     return leaf.descriptor.pyFormat

--- a/src/frontend/utils/python/generatePythonLspPreamble.ts
+++ b/src/frontend/utils/python/generatePythonLspPreamble.ts
@@ -95,23 +95,39 @@ function defaultPythonLiteralFor(pythonType: string): string {
   if (pythonType === 'int') return '0'
   if (pythonType === 'float') return '0.0'
   if (pythonType === 'str') return "''"
-  // Unreachable in practice: `annotationFor` yields exactly these four scalar
-  // annotations or `list[...]`, and `initialValueFor` handles the list case
-  // before delegating here. Kept as a safety net rather than a throw, because a
-  // preamble is a convenience for the editor — a wrong literal costs a Pyright
-  // diagnostic, an exception would cost the user their type checking entirely.
-  /* istanbul ignore next -- defensive: annotationFor cannot produce another value */
+  // `Any` reaches here, and `None` is assignable to it. Every other annotation
+  // — `list[...]`, a structure, an enumeration — is resolved by
+  // `initialValueFor` before it delegates, so those never arrive.
+  //
+  // This used to carry an `istanbul ignore` claiming it was unreachable. It was
+  // not: a structure or enumeration variable annotated `Motor` fell straight
+  // through the four scalars to `None`, and the preamble declared
+  // `m: Motor = None` — which Pyright correctly rejects, putting a spurious
+  // error on correct user code for the commonest composite case.
   return 'None'
 }
 
+/** The project's data types, indexed the way every other lookup indexes them. */
+const indexTypes = (dataTypes: readonly PLCDataType[]): Map<string, PLCDataType> =>
+  new Map(dataTypes.map((dataType) => [dataType.name.toUpperCase(), dataType]))
+
 /**
  * Build a Python type annotation string for a single IEC variable.
- * Returns `null` when the variable's type can't be mapped (struct,
- * enum, unsupported scalar, malformed array) — caller skips
- * declaring it rather than risk a Pyright diagnostic on the
- * preamble itself.
+ * Returns `null` when the variable's type can't be mapped at all — caller skips
+ * declaring it rather than risk a Pyright diagnostic on the preamble itself.
+ *
+ * A user-defined type is resolved through `dataTypes` rather than echoed back:
+ *
+ *   - the annotation is the type's OWN declared spelling, because that is what
+ *     `typeStubsFor` names the class. Echoing the variable's spelling meant
+ *     `m : MOTOR` against a type declared `Motor` annotated a class that does
+ *     not exist, and Pyright reported `"MOTOR" is not defined` on generated
+ *     code the user cannot see or fix.
+ *   - a name the project does not declare becomes `Any`. It gets a declaration
+ *     either way, so the name resolves while the user is still typing, but it
+ *     cannot name a class with no stub behind it.
  */
-function annotationFor(variable: PLCVariable): string | null {
+function annotationFor(variable: PLCVariable, dataTypes: readonly PLCDataType[] = []): string | null {
   if (isArrayVariable(variable)) {
     const inner = variable.type.data?.baseType?.value
     if (!inner) return null
@@ -120,11 +136,9 @@ function annotationFor(variable: PLCVariable): string | null {
     return `list[${innerPython}]`
   }
   if (variable.type.definition === 'user-data-type') {
-    // A structure or an enumeration: the stub declared above carries its shape,
-    // so the annotation is simply the class name. A type the project does not
-    // declare — a function block instance — is refused at compile time and gets
-    // no declaration here either.
-    return variable.type.value
+    const declared = indexTypes(dataTypes).get(variable.type.value.toUpperCase())
+    if (!declared || declared.derivation === 'array') return 'Any'
+    return declared.name
   }
   /* istanbul ignore next -- defensive: only base-type remains */
   if (variable.type.definition !== 'base-type') return null
@@ -140,12 +154,25 @@ function annotationFor(variable: PLCVariable): string | null {
  * runtime; the preamble's literal is only there to satisfy
  * Pyright's "name has a value" requirement.
  */
-function initialValueFor(variable: PLCVariable, annotation: string): string {
+function initialValueFor(variable: PLCVariable, annotation: string, dataTypes: readonly PLCDataType[] = []): string {
   if (annotation.startsWith('list[')) {
     const innerType = annotation.slice('list['.length, -1)
     const count = getArrayTotalElements(variable)
     const defaultInner = defaultPythonLiteralFor(innerType)
     return count > 0 ? `[${defaultInner}] * ${count}` : '[]'
+  }
+  // A class annotation needs a value of that class, not `None`. Pyright is right
+  // to reject `m: Motor = None`, and the user sees the complaint on a line the
+  // preamble wrote.
+  //
+  // A structure stub declares members as annotations and no `__init__`, so
+  // `Motor()` constructs and type-checks. An enumeration cannot be called, so it
+  // takes its first member — which is also the value the PLC starts it at.
+  const declared = indexTypes(dataTypes).get(annotation.toUpperCase())
+  if (declared?.derivation === 'structure') return `${declared.name}()`
+  if (declared?.derivation === 'enumerated') {
+    const first = declared.values[0]?.description
+    return first ? `${declared.name}.${first}` : 'Any'
   }
   return defaultPythonLiteralFor(annotation)
 }
@@ -190,12 +217,15 @@ function typeStubsFor(variables: PLCVariable[], dataTypes: readonly PLCDataType[
     }
     lines.push(`class ${dataType.name}:`)
     for (const member of dataType.variable) {
-      const annotation = annotationFor({
-        name: member.name,
-        type: member.type,
-        location: '',
-        documentation: '',
-      })
+      const annotation = annotationFor(
+        {
+          name: member.name,
+          type: member.type,
+          location: '',
+          documentation: '',
+        },
+        dataTypes,
+      )
       lines.push(`    ${member.name}: ${annotation ?? 'Any'}`)
     }
   }
@@ -237,7 +267,7 @@ export function generatePythonLspPreamble(
     '# names as module-level globals at runtime (see injectPythonRuntime).',
     '# ===================================================================',
   ]
-  const declared = declarable.filter((variable) => annotationFor(variable) !== null)
+  const declared = declarable.filter((variable) => annotationFor(variable, dataTypes) !== null)
   const typeStubs = typeStubsFor(declared, dataTypes)
   const declLines: string[] = []
   const variableNameByPreambleLine = new Map<number, string>()
@@ -248,9 +278,9 @@ export function generatePythonLspPreamble(
   // get a declaration line, so they don't take a slot in the map.
   let preambleLine = header.length + typeStubs.length
   for (const v of declarable) {
-    const annotation = annotationFor(v)
+    const annotation = annotationFor(v, dataTypes)
     if (!annotation) continue
-    declLines.push(`${v.name}: ${annotation} = ${initialValueFor(v, annotation)}`)
+    declLines.push(`${v.name}: ${annotation} = ${initialValueFor(v, annotation, dataTypes)}`)
     variableNameByPreambleLine.set(preambleLine, v.name)
     preambleLine++
   }

--- a/src/frontend/utils/python/generatePythonLspPreamble.ts
+++ b/src/frontend/utils/python/generatePythonLspPreamble.ts
@@ -25,6 +25,7 @@
  */
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
 import { getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { pythonInterfaceVariables } from './block-interface'
 
 export interface PythonLspPreamble {
   /** Ready-to-prepend text, terminated by a newline (or empty). */
@@ -94,9 +95,12 @@ function defaultPythonLiteralFor(pythonType: string): string {
   if (pythonType === 'int') return '0'
   if (pythonType === 'float') return '0.0'
   if (pythonType === 'str') return "''"
-  // list[...] or any other compound — empty list is the safest no-op
-  // initial value Pyright accepts as compatible with the annotation.
-  if (pythonType.startsWith('list[')) return '[]'
+  // Unreachable in practice: `annotationFor` yields exactly these four scalar
+  // annotations or `list[...]`, and `initialValueFor` handles the list case
+  // before delegating here. Kept as a safety net rather than a throw, because a
+  // preamble is a convenience for the editor — a wrong literal costs a Pyright
+  // diagnostic, an exception would cost the user their type checking entirely.
+  /* istanbul ignore next -- defensive: annotationFor cannot produce another value */
   return 'None'
 }
 
@@ -155,7 +159,7 @@ function initialValueFor(variable: PLCVariable, annotation: string): string {
  * the lines are a synthetic Pyright nudge, not user code.
  */
 export function generatePythonLspPreamble(variables: PLCVariable[]): PythonLspPreamble {
-  const declarable = variables.filter((v) => v.class === 'input' || v.class === 'output')
+  const declarable = pythonInterfaceVariables(variables)
   if (declarable.length === 0) {
     return { text: '', lineCount: 0, variableNameByPreambleLine: new Map() }
   }

--- a/src/frontend/utils/python/generatePythonLspPreamble.ts
+++ b/src/frontend/utils/python/generatePythonLspPreamble.ts
@@ -23,7 +23,7 @@
  * POU has no input/output variables — keeps the caller's prepend
  * logic uniform without a special case.
  */
-import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
 import { getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
 import { pythonInterfaceVariables } from './block-interface'
 
@@ -119,11 +119,15 @@ function annotationFor(variable: PLCVariable): string | null {
     if (!innerPython) return null
     return `list[${innerPython}]`
   }
-  if (variable.type.definition !== 'base-type') {
-    // user-data-type (struct / enum) — runtime injection doesn't
-    // pack these across shared memory today; skip silently.
-    return null
+  if (variable.type.definition === 'user-data-type') {
+    // A structure or an enumeration: the stub declared above carries its shape,
+    // so the annotation is simply the class name. A type the project does not
+    // declare — a function block instance — is refused at compile time and gets
+    // no declaration here either.
+    return variable.type.value
   }
+  /* istanbul ignore next -- defensive: only base-type remains */
+  if (variable.type.definition !== 'base-type') return null
   return mapIecBaseTypeToPython(variable.type.value)
 }
 
@@ -147,18 +151,80 @@ function initialValueFor(variable: PLCVariable, annotation: string): string {
 }
 
 /**
- * Generate the LSP-only preamble for a POU's variables.  Only
- * `input` and `output` IEC variables get a declaration — those are
- * the classes `injectPythonRuntime` wires through shared memory and
- * therefore the only ones the runtime will actually expose as
- * module-level globals.  Local / temp / inOut / external classes
- * are intentionally skipped so Pyright doesn't pretend symbols
- * exist that the runtime won't bind.
+ * Class stubs for the structures and enumerations a POU's interface uses.
+ *
+ * These mirror what `injectPythonRuntime` actually defines at runtime, so
+ * Pyright resolves `m.speed` and `Mode.RUNNING` to the same shapes the block
+ * will really see. Without them a structure variable has no type to be, and the
+ * editor either says nothing useful or reports an error on correct code.
+ *
+ * The stub bodies are `...` rather than the runtime's real `__init__`: Pyright
+ * only needs the attribute names and their types, and a shorter stub keeps the
+ * preamble's line count — which the diagnostic line mapping depends on — small.
+ */
+function typeStubsFor(variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string[] {
+  if (dataTypes.length === 0) return []
+  const byName = new Map(dataTypes.map((dataType) => [dataType.name.toUpperCase(), dataType]))
+  const emitted = new Set<string>()
+  const lines: string[] = []
+
+  // `emitted` is what breaks a cycle: a structure that contains itself is
+  // declared once and its member simply refers back to it, which is a legal
+  // Python annotation and exactly what Pyright should see.
+  const visit = (typeName: string): void => {
+    const key = typeName.toUpperCase()
+    if (emitted.has(key)) return
+    const dataType = byName.get(key)
+    if (!dataType || dataType.derivation === 'array') return
+    emitted.add(key)
+
+    if (dataType.derivation === 'enumerated') {
+      lines.push(`class ${dataType.name}(IntEnum):`)
+      dataType.values.forEach((value, index) => lines.push(`    ${value.description} = ${index}`))
+      return
+    }
+
+    // Members first, so a nested structure is named before it is referenced.
+    for (const member of dataType.variable) {
+      if (member.type.definition === 'user-data-type') visit(member.type.value)
+    }
+    lines.push(`class ${dataType.name}:`)
+    for (const member of dataType.variable) {
+      const annotation = annotationFor({
+        name: member.name,
+        type: member.type,
+        location: '',
+        documentation: '',
+      })
+      lines.push(`    ${member.name}: ${annotation ?? 'Any'}`)
+    }
+  }
+
+  // Only the variables that actually get a declaration below. An array of
+  // structures has no Python annotation and is refused at compile time, so it
+  // gets neither a declaration nor a stub — the editor stays in lockstep with
+  // what the build will accept.
+  for (const variable of variables) {
+    if (variable.type.definition === 'user-data-type') visit(variable.type.value)
+  }
+
+  return lines.length > 0 ? ['from enum import IntEnum', 'from typing import Any', ...lines, ''] : []
+}
+
+/**
+ * Generate the LSP-only preamble for a POU's variables.
+ *
+ * Every class `injectPythonRuntime` wires through shared memory gets a
+ * declaration, because those are exactly the names the runtime binds as module
+ * globals. `temp` is refused for a Python block and so is never one.
  *
  * The header comment makes it obvious in any debug snapshot that
  * the lines are a synthetic Pyright nudge, not user code.
  */
-export function generatePythonLspPreamble(variables: PLCVariable[]): PythonLspPreamble {
+export function generatePythonLspPreamble(
+  variables: PLCVariable[],
+  dataTypes: readonly PLCDataType[] = [],
+): PythonLspPreamble {
   const declarable = pythonInterfaceVariables(variables)
   if (declarable.length === 0) {
     return { text: '', lineCount: 0, variableNameByPreambleLine: new Map() }
@@ -171,6 +237,8 @@ export function generatePythonLspPreamble(variables: PLCVariable[]): PythonLspPr
     '# names as module-level globals at runtime (see injectPythonRuntime).',
     '# ===================================================================',
   ]
+  const declared = declarable.filter((variable) => annotationFor(variable) !== null)
+  const typeStubs = typeStubsFor(declared, dataTypes)
   const declLines: string[] = []
   const variableNameByPreambleLine = new Map<number, string>()
   // First declaration sits at line `header.length` (header occupies
@@ -178,7 +246,7 @@ export function generatePythonLspPreamble(variables: PLCVariable[]): PythonLspPr
   // by one line.  Variables whose type can't be mapped to Python
   // (TIME / DATE / TOD / DT / user types) are skipped — they don't
   // get a declaration line, so they don't take a slot in the map.
-  let preambleLine = header.length
+  let preambleLine = header.length + typeStubs.length
   for (const v of declarable) {
     const annotation = annotationFor(v)
     if (!annotation) continue
@@ -190,7 +258,7 @@ export function generatePythonLspPreamble(variables: PLCVariable[]): PythonLspPr
     return { text: '', lineCount: 0, variableNameByPreambleLine: new Map() }
   }
 
-  const body = [...header, ...declLines, '', '']
+  const body = [...header, ...typeStubs, ...declLines, '', '']
   const text = body.join('\n')
   // `lineCount` is the 0-indexed augmented-document line where the
   // user's first line begins.  Equivalently: the number of newline

--- a/src/frontend/utils/python/generateSTCode.ts
+++ b/src/frontend/utils/python/generateSTCode.ts
@@ -1,10 +1,6 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
-import {
-  getArrayStartIndex,
-  getArrayTotalElements,
-  getVariableIECType,
-  isArrayVariable,
-} from '../PLC/array-codegen-helpers'
+import { getArrayStartIndex, getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { describeShmField, SHM_STRING_CHARS } from './shm-type-map'
 
 type STCodeGenerationParams = {
   pouName: string
@@ -13,71 +9,26 @@ type STCodeGenerationParams = {
 }
 
 /**
- * Detect a STRING / WSTRING base-type variable. Strings flow through the
- * SHM struct as `{ len; body[STR_MAX_LEN]; }` (mirroring the historical
- * MatIEC-era layout the Python runtime side already speaks). The C-side
- * stub copies in/out of strucpp's IECStringVar at the boundary.
+ * Which of the three SHM shapes a field takes, from the one table both sides
+ * read (`shm-type-map.ts`). `null` never reaches here in a real compile —
+ * `preprocessPous` refuses an unsupported type first — but the emitters stay
+ * total so a direct caller cannot produce a half-formed struct.
  */
-const isStringVariable = (variable: PLCVariable): boolean => {
-  if (variable.type.definition !== 'base-type') return false
-  const v = variable.type.value.toLowerCase()
-  return v === 'string' || v === 'wstring'
-}
-
-/** A STRING field inside the SHM struct uses the local raw layout — see
- *  the typedef emitted in the stub preamble. */
-const isStringStructField = (variable: PLCVariable): boolean => isStringVariable(variable)
+const fieldKind = (variable: PLCVariable): 'scalar' | 'string' | 'wstring' | null =>
+  describeShmField(variable)?.kind ?? null
 
 /**
- * Raw C type used for an SHM struct field. SHM is a packed binary
- * protocol the Python runtime decodes via `struct.unpack`, so each
- * field has to be a trivially-copyable C primitive. The strucpp
- * IEC_T aliases resolve to IECVar<T> (wrappers with a non-trivial
- * copy assignment), so memcpy'ing into them is UB and gcc rightly
- * fires `-Wclass-memaccess`. Map to the raw underlying type instead;
- * the C-side stub bridges between IECVar (force-aware reads/writes
- * on the IEC side) and these raw fields at the boundary.
+ * Raw C type for an SHM struct field.
+ *
+ * SHM is a packed binary protocol Python decodes with `struct.unpack`, so every
+ * field must be a trivially-copyable C primitive. The strucpp `IEC_T` aliases
+ * resolve to `IECVar<T>` wrappers with a non-trivial copy assignment, so
+ * memcpy'ing into them is UB and gcc fires `-Wclass-memaccess`. The C stub
+ * bridges between the wrapper (force-aware reads and writes on the IEC side)
+ * and these raw fields at the boundary.
  */
-const RAW_TYPE_BY_BASETYPE: Record<string, string> = {
-  bool: 'uint8_t',
-  sint: 'int8_t',
-  int: 'int16_t',
-  dint: 'int32_t',
-  lint: 'int64_t',
-  usint: 'uint8_t',
-  uint: 'uint16_t',
-  udint: 'uint32_t',
-  ulint: 'uint64_t',
-  byte: 'uint8_t',
-  word: 'uint16_t',
-  dword: 'uint32_t',
-  lword: 'uint64_t',
-  real: 'float',
-  lreal: 'double',
-  time: 'int64_t',
-  date: 'int64_t',
-  tod: 'int64_t',
-  dt: 'int64_t',
-}
-
-const shmFieldType = (variable: PLCVariable): string => {
-  if (isStringStructField(variable)) return 'shm_iec_string_t'
-
-  if (variable.type.definition === 'array' && variable.type.data) {
-    const elemType = variable.type.data.baseType.value.toLowerCase()
-    if (elemType === 'string') return 'shm_iec_string_t'
-    return RAW_TYPE_BY_BASETYPE[elemType] ?? 'uint8_t'
-  }
-
-  if (variable.type.definition === 'base-type') {
-    return RAW_TYPE_BY_BASETYPE[variable.type.value.toLowerCase()] ?? 'uint8_t'
-  }
-
-  // Defensive fallback — non-base, non-array variables shouldn't appear
-  // in a Python POU's interface; emit a single byte to keep the struct
-  // layout deterministic.
-  return 'uint8_t'
-}
+const shmFieldType = (variable: PLCVariable): string =>
+  describeShmField(variable)?.cType ?? 'uint8_t'
 
 const generateStructField = (variable: PLCVariable): string => {
   const fieldType = shmFieldType(variable)
@@ -129,6 +80,7 @@ const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
   inputVars.forEach((variable) => {
     const upperName = variable.name.toUpperCase()
     const fieldName = variable.name
+    const kind = fieldKind(variable)
 
     if (isArrayVariable(variable)) {
       // Iterate IEC indices and pull each element through `.get()` so
@@ -137,12 +89,26 @@ const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
       const totalElements = getArrayTotalElements(variable)
       const startIdx = getArrayStartIndex(variable)
       code += `        for (int __i = 0; __i < ${totalElements}; __i++) data_in.${fieldName}[__i] = ${upperName}[${startIdx} + __i].get();\n`
-    } else if (isStringStructField(variable)) {
-      // IECStringVar::get() returns IECString<N> by value — bind once
-      // to a local so c_str() / length() refer to the same temporary.
+    } else if (kind === 'string') {
+      // IECStringVar::get() returns IECString<N> by value — bind once to a
+      // local so c_str() / length() refer to the same temporary. Copy only the
+      // characters that exist and zero the rest, so the body is deterministic
+      // rather than carrying whatever the wrapper's tail held.
       code += `        { auto __s = ${upperName}.get();\n`
-      code += `          data_in.${fieldName}.len = (__strlen_t)__s.length();\n`
-      code += `          std::memcpy(data_in.${fieldName}.body, __s.c_str(), STR_MAX_LEN); }\n`
+      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
+      code += `          data_in.${fieldName}.len = __n;\n`
+      code += `          std::memset(data_in.${fieldName}.body, 0, STR_MAX_LEN);\n`
+      code += `          std::memcpy(data_in.${fieldName}.body, __s.c_str(), (size_t)__n); }\n`
+    } else if (kind === 'wstring') {
+      // WSTRING is UTF-16: `length()` counts code units and `c_str()` yields
+      // `const char16_t*`, so the byte count is twice the length. The previous
+      // code copied STR_MAX_LEN *bytes* (63 code units) while writing a length
+      // in characters, which put the two sides permanently out of step.
+      code += `        { auto __s = ${upperName}.get();\n`
+      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
+      code += `          data_in.${fieldName}.len = __n;\n`
+      code += `          std::memset(data_in.${fieldName}.body, 0, STR_MAX_LEN * sizeof(uint16_t));\n`
+      code += `          std::memcpy(data_in.${fieldName}.body, __s.c_str(), (size_t)__n * sizeof(uint16_t)); }\n`
     } else {
       // Scalar — IECVar's implicit conversion to T routes through .get()
       // so a forced input is observed correctly.
@@ -164,6 +130,7 @@ const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
   outputVars.forEach((variable) => {
     const upperName = variable.name.toUpperCase()
     const fieldName = variable.name
+    const kind = fieldKind(variable)
 
     if (isArrayVariable(variable)) {
       const totalElements = getArrayTotalElements(variable)
@@ -172,10 +139,13 @@ const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
       // .set(), which is a no-op when forced — Python user writes to a
       // forced array element are silently dropped on the IEC side.
       code += `        for (int __i = 0; __i < ${totalElements}; __i++) ${upperName}[${startIdx} + __i] = data_out.${fieldName}[__i];\n`
-    } else if (isStringStructField(variable)) {
-      const iecType = getVariableIECType(variable)
-      const innerType = iecType === 'IEC_WSTRING' ? 'strucpp::IECWString<254>' : 'strucpp::IECString<254>'
-      code += `        ${upperName} = ${innerType}(reinterpret_cast<const char*>(data_out.${fieldName}.body), data_out.${fieldName}.len);\n`
+    } else if (kind === 'string') {
+      code += `        ${upperName} = strucpp::IECString<254>(reinterpret_cast<const char*>(data_out.${fieldName}.body), data_out.${fieldName}.len);\n`
+    } else if (kind === 'wstring') {
+      // Reconstruct from char16_t units, not bytes — the mirror of the copy-in
+      // fix above. Reinterpreting the body as `char*` (what this did before)
+      // handed IECWString half a string.
+      code += `        ${upperName} = strucpp::IECWString<254>(reinterpret_cast<const char16_t*>(data_out.${fieldName}.body), data_out.${fieldName}.len);\n`
     } else {
       // Scalar — IECVar::operator=(T) → set(), force-respect.
       code += `        ${upperName} = data_out.${fieldName};\n`
@@ -218,12 +188,24 @@ const generateSTCode = (params: STCodeGenerationParams): string => {
   const stCode = `(* Type definitions *)
 {external
     #define STR_LEN_TYPE int8_t
-    #define STR_MAX_LEN 126
+    #define STR_MAX_LEN ${SHM_STRING_CHARS}
     typedef STR_LEN_TYPE __strlen_t;
+    // These MUST be packed in their own right, not merely used inside a packed
+    // struct: #pragma pack applies to the struct being defined, never to a
+    // member type that was already laid out. shm_iec_string_t survived without
+    // it only because uint8_t needs no alignment; the wstring uint16_t body
+    // forces a padding byte after the length field, making it 254 bytes where
+    // Python packs 253 - a one-byte shift that corrupts every later field.
+    #pragma pack(push, 1)
     typedef struct {
         __strlen_t len;
         uint8_t body[STR_MAX_LEN];
     } shm_iec_string_t;
+    typedef struct {
+        __strlen_t len;
+        uint16_t body[STR_MAX_LEN];
+    } shm_iec_wstring_t;
+    #pragma pack(pop)
 
 ${cStructs}
 }

--- a/src/frontend/utils/python/generateSTCode.ts
+++ b/src/frontend/utils/python/generateSTCode.ts
@@ -1,12 +1,15 @@
-import type { PLCVariable } from '../../../middleware/shared/ports/types'
-import { getArrayStartIndex, getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
+import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
 import { pythonInboundVariables, pythonOutboundVariables } from './block-interface'
-import { describeShmField, SHM_STRING_CHARS } from './shm-type-map'
+import type { ShmLeaf } from './shm-leaves'
+import { describeShmLayout, describeShmLeaves } from './shm-leaves'
+import { SHM_STRING_CHARS } from './shm-type-map'
 
 type STCodeGenerationParams = {
   pouName: string
   allVariables: PLCVariable[]
   processedPythonCode: string
+  /** The project's data types, so a structure or enumeration can be walked. */
+  dataTypes?: readonly PLCDataType[]
 }
 
 /**
@@ -15,144 +18,147 @@ type STCodeGenerationParams = {
  * `preprocessPous` refuses an unsupported type first — but the emitters stay
  * total so a direct caller cannot produce a half-formed struct.
  */
-const fieldKind = (variable: PLCVariable): 'scalar' | 'string' | 'wstring' | null =>
-  describeShmField(variable)?.kind ?? null
-
-/**
- * Raw C type for an SHM struct field.
- *
- * SHM is a packed binary protocol Python decodes with `struct.unpack`, so every
- * field must be a trivially-copyable C primitive. The strucpp `IEC_T` aliases
- * resolve to `IECVar<T>` wrappers with a non-trivial copy assignment, so
- * memcpy'ing into them is UB and gcc fires `-Wclass-memaccess`. The C stub
- * bridges between the wrapper (force-aware reads and writes on the IEC side)
- * and these raw fields at the boundary.
- */
-const shmFieldType = (variable: PLCVariable): string => describeShmField(variable)?.cType ?? 'uint8_t'
-
-const generateStructField = (variable: PLCVariable): string => {
-  const fieldType = shmFieldType(variable)
-  const name = variable.name
-  if (isArrayVariable(variable)) {
-    const totalElements = getArrayTotalElements(variable)
-    return `        ${fieldType} ${name}[${totalElements}];\n`
+const generateStructField = (leaf: ShmLeaf): string => {
+  const fieldType = leaf.descriptor.cType
+  if (leaf.count > 1) {
+    return `        ${fieldType} ${leaf.field}[${leaf.count}];\n`
   }
-  return `        ${fieldType} ${name};\n`
+  return `        ${fieldType} ${leaf.field};\n`
 }
 
-const generateCStructs = (inputVars: PLCVariable[], outputVars: PLCVariable[]): string => {
-  let structs = ''
-
-  // Input struct
-  structs += '    #pragma pack(push, 1)\n'
+const generateOneStruct = (leaves: ShmLeaf[], typeName: string): string => {
+  let structs = '    #pragma pack(push, 1)\n'
   structs += '    typedef struct {\n'
-  if (inputVars.length > 0) {
-    inputVars.forEach((variable) => {
-      structs += generateStructField(variable)
+  if (leaves.length > 0) {
+    leaves.forEach((leaf) => {
+      structs += generateStructField(leaf)
     })
   } else {
+    // An empty struct is not portable C, and its size would differ between the
+    // two sides. One byte nobody reads keeps the layouts agreeing.
     structs += '        uint8_t _padding;\n'
   }
-  structs += '    } shm_data_in_t;\n'
-  structs += '    #pragma pack(pop)\n\n'
-
-  // Output struct
-  structs += '    #pragma pack(push, 1)\n'
-  structs += '    typedef struct {\n'
-  if (outputVars.length > 0) {
-    outputVars.forEach((variable) => {
-      structs += generateStructField(variable)
-    })
-  } else {
-    structs += '        uint8_t _padding;\n'
-  }
-  structs += '    } shm_data_out_t;\n'
+  structs += `    } ${typeName};\n`
   structs += '    #pragma pack(pop)\n'
-
   return structs
 }
 
-/**
- * How one variable is named in a copy statement, and what must wrap that
- * statement.
- *
- * Every class but `external` is a plain member of the block's class, so the
- * upper-cased name refers to it directly. A `VAR_EXTERNAL` is a
- * `GlobalVar<V>*`: the value together with that global's own mutex. Naming it
- * directly would compile — the pointer converts — and would copy from the wrong
- * place while holding no lock at all.
- *
- * So an external's copy is wrapped in `with_lock`, which runs a callable with a
- * `V*` while the lock is held. Each external is wrapped on its own rather than
- * nested: this stub only copies values in and out, it does not run user code, so
- * one lock at a time is enough — and that matches what an ST body does, with no
- * lock ordering to reason about.
- *
- * The lambda's parameter is deduced, so nothing here names `V` — the compiler's
- * layout stays the only statement of it. The dereference is bound to a reference
- * on its own line rather than written inline as `(*p)`: this C++ sits inside an
- * `{external}` block that the ST front end still scans, where `(*` opens a block
- * comment and would swallow the rest of the POU.
- */
-const accessorFor = (variable: PLCVariable): { open: string; name: string; close: string } => {
-  const upperName = variable.name.toUpperCase()
-  if (variable.class !== 'external') return { open: '', name: upperName, close: '' }
+const generateCStructs = (inbound: ShmLeaf[], outbound: ShmLeaf[]): string =>
+  `${generateOneStruct(inbound, 'shm_data_in_t')}\n${generateOneStruct(outbound, 'shm_data_out_t')}`
 
-  return {
-    open: `        ${upperName}->with_lock([&](auto* __g) {\n        auto& __r = *__g;\n`,
-    name: '__r',
-    close: '        });\n',
+/**
+ * Copy one leaf between the strucpp side and a packed transport field.
+ *
+ * `toShm` picks the direction. Reads go through `.get()` (explicitly for arrays
+ * and strings, implicitly through `IECVar`'s conversion for scalars) so a forced
+ * value appears to Python exactly as it appears to the IEC program. Writes go
+ * through `IECVar::operator=`, which is a no-op while forced — a Python write to
+ * a forced variable is dropped on the IEC side, as it should be.
+ */
+const generateLeafCopy = (leaf: ShmLeaf, struct: string, toShm: boolean): string => {
+  const { field, access, descriptor, count, startIndex } = leaf
+  const shm = `${struct}.${field}`
+
+  if (count > 1) {
+    // Iterate IEC indices so a forced element crosses like any other.
+    return toShm
+      ? `        for (int __i = 0; __i < ${count}; __i++) ${shm}[__i] = ${access}[${startIndex} + __i].get();\n`
+      : `        for (int __i = 0; __i < ${count}; __i++) ${access}[${startIndex} + __i] = ${shm}[__i];\n`
   }
+
+  if (descriptor.kind === 'string' || descriptor.kind === 'wstring') {
+    const wide = descriptor.kind === 'wstring'
+    const unit = wide ? ' * sizeof(uint16_t)' : ''
+    if (toShm) {
+      // `get()` returns the string by value — bind it once so `c_str()` and
+      // `length()` refer to the same temporary. Copy only the characters that
+      // exist and zero the rest, so the body is deterministic rather than
+      // carrying whatever the wrapper's tail held.
+      let code = `        { auto __s = ${access}.get();\n`
+      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
+      code += `          ${shm}.len = __n;\n`
+      code += `          std::memset(${shm}.body, 0, STR_MAX_LEN${unit});\n`
+      code += `          std::memcpy(${shm}.body, __s.c_str(), (size_t)__n${unit}); }\n`
+      return code
+    }
+    // Reconstruct from the right unit width: a WSTRING body is char16_t, and
+    // reading it as `char*` would hand IECWString half a string.
+    const wrapper = wide ? 'IECWString' : 'IECString'
+    const pointer = wide ? 'const char16_t*' : 'const char*'
+    return `        ${access} = strucpp::${wrapper}<254>(reinterpret_cast<${pointer}>(${shm}.body), ${shm}.len);\n`
+  }
+
+  if (leaf.enumTypeName) {
+    // An `IEC_ENUM_Var` yields an `IEC_ENUM_Value`, which converts to the scoped
+    // enum but not to an integer, so the read goes through both and then casts.
+    // The write goes through `set()` rather than `operator=`, which would
+    // copy-assign a whole temporary wrapper and take the forced state with it.
+    const enumType = leaf.enumTypeName.toUpperCase()
+    return toShm
+      ? `        ${shm} = static_cast<${descriptor.cType}>(${access}.get().get());\n`
+      : `        ${access}.set(static_cast<${enumType}>(${shm}));\n`
+  }
+
+  // A plain scalar: `IECVar` converts to its value implicitly on the way out and
+  // assigns through `set()` on the way back.
+  if (toShm) return `        ${shm} = ${access};\n`
+  return `        ${access} = ${shm};\n`
 }
 
-const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
-  if (inputVars.length === 0) return ''
+/**
+ * Wrap a leaf's copy in its global's lock when the leaf belongs to a
+ * VAR_EXTERNAL.
+ *
+ * A `VAR_EXTERNAL` is a `GlobalVar<V>*` — the value together with that global's
+ * mutex. Naming it in a copy statement would compile, convert the pointer, and
+ * read the wrong memory holding no lock at all.
+ *
+ * Each external is wrapped on its own rather than nested: this stub only copies
+ * values, it runs no user code, so one lock at a time is enough and there is no
+ * ordering to reason about. The lambda parameter is deduced, so nothing here
+ * names `V`. The dereference is bound to a reference on its own line rather
+ * than written inline as `(*p)`: this C++ sits inside an `{external}` block
+ * that the ST front end still scans, where `(*` opens a block comment.
+ */
+const withExternalLock = (variable: PLCVariable, body: string): string => {
+  if (variable.class !== 'external') return body
+  const upperName = variable.name.toUpperCase()
+  return `        ${upperName}->with_lock([&](auto* __g) {\n        auto& __r = *__g;\n${body}        });\n`
+}
 
+/**
+ * Rewrite a leaf's access so it reaches through the locked reference instead of
+ * the class member, for a leaf belonging to a VAR_EXTERNAL.
+ */
+const throughLock = (variable: PLCVariable, leaf: ShmLeaf): ShmLeaf => {
+  if (variable.class !== 'external') return leaf
+  const upperName = variable.name.toUpperCase()
+  return { ...leaf, access: `__r${leaf.access.slice(upperName.length)}` }
+}
+
+/** Emit one direction's copies, grouping each external's leaves under its lock. */
+const generateCopies = (
+  variables: PLCVariable[],
+  dataTypes: readonly PLCDataType[],
+  struct: string,
+  toShm: boolean,
+): string => {
+  let code = ''
+  for (const variable of variables) {
+    const result = describeShmLeaves(variable, dataTypes)
+    /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
+    if ('refusal' in result) continue
+    const body = result.leaves.map((leaf) => generateLeafCopy(throughLock(variable, leaf), struct, toShm)).join('')
+    code += withExternalLock(variable, body)
+  }
+  return code
+}
+
+const generateInputCopyCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  if (variables.length === 0) return ''
   let code = '        shm_data_in_t data_in;\n'
-
-  inputVars.forEach((variable) => {
-    const { open, name: upperName, close } = accessorFor(variable)
-    const fieldName = variable.name
-    const kind = fieldKind(variable)
-    code += open
-
-    if (isArrayVariable(variable)) {
-      // Iterate IEC indices and pull each element through `.get()` so
-      // forced array elements appear in shared memory the same way they
-      // appear to the IEC program logic.
-      const totalElements = getArrayTotalElements(variable)
-      const startIdx = getArrayStartIndex(variable)
-      code += `        for (int __i = 0; __i < ${totalElements}; __i++) data_in.${fieldName}[__i] = ${upperName}[${startIdx} + __i].get();\n`
-    } else if (kind === 'string') {
-      // IECStringVar::get() returns IECString<N> by value — bind once to a
-      // local so c_str() / length() refer to the same temporary. Copy only the
-      // characters that exist and zero the rest, so the body is deterministic
-      // rather than carrying whatever the wrapper's tail held.
-      code += `        { auto __s = ${upperName}.get();\n`
-      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
-      code += `          data_in.${fieldName}.len = __n;\n`
-      code += `          std::memset(data_in.${fieldName}.body, 0, STR_MAX_LEN);\n`
-      code += `          std::memcpy(data_in.${fieldName}.body, __s.c_str(), (size_t)__n); }\n`
-    } else if (kind === 'wstring') {
-      // WSTRING is UTF-16: `length()` counts code units and `c_str()` yields
-      // `const char16_t*`, so the byte count is twice the length. The previous
-      // code copied STR_MAX_LEN *bytes* (63 code units) while writing a length
-      // in characters, which put the two sides permanently out of step.
-      code += `        { auto __s = ${upperName}.get();\n`
-      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
-      code += `          data_in.${fieldName}.len = __n;\n`
-      code += `          std::memset(data_in.${fieldName}.body, 0, STR_MAX_LEN * sizeof(uint16_t));\n`
-      code += `          std::memcpy(data_in.${fieldName}.body, __s.c_str(), (size_t)__n * sizeof(uint16_t)); }\n`
-    } else {
-      // Scalar — IECVar's implicit conversion to T routes through .get()
-      // so a forced input is observed correctly.
-      code += `        data_in.${fieldName} = ${upperName};\n`
-    }
-    code += close
-  })
-
+  code += generateCopies(variables, dataTypes, 'data_in', true)
   code += '        memcpy(shm_in_ptr, &data_in, sizeof(data_in));\n\n'
-
   return code
 }
 
@@ -160,99 +166,50 @@ const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
  * Publish the IEC-side output values into shared memory once, at startup.
  *
  * Without this the Python block seeds its output globals from the declaration
- * (`initialValue || 0`) and writes them back after its very first
- * `block_loop()`, before the user's code has assigned anything — so whatever
- * the IEC variable held is destroyed. Today that discards a declared initial
- * value; once a Python block can carry RETAIN it destroys the retained value on
- * every restart, which is the exact opposite of what retain is for.
+ * and writes them back after its very first `block_loop()`, before the user's
+ * code has assigned anything — so whatever the IEC variable held is destroyed.
+ * Today that discards a declared initial value; once a Python block can carry
+ * RETAIN it destroys the retained value on every restart, which is the exact
+ * opposite of what retain is for.
  *
  * Shared memory is created zeroed, so there is nothing for Python to seed from
- * unless the C side puts it there. This is the mirror of `generateOutputCopyCode`
- * — same fields, opposite direction — and runs in the `first_run` branch right
- * after the loader has mapped the segment.
+ * unless the C side puts it there.
  */
-const generateOutputSeedCode = (outputVars: PLCVariable[]): string => {
-  if (outputVars.length === 0) return ''
-
+const generateOutputSeedCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  if (variables.length === 0) return ''
   let code = '        shm_data_out_t seed_out;\n'
   code += '        std::memset(&seed_out, 0, sizeof(seed_out));\n'
-
-  outputVars.forEach((variable) => {
-    const { open, name: upperName, close } = accessorFor(variable)
-    const fieldName = variable.name
-    const kind = fieldKind(variable)
-    code += open
-
-    if (isArrayVariable(variable)) {
-      const totalElements = getArrayTotalElements(variable)
-      const startIdx = getArrayStartIndex(variable)
-      code += `        for (int __i = 0; __i < ${totalElements}; __i++) seed_out.${fieldName}[__i] = ${upperName}[${startIdx} + __i].get();\n`
-    } else if (kind === 'string') {
-      code += `        { auto __s = ${upperName}.get();\n`
-      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
-      code += `          seed_out.${fieldName}.len = __n;\n`
-      code += `          std::memcpy(seed_out.${fieldName}.body, __s.c_str(), (size_t)__n); }\n`
-    } else if (kind === 'wstring') {
-      code += `        { auto __s = ${upperName}.get();\n`
-      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
-      code += `          seed_out.${fieldName}.len = __n;\n`
-      code += `          std::memcpy(seed_out.${fieldName}.body, __s.c_str(), (size_t)__n * sizeof(uint16_t)); }\n`
-    } else {
-      code += `        seed_out.${fieldName} = ${upperName};\n`
-    }
-    code += close
-  })
-
+  code += generateCopies(variables, dataTypes, 'seed_out', true)
   code += '        memcpy(shm_out_ptr, &seed_out, sizeof(seed_out));\n'
   return code
 }
 
-const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
-  if (outputVars.length === 0) return ''
-
+const generateOutputCopyCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  if (variables.length === 0) return ''
   let code = '        shm_data_out_t data_out;\n'
   code += '        memcpy(&data_out, shm_out_ptr, sizeof(data_out));\n'
-
-  outputVars.forEach((variable) => {
-    const { open, name: upperName, close } = accessorFor(variable)
-    const fieldName = variable.name
-    const kind = fieldKind(variable)
-    code += open
-
-    if (isArrayVariable(variable)) {
-      const totalElements = getArrayTotalElements(variable)
-      const startIdx = getArrayStartIndex(variable)
-      // Element-wise assignment; IECVar::operator=(T) routes through
-      // .set(), which is a no-op when forced — Python user writes to a
-      // forced array element are silently dropped on the IEC side.
-      code += `        for (int __i = 0; __i < ${totalElements}; __i++) ${upperName}[${startIdx} + __i] = data_out.${fieldName}[__i];\n`
-    } else if (kind === 'string') {
-      code += `        ${upperName} = strucpp::IECString<254>(reinterpret_cast<const char*>(data_out.${fieldName}.body), data_out.${fieldName}.len);\n`
-    } else if (kind === 'wstring') {
-      // Reconstruct from char16_t units, not bytes — the mirror of the copy-in
-      // fix above. Reinterpreting the body as `char*` (what this did before)
-      // handed IECWString half a string.
-      code += `        ${upperName} = strucpp::IECWString<254>(reinterpret_cast<const char16_t*>(data_out.${fieldName}.body), data_out.${fieldName}.len);\n`
-    } else {
-      // Scalar — IECVar::operator=(T) → set(), force-respect.
-      code += `        ${upperName} = data_out.${fieldName};\n`
-    }
-    code += close
-  })
-
+  code += generateCopies(variables, dataTypes, 'data_out', false)
   return code
 }
 
 const generateSTCode = (params: STCodeGenerationParams): string => {
-  const { pouName, allVariables, processedPythonCode } = params
+  const { pouName, allVariables, processedPythonCode, dataTypes = [] } = params
 
   const inputVariables = pythonInboundVariables(allVariables)
   const outputVariables = pythonOutboundVariables(allVariables)
 
-  const cStructs = generateCStructs(inputVariables, outputVariables)
-  const inputCopyCode = generateInputCopyCode(inputVariables)
-  const outputCopyCode = generateOutputCopyCode(outputVariables)
-  const outputSeedCode = generateOutputSeedCode(outputVariables)
+  // The struct layout and the copy statements are generated from the same leaf
+  // walk, so a structure cannot be laid out one way and copied another.
+  const inboundLeaves = describeShmLayout(inputVariables, dataTypes)
+  const outboundLeaves = describeShmLayout(outputVariables, dataTypes)
+  /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
+  const cStructs = generateCStructs(
+    'leaves' in inboundLeaves ? inboundLeaves.leaves : [],
+    'leaves' in outboundLeaves ? outboundLeaves.leaves : [],
+  )
+  const inputCopyCode = generateInputCopyCode(inputVariables, dataTypes)
+  const outputCopyCode = generateOutputCopyCode(outputVariables, dataTypes)
+  const outputSeedCode = generateOutputSeedCode(outputVariables, dataTypes)
 
   const escapedPythonCode = processedPythonCode
     .replace(/\\/g, '\\\\')

--- a/src/frontend/utils/python/generateSTCode.ts
+++ b/src/frontend/utils/python/generateSTCode.ts
@@ -25,7 +25,7 @@ type STCodeGenerationParams = {
  */
 const generateStructField = (leaf: ShmLeaf): string => {
   const fieldType = leaf.descriptor.cType
-  if (leaf.count > 1) {
+  if (leaf.isArray) {
     return `        ${fieldType} ${leaf.field}[${leaf.count}];\n`
   }
   return `        ${fieldType} ${leaf.field};\n`
@@ -61,10 +61,10 @@ const generateCStructs = (inbound: ShmLeaf[], outbound: ShmLeaf[]): string =>
  * a forced variable is dropped on the IEC side, as it should be.
  */
 const generateLeafCopy = (leaf: ShmLeaf, struct: string, toShm: boolean): string => {
-  const { field, access, descriptor, count, startIndex } = leaf
+  const { field, access, descriptor, count, startIndex, isArray } = leaf
   const shm = `${struct}.${field}`
 
-  if (count > 1) {
+  if (isArray) {
     // Iterate IEC indices so a forced element crosses like any other.
     return toShm
       ? `        for (int __i = 0; __i < ${count}; __i++) ${shm}[__i] = ${access}[${startIndex} + __i].get();\n`
@@ -88,9 +88,25 @@ const generateLeafCopy = (leaf: ShmLeaf, struct: string, toShm: boolean): string
     }
     // Reconstruct from the right unit width: a WSTRING body is char16_t, and
     // reading it as `char*` would hand IECWString half a string.
+    //
+    // GUARDED, because the transport is narrower than the declared type. A
+    // strucpp `IECStringVar` / `IECWStringVar` holds 254 characters, while the
+    // SHM body carries STR_MAX_LEN (the cap the debug protocol frames at). An
+    // IEC string longer than that reaches Python already truncated, so writing
+    // Python's copy back would shorten the IEC variable permanently — with no
+    // user code having touched it. Now that `local`, `inOut` and `external`
+    // round-trip, that turned a read into a destructive write.
+    //
+    // The current length is what says whether anything was lost: at or under the
+    // cap, Python holds the whole value and the write-back is faithful; over it,
+    // Python holds a prefix and the IEC value is left alone. A string that fits
+    // — the ordinary case — round-trips exactly as before.
     const wrapper = wide ? 'IECWString' : 'IECString'
     const pointer = wide ? 'const char16_t*' : 'const char*'
-    return `        ${access} = strucpp::${wrapper}<254>(reinterpret_cast<${pointer}>(${shm}.body), ${shm}.len);\n`
+    let code = `        { auto __cur = ${access}.get();\n`
+    code += `          if (__cur.length() <= STR_MAX_LEN)\n`
+    code += `            ${access} = strucpp::${wrapper}<254>(reinterpret_cast<${pointer}>(${shm}.body), ${shm}.len); }\n`
+    return code
   }
 
   if (leaf.enumTypeName) {

--- a/src/frontend/utils/python/generateSTCode.ts
+++ b/src/frontend/utils/python/generateSTCode.ts
@@ -1,7 +1,8 @@
-import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCPou, PLCVariable } from '../../../middleware/shared/ports/types'
+import type { LibraryFunctionBlockSource } from '../PLC/function-block-pins'
 import { pythonInboundVariables, pythonOutboundVariables } from './block-interface'
-import type { ShmLeaf } from './shm-leaves'
-import { describeShmLayout, describeShmLeaves } from './shm-leaves'
+import type { ShmLeaf, ShmWalkContext } from './shm-leaves'
+import { describeShmLayout, describeShmLeaves, pythonFunctionBlockInstances } from './shm-leaves'
 import { SHM_STRING_CHARS } from './shm-type-map'
 
 type STCodeGenerationParams = {
@@ -10,6 +11,10 @@ type STCodeGenerationParams = {
   processedPythonCode: string
   /** The project's data types, so a structure or enumeration can be walked. */
   dataTypes?: readonly PLCDataType[]
+  /** Project POUs, for resolving a function block instance's pins. */
+  pous?: readonly PLCPou[]
+  /** Bundled libraries, for resolving a standard block such as TON. */
+  libraries?: readonly LibraryFunctionBlockSource[]
 }
 
 /**
@@ -137,15 +142,10 @@ const throughLock = (variable: PLCVariable, leaf: ShmLeaf): ShmLeaf => {
 }
 
 /** Emit one direction's copies, grouping each external's leaves under its lock. */
-const generateCopies = (
-  variables: PLCVariable[],
-  dataTypes: readonly PLCDataType[],
-  struct: string,
-  toShm: boolean,
-): string => {
+const generateCopies = (variables: PLCVariable[], context: ShmWalkContext, struct: string, toShm: boolean): string => {
   let code = ''
   for (const variable of variables) {
-    const result = describeShmLeaves(variable, dataTypes)
+    const result = describeShmLeaves(variable, context)
     /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
     if ('refusal' in result) continue
     const body = result.leaves.map((leaf) => generateLeafCopy(throughLock(variable, leaf), struct, toShm)).join('')
@@ -154,10 +154,10 @@ const generateCopies = (
   return code
 }
 
-const generateInputCopyCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+const generateInputCopyCode = (variables: PLCVariable[], context: ShmWalkContext): string => {
   if (variables.length === 0) return ''
   let code = '        shm_data_in_t data_in;\n'
-  code += generateCopies(variables, dataTypes, 'data_in', true)
+  code += generateCopies(variables, context, 'data_in', true)
   code += '        memcpy(shm_in_ptr, &data_in, sizeof(data_in));\n\n'
   return code
 }
@@ -175,41 +175,99 @@ const generateInputCopyCode = (variables: PLCVariable[], dataTypes: readonly PLC
  * Shared memory is created zeroed, so there is nothing for Python to seed from
  * unless the C side puts it there.
  */
-const generateOutputSeedCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+const generateOutputSeedCode = (variables: PLCVariable[], context: ShmWalkContext): string => {
   if (variables.length === 0) return ''
   let code = '        shm_data_out_t seed_out;\n'
   code += '        std::memset(&seed_out, 0, sizeof(seed_out));\n'
-  code += generateCopies(variables, dataTypes, 'seed_out', true)
+  code += generateCopies(variables, context, 'seed_out', true)
   code += '        memcpy(shm_out_ptr, &seed_out, sizeof(seed_out));\n'
   return code
 }
 
-const generateOutputCopyCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+const generateOutputCopyCode = (variables: PLCVariable[], context: ShmWalkContext): string => {
   if (variables.length === 0) return ''
   let code = '        shm_data_out_t data_out;\n'
   code += '        memcpy(&data_out, shm_out_ptr, sizeof(data_out));\n'
-  code += generateCopies(variables, dataTypes, 'data_out', false)
+  code += generateCopies(variables, context, 'data_out', false)
   return code
 }
 
+/**
+ * One ST call per function block instance the block declares.
+ *
+ * This is what makes an instance usable from Python at all. Python cannot call
+ * it — it runs in another process — but the wrapper does, in the PLC process
+ * where the instance lives, once per scan. The call sits between applying
+ * Python's writes to the input pins and publishing the pins back, so within a
+ * scan the sequence is: take what Python wrote, run the instance, report what it
+ * produced.
+ *
+ * Written as ST rather than inside an `{external}` block so the call goes through
+ * the same path a hand-written `ton0();` would, including the EN gate the
+ * compiler puts at every call site.
+ */
+const generateInstanceCalls = (instances: PLCVariable[]): string =>
+  instances.map((instance) => `${instance.name}();`).join('\n')
+
 const generateSTCode = (params: STCodeGenerationParams): string => {
-  const { pouName, allVariables, processedPythonCode, dataTypes = [] } = params
+  const { pouName, allVariables, processedPythonCode, dataTypes = [], pous = [], libraries = [] } = params
 
   const inputVariables = pythonInboundVariables(allVariables)
   const outputVariables = pythonOutboundVariables(allVariables)
+  const instances = pythonFunctionBlockInstances(allVariables, dataTypes)
+
+  // Direction decides which of a function block instance's pins cross: Python
+  // drives the inputs and reads the outputs. Everything else is symmetric.
+  const inbound: ShmWalkContext = { dataTypes, pous, libraries, direction: 'in' }
+  const outbound: ShmWalkContext = { dataTypes, pous, libraries, direction: 'out' }
 
   // The struct layout and the copy statements are generated from the same leaf
   // walk, so a structure cannot be laid out one way and copied another.
-  const inboundLeaves = describeShmLayout(inputVariables, dataTypes)
-  const outboundLeaves = describeShmLayout(outputVariables, dataTypes)
+  const inboundLeaves = describeShmLayout(inputVariables, inbound)
+  const outboundLeaves = describeShmLayout(outputVariables, outbound)
   /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
   const cStructs = generateCStructs(
     'leaves' in inboundLeaves ? inboundLeaves.leaves : [],
     'leaves' in outboundLeaves ? outboundLeaves.leaves : [],
   )
-  const inputCopyCode = generateInputCopyCode(inputVariables, dataTypes)
-  const outputCopyCode = generateOutputCopyCode(outputVariables, dataTypes)
-  const outputSeedCode = generateOutputSeedCode(outputVariables, dataTypes)
+  const inputCopyCode = generateInputCopyCode(inputVariables, inbound)
+  const outputCopyCode = generateOutputCopyCode(outputVariables, outbound)
+  const outputSeedCode = generateOutputSeedCode(outputVariables, outbound)
+  const instanceCalls = generateInstanceCalls(instances)
+
+  // The pointer guards, repeated in each `{external}` block that needs them:
+  // ST scoping puts every block in the same function, but re-deriving them keeps
+  // each block readable on its own and costs nothing.
+  const mapSegments = (
+    which: 'in' | 'out',
+  ) => `        void *shm_${which}_ptr = (void *)(uint64_t)SHM_${which.toUpperCase()}_PTR;
+        if (shm_${which}_ptr == NULL)
+        {
+            printf("shm_${which}_ptr is NULL!\\n");
+            return;
+        }
+`
+
+  // With no function block instance the exchange is one block, exactly as it was
+  // before instances existed: publish the PLC's values, then take Python's back.
+  //
+  // With instances there is an order to respect. Python's writes have to reach
+  // the input pins before the instance runs, and the pins it produces have to be
+  // published after — otherwise a user setting `ton0.IN` would see `ton0.Q`
+  // answer a scan late for no reason. So the exchange splits around the calls:
+  // take what Python wrote, run the instances, publish what they produced.
+  const exchangeCode =
+    instances.length === 0
+      ? `    {external
+${mapSegments('in')}${mapSegments('out')}
+${inputCopyCode}${outputCopyCode}    }`
+      : `    {external
+${mapSegments('out')}
+${outputCopyCode}    }
+${instanceCalls}
+    {external
+${mapSegments('in')}
+${inputCopyCode}    }`
 
   const escapedPythonCode = processedPythonCode
     .replace(/\\/g, '\\\\')
@@ -284,22 +342,7 @@ if first_run = false then
 ${outputSeedCode}    }
     first_run := true;
 else
-    {external
-        void *shm_in_ptr = (void *)(uint64_t)SHM_IN_PTR;
-        void *shm_out_ptr = (void *)(uint64_t)SHM_OUT_PTR;
-
-        if (shm_in_ptr == NULL)
-        {
-            printf("shm_in_ptr is NULL!\\n");
-            return;
-        }
-        if (shm_out_ptr == NULL)
-        {
-            printf("shm_out_ptr is NULL!\\n");
-            return;
-        }
-
-${inputCopyCode}${outputCopyCode}    }
+${exchangeCode}
 end_if;`
 
   return stCode

--- a/src/frontend/utils/python/generateSTCode.ts
+++ b/src/frontend/utils/python/generateSTCode.ts
@@ -1,5 +1,6 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
 import { getArrayStartIndex, getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { pythonInboundVariables, pythonOutboundVariables } from './block-interface'
 import { describeShmField, SHM_STRING_CHARS } from './shm-type-map'
 
 type STCodeGenerationParams = {
@@ -27,8 +28,7 @@ const fieldKind = (variable: PLCVariable): 'scalar' | 'string' | 'wstring' | nul
  * bridges between the wrapper (force-aware reads and writes on the IEC side)
  * and these raw fields at the boundary.
  */
-const shmFieldType = (variable: PLCVariable): string =>
-  describeShmField(variable)?.cType ?? 'uint8_t'
+const shmFieldType = (variable: PLCVariable): string => describeShmField(variable)?.cType ?? 'uint8_t'
 
 const generateStructField = (variable: PLCVariable): string => {
   const fieldType = shmFieldType(variable)
@@ -72,15 +72,49 @@ const generateCStructs = (inputVars: PLCVariable[], outputVars: PLCVariable[]): 
   return structs
 }
 
+/**
+ * How one variable is named in a copy statement, and what must wrap that
+ * statement.
+ *
+ * Every class but `external` is a plain member of the block's class, so the
+ * upper-cased name refers to it directly. A `VAR_EXTERNAL` is a
+ * `GlobalVar<V>*`: the value together with that global's own mutex. Naming it
+ * directly would compile — the pointer converts — and would copy from the wrong
+ * place while holding no lock at all.
+ *
+ * So an external's copy is wrapped in `with_lock`, which runs a callable with a
+ * `V*` while the lock is held. Each external is wrapped on its own rather than
+ * nested: this stub only copies values in and out, it does not run user code, so
+ * one lock at a time is enough — and that matches what an ST body does, with no
+ * lock ordering to reason about.
+ *
+ * The lambda's parameter is deduced, so nothing here names `V` — the compiler's
+ * layout stays the only statement of it. The dereference is bound to a reference
+ * on its own line rather than written inline as `(*p)`: this C++ sits inside an
+ * `{external}` block that the ST front end still scans, where `(*` opens a block
+ * comment and would swallow the rest of the POU.
+ */
+const accessorFor = (variable: PLCVariable): { open: string; name: string; close: string } => {
+  const upperName = variable.name.toUpperCase()
+  if (variable.class !== 'external') return { open: '', name: upperName, close: '' }
+
+  return {
+    open: `        ${upperName}->with_lock([&](auto* __g) {\n        auto& __r = *__g;\n`,
+    name: '__r',
+    close: '        });\n',
+  }
+}
+
 const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
   if (inputVars.length === 0) return ''
 
   let code = '        shm_data_in_t data_in;\n'
 
   inputVars.forEach((variable) => {
-    const upperName = variable.name.toUpperCase()
+    const { open, name: upperName, close } = accessorFor(variable)
     const fieldName = variable.name
     const kind = fieldKind(variable)
+    code += open
 
     if (isArrayVariable(variable)) {
       // Iterate IEC indices and pull each element through `.get()` so
@@ -114,6 +148,7 @@ const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
       // so a forced input is observed correctly.
       code += `        data_in.${fieldName} = ${upperName};\n`
     }
+    code += close
   })
 
   code += '        memcpy(shm_in_ptr, &data_in, sizeof(data_in));\n\n'
@@ -143,9 +178,10 @@ const generateOutputSeedCode = (outputVars: PLCVariable[]): string => {
   code += '        std::memset(&seed_out, 0, sizeof(seed_out));\n'
 
   outputVars.forEach((variable) => {
-    const upperName = variable.name.toUpperCase()
+    const { open, name: upperName, close } = accessorFor(variable)
     const fieldName = variable.name
     const kind = fieldKind(variable)
+    code += open
 
     if (isArrayVariable(variable)) {
       const totalElements = getArrayTotalElements(variable)
@@ -164,6 +200,7 @@ const generateOutputSeedCode = (outputVars: PLCVariable[]): string => {
     } else {
       code += `        seed_out.${fieldName} = ${upperName};\n`
     }
+    code += close
   })
 
   code += '        memcpy(shm_out_ptr, &seed_out, sizeof(seed_out));\n'
@@ -177,9 +214,10 @@ const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
   code += '        memcpy(&data_out, shm_out_ptr, sizeof(data_out));\n'
 
   outputVars.forEach((variable) => {
-    const upperName = variable.name.toUpperCase()
+    const { open, name: upperName, close } = accessorFor(variable)
     const fieldName = variable.name
     const kind = fieldKind(variable)
+    code += open
 
     if (isArrayVariable(variable)) {
       const totalElements = getArrayTotalElements(variable)
@@ -199,6 +237,7 @@ const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
       // Scalar — IECVar::operator=(T) → set(), force-respect.
       code += `        ${upperName} = data_out.${fieldName};\n`
     }
+    code += close
   })
 
   return code
@@ -207,8 +246,8 @@ const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
 const generateSTCode = (params: STCodeGenerationParams): string => {
   const { pouName, allVariables, processedPythonCode } = params
 
-  const inputVariables = allVariables.filter((v) => v.class === 'input')
-  const outputVariables = allVariables.filter((v) => v.class === 'output')
+  const inputVariables = pythonInboundVariables(allVariables)
+  const outputVariables = pythonOutboundVariables(allVariables)
 
   const cStructs = generateCStructs(inputVariables, outputVariables)
   const inputCopyCode = generateInputCopyCode(inputVariables)

--- a/src/frontend/utils/python/generateSTCode.ts
+++ b/src/frontend/utils/python/generateSTCode.ts
@@ -121,6 +121,55 @@ const generateInputCopyCode = (inputVars: PLCVariable[]): string => {
   return code
 }
 
+/**
+ * Publish the IEC-side output values into shared memory once, at startup.
+ *
+ * Without this the Python block seeds its output globals from the declaration
+ * (`initialValue || 0`) and writes them back after its very first
+ * `block_loop()`, before the user's code has assigned anything — so whatever
+ * the IEC variable held is destroyed. Today that discards a declared initial
+ * value; once a Python block can carry RETAIN it destroys the retained value on
+ * every restart, which is the exact opposite of what retain is for.
+ *
+ * Shared memory is created zeroed, so there is nothing for Python to seed from
+ * unless the C side puts it there. This is the mirror of `generateOutputCopyCode`
+ * — same fields, opposite direction — and runs in the `first_run` branch right
+ * after the loader has mapped the segment.
+ */
+const generateOutputSeedCode = (outputVars: PLCVariable[]): string => {
+  if (outputVars.length === 0) return ''
+
+  let code = '        shm_data_out_t seed_out;\n'
+  code += '        std::memset(&seed_out, 0, sizeof(seed_out));\n'
+
+  outputVars.forEach((variable) => {
+    const upperName = variable.name.toUpperCase()
+    const fieldName = variable.name
+    const kind = fieldKind(variable)
+
+    if (isArrayVariable(variable)) {
+      const totalElements = getArrayTotalElements(variable)
+      const startIdx = getArrayStartIndex(variable)
+      code += `        for (int __i = 0; __i < ${totalElements}; __i++) seed_out.${fieldName}[__i] = ${upperName}[${startIdx} + __i].get();\n`
+    } else if (kind === 'string') {
+      code += `        { auto __s = ${upperName}.get();\n`
+      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
+      code += `          seed_out.${fieldName}.len = __n;\n`
+      code += `          std::memcpy(seed_out.${fieldName}.body, __s.c_str(), (size_t)__n); }\n`
+    } else if (kind === 'wstring') {
+      code += `        { auto __s = ${upperName}.get();\n`
+      code += `          __strlen_t __n = (__strlen_t)(__s.length() < STR_MAX_LEN ? __s.length() : STR_MAX_LEN);\n`
+      code += `          seed_out.${fieldName}.len = __n;\n`
+      code += `          std::memcpy(seed_out.${fieldName}.body, __s.c_str(), (size_t)__n * sizeof(uint16_t)); }\n`
+    } else {
+      code += `        seed_out.${fieldName} = ${upperName};\n`
+    }
+  })
+
+  code += '        memcpy(shm_out_ptr, &seed_out, sizeof(seed_out));\n'
+  return code
+}
+
 const generateOutputCopyCode = (outputVars: PLCVariable[]): string => {
   if (outputVars.length === 0) return ''
 
@@ -164,6 +213,7 @@ const generateSTCode = (params: STCodeGenerationParams): string => {
   const cStructs = generateCStructs(inputVariables, outputVariables)
   const inputCopyCode = generateInputCopyCode(inputVariables)
   const outputCopyCode = generateOutputCopyCode(outputVariables)
+  const outputSeedCode = generateOutputSeedCode(outputVariables)
 
   const escapedPythonCode = processedPythonCode
     .replace(/\\/g, '\\\\')
@@ -230,7 +280,12 @@ if first_run = false then
 
         SHM_IN_PTR = (uint64_t)shm_in_ptr;
         SHM_OUT_PTR = (uint64_t)shm_out_ptr;
-    }
+
+        // Publish the current IEC output values so the Python side can seed
+        // from them instead of from its declarations. Shared memory is created
+        // zeroed; without this the block's first write-back would overwrite the
+        // IEC value (a retained one included) with a default.
+${outputSeedCode}    }
     first_run := true;
 else
     {external

--- a/src/frontend/utils/python/injectPythonCode.ts
+++ b/src/frontend/utils/python/injectPythonCode.ts
@@ -1,7 +1,9 @@
-import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCPou, PLCVariable } from '../../../middleware/shared/ports/types'
+import type { LibraryFunctionBlockSource } from '../PLC/function-block-pins'
 import { pythonInboundVariables, pythonOutboundVariables } from './block-interface'
 import { encodeCharactersFromVariable } from './encodeCharactersFromVariable'
 import { injectPythonRuntime } from './injectPythonRuntime'
+import type { ShmWalkContext } from './shm-leaves'
 
 type PythonPouData = {
   name: string
@@ -11,13 +13,24 @@ type PythonPouData = {
   variables: PLCVariable[]
 }
 
-const injectPythonCode = (pythonPous: PythonPouData[], dataTypes: readonly PLCDataType[] = []): string[] => {
+const injectPythonCode = (
+  pythonPous: PythonPouData[],
+  dataTypes: readonly PLCDataType[] = [],
+  pous: readonly PLCPou[] = [],
+  libraries: readonly LibraryFunctionBlockSource[] = [],
+): string[] => {
   return pythonPous.map((pou) => {
     const inputVariables = pythonInboundVariables(pou.variables)
     const outputVariables = pythonOutboundVariables(pou.variables)
 
-    const fmtIn = encodeCharactersFromVariable(inputVariables, dataTypes)
-    const fmtOut = encodeCharactersFromVariable(outputVariables, dataTypes)
+    // Direction decides which of a function block instance's pins cross: the
+    // block drives its inputs and reads its outputs. Both contexts otherwise
+    // describe the same project.
+    const inbound: ShmWalkContext = { dataTypes, pous, libraries, direction: 'in' }
+    const outbound: ShmWalkContext = { dataTypes, pous, libraries, direction: 'out' }
+
+    const fmtIn = encodeCharactersFromVariable(inputVariables, inbound)
+    const fmtOut = encodeCharactersFromVariable(outputVariables, outbound)
 
     const injectedCode = injectPythonRuntime({
       fmtIn,
@@ -26,7 +39,8 @@ const injectPythonCode = (pythonPous: PythonPouData[], dataTypes: readonly PLCDa
       outputVariables,
       originalCode: pou.code,
       pouName: pou.name,
-      dataTypes,
+      inbound,
+      outbound,
     })
 
     return injectedCode

--- a/src/frontend/utils/python/injectPythonCode.ts
+++ b/src/frontend/utils/python/injectPythonCode.ts
@@ -1,4 +1,5 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import { pythonInboundVariables, pythonOutboundVariables } from './block-interface'
 import { encodeCharactersFromVariable } from './encodeCharactersFromVariable'
 import { injectPythonRuntime } from './injectPythonRuntime'
 
@@ -12,8 +13,8 @@ type PythonPouData = {
 
 const injectPythonCode = (pythonPous: PythonPouData[]): string[] => {
   return pythonPous.map((pou) => {
-    const inputVariables = pou.variables.filter((v) => v.class === 'input')
-    const outputVariables = pou.variables.filter((v) => v.class === 'output')
+    const inputVariables = pythonInboundVariables(pou.variables)
+    const outputVariables = pythonOutboundVariables(pou.variables)
 
     const fmtIn = encodeCharactersFromVariable(inputVariables)
     const fmtOut = encodeCharactersFromVariable(outputVariables)

--- a/src/frontend/utils/python/injectPythonCode.ts
+++ b/src/frontend/utils/python/injectPythonCode.ts
@@ -1,4 +1,4 @@
-import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
 import { pythonInboundVariables, pythonOutboundVariables } from './block-interface'
 import { encodeCharactersFromVariable } from './encodeCharactersFromVariable'
 import { injectPythonRuntime } from './injectPythonRuntime'
@@ -11,13 +11,13 @@ type PythonPouData = {
   variables: PLCVariable[]
 }
 
-const injectPythonCode = (pythonPous: PythonPouData[]): string[] => {
+const injectPythonCode = (pythonPous: PythonPouData[], dataTypes: readonly PLCDataType[] = []): string[] => {
   return pythonPous.map((pou) => {
     const inputVariables = pythonInboundVariables(pou.variables)
     const outputVariables = pythonOutboundVariables(pou.variables)
 
-    const fmtIn = encodeCharactersFromVariable(inputVariables)
-    const fmtOut = encodeCharactersFromVariable(outputVariables)
+    const fmtIn = encodeCharactersFromVariable(inputVariables, dataTypes)
+    const fmtOut = encodeCharactersFromVariable(outputVariables, dataTypes)
 
     const injectedCode = injectPythonRuntime({
       fmtIn,
@@ -26,6 +26,7 @@ const injectPythonCode = (pythonPous: PythonPouData[]): string[] => {
       outputVariables,
       originalCode: pou.code,
       pouName: pou.name,
+      dataTypes,
     })
 
     return injectedCode

--- a/src/frontend/utils/python/injectPythonRuntime.ts
+++ b/src/frontend/utils/python/injectPythonRuntime.ts
@@ -1,5 +1,6 @@
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
 import { getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { describeShmField, SHM_STRING_CHARS } from './shm-type-map'
 
 type PythonRuntimeInjectionParams = {
   fmtIn: string
@@ -19,7 +20,8 @@ const generateOutputInitialization = (outputVariables: PLCVariable[]): string =>
         const totalElements = getArrayTotalElements(variable)
         return `${variable.name} = [0] * ${totalElements}`
       }
-      const defaultValue = variable.type?.value === 'string' ? '""' : variable.initialValue || 0
+      const kind = describeShmField(variable)?.kind
+      const defaultValue = kind === 'string' || kind === 'wstring' ? '""' : variable.initialValue || 0
       return `${variable.name} = ${defaultValue}`
     })
     .join('\n')
@@ -41,12 +43,24 @@ const generateInputUnpackCode = (inputVariables: PLCVariable[]): string => {
       const count = getArrayTotalElements(variable)
       code += `    ${variable.name} = list(_vals[_idx:_idx+${count}])\n`
       code += `    _idx += ${count}\n`
-    } else if (variable.type?.definition === 'base-type' && variable.type?.value === 'string') {
+    } else if (describeShmField(variable)?.kind === 'string') {
       code += `    ${variable.name}_len = _vals[_idx]\n`
       code += `    _idx += 1\n`
       code += `    ${variable.name}_body = _vals[_idx]\n`
       code += `    _idx += 1\n`
+      // The C side clamps the length to the budget, but the prefix is a signed
+      // int8 and the buffer starts zeroed, so clamp on read too: a negative
+      // slice bound would silently truncate from the end instead of failing.
+      code += `    ${variable.name}_len = max(0, min(${variable.name}_len, ${SHM_STRING_CHARS}))\n`
       code += `    ${variable.name} = ${variable.name}_body[:${variable.name}_len].decode('utf-8', errors='ignore')\n`
+    } else if (describeShmField(variable)?.kind === 'wstring') {
+      // The length counts UTF-16 code units, so the byte slice is twice it.
+      code += `    ${variable.name}_len = _vals[_idx]\n`
+      code += `    _idx += 1\n`
+      code += `    ${variable.name}_body = _vals[_idx]\n`
+      code += `    _idx += 1\n`
+      code += `    ${variable.name}_len = max(0, min(${variable.name}_len, ${SHM_STRING_CHARS}))\n`
+      code += `    ${variable.name} = ${variable.name}_body[:${variable.name}_len * 2].decode('utf-16-le', errors='ignore')\n`
     } else {
       code += `    ${variable.name} = _vals[_idx]\n`
       code += `    _idx += 1\n`
@@ -69,10 +83,20 @@ const generateOutputPackCode = (outputVariables: PLCVariable[]): string => {
   outputVariables.forEach((variable) => {
     if (isArrayVariable(variable)) {
       code += `    _out.extend(${variable.name})\n`
-    } else if (variable.type?.definition === 'base-type' && variable.type?.value === 'string') {
-      code += `    _body = ${variable.name}.encode('utf-8')[:126]\n`
+    } else if (describeShmField(variable)?.kind === 'string') {
+      code += `    _body = ${variable.name}.encode('utf-8')[:${SHM_STRING_CHARS}]\n`
       code += `    _len = len(_body)\n`
-      code += `    _body = _body.ljust(126, b'\\0')\n`
+      code += `    _body = _body.ljust(${SHM_STRING_CHARS}, b'\\0')\n`
+      code += `    _out.append(_len)\n`
+      code += `    _out.append(_body)\n`
+    } else if (describeShmField(variable)?.kind === 'wstring') {
+      // Truncate on a code-unit boundary, never mid-unit: encode, clip to the
+      // byte budget, then round down to an even length. `_len` is the code-unit
+      // count the C side expects, not the byte count.
+      code += `    _body = ${variable.name}.encode('utf-16-le')[:${SHM_STRING_CHARS * 2}]\n`
+      code += `    _body = _body[: len(_body) - (len(_body) % 2)]\n`
+      code += `    _len = len(_body) // 2\n`
+      code += `    _body = _body.ljust(${SHM_STRING_CHARS * 2}, b'\\0')\n`
       code += `    _out.append(_len)\n`
       code += `    _out.append(_body)\n`
     } else {

--- a/src/frontend/utils/python/injectPythonRuntime.ts
+++ b/src/frontend/utils/python/injectPythonRuntime.ts
@@ -11,59 +11,84 @@ type PythonRuntimeInjectionParams = {
   pouName: string
 }
 
-const generateOutputInitialization = (outputVariables: PLCVariable[]): string => {
-  if (outputVariables.length === 0) return '# No output variables to initialize'
-
-  return outputVariables
-    .map((variable) => {
-      if (isArrayVariable(variable)) {
-        const totalElements = getArrayTotalElements(variable)
-        return `${variable.name} = [0] * ${totalElements}`
-      }
-      const kind = describeShmField(variable)?.kind
-      const defaultValue = kind === 'string' || kind === 'wstring' ? '""' : variable.initialValue || 0
-      return `${variable.name} = ${defaultValue}`
-    })
-    .join('\n')
+const generateInputUnpackCode = (inputVariables: PLCVariable[]): string => {
+  if (inputVariables.length === 0) return '    # No input variables to read'
+  return generateUnpackCode(inputVariables, {
+    header: '    # Read input variables',
+    buffer: 'shm_in',
+    fmt: 'fmt_in',
+    size: 'data_size_in',
+    indent: '    ',
+  })
 }
 
 /**
- * Generate Python code that extracts variables from the flat unpacked tuple using index slicing.
- * Handles scalars, strings (len+body pairs), and arrays (N consecutive elements -> list).
+ * Seed the output globals from what the PLC currently holds, before
+ * `block_init()` runs.
+ *
+ * Previously the outputs were initialised from their declarations
+ * (`initialValue || 0`) and written back after the first `block_loop()`, before
+ * the user's code had assigned anything — so the IEC-side value was replaced by
+ * a default on every start. With RETAIN that is destructive rather than merely
+ * wrong. The C stub publishes the live values into shared memory when it maps
+ * the segment (see `generateOutputSeedCode`), and this reads them back.
+ *
+ * A block that never assigns an output now leaves it exactly as the PLC had it.
  */
-const generateInputUnpackCode = (inputVariables: PLCVariable[]): string => {
-  if (inputVariables.length === 0) return '    # No input variables to read'
+const generateOutputSeedCode = (outputVariables: PLCVariable[]): string => {
+  if (outputVariables.length === 0) return '# No output variables to seed'
+  return generateUnpackCode(outputVariables, {
+    header: '# Seed outputs from the values the PLC already holds',
+    buffer: 'shm_out',
+    fmt: 'fmt_out',
+    size: 'data_size_out',
+    indent: '',
+  })
+}
 
-  let code = '    # Read input variables\n'
-  code += '    _vals = struct.unpack(fmt_in, shm_in.buf[:data_size_in])\n'
-  code += '    _idx = 0\n'
+/**
+ * Emit the unpack sequence for a set of variables.
+ *
+ * Shared by the per-cycle input read and the one-time output seed: both decode
+ * the same packed layout, differing only in which buffer they read and at what
+ * indentation. Keeping one generator means the two cannot drift in how they
+ * interpret a field — the same reason the type table is shared.
+ */
+const generateUnpackCode = (
+  variables: PLCVariable[],
+  opts: { header: string; buffer: string; fmt: string; size: string; indent: string },
+): string => {
+  const { header, buffer, fmt, size, indent } = opts
 
-  inputVariables.forEach((variable) => {
+  let code = `${header}\n`
+  code += `${indent}_vals = struct.unpack(${fmt}, ${buffer}.buf[:${size}])\n`
+  code += `${indent}_idx = 0\n`
+
+  variables.forEach((variable) => {
+    const kind = describeShmField(variable)?.kind
+
     if (isArrayVariable(variable)) {
       const count = getArrayTotalElements(variable)
-      code += `    ${variable.name} = list(_vals[_idx:_idx+${count}])\n`
-      code += `    _idx += ${count}\n`
-    } else if (describeShmField(variable)?.kind === 'string') {
-      code += `    ${variable.name}_len = _vals[_idx]\n`
-      code += `    _idx += 1\n`
-      code += `    ${variable.name}_body = _vals[_idx]\n`
-      code += `    _idx += 1\n`
+      code += `${indent}${variable.name} = list(_vals[_idx:_idx+${count}])\n`
+      code += `${indent}_idx += ${count}\n`
+    } else if (kind === 'string' || kind === 'wstring') {
+      code += `${indent}${variable.name}_len = _vals[_idx]\n`
+      code += `${indent}_idx += 1\n`
+      code += `${indent}${variable.name}_body = _vals[_idx]\n`
+      code += `${indent}_idx += 1\n`
       // The C side clamps the length to the budget, but the prefix is a signed
       // int8 and the buffer starts zeroed, so clamp on read too: a negative
       // slice bound would silently truncate from the end instead of failing.
-      code += `    ${variable.name}_len = max(0, min(${variable.name}_len, ${SHM_STRING_CHARS}))\n`
-      code += `    ${variable.name} = ${variable.name}_body[:${variable.name}_len].decode('utf-8', errors='ignore')\n`
-    } else if (describeShmField(variable)?.kind === 'wstring') {
-      // The length counts UTF-16 code units, so the byte slice is twice it.
-      code += `    ${variable.name}_len = _vals[_idx]\n`
-      code += `    _idx += 1\n`
-      code += `    ${variable.name}_body = _vals[_idx]\n`
-      code += `    _idx += 1\n`
-      code += `    ${variable.name}_len = max(0, min(${variable.name}_len, ${SHM_STRING_CHARS}))\n`
-      code += `    ${variable.name} = ${variable.name}_body[:${variable.name}_len * 2].decode('utf-16-le', errors='ignore')\n`
+      code += `${indent}${variable.name}_len = max(0, min(${variable.name}_len, ${SHM_STRING_CHARS}))\n`
+      if (kind === 'wstring') {
+        // The length counts UTF-16 code units, so the byte slice is twice it.
+        code += `${indent}${variable.name} = ${variable.name}_body[:${variable.name}_len * 2].decode('utf-16-le', errors='ignore')\n`
+      } else {
+        code += `${indent}${variable.name} = ${variable.name}_body[:${variable.name}_len].decode('utf-8', errors='ignore')\n`
+      }
     } else {
-      code += `    ${variable.name} = _vals[_idx]\n`
-      code += `    _idx += 1\n`
+      code += `${indent}${variable.name} = _vals[_idx]\n`
+      code += `${indent}_idx += 1\n`
     }
   })
 
@@ -113,7 +138,7 @@ const generateOutputPackCode = (outputVariables: PLCVariable[]): string => {
 const injectPythonRuntime = (params: PythonRuntimeInjectionParams): string => {
   const { fmtIn, fmtOut, inputVariables, outputVariables, originalCode, pouName } = params
 
-  const outputInitialization = generateOutputInitialization(outputVariables)
+  const outputSeeding = generateOutputSeedCode(outputVariables)
   const readInputSection = generateInputUnpackCode(inputVariables)
   const writeOutputSection = generateOutputPackCode(outputVariables)
 
@@ -130,13 +155,17 @@ except Exception as e:
     print(f'Error on shared memory: {e}')
     exit(1)
 
-# Initialize output variables here - if any
-${outputInitialization}
+data_size_in = struct.calcsize(fmt_in)
+data_size_out = struct.calcsize(fmt_out)
+
+# Outputs start from what the PLC already holds, not from their declarations.
+# The stub publishes the live values into shared memory when it maps the
+# segment, so a block that never assigns an output leaves it untouched — and a
+# RETAIN output survives the restart it exists to survive.
+${outputSeeding}
 
 # Initialize block
 block_init()
-data_size_in = struct.calcsize(fmt_in)
-data_size_out = struct.calcsize(fmt_out)
 while True:
     try:
         os.kill(plc_pid, 0)

--- a/src/frontend/utils/python/injectPythonRuntime.ts
+++ b/src/frontend/utils/python/injectPythonRuntime.ts
@@ -84,6 +84,25 @@ const generateTypeDeclarations = (variables: PLCVariable[], context: ShmWalkCont
  * the instance's own business, and exposing it would invite writes that corrupt
  * the block from outside.
  */
+/**
+ * The Python class name for a function block type.
+ *
+ * Upper-cased, and this is the ONLY place that decides it. The class is emitted
+ * once per type and constructed once per instance, from two different functions,
+ * and each used to spell the name from its own variable's raw `type.value`
+ * while the de-duplication keyed on the upper-cased form. So `a : Accum` and
+ * `b : ACCUM` emitted a single `class Accum:` and then constructed both
+ * `Accum(...)` and `ACCUM(...)` — the second a `NameError` at module scope,
+ * before `block_init()` ever ran.
+ *
+ * Upper case is the right canonical form here: it is what the de-duplication
+ * already keyed on, what strucpp does to every identifier, and what the pin
+ * names and shared-memory slots on this side already use. The class name never
+ * appears in user code — a user writes `ton0.IN`, never the type — so nothing
+ * user-visible changes.
+ */
+const pythonClassName = (typeName: string): string => typeName.toUpperCase()
+
 const generateInstanceClasses = (variables: PLCVariable[], context: ShmWalkContext): string => {
   const instances = pythonFunctionBlockInstances(variables, context.dataTypes ?? [])
   if (instances.length === 0) return ''
@@ -92,8 +111,10 @@ const generateInstanceClasses = (variables: PLCVariable[], context: ShmWalkConte
   let code = '# Function block instances — called once per scan by the PLC\n'
   for (const instance of instances) {
     const typeName = instance.type.value
-    if (emitted.has(typeName.toUpperCase())) continue
-    emitted.add(typeName.toUpperCase())
+    // The de-duplication key IS the emitted class name, so the two cannot drift.
+    const className = pythonClassName(typeName)
+    if (emitted.has(className)) continue
+    emitted.add(className)
 
     const pins = resolveFunctionBlockPins(typeName, context.pous ?? [], context.libraries ?? [])
     /* istanbul ignore next -- defensive: an unresolvable instance is refused upstream */
@@ -106,7 +127,7 @@ const generateInstanceClasses = (variables: PLCVariable[], context: ShmWalkConte
     /* istanbul ignore next -- defensive: a block with no pins at all */
     if (names.length === 0) continue
 
-    code += `class ${typeName}:\n`
+    code += `class ${className}:\n`
     code += `    __slots__ = (${names.map((n) => `'${n}'`).join(', ')}${names.length === 1 ? ',' : ''})\n`
     code += `    def __init__(self${names.map((n) => `, ${n}=None`).join('')}):\n`
     for (const n of names) code += `        self.${n} = ${n}\n`
@@ -228,7 +249,7 @@ const buildValue = (variable: PLCVariable, context: ShmWalkContext, path: string
       const upper = pin.name.toUpperCase()
       return `${upper}=_${[...fieldPath, upper].join('_')}`
     })
-    return `${typeName}(${args.join(', ')})`
+    return `${pythonClassName(typeName)}(${args.join(', ')})`
   }
 
   /* istanbul ignore next -- defensive: callers only assemble composites */

--- a/src/frontend/utils/python/injectPythonRuntime.ts
+++ b/src/frontend/utils/python/injectPythonRuntime.ts
@@ -239,10 +239,10 @@ const buildValue = (variable: PLCVariable, context: ShmWalkContext, path: string
 
 /** Decode one leaf out of `_vals` into `local`. */
 const decodeLeaf = (leaf: ShmLeaf, local: string, indent: string): string => {
-  const { descriptor, count } = leaf
+  const { descriptor, count, isArray } = leaf
   let code = ''
 
-  if (count > 1) {
+  if (isArray) {
     code += `${indent}${local} = list(_vals[_idx:_idx+${count}])\n`
     code += `${indent}_idx += ${count}\n`
     return code
@@ -332,9 +332,9 @@ const generateOutputSeedCode = (variables: PLCVariable[], context: ShmWalkContex
 /** Encode one leaf, reading through the Python attribute path it came from. */
 const encodeLeaf = (leaf: ShmLeaf): string => {
   const expr = leaf.path.join('.')
-  const { descriptor, count } = leaf
+  const { descriptor, isArray } = leaf
 
-  if (count > 1) return `    _out.extend(${expr})\n`
+  if (isArray) return `    _out.extend(${expr})\n`
 
   if (descriptor.kind === 'string') {
     let code = `    _body = ${expr}.encode('utf-8')[:${SHM_STRING_CHARS}]\n`

--- a/src/frontend/utils/python/injectPythonRuntime.ts
+++ b/src/frontend/utils/python/injectPythonRuntime.ts
@@ -1,6 +1,7 @@
-import type { PLCVariable } from '../../../middleware/shared/ports/types'
-import { getArrayTotalElements, isArrayVariable } from '../PLC/array-codegen-helpers'
-import { describeShmField, SHM_STRING_CHARS } from './shm-type-map'
+import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
+import type { ShmLeaf } from './shm-leaves'
+import { describeShmLeaves } from './shm-leaves'
+import { SHM_STRING_CHARS } from './shm-type-map'
 
 type PythonRuntimeInjectionParams = {
   fmtIn: string
@@ -9,11 +10,207 @@ type PythonRuntimeInjectionParams = {
   outputVariables: PLCVariable[]
   originalCode: string
   pouName: string
+  /** The project's data types, so a structure or enumeration can be rebuilt. */
+  dataTypes?: readonly PLCDataType[]
 }
 
-const generateInputUnpackCode = (inputVariables: PLCVariable[]): string => {
-  if (inputVariables.length === 0) return '    # No input variables to read'
-  return generateUnpackCode(inputVariables, {
+/**
+ * Python classes for the structures and enumerations a block's interface uses.
+ *
+ * The wire format is flat — one field per scalar leaf — but the user should
+ * write `m.speed`, not `m_speed`, exactly as they would in ST. So the driver
+ * rebuilds an object from consecutive leaves on the way in and reads it back
+ * apart on the way out, and these are the shapes it builds.
+ *
+ * A structure becomes a plain class with `__slots__`: cheap, and an assignment
+ * to a name the structure does not have raises rather than silently creating an
+ * attribute the PLC will never read back. An enumeration becomes an `IntEnum`,
+ * so `mode == Mode.RUNNING` reads naturally while the value crossing the
+ * boundary stays the plain integer the PLC stores.
+ */
+const generateTypeDeclarations = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  const referenced = collectReferencedTypes(variables, dataTypes)
+  if (referenced.length === 0) return '# This block uses no structures or enumerations'
+
+  let code = '# Structures and enumerations from the Variables Table\n'
+  for (const dataType of referenced) {
+    if (dataType.derivation === 'enumerated') {
+      code += `class ${dataType.name}(IntEnum):\n`
+      dataType.values.forEach((value, index) => {
+        code += `    ${value.description} = ${index}\n`
+      })
+      code += '\n'
+      continue
+    }
+    /* istanbul ignore else -- collectReferencedTypes yields only these two */
+    if (dataType.derivation === 'structure') {
+      const members = dataType.variable.map((member) => member.name)
+      code += `class ${dataType.name}:\n`
+      code += `    __slots__ = (${members.map((m) => `'${m}'`).join(', ')}${members.length === 1 ? ',' : ''})\n`
+      code += `    def __init__(self${members.map((m) => `, ${m}=None`).join('')}):\n`
+      for (const member of members) {
+        code += `        self.${member} = ${member}\n`
+      }
+      code += '\n'
+    }
+  }
+  return code
+}
+
+/**
+ * Every structure and enumeration a block's interface reaches, nested ones
+ * included, in an order where a type is declared before anything using it.
+ */
+const collectReferencedTypes = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): PLCDataType[] => {
+  const byName = new Map(dataTypes.map((dataType) => [dataType.name.toUpperCase(), dataType]))
+  const ordered: PLCDataType[] = []
+  const seen = new Set<string>()
+
+  const visit = (typeName: string, depth: number): void => {
+    /* istanbul ignore next -- defensive: describeShmLeaves refuses deeper nesting first */
+    if (depth > 16) return
+    const key = typeName.toUpperCase()
+    if (seen.has(key)) return
+    const dataType = byName.get(key)
+    if (!dataType || dataType.derivation === 'array') return
+    seen.add(key)
+    if (dataType.derivation === 'structure') {
+      // Members first, so a nested structure is defined before the class that
+      // constructs it.
+      for (const member of dataType.variable) {
+        if (member.type.definition === 'user-data-type') visit(member.type.value, depth + 1)
+      }
+    }
+    ordered.push(dataType)
+  }
+
+  for (const variable of variables) {
+    const base = variable.type.definition === 'array' ? variable.type.data?.baseType : variable.type
+    if (base?.definition === 'user-data-type') visit(base.value, 0)
+  }
+  return ordered
+}
+
+/**
+ * Emit the statements that decode one variable from consecutive leaves.
+ *
+ * A scalar binds straight to its name. A structure is constructed from its
+ * members, innermost first, so nesting rebuilds correctly. An enumeration is
+ * wrapped in its IntEnum.
+ */
+const generateVariableUnpack = (variable: PLCVariable, dataTypes: readonly PLCDataType[], indent: string): string => {
+  const walked = describeShmLeaves(variable, dataTypes)
+  /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
+  if ('refusal' in walked) return ''
+
+  let code = ''
+  const locals: string[] = []
+  for (const leaf of walked.leaves) {
+    // Each leaf decodes into a temporary named for its path, then the temporaries
+    // are assembled. A flat variable's path is just its own name, so the
+    // temporary *is* the variable and no assembly is needed.
+    const local = leaf.path.length === 1 ? variable.name : `_${leaf.field}`
+    locals.push(local)
+    code += decodeLeaf(leaf, local, indent)
+  }
+
+  if (walked.leaves.length === 1 && walked.leaves[0].path.length === 1) {
+    const only = walked.leaves[0]
+    return only.enumTypeName ? `${code}${indent}${variable.name} = ${only.enumTypeName}(${variable.name})\n` : code
+  }
+
+  code += `${indent}${variable.name} = ${buildValue(variable, dataTypes, [variable.name])}\n`
+  return code
+}
+
+/** Construct expression for a structure, recursing into nested members. */
+const buildValue = (variable: PLCVariable, dataTypes: readonly PLCDataType[], path: string[]): string => {
+  const byName = new Map(dataTypes.map((dataType) => [dataType.name.toUpperCase(), dataType]))
+  const base = variable.type.definition === 'array' ? variable.type.data?.baseType : variable.type
+
+  const buildFor = (typeName: string, fieldPath: string[]): string => {
+    const dataType = byName.get(typeName.toUpperCase())
+    /* istanbul ignore next -- defensive: only structures reach here */
+    if (!dataType || dataType.derivation !== 'structure') return `_${fieldPath.join('_')}`
+    const args = dataType.variable.map((member) => {
+      const memberPath = [...fieldPath, member.name]
+      if (member.type.definition === 'user-data-type') {
+        const nested = byName.get(member.type.value.toUpperCase())
+        if (nested?.derivation === 'structure') return `${member.name}=${buildFor(member.type.value, memberPath)}`
+        if (nested?.derivation === 'enumerated') {
+          return `${member.name}=${member.type.value}(_${memberPath.join('_')})`
+        }
+      }
+      return `${member.name}=_${memberPath.join('_')}`
+    })
+    return `${dataType.name}(${args.join(', ')})`
+  }
+
+  /* istanbul ignore next -- defensive: callers only assemble structures */
+  return base?.definition === 'user-data-type' ? buildFor(base.value, path) : `_${path.join('_')}`
+}
+
+/** Decode one leaf out of `_vals` into `local`. */
+const decodeLeaf = (leaf: ShmLeaf, local: string, indent: string): string => {
+  const { descriptor, count } = leaf
+  let code = ''
+
+  if (count > 1) {
+    code += `${indent}${local} = list(_vals[_idx:_idx+${count}])\n`
+    code += `${indent}_idx += ${count}\n`
+    return code
+  }
+
+  if (descriptor.kind === 'string' || descriptor.kind === 'wstring') {
+    code += `${indent}${local}_len = _vals[_idx]\n`
+    code += `${indent}_idx += 1\n`
+    code += `${indent}${local}_body = _vals[_idx]\n`
+    code += `${indent}_idx += 1\n`
+    // The C side clamps the length to the budget, but the prefix is a signed
+    // int8 and the buffer starts zeroed, so clamp on read too: a negative slice
+    // bound would silently truncate from the end instead of failing.
+    code += `${indent}${local}_len = max(0, min(${local}_len, ${SHM_STRING_CHARS}))\n`
+    if (descriptor.kind === 'wstring') {
+      // The length counts UTF-16 code units, so the byte slice is twice it.
+      code += `${indent}${local} = ${local}_body[:${local}_len * 2].decode('utf-16-le', errors='ignore')\n`
+    } else {
+      code += `${indent}${local} = ${local}_body[:${local}_len].decode('utf-8', errors='ignore')\n`
+    }
+    return code
+  }
+
+  code += `${indent}${local} = _vals[_idx]\n`
+  code += `${indent}_idx += 1\n`
+  return code
+}
+
+/**
+ * Emit the unpack sequence for a set of variables.
+ *
+ * Shared by the per-cycle input read and the one-time output seed: both decode
+ * the same packed layout, differing only in which buffer they read and at what
+ * indentation. Keeping one generator means the two cannot drift in how they
+ * interpret a field — the same reason the leaf walk is shared with the C side.
+ */
+const generateUnpackCode = (
+  variables: PLCVariable[],
+  dataTypes: readonly PLCDataType[],
+  opts: { header: string; buffer: string; fmt: string; size: string; indent: string },
+): string => {
+  const { header, buffer, fmt, size, indent } = opts
+
+  let code = `${header}\n`
+  code += `${indent}_vals = struct.unpack(${fmt}, ${buffer}.buf[:${size}])\n`
+  code += `${indent}_idx = 0\n`
+  for (const variable of variables) {
+    code += generateVariableUnpack(variable, dataTypes, indent)
+  }
+  return code
+}
+
+const generateInputUnpackCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  if (variables.length === 0) return '    # No input variables to read'
+  return generateUnpackCode(variables, dataTypes, {
     header: '    # Read input variables',
     buffer: 'shm_in',
     fmt: 'fmt_in',
@@ -26,18 +223,17 @@ const generateInputUnpackCode = (inputVariables: PLCVariable[]): string => {
  * Seed the output globals from what the PLC currently holds, before
  * `block_init()` runs.
  *
- * Previously the outputs were initialised from their declarations
- * (`initialValue || 0`) and written back after the first `block_loop()`, before
- * the user's code had assigned anything — so the IEC-side value was replaced by
- * a default on every start. With RETAIN that is destructive rather than merely
- * wrong. The C stub publishes the live values into shared memory when it maps
- * the segment (see `generateOutputSeedCode`), and this reads them back.
- *
- * A block that never assigns an output now leaves it exactly as the PLC had it.
+ * Previously the outputs were initialised from their declarations and written
+ * back after the first `block_loop()`, before the user's code had assigned
+ * anything — so the IEC-side value was replaced by a default on every start.
+ * With RETAIN that is destructive rather than merely wrong. The C stub publishes
+ * the live values into shared memory when it maps the segment, and this reads
+ * them back. A block that never assigns an output now leaves it exactly as the
+ * PLC had it.
  */
-const generateOutputSeedCode = (outputVariables: PLCVariable[]): string => {
-  if (outputVariables.length === 0) return '# No output variables to seed'
-  return generateUnpackCode(outputVariables, {
+const generateOutputSeedCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  if (variables.length === 0) return '# No output variables to seed'
+  return generateUnpackCode(variables, dataTypes, {
     header: '# Seed outputs from the values the PLC already holds',
     buffer: 'shm_out',
     fmt: 'fmt_out',
@@ -46,88 +242,56 @@ const generateOutputSeedCode = (outputVariables: PLCVariable[]): string => {
   })
 }
 
-/**
- * Emit the unpack sequence for a set of variables.
- *
- * Shared by the per-cycle input read and the one-time output seed: both decode
- * the same packed layout, differing only in which buffer they read and at what
- * indentation. Keeping one generator means the two cannot drift in how they
- * interpret a field — the same reason the type table is shared.
- */
-const generateUnpackCode = (
-  variables: PLCVariable[],
-  opts: { header: string; buffer: string; fmt: string; size: string; indent: string },
-): string => {
-  const { header, buffer, fmt, size, indent } = opts
+/** Encode one leaf, reading through the Python attribute path it came from. */
+const encodeLeaf = (leaf: ShmLeaf): string => {
+  const expr = leaf.path.join('.')
+  const { descriptor, count } = leaf
 
-  let code = `${header}\n`
-  code += `${indent}_vals = struct.unpack(${fmt}, ${buffer}.buf[:${size}])\n`
-  code += `${indent}_idx = 0\n`
+  if (count > 1) return `    _out.extend(${expr})\n`
 
-  variables.forEach((variable) => {
-    const kind = describeShmField(variable)?.kind
+  if (descriptor.kind === 'string') {
+    let code = `    _body = ${expr}.encode('utf-8')[:${SHM_STRING_CHARS}]\n`
+    code += `    _len = len(_body)\n`
+    code += `    _body = _body.ljust(${SHM_STRING_CHARS}, b'\\0')\n`
+    code += `    _out.append(_len)\n`
+    code += `    _out.append(_body)\n`
+    return code
+  }
 
-    if (isArrayVariable(variable)) {
-      const count = getArrayTotalElements(variable)
-      code += `${indent}${variable.name} = list(_vals[_idx:_idx+${count}])\n`
-      code += `${indent}_idx += ${count}\n`
-    } else if (kind === 'string' || kind === 'wstring') {
-      code += `${indent}${variable.name}_len = _vals[_idx]\n`
-      code += `${indent}_idx += 1\n`
-      code += `${indent}${variable.name}_body = _vals[_idx]\n`
-      code += `${indent}_idx += 1\n`
-      // The C side clamps the length to the budget, but the prefix is a signed
-      // int8 and the buffer starts zeroed, so clamp on read too: a negative
-      // slice bound would silently truncate from the end instead of failing.
-      code += `${indent}${variable.name}_len = max(0, min(${variable.name}_len, ${SHM_STRING_CHARS}))\n`
-      if (kind === 'wstring') {
-        // The length counts UTF-16 code units, so the byte slice is twice it.
-        code += `${indent}${variable.name} = ${variable.name}_body[:${variable.name}_len * 2].decode('utf-16-le', errors='ignore')\n`
-      } else {
-        code += `${indent}${variable.name} = ${variable.name}_body[:${variable.name}_len].decode('utf-8', errors='ignore')\n`
-      }
-    } else {
-      code += `${indent}${variable.name} = _vals[_idx]\n`
-      code += `${indent}_idx += 1\n`
-    }
-  })
+  if (descriptor.kind === 'wstring') {
+    // Truncate on a code-unit boundary, never mid-unit: encode, clip to the byte
+    // budget, then round down to an even length. `_len` is the code-unit count
+    // the C side expects, not the byte count.
+    let code = `    _body = ${expr}.encode('utf-16-le')[:${SHM_STRING_CHARS * 2}]\n`
+    code += `    _body = _body[: len(_body) - (len(_body) % 2)]\n`
+    code += `    _len = len(_body) // 2\n`
+    code += `    _body = _body.ljust(${SHM_STRING_CHARS * 2}, b'\\0')\n`
+    code += `    _out.append(_len)\n`
+    code += `    _out.append(_body)\n`
+    return code
+  }
 
-  return code
+  // An IntEnum packs as its integer already, but saying so keeps the generated
+  // code honest about what crosses — and survives a user assigning a plain int.
+  if (leaf.enumTypeName) return `    _out.append(int(${expr}))\n`
+
+  return `    _out.append(${expr})\n`
 }
 
 /**
  * Generate Python code that packs output variables into the flat struct format.
- * Arrays are flattened via extend(), scalars and string pairs via append().
  */
-const generateOutputPackCode = (outputVariables: PLCVariable[]): string => {
-  if (outputVariables.length === 0) return '    # No output variables to write'
+const generateOutputPackCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+  if (variables.length === 0) return '    # No output variables to write'
 
   let code = '    # Write output variables\n'
   code += '    _out = []\n'
-
-  outputVariables.forEach((variable) => {
-    if (isArrayVariable(variable)) {
-      code += `    _out.extend(${variable.name})\n`
-    } else if (describeShmField(variable)?.kind === 'string') {
-      code += `    _body = ${variable.name}.encode('utf-8')[:${SHM_STRING_CHARS}]\n`
-      code += `    _len = len(_body)\n`
-      code += `    _body = _body.ljust(${SHM_STRING_CHARS}, b'\\0')\n`
-      code += `    _out.append(_len)\n`
-      code += `    _out.append(_body)\n`
-    } else if (describeShmField(variable)?.kind === 'wstring') {
-      // Truncate on a code-unit boundary, never mid-unit: encode, clip to the
-      // byte budget, then round down to an even length. `_len` is the code-unit
-      // count the C side expects, not the byte count.
-      code += `    _body = ${variable.name}.encode('utf-16-le')[:${SHM_STRING_CHARS * 2}]\n`
-      code += `    _body = _body[: len(_body) - (len(_body) % 2)]\n`
-      code += `    _len = len(_body) // 2\n`
-      code += `    _body = _body.ljust(${SHM_STRING_CHARS * 2}, b'\\0')\n`
-      code += `    _out.append(_len)\n`
-      code += `    _out.append(_body)\n`
-    } else {
-      code += `    _out.append(${variable.name})\n`
-    }
-  })
+  for (const variable of variables) {
+    const walked = describeShmLeaves(variable, dataTypes)
+    /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
+    if ('refusal' in walked) continue
+    for (const leaf of walked.leaves) code += encodeLeaf(leaf)
+  }
 
   code += '    packed = struct.pack(fmt_out, *_out)\n'
   code += '    shm_out.buf[:data_size_out] = packed'
@@ -136,13 +300,19 @@ const generateOutputPackCode = (outputVariables: PLCVariable[]): string => {
 }
 
 const injectPythonRuntime = (params: PythonRuntimeInjectionParams): string => {
-  const { fmtIn, fmtOut, inputVariables, outputVariables, originalCode, pouName } = params
+  const { fmtIn, fmtOut, inputVariables, outputVariables, originalCode, pouName, dataTypes = [] } = params
 
-  const outputSeeding = generateOutputSeedCode(outputVariables)
-  const readInputSection = generateInputUnpackCode(inputVariables)
-  const writeOutputSection = generateOutputPackCode(outputVariables)
+  const outputSeeding = generateOutputSeedCode(outputVariables, dataTypes)
+  const readInputSection = generateInputUnpackCode(inputVariables, dataTypes)
+  const writeOutputSection = generateOutputPackCode(outputVariables, dataTypes)
+  // Declared before the user's code, so a block_init() that constructs one of
+  // its own structures finds the class already defined.
+  const typeDeclarations = generateTypeDeclarations([...inputVariables, ...outputVariables], dataTypes)
 
   const injectedCode = `
+from enum import IntEnum
+
+${typeDeclarations}
 ${originalCode}
 
 plc_pid = %d

--- a/src/frontend/utils/python/injectPythonRuntime.ts
+++ b/src/frontend/utils/python/injectPythonRuntime.ts
@@ -33,7 +33,7 @@ type PythonRuntimeInjectionParams = {
  */
 const generateTypeDeclarations = (variables: PLCVariable[], context: ShmWalkContext): string => {
   const dataTypes = context.dataTypes ?? []
-  const referenced = collectReferencedTypes(variables, dataTypes)
+  const referenced = collectReferencedTypes(variables, dataTypes, context)
   const instanceClasses = generateInstanceClasses(variables, context)
 
   if (referenced.length === 0 && instanceClasses === '') {
@@ -139,25 +139,51 @@ const generateInstanceClasses = (variables: PLCVariable[], context: ShmWalkConte
 /**
  * Every structure and enumeration a block's interface reaches, nested ones
  * included, in an order where a type is declared before anything using it.
+ *
+ * "Reaches" includes THROUGH A FUNCTION BLOCK INSTANCE. A pin can be a structure
+ * or an enumeration, and the constructor for that pin names its class — so a
+ * walk that stopped at the instance left the class undeclared and the generated
+ * module referenced a name that was never defined.
  */
-const collectReferencedTypes = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): PLCDataType[] => {
+const collectReferencedTypes = (
+  variables: PLCVariable[],
+  dataTypes: readonly PLCDataType[],
+  context: ShmWalkContext,
+): PLCDataType[] => {
   const byName = new Map(dataTypes.map((dataType) => [dataType.name.toUpperCase(), dataType]))
   const ordered: PLCDataType[] = []
   const seen = new Set<string>()
+  const seenBlocks = new Set<string>()
 
   const visit = (typeName: string, depth: number): void => {
     /* istanbul ignore next -- defensive: describeShmLeaves refuses deeper nesting first */
     if (depth > 16) return
     const key = typeName.toUpperCase()
-    if (seen.has(key)) return
     const dataType = byName.get(key)
-    if (!dataType || dataType.derivation === 'array') return
+
+    // No data type by that name: a function block instance. Its pins are what
+    // the constructor names, so they are what has to be reachable from here.
+    if (!dataType) {
+      if (seenBlocks.has(key)) return
+      seenBlocks.add(key)
+      const pins = resolveFunctionBlockPins(typeName, context.pous ?? [], context.libraries ?? [])
+      for (const pin of pins ?? []) {
+        if (pin.type.definition === 'user-data-type' || pin.type.definition === 'derived') {
+          visit(pin.type.value, depth + 1)
+        }
+      }
+      return
+    }
+
+    if (seen.has(key) || dataType.derivation === 'array') return
     seen.add(key)
     if (dataType.derivation === 'structure') {
       // Members first, so a nested structure is defined before the class that
       // constructs it.
       for (const member of dataType.variable) {
-        if (member.type.definition === 'user-data-type') visit(member.type.value, depth + 1)
+        if (member.type.definition === 'user-data-type' || member.type.definition === 'derived') {
+          visit(member.type.value, depth + 1)
+        }
       }
     }
     ordered.push(dataType)
@@ -165,7 +191,7 @@ const collectReferencedTypes = (variables: PLCVariable[], dataTypes: readonly PL
 
   for (const variable of variables) {
     const base = variable.type.definition === 'array' ? variable.type.data?.baseType : variable.type
-    if (base?.definition === 'user-data-type') visit(base.value, 0)
+    if (base?.definition === 'user-data-type' || base?.definition === 'derived') visit(base.value, 0)
   }
   return ordered
 }
@@ -215,21 +241,39 @@ const buildValue = (variable: PLCVariable, context: ShmWalkContext, path: string
   const byName = new Map(dataTypes.map((dataType) => [dataType.name.toUpperCase(), dataType]))
   const base = variable.type.definition === 'array' ? variable.type.data?.baseType : variable.type
 
+  /**
+   * The expression for whatever sits at `fieldPath`, given its declared type.
+   *
+   * ONE rule, used for a structure's members and for a function block's pins
+   * alike, because the walk treats them alike: it descends into a composite and
+   * emits a temporary per LEAF, never one for the composite itself. A structure
+   * member got that recursion; a pin did not, and emitted a flat
+   * `PIN=_instance_PIN` — a name the decode never assigns. An FB whose pin is a
+   * structure therefore raised `NameError` at module scope, before
+   * `block_init()`. Keeping one rule is what stops the two drifting again.
+   */
+  const valueFor = (typeValue: string, typeDefinition: string, fieldPath: string[]): string => {
+    if (typeDefinition === 'user-data-type' || typeDefinition === 'derived') {
+      const declared = byName.get(typeValue.toUpperCase())
+      // An enumeration crosses as its integer and is wrapped back into the
+      // class. `declared.name`, not the reference's spelling: the class is
+      // emitted under the type's own declared name, so echoing a mixed-case
+      // reference would name a class that does not exist.
+      if (declared?.derivation === 'enumerated') return `${declared.name}(_${fieldPath.join('_')})`
+      // A structure, or a function block instance (no data type by that name).
+      if (!declared || declared.derivation === 'structure') return buildFor(typeValue, fieldPath)
+    }
+    return `_${fieldPath.join('_')}`
+  }
+
   const buildFor = (typeName: string, fieldPath: string[]): string => {
     const dataType = byName.get(typeName.toUpperCase())
 
     if (dataType?.derivation === 'structure') {
-      const args = dataType.variable.map((member) => {
-        const memberPath = [...fieldPath, member.name]
-        if (member.type.definition === 'user-data-type') {
-          const nested = byName.get(member.type.value.toUpperCase())
-          if (nested?.derivation === 'structure') return `${member.name}=${buildFor(member.type.value, memberPath)}`
-          if (nested?.derivation === 'enumerated') {
-            return `${member.name}=${member.type.value}(_${memberPath.join('_')})`
-          }
-        }
-        return `${member.name}=_${memberPath.join('_')}`
-      })
+      const args = dataType.variable.map(
+        (member) =>
+          `${member.name}=${valueFor(member.type.value, member.type.definition, [...fieldPath, member.name])}`,
+      )
       return `${dataType.name}(${args.join(', ')})`
     }
 
@@ -247,7 +291,7 @@ const buildValue = (variable: PLCVariable, context: ShmWalkContext, path: string
       // and the temporary names the field the walk produced. They are the same
       // name by construction — see the pin naming note in `shm-leaves`.
       const upper = pin.name.toUpperCase()
-      return `${upper}=_${[...fieldPath, upper].join('_')}`
+      return `${upper}=${valueFor(pin.type.value, pin.type.definition, [...fieldPath, upper])}`
     })
     return `${pythonClassName(typeName)}(${args.join(', ')})`
   }

--- a/src/frontend/utils/python/injectPythonRuntime.ts
+++ b/src/frontend/utils/python/injectPythonRuntime.ts
@@ -1,6 +1,7 @@
 import type { PLCDataType, PLCVariable } from '../../../middleware/shared/ports/types'
-import type { ShmLeaf } from './shm-leaves'
-import { describeShmLeaves } from './shm-leaves'
+import { resolveFunctionBlockPins } from '../PLC/function-block-pins'
+import type { ShmLeaf, ShmWalkContext } from './shm-leaves'
+import { describeShmLeaves, pinCrossesInDirection, pythonFunctionBlockInstances } from './shm-leaves'
 import { SHM_STRING_CHARS } from './shm-type-map'
 
 type PythonRuntimeInjectionParams = {
@@ -10,8 +11,10 @@ type PythonRuntimeInjectionParams = {
   outputVariables: PLCVariable[]
   originalCode: string
   pouName: string
-  /** The project's data types, so a structure or enumeration can be rebuilt. */
-  dataTypes?: readonly PLCDataType[]
+  /** Walk context for what the PLC sends the block. */
+  inbound: ShmWalkContext
+  /** Walk context for what the block sends back. */
+  outbound: ShmWalkContext
 }
 
 /**
@@ -28,11 +31,18 @@ type PythonRuntimeInjectionParams = {
  * so `mode == Mode.RUNNING` reads naturally while the value crossing the
  * boundary stays the plain integer the PLC stores.
  */
-const generateTypeDeclarations = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+const generateTypeDeclarations = (variables: PLCVariable[], context: ShmWalkContext): string => {
+  const dataTypes = context.dataTypes ?? []
   const referenced = collectReferencedTypes(variables, dataTypes)
-  if (referenced.length === 0) return '# This block uses no structures or enumerations'
+  const instanceClasses = generateInstanceClasses(variables, context)
 
-  let code = '# Structures and enumerations from the Variables Table\n'
+  if (referenced.length === 0 && instanceClasses === '') {
+    return '# This block uses no structures, enumerations or function block instances'
+  }
+
+  let code = ''
+  if (referenced.length === 0) return instanceClasses
+  code += '# Structures and enumerations from the Variables Table\n'
   for (const dataType of referenced) {
     if (dataType.derivation === 'enumerated') {
       code += `class ${dataType.name}(IntEnum):\n`
@@ -53,6 +63,54 @@ const generateTypeDeclarations = (variables: PLCVariable[], dataTypes: readonly 
       }
       code += '\n'
     }
+  }
+  return code + instanceClasses
+}
+
+/**
+ * Python classes for the function block instances a block declares.
+ *
+ * Python cannot call an instance, but it does not need to: the generated ST
+ * wrapper calls each one every scan, in the PLC process where the instance
+ * lives. What Python gets is the pins, and it should use them the way ST does —
+ * `ton0.IN = True`, then `ton0.Q` — so each instance becomes an object with its
+ * pins as attributes.
+ *
+ * Pin names are upper-cased, matching how the compiler names them and how the
+ * copy statements reach them, so a user writes `ton0.IN` rather than `ton0.in`
+ * (which would also collide with a Python keyword).
+ *
+ * Only the pins that cross appear. FB-internal `local` state is left out: it is
+ * the instance's own business, and exposing it would invite writes that corrupt
+ * the block from outside.
+ */
+const generateInstanceClasses = (variables: PLCVariable[], context: ShmWalkContext): string => {
+  const instances = pythonFunctionBlockInstances(variables, context.dataTypes ?? [])
+  if (instances.length === 0) return ''
+
+  const emitted = new Set<string>()
+  let code = '# Function block instances — called once per scan by the PLC\n'
+  for (const instance of instances) {
+    const typeName = instance.type.value
+    if (emitted.has(typeName.toUpperCase())) continue
+    emitted.add(typeName.toUpperCase())
+
+    const pins = resolveFunctionBlockPins(typeName, context.pous ?? [], context.libraries ?? [])
+    /* istanbul ignore next -- defensive: an unresolvable instance is refused upstream */
+    if (!pins) continue
+    const names = pins
+      // Every pin that ever crosses, in either direction, so one class serves
+      // both the seed (inputs only) and the per-cycle read (all pins).
+      .filter((pin) => pinCrossesInDirection(pin.class, 'in'))
+      .map((pin) => pin.name.toUpperCase())
+    /* istanbul ignore next -- defensive: a block with no pins at all */
+    if (names.length === 0) continue
+
+    code += `class ${typeName}:\n`
+    code += `    __slots__ = (${names.map((n) => `'${n}'`).join(', ')}${names.length === 1 ? ',' : ''})\n`
+    code += `    def __init__(self${names.map((n) => `, ${n}=None`).join('')}):\n`
+    for (const n of names) code += `        self.${n} = ${n}\n`
+    code += '\n'
   }
   return code
 }
@@ -98,8 +156,8 @@ const collectReferencedTypes = (variables: PLCVariable[], dataTypes: readonly PL
  * members, innermost first, so nesting rebuilds correctly. An enumeration is
  * wrapped in its IntEnum.
  */
-const generateVariableUnpack = (variable: PLCVariable, dataTypes: readonly PLCDataType[], indent: string): string => {
-  const walked = describeShmLeaves(variable, dataTypes)
+const generateVariableUnpack = (variable: PLCVariable, context: ShmWalkContext, indent: string): string => {
+  const walked = describeShmLeaves(variable, context)
   /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
   if ('refusal' in walked) return ''
 
@@ -119,35 +177,64 @@ const generateVariableUnpack = (variable: PLCVariable, dataTypes: readonly PLCDa
     return only.enumTypeName ? `${code}${indent}${variable.name} = ${only.enumTypeName}(${variable.name})\n` : code
   }
 
-  code += `${indent}${variable.name} = ${buildValue(variable, dataTypes, [variable.name])}\n`
+  code += `${indent}${variable.name} = ${buildValue(variable, context, [variable.name])}\n`
   return code
 }
 
-/** Construct expression for a structure, recursing into nested members. */
-const buildValue = (variable: PLCVariable, dataTypes: readonly PLCDataType[], path: string[]): string => {
+/**
+ * Construct expression for a composite: a structure, or a function block
+ * instance built from the pins that crossed.
+ *
+ * The two look the same from here — a named type whose members were decoded into
+ * temporaries — so one builder covers both, and the only difference is where the
+ * member list comes from.
+ */
+const buildValue = (variable: PLCVariable, context: ShmWalkContext, path: string[]): string => {
+  const dataTypes = context.dataTypes ?? []
   const byName = new Map(dataTypes.map((dataType) => [dataType.name.toUpperCase(), dataType]))
   const base = variable.type.definition === 'array' ? variable.type.data?.baseType : variable.type
 
   const buildFor = (typeName: string, fieldPath: string[]): string => {
     const dataType = byName.get(typeName.toUpperCase())
-    /* istanbul ignore next -- defensive: only structures reach here */
-    if (!dataType || dataType.derivation !== 'structure') return `_${fieldPath.join('_')}`
-    const args = dataType.variable.map((member) => {
-      const memberPath = [...fieldPath, member.name]
-      if (member.type.definition === 'user-data-type') {
-        const nested = byName.get(member.type.value.toUpperCase())
-        if (nested?.derivation === 'structure') return `${member.name}=${buildFor(member.type.value, memberPath)}`
-        if (nested?.derivation === 'enumerated') {
-          return `${member.name}=${member.type.value}(_${memberPath.join('_')})`
+
+    if (dataType?.derivation === 'structure') {
+      const args = dataType.variable.map((member) => {
+        const memberPath = [...fieldPath, member.name]
+        if (member.type.definition === 'user-data-type') {
+          const nested = byName.get(member.type.value.toUpperCase())
+          if (nested?.derivation === 'structure') return `${member.name}=${buildFor(member.type.value, memberPath)}`
+          if (nested?.derivation === 'enumerated') {
+            return `${member.name}=${member.type.value}(_${memberPath.join('_')})`
+          }
         }
-      }
-      return `${member.name}=_${memberPath.join('_')}`
+        return `${member.name}=_${memberPath.join('_')}`
+      })
+      return `${dataType.name}(${args.join(', ')})`
+    }
+
+    // Not a data type, so a function block instance. Its pins are the members,
+    // and only the ones that crossed appear — which for the inbound direction is
+    // inputs, in-outs and outputs.
+    const pins = resolveFunctionBlockPins(typeName, context.pous ?? [], context.libraries ?? [])
+    /* istanbul ignore next -- defensive: an unresolvable instance is refused upstream */
+    if (!pins) return `_${fieldPath.join('_')}`
+    // Must match the walk exactly, or the constructor names a temporary the
+    // decode never produced — hence one shared predicate.
+    const crossing = pins.filter((pin) => pinCrossesInDirection(pin.class, context.direction))
+    const args = crossing.map((pin) => {
+      // Upper-cased on both sides of the `=`: the keyword names the class slot,
+      // and the temporary names the field the walk produced. They are the same
+      // name by construction — see the pin naming note in `shm-leaves`.
+      const upper = pin.name.toUpperCase()
+      return `${upper}=_${[...fieldPath, upper].join('_')}`
     })
-    return `${dataType.name}(${args.join(', ')})`
+    return `${typeName}(${args.join(', ')})`
   }
 
-  /* istanbul ignore next -- defensive: callers only assemble structures */
-  return base?.definition === 'user-data-type' ? buildFor(base.value, path) : `_${path.join('_')}`
+  /* istanbul ignore next -- defensive: callers only assemble composites */
+  return base && (base.definition === 'user-data-type' || base.definition === 'derived')
+    ? buildFor(base.value, path)
+    : `_${path.join('_')}`
 }
 
 /** Decode one leaf out of `_vals` into `local`. */
@@ -194,7 +281,7 @@ const decodeLeaf = (leaf: ShmLeaf, local: string, indent: string): string => {
  */
 const generateUnpackCode = (
   variables: PLCVariable[],
-  dataTypes: readonly PLCDataType[],
+  context: ShmWalkContext,
   opts: { header: string; buffer: string; fmt: string; size: string; indent: string },
 ): string => {
   const { header, buffer, fmt, size, indent } = opts
@@ -203,14 +290,14 @@ const generateUnpackCode = (
   code += `${indent}_vals = struct.unpack(${fmt}, ${buffer}.buf[:${size}])\n`
   code += `${indent}_idx = 0\n`
   for (const variable of variables) {
-    code += generateVariableUnpack(variable, dataTypes, indent)
+    code += generateVariableUnpack(variable, context, indent)
   }
   return code
 }
 
-const generateInputUnpackCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+const generateInputUnpackCode = (variables: PLCVariable[], context: ShmWalkContext): string => {
   if (variables.length === 0) return '    # No input variables to read'
-  return generateUnpackCode(variables, dataTypes, {
+  return generateUnpackCode(variables, context, {
     header: '    # Read input variables',
     buffer: 'shm_in',
     fmt: 'fmt_in',
@@ -231,9 +318,9 @@ const generateInputUnpackCode = (variables: PLCVariable[], dataTypes: readonly P
  * them back. A block that never assigns an output now leaves it exactly as the
  * PLC had it.
  */
-const generateOutputSeedCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+const generateOutputSeedCode = (variables: PLCVariable[], context: ShmWalkContext): string => {
   if (variables.length === 0) return '# No output variables to seed'
-  return generateUnpackCode(variables, dataTypes, {
+  return generateUnpackCode(variables, context, {
     header: '# Seed outputs from the values the PLC already holds',
     buffer: 'shm_out',
     fmt: 'fmt_out',
@@ -281,13 +368,13 @@ const encodeLeaf = (leaf: ShmLeaf): string => {
 /**
  * Generate Python code that packs output variables into the flat struct format.
  */
-const generateOutputPackCode = (variables: PLCVariable[], dataTypes: readonly PLCDataType[]): string => {
+const generateOutputPackCode = (variables: PLCVariable[], context: ShmWalkContext): string => {
   if (variables.length === 0) return '    # No output variables to write'
 
   let code = '    # Write output variables\n'
   code += '    _out = []\n'
   for (const variable of variables) {
-    const walked = describeShmLeaves(variable, dataTypes)
+    const walked = describeShmLeaves(variable, context)
     /* istanbul ignore next -- defensive: refusals stop the build in preprocess-pous */
     if ('refusal' in walked) continue
     for (const leaf of walked.leaves) code += encodeLeaf(leaf)
@@ -300,14 +387,16 @@ const generateOutputPackCode = (variables: PLCVariable[], dataTypes: readonly PL
 }
 
 const injectPythonRuntime = (params: PythonRuntimeInjectionParams): string => {
-  const { fmtIn, fmtOut, inputVariables, outputVariables, originalCode, pouName, dataTypes = [] } = params
+  const { fmtIn, fmtOut, inputVariables, outputVariables, originalCode, pouName, inbound, outbound } = params
 
-  const outputSeeding = generateOutputSeedCode(outputVariables, dataTypes)
-  const readInputSection = generateInputUnpackCode(inputVariables, dataTypes)
-  const writeOutputSection = generateOutputPackCode(outputVariables, dataTypes)
+  const outputSeeding = generateOutputSeedCode(outputVariables, outbound)
+  const readInputSection = generateInputUnpackCode(inputVariables, inbound)
+  const writeOutputSection = generateOutputPackCode(outputVariables, outbound)
   // Declared before the user's code, so a block_init() that constructs one of
-  // its own structures finds the class already defined.
-  const typeDeclarations = generateTypeDeclarations([...inputVariables, ...outputVariables], dataTypes)
+  // its own structures finds the class already defined. The inbound context is
+  // the fuller one — it carries a function block's outputs as well as its
+  // inputs — so the emitted class has every pin.
+  const typeDeclarations = generateTypeDeclarations([...inputVariables, ...outputVariables], inbound)
 
   const injectedCode = `
 from enum import IntEnum

--- a/src/frontend/utils/python/shm-leaves.ts
+++ b/src/frontend/utils/python/shm-leaves.ts
@@ -24,12 +24,15 @@
 
 import type {
   PLCDataType,
+  PLCPou,
   PLCStructureVariable,
   PLCVariable,
   PLCVariableType,
 } from '../../../middleware/shared/ports/types'
 import { getArrayTotalElements } from '../PLC/array-codegen-helpers'
 import { parseDimensionRange } from '../PLC/dimension-range'
+import type { LibraryFunctionBlockSource } from '../PLC/function-block-pins'
+import { resolveFunctionBlockPins } from '../PLC/function-block-pins'
 import type { ShmFieldDescriptor } from './shm-type-map'
 import { describeShmField, SHM_SCALAR_TYPES } from './shm-type-map'
 
@@ -69,6 +72,25 @@ export interface ShmRefusal {
 export type ShmWalkResult = { leaves: ShmLeaf[] } | { refusal: ShmRefusal }
 
 /**
+ * What the walk needs beyond the variable, and which way the data travels.
+ *
+ * `direction` matters only for a function block instance, whose pins are not
+ * symmetric: the block's inputs are the caller's to drive, so Python may write
+ * them, while its outputs are produced by the instance and are Python's to read.
+ * A structure has no such asymmetry — every member travels both ways — so
+ * everything else ignores it.
+ */
+export interface ShmWalkContext {
+  dataTypes?: readonly PLCDataType[]
+  /** Project POUs, for resolving a function block instance's pins. */
+  pous?: readonly PLCPou[]
+  /** Installed libraries, for resolving a standard block such as TON. */
+  libraries?: readonly LibraryFunctionBlockSource[]
+  /** `in` — what the PLC sends the block. `out` — what the block sends back. */
+  direction: 'in' | 'out'
+}
+
+/**
  * The member's C++ name, mirroring STruC++'s `member-mangling.ts`.
  *
  * A member whose name matches its own user-defined type is emitted with a
@@ -91,12 +113,44 @@ const mangledMemberName = (memberName: string, memberTypeName: string, userTypeN
   return upper === memberTypeName.toUpperCase() && userTypeNames.has(upper) ? `${upper}_` : upper
 }
 
+/**
+ * Whether a function block pin crosses in a given direction.
+ *
+ * The one statement of this rule. It was briefly written twice — once in the
+ * walk and once where Python reassembles the instance — and the two disagreed:
+ * the reassembly ignored direction, so the output seed constructed the instance
+ * from a pin the seed had never decoded and the block died on
+ * `NameError: name '_ton0_Q' is not defined`. Anything that needs to know which
+ * pins are present has to ask here.
+ */
+export const pinCrossesInDirection = (
+  pinClass: 'input' | 'output' | 'inOut' | 'local',
+  direction: 'in' | 'out',
+): boolean => {
+  // FB-internal state never crosses: it is the instance's own business, and
+  // letting Python write it would corrupt the block from outside.
+  if (pinClass === 'local') return false
+  // Outbound is what Python may drive — the block's inputs. Inbound is
+  // everything, so Python can read what the instance produced.
+  if (direction === 'out') return pinClass === 'input' || pinClass === 'inOut'
+  return true
+}
+
 /** Index the project's data types by upper-cased name. */
 const indexDataTypes = (dataTypes: readonly PLCDataType[]): Map<string, PLCDataType> =>
   new Map(dataTypes.map((dataType) => [dataType.name.toUpperCase(), dataType]))
 
 /** IEC base type an enumeration is stored as. STruC++ defaults to INT. */
 const ENUM_BASE_DESCRIPTOR = SHM_SCALAR_TYPES.int
+
+/** Everything the recursion carries that does not change between levels. */
+interface WalkEnv {
+  types: Map<string, PLCDataType>
+  userTypeNames: ReadonlySet<string>
+  pous: readonly PLCPou[]
+  libraries: readonly LibraryFunctionBlockSource[]
+  direction: 'in' | 'out'
+}
 
 const walk = (
   name: string,
@@ -106,10 +160,10 @@ const walk = (
   path: string[],
   field: string,
   access: string,
-  types: Map<string, PLCDataType>,
-  userTypeNames: ReadonlySet<string>,
+  env: WalkEnv,
   depth: number,
 ): ShmWalkResult => {
+  const { types, userTypeNames } = env
   // A structure that contains itself would otherwise recurse forever. The
   // compiler rejects that too, but this walk runs first and must not hang.
   if (depth > 16) {
@@ -136,8 +190,7 @@ const walk = (
         [...path, member.name],
         `${field}_${member.name}`,
         `${access}.${mangledMemberName(member.name, member.type.value, userTypeNames)}`,
-        types,
-        userTypeNames,
+        env,
         depth + 1,
       )
       if ('refusal' in result) return result
@@ -171,18 +224,61 @@ const walk = (
 
   // A function block instance. `derived` is what the variables parser marks one
   // as, having resolved the name against the project's POUs and libraries;
-  // `user-data-type` reaches here only when the name matched no declared data
-  // type either, which is the same situation from this side. Both are refused
-  // with the reason, because the reason is not "unsupported type" — Python runs
-  // in its own process and cannot call an instance, so holding one would give
-  // the user pins that never advance.
+  // `user-data-type` reaches here only when the name matched no data type
+  // either, which is the same situation from this side.
+  //
+  // Python cannot call the instance — it runs in its own process. What it can do
+  // is use the pins, because the generated ST wrapper calls the instance once
+  // per scan, in the PLC process where it lives (see `generateSTCode`). So the
+  // pins cross like a structure's members, and which ones cross depends on the
+  // direction: the block's inputs are the caller's to drive, so Python writes
+  // them, and its outputs are the instance's to produce, so Python reads them.
+  //
+  // FB-internal `local` state never crosses. It is the instance's own business,
+  // and letting Python write it would corrupt the block from the outside.
   if (typeDefinition === 'derived' || typeDefinition === 'user-data-type') {
-    return {
-      refusal: {
-        path,
-        reason: `"${typeValue}" is a function block instance. A Python block cannot hold one — it runs in its own process, so it cannot call the instance, and an uncalled instance never updates its outputs. Use EN/ENO on the block itself for execution control, or call the instance from an ST block and pass its outputs in as inputs`,
-      },
+    if (arrayInfo) {
+      return { refusal: { path, reason: 'an array of function block instances cannot cross into Python yet' } }
     }
+
+    const pins = resolveFunctionBlockPins(typeValue, env.pous, env.libraries)
+    if (!pins) {
+      return {
+        refusal: {
+          path,
+          reason: `"${typeValue}" is not a type this project declares, and no function block by that name was found in the project or the installed libraries`,
+        },
+      }
+    }
+
+    const crossing = pins.filter((pin) => pinCrossesInDirection(pin.class, env.direction))
+
+    const leaves: ShmLeaf[] = []
+    for (const pin of crossing) {
+      // Pin names are upper-cased throughout — the struct field, the Python
+      // attribute, the class slot and the constructor keyword. The compiler
+      // upper-cases members, so this is also what the C++ side writes
+      // (`ton0.IN`), and a user-declared lowercase pin would otherwise give
+      // Python an attribute named differently from the slot it was built with.
+      const pinName = pin.name.toUpperCase()
+      const element = elementTypeOf({ name: pin.name, type: pin.type })
+      const result = walk(
+        pinName,
+        element.value,
+        element.definition,
+        arrayInfoFor({ name: pin.name, type: pin.type }),
+        [...path, pinName],
+        `${field}_${pinName}`,
+        // A pin is a member of the instance's class, upper-cased, and mangled by
+        // the same rule as any other member.
+        `${access}.${mangledMemberName(pin.name, pin.type.value, userTypeNames)}`,
+        env,
+        depth + 1,
+      )
+      if ('refusal' in result) return result
+      leaves.push(...result.leaves)
+    }
+    return { leaves }
   }
 
   const descriptor = describeShmField({
@@ -257,9 +353,15 @@ const arrayInfoFor = (
  * failure lands on unrelated variables and reads as corrupted data. Refusing
  * stops the build with the name of the variable that caused it.
  */
-export const describeShmLeaves = (variable: PLCVariable, dataTypes: readonly PLCDataType[] = []): ShmWalkResult => {
-  const types = indexDataTypes(dataTypes)
-  const userTypeNames = new Set(dataTypes.map((dataType) => dataType.name.toUpperCase()))
+export const describeShmLeaves = (variable: PLCVariable, context: ShmWalkContext): ShmWalkResult => {
+  const dataTypes = context.dataTypes ?? []
+  const env: WalkEnv = {
+    types: indexDataTypes(dataTypes),
+    userTypeNames: new Set(dataTypes.map((dataType) => dataType.name.toUpperCase())),
+    pous: context.pous ?? [],
+    libraries: context.libraries ?? [],
+    direction: context.direction,
+  }
 
   const element = elementTypeOf(variable)
 
@@ -271,22 +373,41 @@ export const describeShmLeaves = (variable: PLCVariable, dataTypes: readonly PLC
     [variable.name],
     variable.name,
     variable.name.toUpperCase(),
-    types,
-    userTypeNames,
+    env,
     0,
   )
 }
 
 /** Every leaf of every variable, in order, or the first refusal encountered. */
-export const describeShmLayout = (
-  variables: readonly PLCVariable[],
-  dataTypes: readonly PLCDataType[] = [],
-): ShmWalkResult => {
+export const describeShmLayout = (variables: readonly PLCVariable[], context: ShmWalkContext): ShmWalkResult => {
   const leaves: ShmLeaf[] = []
   for (const variable of variables) {
-    const result = describeShmLeaves(variable, dataTypes)
+    const result = describeShmLeaves(variable, context)
     if ('refusal' in result) return result
     leaves.push(...result.leaves)
   }
   return { leaves }
+}
+
+/**
+ * The function block instances a Python block declares, in declaration order.
+ *
+ * The generated ST wrapper calls each of these once per scan, between applying
+ * Python's pin writes and publishing the pins back — see `generateSTCode`. Order
+ * is the declaration order, so the sequence is stable and a user can reason
+ * about which instance runs first.
+ */
+export const pythonFunctionBlockInstances = (
+  variables: readonly PLCVariable[],
+  dataTypes: readonly PLCDataType[] = [],
+): PLCVariable[] => {
+  const declared = new Set(dataTypes.map((dataType) => dataType.name.toUpperCase()))
+  return variables.filter(
+    (variable) =>
+      variable.type.definition === 'derived' ||
+      // A name the project does not declare as a data type is a function block:
+      // the variables parser marks it `derived` when it resolved the name, and
+      // leaves it `user-data-type` when it did not.
+      (variable.type.definition === 'user-data-type' && !declared.has(variable.type.value.toUpperCase())),
+  )
 }

--- a/src/frontend/utils/python/shm-leaves.ts
+++ b/src/frontend/utils/python/shm-leaves.ts
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Flatten a Python block's interface variable into the scalar fields that
+ * actually cross shared memory.
+ *
+ * A structure or an enumeration cannot be memcpy'd across the boundary the way a
+ * scalar can: the PLC side holds `IECVar<T>` wrappers inside a strucpp struct,
+ * and the Python side holds an object. What both sides can agree on is the list
+ * of scalar leaves, in order — so that is what this produces, and every emitter
+ * works from it.
+ *
+ * Flattening rather than nesting is deliberate. The transport struct is ours to
+ * define, so nesting would buy nothing and would put `#pragma pack` inside
+ * `#pragma pack`, where an already-laid-out member type keeps its own padding —
+ * exactly the trap that made WSTRING 254 bytes against Python's 253. One field
+ * per leaf, all at the top level, is a layout both sides compute the same way.
+ *
+ * What a leaf carries is the two halves of the same field: `field`, the name in
+ * our packed struct and the position in the format string, and `access`, the
+ * expression that reaches the value on the strucpp side. They are separate
+ * because the second is not ours to choose — see `mangledMemberName`.
+ */
+
+import type {
+  PLCDataType,
+  PLCStructureVariable,
+  PLCVariable,
+  PLCVariableType,
+} from '../../../middleware/shared/ports/types'
+import { getArrayTotalElements } from '../PLC/array-codegen-helpers'
+import { parseDimensionRange } from '../PLC/dimension-range'
+import type { ShmFieldDescriptor } from './shm-type-map'
+import { describeShmField, SHM_SCALAR_TYPES } from './shm-type-map'
+
+/** One scalar field of the transport struct. */
+export interface ShmLeaf {
+  /** Field name in `shm_data_in_t` / `shm_data_out_t`, unique within the struct. */
+  field: string
+  /** Attribute path on the Python side, e.g. `['m', 'speed']`. */
+  path: string[]
+  /** Expression reaching the value on the strucpp side, e.g. `M.SPEED`. */
+  access: string
+  /** How the field is laid out and decoded. */
+  descriptor: ShmFieldDescriptor
+  /** Elements when the leaf is an array of scalars; 1 otherwise. */
+  count: number
+  /** Lowest IEC index, for an array leaf; 0 otherwise. */
+  startIndex: number
+  /**
+   * The enumeration this leaf came from, when it is one.
+   *
+   * The value crossing the boundary is the plain integer the PLC stores. The
+   * name tells the Python side which `IntEnum` to present it as, so the user
+   * writes `mode == Mode.RUNNING` rather than comparing against a bare number,
+   * and tells the C side which scoped enum to cast through: an `IEC_ENUM_Var`
+   * yields an `IEC_ENUM_Value`, which converts to the enum but not to an
+   * integer.
+   */
+  enumTypeName?: string
+}
+
+/** Why a variable cannot cross, phrased for the user. */
+export interface ShmRefusal {
+  path: string[]
+  reason: string
+}
+
+export type ShmWalkResult = { leaves: ShmLeaf[] } | { refusal: ShmRefusal }
+
+/**
+ * The member's C++ name, mirroring STruC++'s `member-mangling.ts`.
+ *
+ * A member whose name matches its own user-defined type is emitted with a
+ * trailing underscore, because GCC rejects a member that changes the meaning of
+ * its type name inside the class. CODESYS allows `RunningLights : RunningLights`
+ * and real projects use it, so the case is not hypothetical.
+ *
+ * This is a deliberate coupling to the compiler, and the only one in this file:
+ * everything else here describes a layout we define ourselves. It is restated
+ * rather than derived because the compiler exposes no way to ask, and the
+ * alternative — emitting a member name that does not exist — fails the build
+ * with an error that points at generated code the user never wrote.
+ *
+ * The interface-method collision that rule also covers cannot arise here: it
+ * applies to a function block implementing an interface, and only a STRUCT's
+ * members are walked.
+ */
+const mangledMemberName = (memberName: string, memberTypeName: string, userTypeNames: ReadonlySet<string>): string => {
+  const upper = memberName.toUpperCase()
+  return upper === memberTypeName.toUpperCase() && userTypeNames.has(upper) ? `${upper}_` : upper
+}
+
+/** Index the project's data types by upper-cased name. */
+const indexDataTypes = (dataTypes: readonly PLCDataType[]): Map<string, PLCDataType> =>
+  new Map(dataTypes.map((dataType) => [dataType.name.toUpperCase(), dataType]))
+
+/** IEC base type an enumeration is stored as. STruC++ defaults to INT. */
+const ENUM_BASE_DESCRIPTOR = SHM_SCALAR_TYPES.int
+
+const walk = (
+  name: string,
+  typeValue: string,
+  typeDefinition: PLCVariableType['definition'],
+  arrayInfo: { count: number; startIndex: number } | null,
+  path: string[],
+  field: string,
+  access: string,
+  types: Map<string, PLCDataType>,
+  userTypeNames: ReadonlySet<string>,
+  depth: number,
+): ShmWalkResult => {
+  // A structure that contains itself would otherwise recurse forever. The
+  // compiler rejects that too, but this walk runs first and must not hang.
+  if (depth > 16) {
+    return { refusal: { path, reason: 'the type nests too deeply, or refers to itself' } }
+  }
+
+  const dataType = typeDefinition === 'user-data-type' ? types.get(typeValue.toUpperCase()) : undefined
+
+  if (dataType?.derivation === 'structure') {
+    if (arrayInfo) {
+      return { refusal: { path, reason: 'an array of structures cannot cross into Python yet' } }
+    }
+    const leaves: ShmLeaf[] = []
+    for (const member of dataType.variable) {
+      // An array member is walked by its element type, exactly as a top-level
+      // array variable is: the count and lower bound travel separately, so the
+      // element is what has to be describable.
+      const element = elementTypeOf(member)
+      const result = walk(
+        member.name,
+        element.value,
+        element.definition,
+        arrayInfoFor(member),
+        [...path, member.name],
+        `${field}_${member.name}`,
+        `${access}.${mangledMemberName(member.name, member.type.value, userTypeNames)}`,
+        types,
+        userTypeNames,
+        depth + 1,
+      )
+      if ('refusal' in result) return result
+      leaves.push(...result.leaves)
+    }
+    return { leaves }
+  }
+
+  if (dataType?.derivation === 'enumerated') {
+    // An enumeration is stored as its base integer, which is what crosses. The
+    // Python side gets an IntEnum, so `mode == Mode.RUNNING` reads naturally
+    // while the wire format stays a plain int.
+    return {
+      leaves: [
+        {
+          field,
+          path,
+          access,
+          descriptor: ENUM_BASE_DESCRIPTOR,
+          count: arrayInfo?.count ?? 1,
+          startIndex: arrayInfo?.startIndex ?? 0,
+          enumTypeName: dataType.name,
+        },
+      ],
+    }
+  }
+
+  if (dataType?.derivation === 'array') {
+    return { refusal: { path, reason: 'a named ARRAY type cannot cross into Python yet' } }
+  }
+
+  if (typeDefinition === 'user-data-type') {
+    // Not in the project's data types: a function block instance. Python runs in
+    // its own process and cannot call one — the block would have to reach back
+    // into the scan it is not part of.
+    return {
+      refusal: {
+        path,
+        reason: `"${typeValue}" is a function block instance, which a Python block cannot hold — it runs in its own process and cannot call into the scan`,
+      },
+    }
+  }
+
+  const descriptor = describeShmField({
+    name,
+    type: { definition: typeDefinition, value: typeValue },
+    location: '',
+    documentation: '',
+  })
+  if (!descriptor) {
+    return { refusal: { path, reason: `${typeValue.toUpperCase()} is not a type Python can exchange` } }
+  }
+
+  return {
+    leaves: [
+      {
+        field,
+        path,
+        access,
+        descriptor,
+        count: arrayInfo?.count ?? 1,
+        startIndex: arrayInfo?.startIndex ?? 0,
+      },
+    ],
+  }
+}
+
+/**
+ * The type that actually describes a declaration's elements.
+ *
+ * For an array that is its element type; for anything else it is the type
+ * itself. An array's own `value` is the whole declaration text
+ * (`ARRAY [0..2] OF INT`), which names nothing describable — reading it as a
+ * type is what made an array member inside a structure refuse.
+ */
+const elementTypeOf = (declaration: PLCVariable | PLCStructureVariable): PLCVariableType => {
+  if (declaration.type.definition === 'array' && declaration.type.data) {
+    return { definition: declaration.type.data.baseType.definition, value: declaration.type.data.baseType.value }
+  }
+  return declaration.type
+}
+
+/** Element count and lower bound when a declaration is an array. */
+const arrayInfoFor = (
+  declaration: PLCVariable | PLCStructureVariable,
+): { count: number; startIndex: number } | null => {
+  if (declaration.type.definition !== 'array' || !declaration.type.data) return null
+  const dimensions = declaration.type.data.dimensions
+  const first = dimensions[0] ? parseDimensionRange(dimensions[0].dimension) : null
+  const asVariable: PLCVariable = {
+    name: declaration.name,
+    type: declaration.type,
+    location: '',
+    documentation: '',
+  }
+  return { count: getArrayTotalElements(asVariable), startIndex: first ? first.lower : 0 }
+}
+
+/**
+ * The scalar fields one interface variable contributes, in order — or the reason
+ * it cannot cross.
+ *
+ * A refusal is not a skip. A field the Python format string omits does not go
+ * missing: `struct.unpack` reads every later field from the wrong offset, so the
+ * failure lands on unrelated variables and reads as corrupted data. Refusing
+ * stops the build with the name of the variable that caused it.
+ */
+export const describeShmLeaves = (variable: PLCVariable, dataTypes: readonly PLCDataType[] = []): ShmWalkResult => {
+  const types = indexDataTypes(dataTypes)
+  const userTypeNames = new Set(dataTypes.map((dataType) => dataType.name.toUpperCase()))
+
+  const element = elementTypeOf(variable)
+
+  return walk(
+    variable.name,
+    element.value,
+    element.definition,
+    arrayInfoFor(variable),
+    [variable.name],
+    variable.name,
+    variable.name.toUpperCase(),
+    types,
+    userTypeNames,
+    0,
+  )
+}
+
+/** Every leaf of every variable, in order, or the first refusal encountered. */
+export const describeShmLayout = (
+  variables: readonly PLCVariable[],
+  dataTypes: readonly PLCDataType[] = [],
+): ShmWalkResult => {
+  const leaves: ShmLeaf[] = []
+  for (const variable of variables) {
+    const result = describeShmLeaves(variable, dataTypes)
+    if ('refusal' in result) return result
+    leaves.push(...result.leaves)
+  }
+  return { leaves }
+}

--- a/src/frontend/utils/python/shm-leaves.ts
+++ b/src/frontend/utils/python/shm-leaves.ts
@@ -169,14 +169,18 @@ const walk = (
     return { refusal: { path, reason: 'a named ARRAY type cannot cross into Python yet' } }
   }
 
-  if (typeDefinition === 'user-data-type') {
-    // Not in the project's data types: a function block instance. Python runs in
-    // its own process and cannot call one — the block would have to reach back
-    // into the scan it is not part of.
+  // A function block instance. `derived` is what the variables parser marks one
+  // as, having resolved the name against the project's POUs and libraries;
+  // `user-data-type` reaches here only when the name matched no declared data
+  // type either, which is the same situation from this side. Both are refused
+  // with the reason, because the reason is not "unsupported type" — Python runs
+  // in its own process and cannot call an instance, so holding one would give
+  // the user pins that never advance.
+  if (typeDefinition === 'derived' || typeDefinition === 'user-data-type') {
     return {
       refusal: {
         path,
-        reason: `"${typeValue}" is a function block instance, which a Python block cannot hold — it runs in its own process and cannot call into the scan`,
+        reason: `"${typeValue}" is a function block instance. A Python block cannot hold one — it runs in its own process, so it cannot call the instance, and an uncalled instance never updates its outputs. Use EN/ENO on the block itself for execution control, or call the instance from an ST block and pass its outputs in as inputs`,
       },
     }
   }
@@ -188,7 +192,15 @@ const walk = (
     documentation: '',
   })
   if (!descriptor) {
-    return { refusal: { path, reason: `${typeValue.toUpperCase()} is not a type Python can exchange` } }
+    return {
+      refusal: {
+        path,
+        reason:
+          `${typeValue.toUpperCase()} is not a type a Python block can exchange. Supported are BOOL, ` +
+          'the integer and bit-string types, REAL/LREAL, TIME/DATE/TOD/DT, STRING, WSTRING, arrays of ' +
+          'those, and structures and enumerations built from them',
+      },
+    }
   }
 
   return {

--- a/src/frontend/utils/python/shm-leaves.ts
+++ b/src/frontend/utils/python/shm-leaves.ts
@@ -46,7 +46,18 @@ export interface ShmLeaf {
   access: string
   /** How the field is laid out and decoded. */
   descriptor: ShmFieldDescriptor
-  /** Elements when the leaf is an array of scalars; 1 otherwise. */
+  /**
+   * Whether this leaf is an array, stated rather than inferred.
+   *
+   * Every emitter used to test `count > 1`, which silently mis-handled the two
+   * shapes where an array's element count is not greater than one:
+   * `ARRAY [0..0] OF INT` (count 1) took the scalar path and bound a plain int
+   * where the user declared a one-element array. Array-ness is a property of
+   * the declaration, not of how many elements it happens to have, so it is
+   * carried here and `count` is only ever a length.
+   */
+  isArray: boolean
+  /** Elements when the leaf is an array; 1 otherwise. */
   count: number
   /** Lowest IEC index, for an array leaf; 0 otherwise. */
   startIndex: number
@@ -182,11 +193,15 @@ const walk = (
       // array variable is: the count and lower bound travel separately, so the
       // element is what has to be describable.
       const element = elementTypeOf(member)
+      const memberShape = arrayShapeOf(member)
+      if ('reason' in memberShape) {
+        return { refusal: { path: [...path, member.name], reason: memberShape.reason } }
+      }
       const result = walk(
         member.name,
         element.value,
         element.definition,
-        arrayInfoFor(member),
+        memberShape.info,
         [...path, member.name],
         `${field}_${member.name}`,
         `${access}.${mangledMemberName(member.name, member.type.value, userTypeNames)}`,
@@ -200,8 +215,17 @@ const walk = (
   }
 
   if (dataType?.derivation === 'enumerated') {
-    // An enumeration is stored as its base integer, which is what crosses. The
-    // Python side gets an IntEnum, so `mode == Mode.RUNNING` reads naturally
+    // An array of enumerations is refused rather than described. Both sides
+    // would have to combine the array shape with the enum cast, and neither
+    // does: the C stub's array copy assigns the raw slot without the scoped-enum
+    // cast, and the Python decoder binds a list of plain ints while the seed
+    // emits `Mode([0, 0, 0])`, which raises at module level before `block_init`
+    // ever runs.
+    if (arrayInfo) {
+      return { refusal: { path, reason: 'an array of enumerations cannot cross into Python yet' } }
+    }
+    // A scalar enumeration is stored as its base integer, which is what crosses.
+    // The Python side gets an IntEnum, so `mode == Mode.RUNNING` reads naturally
     // while the wire format stays a plain int.
     return {
       leaves: [
@@ -210,8 +234,9 @@ const walk = (
           path,
           access,
           descriptor: ENUM_BASE_DESCRIPTOR,
-          count: arrayInfo?.count ?? 1,
-          startIndex: arrayInfo?.startIndex ?? 0,
+          isArray: false,
+          count: 1,
+          startIndex: 0,
           enumTypeName: dataType.name,
         },
       ],
@@ -262,11 +287,15 @@ const walk = (
       // Python an attribute named differently from the slot it was built with.
       const pinName = pin.name.toUpperCase()
       const element = elementTypeOf({ name: pin.name, type: pin.type })
+      const pinShape = arrayShapeOf({ name: pin.name, type: pin.type })
+      if ('reason' in pinShape) {
+        return { refusal: { path: [...path, pinName], reason: pinShape.reason } }
+      }
       const result = walk(
         pinName,
         element.value,
         element.definition,
-        arrayInfoFor({ name: pin.name, type: pin.type }),
+        pinShape.info,
         [...path, pinName],
         `${field}_${pinName}`,
         // A pin is a member of the instance's class, upper-cased, and mangled by
@@ -299,6 +328,21 @@ const walk = (
     }
   }
 
+  // An array of STRING or WSTRING is refused rather than described. A string is
+  // not one field but two — a length prefix and a body — so its `struct` format
+  // is multi-character, and a repeat count in that format applies only to the
+  // first item: `4b126s` is not four strings. Repeating the whole format instead
+  // emits two slots per element while the decoder consumes one, so an
+  // `ARRAY [0..3] OF STRING` shifted every variable declared after it.
+  if ((descriptor.kind === 'string' || descriptor.kind === 'wstring') && arrayInfo) {
+    return {
+      refusal: {
+        path,
+        reason: `an array of ${descriptor.kind === 'wstring' ? 'WSTRING' : 'STRING'} cannot cross into Python yet`,
+      },
+    }
+  }
+
   return {
     leaves: [
       {
@@ -306,6 +350,7 @@ const walk = (
         path,
         access,
         descriptor,
+        isArray: arrayInfo !== null,
         count: arrayInfo?.count ?? 1,
         startIndex: arrayInfo?.startIndex ?? 0,
       },
@@ -328,12 +373,42 @@ const elementTypeOf = (declaration: PLCVariable | PLCStructureVariable): PLCVari
   return declaration.type
 }
 
-/** Element count and lower bound when a declaration is an array. */
-const arrayInfoFor = (
-  declaration: PLCVariable | PLCStructureVariable,
-): { count: number; startIndex: number } | null => {
-  if (declaration.type.definition !== 'array' || !declaration.type.data) return null
+/** Element count and lower bound of an array declaration. */
+interface ArrayInfo {
+  count: number
+  startIndex: number
+}
+
+/**
+ * Array shape of a declaration — `null` when it is not an array — or the reason
+ * the shape cannot cross.
+ *
+ * Two shapes are refused here rather than described:
+ *
+ *   - **Rank two or higher.** The generated exchange indexes with a single
+ *     subscript (`A[start + i]`), but strucpp passes a multi-dimensional array
+ *     as `Array2D` / `Array3D`, which is indexed `(i, j)` — `generateCBlocksCode`
+ *     branches on `multiDimensionalContainerType` for exactly that reason. The
+ *     flat element count would also be paired with only dimension 0's lower
+ *     bound, so `ARRAY [1..2, 1..3] OF INT` would read elements 1..6 of a
+ *     6-element field. Python blocks carry one-dimensional arrays only; a
+ *     higher rank is refused with its own message rather than mis-indexed.
+ *   - **Dimensions that do not parse.** `getArrayTotalElements` returns 0 for a
+ *     malformed range, which used to fall through to the scalar path and emit a
+ *     single field against an array member.
+ */
+type ArrayShape = { info: ArrayInfo | null } | { reason: string }
+
+const arrayShapeOf = (declaration: PLCVariable | PLCStructureVariable): ArrayShape => {
+  if (declaration.type.definition !== 'array' || !declaration.type.data) return { info: null }
   const dimensions = declaration.type.data.dimensions
+  if (dimensions.length > 1) {
+    return {
+      reason:
+        `a ${dimensions.length}-dimensional array cannot cross into Python — Python blocks support ` +
+        'one-dimensional arrays only. Flatten it, or split it into separate one-dimensional variables',
+    }
+  }
   const first = dimensions[0] ? parseDimensionRange(dimensions[0].dimension) : null
   const asVariable: PLCVariable = {
     name: declaration.name,
@@ -341,7 +416,11 @@ const arrayInfoFor = (
     location: '',
     documentation: '',
   }
-  return { count: getArrayTotalElements(asVariable), startIndex: first ? first.lower : 0 }
+  const count = getArrayTotalElements(asVariable)
+  if (!first || count < 1) {
+    return { reason: 'its array bounds cannot be read, so the size of the field it needs is unknown' }
+  }
+  return { info: { count, startIndex: first.lower } }
 }
 
 /**
@@ -364,12 +443,16 @@ export const describeShmLeaves = (variable: PLCVariable, context: ShmWalkContext
   }
 
   const element = elementTypeOf(variable)
+  const shape = arrayShapeOf(variable)
+  if ('reason' in shape) {
+    return { refusal: { path: [variable.name], reason: shape.reason } }
+  }
 
   return walk(
     variable.name,
     element.value,
     element.definition,
-    arrayInfoFor(variable),
+    shape.info,
     [variable.name],
     variable.name,
     variable.name.toUpperCase(),

--- a/src/frontend/utils/python/shm-type-map.ts
+++ b/src/frontend/utils/python/shm-type-map.ts
@@ -33,7 +33,9 @@
  */
 
 import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import { IEC_BASE_TYPES, type IECWireFormat, lookupBaseType } from '../iec-types-registry'
 import { getArrayBaseTypeValue, isArrayVariable } from '../PLC/array-codegen-helpers'
+import { DEBUG_STRING_CAP } from '../variable-sizes'
 
 /**
  * How one interface field crosses the boundary.
@@ -69,47 +71,77 @@ export interface ShmFieldDescriptor {
  * read by every emitter, rather than written as a literal in four places as it
  * was before.
  */
-export const SHM_STRING_CHARS = 126
+export const SHM_STRING_CHARS = DEBUG_STRING_CAP
 
 /** Signed 8-bit length prefix, matching the `__strlen_t` the C stub emits. */
 const LEN_PREFIX_BYTES = 1
 
 /**
- * Scalar base types, keyed by the lowercase IEC type name.
+ * The one fact this file owns: how a wire format is spelled on each side of the
+ * boundary.
  *
- * The C types are the raw underlying representations rather than the strucpp
- * `IEC_*` aliases: those alias `IECVar<T>` wrappers, which are not trivially
- * copyable, so memcpy'ing them into a packed struct is undefined behaviour that
- * gcc rightly rejects.  The C stub bridges between the wrapper and these raw
- * fields at the boundary.
+ * Everything else about an elementary type — that it exists, what it is called,
+ * what it is aliased to, how wide it is — comes from strucpp's
+ * `libs/iec-types.json` through {@link IEC_BASE_TYPES}. This table maps only
+ * `wireFormat` to the raw C spelling and the Python `struct` code, which is
+ * genuinely local knowledge: the registry's `cppType` is the strucpp `IEC_*`
+ * wrapper (`INT_t` aliases `IECVar<int16_t>`), and a wrapper is not trivially
+ * copyable, so it cannot be a member of a packed struct that gets memcpy'd.
+ * The C stub bridges the wrapper to these raw fields at the boundary.
+ *
+ * `null` marks a format that needs a layout rather than a single field —
+ * STRING and WSTRING, whose length prefix plus body is described by
+ * {@link SHM_STRING} / {@link SHM_WSTRING} below.
+ *
+ * Exhaustive over `IECWireFormat` by type, so a new wire format in a future
+ * strucpp release fails to compile here instead of silently dropping a type.
  */
-export const SHM_SCALAR_TYPES: Readonly<Record<string, ShmFieldDescriptor>> = {
-  bool: { cType: 'uint8_t', pyFormat: 'B', size: 1, kind: 'scalar' },
-  sint: { cType: 'int8_t', pyFormat: 'b', size: 1, kind: 'scalar' },
-  int: { cType: 'int16_t', pyFormat: 'h', size: 2, kind: 'scalar' },
-  dint: { cType: 'int32_t', pyFormat: 'i', size: 4, kind: 'scalar' },
-  lint: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
-  usint: { cType: 'uint8_t', pyFormat: 'B', size: 1, kind: 'scalar' },
-  uint: { cType: 'uint16_t', pyFormat: 'H', size: 2, kind: 'scalar' },
-  udint: { cType: 'uint32_t', pyFormat: 'I', size: 4, kind: 'scalar' },
-  ulint: { cType: 'uint64_t', pyFormat: 'Q', size: 8, kind: 'scalar' },
-  byte: { cType: 'uint8_t', pyFormat: 'B', size: 1, kind: 'scalar' },
-  word: { cType: 'uint16_t', pyFormat: 'H', size: 2, kind: 'scalar' },
-  dword: { cType: 'uint32_t', pyFormat: 'I', size: 4, kind: 'scalar' },
-  lword: { cType: 'uint64_t', pyFormat: 'Q', size: 8, kind: 'scalar' },
-  real: { cType: 'float', pyFormat: 'f', size: 4, kind: 'scalar' },
-  lreal: { cType: 'double', pyFormat: 'd', size: 8, kind: 'scalar' },
-
+const WIRE_FORMAT_FIELDS: Readonly<Record<IECWireFormat, Pick<ShmFieldDescriptor, 'cType' | 'pyFormat'> | null>> = {
+  bool: { cType: 'uint8_t', pyFormat: 'B' },
+  int8: { cType: 'int8_t', pyFormat: 'b' },
+  uint8: { cType: 'uint8_t', pyFormat: 'B' },
+  int16: { cType: 'int16_t', pyFormat: 'h' },
+  uint16: { cType: 'uint16_t', pyFormat: 'H' },
+  int32: { cType: 'int32_t', pyFormat: 'i' },
+  uint32: { cType: 'uint32_t', pyFormat: 'I' },
+  int64: { cType: 'int64_t', pyFormat: 'q' },
+  uint64: { cType: 'uint64_t', pyFormat: 'Q' },
+  float32: { cType: 'float', pyFormat: 'f' },
+  float64: { cType: 'double', pyFormat: 'd' },
   // Duration and calendar types are 64-bit counts on the strucpp side — TIME is
-  // nanoseconds (`T#1s` lowers to `1000000000LL`).  Python receives the raw
-  // integer, which is what the compiler stores; presenting it as a `timedelta`
-  // would be a second representation of the same fact and is deliberately not
-  // done here.
-  time: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
-  date: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
-  tod: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
-  dt: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
+  // nanoseconds (`T#1s` lowers to `1000000000LL`), DATE is days. Python receives
+  // the raw integer, which is what the compiler stores; presenting it as a
+  // `timedelta` would be a second representation of the same fact and is
+  // deliberately not done here.
+  'duration-ns-i64': { cType: 'int64_t', pyFormat: 'q' },
+  'datetime-ns-i64': { cType: 'int64_t', pyFormat: 'q' },
+  'date-ns-i64': { cType: 'int64_t', pyFormat: 'q' },
+  'tod-ns-i64': { cType: 'int64_t', pyFormat: 'q' },
+  'len8-utf8': null,
+  'len8-utf16le': null,
 }
+
+/**
+ * Scalar base types, keyed by the lowercase IEC type name AND by every alias
+ * the registry declares, so `TIME_OF_DAY` resolves exactly like `TOD`.
+ *
+ * Derived, not written: the byte width is the registry's `byteSize`, so a size
+ * cannot drift from what the compiler emits. Names beginning with `__` are
+ * strucpp internals (`__XWORD`) and are not user-declarable, so they are
+ * skipped.
+ */
+export const SHM_SCALAR_TYPES: Readonly<Record<string, ShmFieldDescriptor>> = (() => {
+  const table: Record<string, ShmFieldDescriptor> = {}
+  for (const type of IEC_BASE_TYPES) {
+    if (type.name.startsWith('__')) continue
+    const field = WIRE_FORMAT_FIELDS[type.wireFormat]
+    if (!field) continue
+    const descriptor: ShmFieldDescriptor = { ...field, size: type.byteSize, kind: 'scalar' }
+    table[type.name.toLowerCase()] = descriptor
+    for (const alias of type.aliases) table[alias.toLowerCase()] = descriptor
+  }
+  return table
+})()
 
 /**
  * STRING — one length byte plus a 126-byte UTF-8 body.  127 bytes packed,
@@ -139,14 +171,39 @@ export const SHM_WSTRING: ShmFieldDescriptor = {
   kind: 'wstring',
 }
 
-/** Lowercased base-type name of a variable, or `null` when it has none. */
+/**
+ * As-declared base-type name of a variable, or `null` when it has none.
+ *
+ * Returned verbatim rather than lower-cased: {@link describeShmBaseType}
+ * normalises through the registry, which trims and folds case and resolves
+ * aliases in one place. Lower-casing here as well would be a second, weaker
+ * copy of that rule — it was one, and it is what made a variable spelled
+ * `TIME_OF_DAY` refuse while `TOD` was accepted.
+ */
 function baseTypeName(variable: PLCVariable): string | null {
   if (isArrayVariable(variable)) {
-    const inner = getArrayBaseTypeValue(variable)
-    return inner ? inner.toLowerCase() : null
+    return getArrayBaseTypeValue(variable) ?? null
   }
   if (variable.type.definition !== 'base-type') return null
-  return variable.type.value.toLowerCase()
+  return variable.type.value
+}
+
+/**
+ * Descriptor for an elementary type named in any spelling the registry accepts
+ * — canonical or alias, any case, whitespace-padded — or `null` when the name
+ * is not an elementary type at all.
+ *
+ * Normalising through `lookupBaseType` is what keeps this in step with the rest
+ * of the editor: the variables-table dropdown offers canonical names, but
+ * PLCopen XML import and library FB manifests both carry aliases, and legacy
+ * project files carry padding.
+ */
+export function describeShmBaseType(typeName: string): ShmFieldDescriptor | null {
+  const metadata = lookupBaseType(typeName)
+  if (!metadata) return null
+  if (metadata.wireFormat === 'len8-utf8') return SHM_STRING
+  if (metadata.wireFormat === 'len8-utf16le') return SHM_WSTRING
+  return SHM_SCALAR_TYPES[metadata.name.toLowerCase()] ?? null
 }
 
 /**
@@ -155,16 +212,12 @@ function baseTypeName(variable: PLCVariable): string | null {
  *
  * `null` is a refusal, not a silent skip: callers surface it to the user.  That
  * is the whole point — a type the emitters cannot agree on must stop the build
- * rather than quietly shift every field after it.  Structures, enumerations and
- * function block instances land in later phases and will return descriptors
- * then.
+ * rather than quietly shift every field after it.
  */
 export function describeShmField(variable: PLCVariable): ShmFieldDescriptor | null {
   const name = baseTypeName(variable)
   if (!name) return null
-  if (name === 'string') return SHM_STRING
-  if (name === 'wstring') return SHM_WSTRING
-  return SHM_SCALAR_TYPES[name] ?? null
+  return describeShmBaseType(name)
 }
 
 /**

--- a/src/frontend/utils/python/shm-type-map.ts
+++ b/src/frontend/utils/python/shm-type-map.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * The shared-memory layout for a Python function block's interface — one table,
+ * read by both sides of the boundary.
+ *
+ * Why this file exists.  The C side (`generateSTCode`) and the Python side
+ * (`encodeCharactersFromVariable`) each used to carry their own hand-maintained
+ * type table, and they disagreed in three places.  Every disagreement was
+ * silent and corrupting, because a field the Python format string omits does
+ * not merely go missing: `struct.unpack` reads every *later* field from the
+ * wrong offset.
+ *
+ *   - TIME / DATE / TOD / DT — the C side emitted `int64_t`, the Python side
+ *     had no entry, so eight bytes vanished from the format string.
+ *   - WSTRING — the C side emitted a byte-oriented STRING field (and copied
+ *     UTF-16 into it with a character count for a length), the Python side had
+ *     no entry at all.
+ *   - User-defined types — the C side emitted a one-byte pad, the Python side
+ *     had no entry.
+ *
+ * The fix is structural rather than three more table rows: a descriptor names
+ * the C type, the Python `struct` code and the size, and both emitters read it.
+ * A field can no longer be added to one side alone, and `shm-type-map.test.ts`
+ * asserts every descriptor's declared size against what `struct.calcsize` would
+ * compute for its format, so a future edit that breaks the correspondence fails
+ * a test instead of a customer's data.
+ *
+ * This is the local expression of the project rule: layout facts are stated
+ * once.  When the codec generator lands (DOPE-584 P6) these descriptors are
+ * what it reads, and eventually what it derives from the compiler's own layout
+ * output rather than restating at all.
+ */
+
+import type { PLCVariable } from '../../../middleware/shared/ports/types'
+import { getArrayBaseTypeValue, isArrayVariable } from '../PLC/array-codegen-helpers'
+
+/**
+ * How one interface field crosses the boundary.
+ *
+ * `size` is the packed byte width — the struct is emitted under
+ * `#pragma pack(push, 1)` and decoded with Python's `=` prefix, so neither side
+ * inserts padding and the two must agree exactly.
+ */
+export interface ShmFieldDescriptor {
+  /** Raw C type for the packed SHM struct field. */
+  cType: string
+  /** Python `struct` format for the same field. */
+  pyFormat: string
+  /** Packed width in bytes. */
+  size: number
+  /**
+   * How Python presents the value.
+   *
+   *   - `scalar`  — a plain int / float / bool, unpacked as-is.
+   *   - `string`  — length-prefixed 8-bit body, decoded as UTF-8.
+   *   - `wstring` — length-prefixed UTF-16 body; the length counts code units,
+   *     so the byte count is twice it.
+   */
+  kind: 'scalar' | 'string' | 'wstring'
+}
+
+/**
+ * Maximum characters carried across the boundary for STRING and WSTRING.
+ *
+ * Not a limit this code chooses: it is the transport convention the debugger
+ * already speaks (`debug-map.json` reports STRING at 127 bytes and WSTRING at
+ * 253, both being one length byte plus 126 characters).  Stated once here and
+ * read by every emitter, rather than written as a literal in four places as it
+ * was before.
+ */
+export const SHM_STRING_CHARS = 126
+
+/** Signed 8-bit length prefix, matching the `__strlen_t` the C stub emits. */
+const LEN_PREFIX_BYTES = 1
+
+/**
+ * Scalar base types, keyed by the lowercase IEC type name.
+ *
+ * The C types are the raw underlying representations rather than the strucpp
+ * `IEC_*` aliases: those alias `IECVar<T>` wrappers, which are not trivially
+ * copyable, so memcpy'ing them into a packed struct is undefined behaviour that
+ * gcc rightly rejects.  The C stub bridges between the wrapper and these raw
+ * fields at the boundary.
+ */
+export const SHM_SCALAR_TYPES: Readonly<Record<string, ShmFieldDescriptor>> = {
+  bool: { cType: 'uint8_t', pyFormat: 'B', size: 1, kind: 'scalar' },
+  sint: { cType: 'int8_t', pyFormat: 'b', size: 1, kind: 'scalar' },
+  int: { cType: 'int16_t', pyFormat: 'h', size: 2, kind: 'scalar' },
+  dint: { cType: 'int32_t', pyFormat: 'i', size: 4, kind: 'scalar' },
+  lint: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
+  usint: { cType: 'uint8_t', pyFormat: 'B', size: 1, kind: 'scalar' },
+  uint: { cType: 'uint16_t', pyFormat: 'H', size: 2, kind: 'scalar' },
+  udint: { cType: 'uint32_t', pyFormat: 'I', size: 4, kind: 'scalar' },
+  ulint: { cType: 'uint64_t', pyFormat: 'Q', size: 8, kind: 'scalar' },
+  byte: { cType: 'uint8_t', pyFormat: 'B', size: 1, kind: 'scalar' },
+  word: { cType: 'uint16_t', pyFormat: 'H', size: 2, kind: 'scalar' },
+  dword: { cType: 'uint32_t', pyFormat: 'I', size: 4, kind: 'scalar' },
+  lword: { cType: 'uint64_t', pyFormat: 'Q', size: 8, kind: 'scalar' },
+  real: { cType: 'float', pyFormat: 'f', size: 4, kind: 'scalar' },
+  lreal: { cType: 'double', pyFormat: 'd', size: 8, kind: 'scalar' },
+
+  // Duration and calendar types are 64-bit counts on the strucpp side — TIME is
+  // nanoseconds (`T#1s` lowers to `1000000000LL`).  Python receives the raw
+  // integer, which is what the compiler stores; presenting it as a `timedelta`
+  // would be a second representation of the same fact and is deliberately not
+  // done here.
+  time: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
+  date: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
+  tod: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
+  dt: { cType: 'int64_t', pyFormat: 'q', size: 8, kind: 'scalar' },
+}
+
+/**
+ * STRING — one length byte plus a 126-byte UTF-8 body.  127 bytes packed,
+ * matching what the debug map reports for the same variable.
+ */
+export const SHM_STRING: ShmFieldDescriptor = {
+  cType: 'shm_iec_string_t',
+  pyFormat: `b${SHM_STRING_CHARS}s`,
+  size: LEN_PREFIX_BYTES + SHM_STRING_CHARS,
+  kind: 'string',
+}
+
+/**
+ * WSTRING — one length byte plus 126 UTF-16 code units.  253 bytes packed,
+ * again matching the debug map.
+ *
+ * This previously shared STRING's descriptor, which was wrong in both
+ * directions: the C stub copied `STR_MAX_LEN` *bytes* out of a `char16_t`
+ * buffer (63 characters, not 126) while writing a length counted in
+ * characters, and read back by reinterpreting a `char16_t` body as `char*`.
+ * A distinct layout is what makes the two sides describable at all.
+ */
+export const SHM_WSTRING: ShmFieldDescriptor = {
+  cType: 'shm_iec_wstring_t',
+  pyFormat: `b${SHM_STRING_CHARS * 2}s`,
+  size: LEN_PREFIX_BYTES + SHM_STRING_CHARS * 2,
+  kind: 'wstring',
+}
+
+/** Lowercased base-type name of a variable, or `null` when it has none. */
+function baseTypeName(variable: PLCVariable): string | null {
+  if (isArrayVariable(variable)) {
+    const inner = getArrayBaseTypeValue(variable)
+    return inner ? inner.toLowerCase() : null
+  }
+  if (variable.type.definition !== 'base-type') return null
+  return variable.type.value.toLowerCase()
+}
+
+/**
+ * Descriptor for the element type of `variable`, or `null` when the type cannot
+ * cross the boundary today.
+ *
+ * `null` is a refusal, not a silent skip: callers surface it to the user.  That
+ * is the whole point — a type the emitters cannot agree on must stop the build
+ * rather than quietly shift every field after it.  Structures, enumerations and
+ * function block instances land in later phases and will return descriptors
+ * then.
+ */
+export function describeShmField(variable: PLCVariable): ShmFieldDescriptor | null {
+  const name = baseTypeName(variable)
+  if (!name) return null
+  if (name === 'string') return SHM_STRING
+  if (name === 'wstring') return SHM_WSTRING
+  return SHM_SCALAR_TYPES[name] ?? null
+}
+
+/**
+ * Human-readable type for an error message — the array form included, so a
+ * refusal names what the user actually declared.
+ */
+export function describeVariableType(variable: PLCVariable): string {
+  if (isArrayVariable(variable)) {
+    const inner = getArrayBaseTypeValue(variable)
+    return `ARRAY OF ${(inner || 'unknown').toUpperCase()}`
+  }
+  return variable.type.value.toUpperCase()
+}

--- a/src/frontend/utils/variable-sizes.ts
+++ b/src/frontend/utils/variable-sizes.ts
@@ -3,14 +3,19 @@ import { parseDurationLiteral } from './iec-duration'
 import { type IECTypeMetadata, type IECWireFormat, lookupBaseType } from './iec-types-registry'
 
 /**
- * STRING / WSTRING wire size cap, in characters. Strucpp's
- * IECStringVar / IECWStringVar default to 254 chars in declarations
- * but the debug protocol pre-dates that change and still frames
- * length-prefixed payloads at 1 length byte + 126 code units. Pull
- * this into a constant so the parser/encoder/sizer all share the cap
- * — bump it in one place when the protocol catches up.
+ * STRING / WSTRING wire size cap, in characters, and the single place it is
+ * written down.
+ *
+ * Strucpp's `IECStringVar` / `IECWStringVar` default to 254 characters in
+ * declarations, but the debug protocol pre-dates that change and still frames
+ * length-prefixed payloads at 1 length byte + 126 code units. Every consumer
+ * reads it from here — the debugger decoder below, the Python SHM layout
+ * (`python/shm-type-map.ts` re-exports it as `SHM_STRING_CHARS`), and the
+ * declaration parser's user-facing message — so the transport, the layout built
+ * on it, and the limit quoted to the user cannot drift apart. Bump it once when
+ * the protocol catches up.
  */
-const DEBUG_STRING_CAP = 126
+export const DEBUG_STRING_CAP = 126
 
 function readInt8(data: Uint8Array, offset: number): number {
   const value = data[offset]

--- a/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
@@ -987,7 +987,9 @@ describe('compileForDebug with invalid C++ POU', () => {
     )
 
     expect(result.success).toBe(false)
-    expect(result.error).toBe('POU validation failed.')
+    // The debug path now surfaces the specific reason instead of a bare
+    // "POU validation failed." — the same text the build path already showed.
+    expect(result.error).toBe('POU validation failed. Check C/C++ code for missing setup()/loop() functions.')
     // The bridge should NOT have been called because validation failed early
     expect(window.bridge.runDebugCompilation).not.toHaveBeenCalled()
     void debugCallback // suppress unused warning

--- a/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
@@ -1026,3 +1026,101 @@ describe('compileForDebug with invalid C++ POU', () => {
     expect(progressEvents.length).toBeGreaterThan(0)
   })
 })
+
+// ---------------------------------------------------------------------------
+// compileForDebug — library FB pins reach the preprocess
+// ---------------------------------------------------------------------------
+describe('compileForDebug — library function block pins', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  /** A Python POU holding an instance of a function block that lives in a library. */
+  const pythonWithLibraryInstance: PLCProjectData = {
+    dataTypes: [],
+    pous: [
+      {
+        name: 'PyTimer',
+        pouType: 'program',
+        interface: {
+          variables: [
+            {
+              name: 'ton0',
+              class: 'local',
+              type: { definition: 'derived', value: 'TON' },
+              location: '',
+              documentation: '',
+              debug: false,
+            },
+          ],
+        },
+        body: { language: 'python', value: 'def block_loop():\n    pass' },
+      },
+    ],
+    configurations: { resource: { tasks: [], instances: [], globalVariables: [] } },
+  }
+
+  const TON_ARCHIVE = {
+    manifest: {
+      name: 'iec_standard_fb',
+      functionBlocks: [
+        {
+          name: 'TON',
+          inputs: [
+            { name: 'IN', type: 'BOOL' },
+            { name: 'PT', type: 'TIME' },
+          ],
+          inouts: [],
+          outputs: [
+            { name: 'Q', type: 'BOOL' },
+            { name: 'ET', type: 'TIME' },
+          ],
+        },
+      ],
+    },
+  }
+
+  it('passes the loaded archives so a library FB instance resolves', async () => {
+    // `compileForDebug` loaded the archives and then did not forward them, so
+    // `libraries` defaulted to `[]`, `resolveFunctionBlockPins` found nothing,
+    // and a Python POU declaring `ton0 : TON` compiled for upload and failed the
+    // DEBUG compile with "cannot exchange these variables". The archives were
+    // already in hand — only the argument was missing.
+    ;(window.bridge.loadAllLibraries as jest.Mock).mockResolvedValue([TON_ARCHIVE])
+    ;(window.bridge.getAvailableBoards as jest.Mock).mockResolvedValue(
+      new Map([['OpenPLC Runtime v4', { name: 'OpenPLC Runtime v4', compiler: 'openplc-compiler' }]]),
+    )
+
+    const adapter = createEditorCompilerAdapter()
+    const promise = adapter.compileForDebug(
+      { projectData: pythonWithLibraryInstance, boardTarget: 'OpenPLC Runtime v4', projectPath: '/p' },
+      () => {},
+    )
+    const result = await Promise.race([promise, new Promise((r) => setTimeout(() => r('pending'), 50))])
+
+    // Either it got past validation (reaching the bridge) or it failed for some
+    // other reason — but NOT for an unresolvable TON.
+    if (typeof result === 'object' && result !== null && 'error' in result) {
+      expect(String((result as { error?: string }).error)).not.toContain('no function block by that name')
+    }
+  })
+
+  it('refuses the same POU when no archive declares the block', async () => {
+    // The other half of the contract: with no library carrying TON, the refusal
+    // is correct and must still name the variable.
+    ;(window.bridge.loadAllLibraries as jest.Mock).mockResolvedValue([])
+    ;(window.bridge.getAvailableBoards as jest.Mock).mockResolvedValue(
+      new Map([['OpenPLC Runtime v4', { name: 'OpenPLC Runtime v4', compiler: 'openplc-compiler' }]]),
+    )
+
+    const adapter = createEditorCompilerAdapter()
+    const result = await adapter.compileForDebug(
+      { projectData: pythonWithLibraryInstance, boardTarget: 'OpenPLC Runtime v4', projectPath: '/p' },
+      () => {},
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('ton0')
+    expect(window.bridge.runDebugCompilation).not.toHaveBeenCalled()
+  })
+})

--- a/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
@@ -1105,6 +1105,41 @@ describe('compileForDebug — library function block pins', () => {
     }
   })
 
+  it('refuses a Python POU on a board that cannot run it, without calling the bridge', async () => {
+    // The build path had this covered; the debug path did not. Same gate, same
+    // reason — a Python block is no more loadable on an Arduino board when the
+    // compile is for debugging — so the message must name the board and the
+    // bridge must never be reached.
+    ;(window.bridge.loadAllLibraries as jest.Mock).mockResolvedValue([])
+    ;(window.bridge.getAvailableBoards as jest.Mock).mockResolvedValue(
+      new Map([['Arduino Mega', { name: 'Arduino Mega', compiler: 'arduino-cli' }]]),
+    )
+
+    const pythonOnly: PLCProjectData = {
+      dataTypes: [],
+      pous: [
+        {
+          name: 'PyBlock',
+          pouType: 'program',
+          interface: { variables: [] },
+          body: { language: 'python', value: 'def block_loop():\n    pass' },
+        },
+      ],
+      configurations: { resource: { tasks: [], instances: [], globalVariables: [] } },
+    }
+
+    const adapter = createEditorCompilerAdapter()
+    const result = await adapter.compileForDebug(
+      { projectData: pythonOnly, boardTarget: 'Arduino Mega', projectPath: '/p' },
+      () => {},
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Arduino Mega')
+    expect(result.error).toContain('"PyBlock"')
+    expect(window.bridge.runDebugCompilation).not.toHaveBeenCalled()
+  })
+
   it('refuses the same POU when no archive declares the block', async () => {
     // The other half of the contract: with no library carrying TON, the refusal
     // is correct and must still name the variable.

--- a/src/middleware/adapters/editor/compile-program-flow.ts
+++ b/src/middleware/adapters/editor/compile-program-flow.ts
@@ -16,10 +16,10 @@
  */
 
 import { preprocessPous } from '../../../backend/shared/utils/PLC/preprocess-pous'
-import { resolveTargetCapabilities } from '../../shared/utils/target-capabilities'
 import type { CompileProgramArgs } from '../../shared/ports/compiler-port'
 import type { StlibArchiveDTO } from '../../shared/ports/library-port'
 import type { BoardInfo, CompileProgressEvent, CompileResult, StructuredCompileError } from '../../shared/ports/types'
+import { resolveTargetCapabilities } from '../../shared/utils/target-capabilities'
 import type { IpcProjectData } from './compiler-adapter'
 import { decodeMessage, inferStage, injectLibraryCppBlocks, toIpcProjectData } from './compiler-adapter'
 

--- a/src/middleware/adapters/editor/compile-program-flow.ts
+++ b/src/middleware/adapters/editor/compile-program-flow.ts
@@ -16,6 +16,7 @@
  */
 
 import { preprocessPous } from '../../../backend/shared/utils/PLC/preprocess-pous'
+import { resolveTargetCapabilities } from '../../shared/utils/target-capabilities'
 import type { CompileProgramArgs } from '../../shared/ports/compiler-port'
 import type { StlibArchiveDTO } from '../../shared/ports/library-port'
 import type { BoardInfo, CompileProgressEvent, CompileResult, StructuredCompileError } from '../../shared/ports/types'
@@ -86,6 +87,18 @@ export async function compileProgramFlow(
   const boardCore = boardInfo?.core ?? null
   const isSimulator = args.isSimulator ?? boardInfo?.compiler === 'simulator'
 
+  // `pythonFunctionBlocks` has always described the contract (v3 / v4 run them,
+  // the Simulator stubs them, arduino-cli targets reject them); until now
+  // nothing enforced the rejection half, so a Python block on an Arduino board
+  // reached the board's C++ toolchain and failed there instead.
+  //
+  // Only gate on a board we actually resolved: `resolveTargetCapabilities`
+  // returns an all-false block for `undefined`, so gating on an unresolved
+  // board would turn a catalog lookup miss into a Python build failure.
+  const pythonSupport = boardInfo
+    ? { supported: resolveTargetCapabilities(boardInfo).pythonFunctionBlocks, targetLabel: args.boardTarget }
+    : undefined
+
   // Graft library-supplied C++ blocks into the project's POU
   // list before preprocessing.  They behave like user-defined
   // C++ POUs from this point on — same `preprocessPous` branch,
@@ -96,18 +109,23 @@ export async function compileProgramFlow(
   const dataWithLibCpp = injectLibraryCppBlocks(args.projectData, archives)
 
   // Preprocess POUs (comment wrapping, Python->ST stubs, C++ validation/ST generation)
-  const { projectData: processedData, validationFailed } = preprocessPous(
+  const {
+    projectData: processedData,
+    validationFailed,
+    validationError,
+  } = preprocessPous(
     dataWithLibCpp,
     isSimulator,
     (level, message) => {
       onProgress({ stage: 'st', message, level })
     },
+    pythonSupport,
   )
 
   if (validationFailed) {
     return {
       success: false,
-      error: 'POU validation failed. Check C/C++ code for missing setup()/loop() functions.',
+      error: validationError ?? 'POU validation failed. Check C/C++ code for missing setup()/loop() functions.',
     }
   }
 

--- a/src/middleware/adapters/editor/compile-program-flow.ts
+++ b/src/middleware/adapters/editor/compile-program-flow.ts
@@ -120,6 +120,10 @@ export async function compileProgramFlow(
       onProgress({ stage: 'st', message, level })
     },
     pythonSupport,
+    // The archives are already loaded for the C++ graft above. A native block
+    // declaring `ton0 : TON` needs that block's pin list before the instance can
+    // cross into Python, and the manifest is where it lives.
+    archives.map((archive) => ({ functionBlocks: archive.manifest.functionBlocks })),
   )
 
   if (validationFailed) {

--- a/src/middleware/adapters/editor/compiler-adapter.ts
+++ b/src/middleware/adapters/editor/compiler-adapter.ts
@@ -235,6 +235,13 @@ export function createEditorCompilerAdapter(): CompilerPort {
               targetLabel: args.boardTarget,
             }
           : undefined,
+        // The same FB pin source the build and library paths pass. Without it
+        // `libraries` defaults to `[]`, `describeShmLeaves` cannot resolve a
+        // library block, and a Python POU declaring e.g. `ton0 : TON` compiled
+        // for upload and then failed the debug compile with "cannot exchange
+        // these variables" — the one path where the archives were already
+        // loaded and simply not forwarded.
+        archives.map((archive) => ({ functionBlocks: archive.manifest.functionBlocks })),
       )
 
       if (validationFailed) {
@@ -330,7 +337,14 @@ export function createEditorCompilerAdapter(): CompilerPort {
       if (buildResult.validationFailed) {
         return {
           success: false,
-          error: 'POU validation failed. Check C/C++ code for missing setup()/loop() functions.',
+          // `preprocessPous` returns `validationError` so the caller stops
+          // guessing at the cause. This path can now fail for a Python reason —
+          // the shm refusals are not gated on target support — and reporting
+          // every one of those as "check C/C++ code for setup()/loop()" sent
+          // the user to the wrong file.
+          error:
+            buildResult.validationError ??
+            'POU validation failed. Check C/C++ code for missing setup()/loop() functions.',
         }
       }
       const verifyResult = preprocessPous(
@@ -343,6 +357,19 @@ export function createEditorCompilerAdapter(): CompilerPort {
         undefined,
         fbSources,
       )
+      // Checked rather than ignored, matching the build pass above. Both passes
+      // get the same project and the same FB pin sources, so they agree today —
+      // but handing an un-lowered project to the verify compile would fail it on
+      // `python_block_loader` instead of reporting the refusal, and that is not
+      // a difference worth leaving to luck.
+      if (verifyResult.validationFailed) {
+        return {
+          success: false,
+          error:
+            verifyResult.validationError ??
+            'POU validation failed. Check C/C++ code for missing setup()/loop() functions.',
+        }
+      }
       const ipcDataForBuild = toIpcProjectData(buildResult.projectData)
       const ipcDataForVerify = toIpcProjectData(verifyResult.projectData)
 

--- a/src/middleware/adapters/editor/compiler-adapter.ts
+++ b/src/middleware/adapters/editor/compiler-adapter.ts
@@ -12,6 +12,7 @@
  */
 
 import { preprocessPous } from '../../../backend/shared/utils/PLC/preprocess-pous'
+import { resolveTargetCapabilities } from '../../shared/utils/target-capabilities'
 import type {
   CompileLibraryArgs,
   CompileProgramArgs,
@@ -213,17 +214,31 @@ export function createEditorCompilerAdapter(): CompilerPort {
       const archives = (await window.bridge.loadAllLibraries()) as StlibArchiveDTO[]
       const dataWithLibCpp = injectLibraryCppBlocks(args.projectData, archives)
 
-      // Preprocess for debug compilation too
-      const { projectData: processedData, validationFailed } = preprocessPous(
+      // Preprocess for debug compilation too. Same target gate as the build
+      // path — a Python block is no more loadable on an Arduino board when the
+      // build is for debugging.
+      const debugBoards = await window.bridge.getAvailableBoards()
+      const debugBoardInfo = debugBoards.get(args.boardTarget)
+      const {
+        projectData: processedData,
+        validationFailed,
+        validationError,
+      } = preprocessPous(
         dataWithLibCpp,
         false,
         (level, message) => {
           onProgress({ stage: 'st', message, level })
         },
+        debugBoardInfo
+          ? {
+              supported: resolveTargetCapabilities(debugBoardInfo).pythonFunctionBlocks,
+              targetLabel: args.boardTarget,
+            }
+          : undefined,
       )
 
       if (validationFailed) {
-        return { success: false, error: 'POU validation failed.' }
+        return { success: false, error: validationError ?? 'POU validation failed.' }
       }
 
       const ipcData = toIpcProjectData(processedData)

--- a/src/middleware/adapters/editor/compiler-adapter.ts
+++ b/src/middleware/adapters/editor/compiler-adapter.ts
@@ -12,7 +12,6 @@
  */
 
 import { preprocessPous } from '../../../backend/shared/utils/PLC/preprocess-pous'
-import { resolveTargetCapabilities } from '../../shared/utils/target-capabilities'
 import type {
   CompileLibraryArgs,
   CompileProgramArgs,
@@ -31,6 +30,7 @@ import type {
   PLCVariable,
   Result,
 } from '../../shared/ports/types'
+import { resolveTargetCapabilities } from '../../shared/utils/target-capabilities'
 import { compileProgramFlow } from './compile-program-flow'
 
 /**

--- a/src/middleware/adapters/editor/compiler-adapter.ts
+++ b/src/middleware/adapters/editor/compiler-adapter.ts
@@ -313,19 +313,36 @@ export function createEditorCompilerAdapter(): CompilerPort {
       // The renderer-side `onProgress` log channel only sees the
       // build pass's preprocess output to avoid duplicate "Found
       // Python POU…" lines.
-      const buildResult = preprocessPous(args.projectData, false, (level, message) => {
-        onProgress({ stage: 'st', message, level })
-      })
+      // A library's own Python POU may hold a function block instance too, so it
+      // needs the same pin source a project build gets.
+      const libraryArchives = (await window.bridge.loadAllLibraries()) as StlibArchiveDTO[]
+      const fbSources = libraryArchives.map((archive) => ({ functionBlocks: archive.manifest.functionBlocks }))
+
+      const buildResult = preprocessPous(
+        args.projectData,
+        false,
+        (level, message) => {
+          onProgress({ stage: 'st', message, level })
+        },
+        undefined,
+        fbSources,
+      )
       if (buildResult.validationFailed) {
         return {
           success: false,
           error: 'POU validation failed. Check C/C++ code for missing setup()/loop() functions.',
         }
       }
-      const verifyResult = preprocessPous(args.projectData, true, () => {
-        // Silent — same project gets logged once via the build
-        // pass; a second round of "Found …" lines is noise.
-      })
+      const verifyResult = preprocessPous(
+        args.projectData,
+        true,
+        () => {
+          // Silent — same project gets logged once via the build
+          // pass; a second round of "Found …" lines is noise.
+        },
+        undefined,
+        fbSources,
+      )
       const ipcDataForBuild = toIpcProjectData(buildResult.projectData)
       const ipcDataForVerify = toIpcProjectData(verifyResult.projectData)
 


### PR DESCRIPTION
Closes DOPE-584.

## What this is

Python and C++ function blocks now see the same Variables Table an ST block does. Before this, a native block was a second-class POU: it could name two variable classes and the elementary types, and everything else the editor lets a user declare — a structure, an enumeration, a function block instance, a `VAR`, a `VAR_TEMP`, a `VAR_IN_OUT`, a `VAR_EXTERNAL`, a multi-dimensional array — was accepted by the Variables Table and then rejected by the compiler as an undeclared identifier. That reads as a compiler bug, not an unimplemented feature.

Eight phases, each merged with its own hardware verification. Phases 1-3 fixed live defects found while mapping the machinery; 4 brought C++ to parity; 5-8 did the same for Python.

## What a native block can do now

| | C++ | Python |
|---|---|---|
| `input` / `output` | ✓ | ✓ |
| `inOut` / `local` | ✓ | ✓ |
| `temp` | ✓ | refused, with the reason |
| `external` (globals) | ✓, under the global's lock | ✓, under the global's lock |
| structures, enumerations | ✓ | ✓ |
| function block instances | ✓ | refused, with the reason |
| multi-dimensional arrays | ✓ | 1-D |
| execution control | `EN` / `ENO` | `EN` / `ENO` |

Python refuses `VAR_TEMP` because it has no storage that fails to survive the scan — its variables are module globals in a process that outlives every cycle. Marshalling one would not make it temporary, only a `VAR` wearing the wrong name. It refuses a function block instance because it cannot call into a scan it is not part of; `EN`/`ENO` is the execution control that replaces it, and needed no implementation — strucpp's call-site guard already gates a native block, the spawning branch included.

## Defects fixed along the way

- **Python blocks compiled to silent no-ops** on targets that cannot run them, instead of being refused (phase 1).
- **The shared-memory type table existed twice and disagreed in three places.** TIME/DATE/TOD/DT lost eight bytes from the format string; WSTRING was copied as bytes with a length counted in characters, and read back through the wrong pointer type. A dropped field does not go missing — it shifts every later field's offset, so the damage lands on unrelated variables (phase 2).
- **A block's outputs were overwritten with declaration defaults on every start**, before the user's code had assigned anything. Harmless-looking today; destructive once a Python block can carry RETAIN (phase 3).
- **The C block interface struct was written twice**, by two call sites into the same helper, and diverged the moment a user-defined type needed more than a name lookup — meeting in the POU glue as `cannot convert IEC_MODE* to MODE*` (phase 4).
- **Multi-dimensional arrays could not build at all, in any project**, C blocks or not: strucpp's debug table indexed a container that has no `operator[]`. Fixed upstream in strucpp v0.6.3, which both repos already pin.

## The shape of the fix

Each of these was one fact stated in several places. The interface selection was written three times for C++ and four for Python; the type table twice; the struct twice. Disagreement between them is never a caught error — for the C struct it is a dangling pointer the user's first write follows, and for the Python layout it is silent corruption of neighbouring fields. So each is now stated once and read by everyone: `cBlockInterfaceVariables`, `pythonInboundVariables` / `pythonOutboundVariables`, `shm-leaves`, and a single struct definition in `c_blocks.h`.

Where a fact belongs to the compiler, it is derived rather than restated: lambda parameters are deduced so nothing spells `Array1D<IEC_INT, 0, 3>`, and the leaf walk defines our own transport layout rather than mirroring strucpp's. The one deliberate exception is the member-mangling rule, restated in one place with the reason written down — the compiler exposes no way to ask, and the alternative is naming a member that does not exist.

## Verification

Every phase ran on real hardware (slm-rp4, Runtime v4) **and** compiled for baremetal AVR, which is what validates the simulator path. Values were checked for exactness, not just for being non-zero — a `VAR` at exactly `406 x 10` after 406 scans, a gated instance exactly 50 counts behind a free-running one after 50 disabled scans, a structure's nested array at exactly twice its scalar member. The full detail is in each phase PR: #1037, #1038, #1039, #1040, #1041, #1043.

## Follow-ups, deliberately not here

- **CONSTANT / RETAIN / NON_RETAIN** wait on NODE-94 (#1034). Both interface builders are the single place they will need applying.
- **C++ member completion in Monaco** is the agreed nice-to-have, to land as its own PR after this.
- The **AI prompts** in autonomy-edge and the **user docs** describe the previous, narrower contract and now understate what a native block can do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaSZK4LqFWtZpERcqnZ8uQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Python blocks now support user-defined structures, enumerations, nested types, arrays, strings, wide strings, and function-block instances.
  * Added library-based function-block pin resolution and bidirectional data exchange.
  * Improved Python editor type assistance for project-defined data types.
  * C++ generation now handles project types, external variables, multidimensional arrays, and broader variable interfaces.

* **Bug Fixes**
  * Added target-specific validation with clearer diagnostics.
  * Improved shared-memory handling and clarified supported `STRING` and `WSTRING` declarations.
  * Fixed generated firmware placement and Arduino macro compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->