### PR TITLE
bugfix(DOPE-586): read a DATE as days, which is what the compiler emits

### DIFF
--- a/src/frontend/utils/__tests__/variable-sizes.test.ts
+++ b/src/frontend/utils/__tests__/variable-sizes.test.ts
@@ -431,17 +431,55 @@ describe('parseVariableValue', () => {
     expect(result.value).toBe('1h1m')
   })
 
-  // DATE and TOD share the int64 nanoseconds wire format with TIME but
-  // represent absolute timestamps (epoch / midnight reference). The
-  // formatters render them as IEC literals matching the watch-panel
-  // convention TIME established (`T#3s800ms`).
+  // TOD and DT are nanoseconds like TIME. DATE is the exception: it is a count
+  // of DAYS since the epoch, because STruC++ lowers a DATE literal through
+  // `parseDateLiteralToDays` — `D#2026-08-26` compiles to `20691LL`. This test
+  // previously wrote a nanosecond count and expected it to render as a date,
+  // which is what let the formatter divide by 1_000_000 and render every DATE
+  // in the debugger as `D#1970-01-01`.
 
-  it('parses DATE as an IEC date literal in UTC, dropping time-of-day', () => {
-    // 1970-01-02 00:00:00 UTC = 86_400_000_000_000 ns since epoch.
+  it('parses DATE as a count of days since the epoch', () => {
     const buf = new Uint8Array(8)
-    writeTimeNs(buf, 86_400_000_000_000n)
+    writeTimeNs(buf, 1n)
     const result = parseVariableValue(buf, 0, makeBaseVar('d', 'DATE'))
     expect(result).toEqual({ value: 'D#1970-01-02', bytesRead: 8 })
+  })
+
+  it('renders the date STruC++ actually compiles a literal to', () => {
+    // The value observed on hardware for `D#2026-08-26`.
+    const buf = new Uint8Array(8)
+    writeTimeNs(buf, 20691n)
+    expect(parseVariableValue(buf, 0, makeBaseVar('d', 'DATE')).value).toBe('D#2026-08-26')
+  })
+
+  it('renders day zero as the epoch itself', () => {
+    const buf = new Uint8Array(8)
+    writeTimeNs(buf, 0n)
+    expect(parseVariableValue(buf, 0, makeBaseVar('d', 'DATE')).value).toBe('D#1970-01-01')
+  })
+
+  it('renders a negative day count as a date before the epoch', () => {
+    const buf = new Uint8Array(8)
+    writeTimeNs(buf, -1n)
+    expect(parseVariableValue(buf, 0, makeBaseVar('d', 'DATE')).value).toBe('D#1969-12-31')
+  })
+
+  it('does not read DATE with the same unit as DT', () => {
+    // The same payload has to mean different things for the two types; reading
+    // both as nanoseconds is precisely the defect.
+    const buf = new Uint8Array(8)
+    writeTimeNs(buf, 20691n)
+    const asDate = parseVariableValue(buf, 0, makeBaseVar('d', 'DATE')).value
+    const asDt = parseVariableValue(buf, 0, makeBaseVar('d', 'DT')).value
+
+    expect(asDate).toBe('D#2026-08-26')
+    expect(asDt).toContain('1970-01-01')
+  })
+
+  it('renders a day count too large for a JS Date as an error, not a wrong date', () => {
+    const buf = new Uint8Array(8)
+    writeTimeNs(buf, 100_000_000_000n)
+    expect(parseVariableValue(buf, 0, makeBaseVar('d', 'DATE')).value).toBe('ERR')
   })
 
   it('parses TOD as nanoseconds-since-midnight, formatted HH:MM:SS.mmm', () => {

--- a/src/frontend/utils/variable-sizes.ts
+++ b/src/frontend/utils/variable-sizes.ts
@@ -92,12 +92,22 @@ function formatDtValue(totalNs: bigint): string {
 }
 
 /**
- * Format a strucpp DATE (int64 nanoseconds since the Unix epoch, but
- * semantically date-only) as `D#YYYY-MM-DD`.
+ * Format a strucpp DATE as `D#YYYY-MM-DD`.
+ *
+ * DATE is a count of **days** since the Unix epoch, not nanoseconds. It is the
+ * one temporal type that is: TIME is a nanosecond duration, TOD is nanoseconds
+ * since midnight and DT is nanoseconds since the epoch, but STruC++ lowers a
+ * DATE literal through a helper it named `parseDateLiteralToDays`, and
+ * `D#2026-08-26` compiles to `20691LL`.
+ *
+ * This used to divide by 1_000_000 as though the payload were nanoseconds, so
+ * every DATE in the debugger read `D#1970-01-01` — 20691 nanoseconds rounds to
+ * zero milliseconds. The value on the device was always correct; only the
+ * display was wrong.
  */
-function formatDateValue(totalNs: bigint): string {
-  const ms = Number(totalNs / 1_000_000n)
-  const d = new Date(ms)
+function formatDateValue(totalDays: bigint): string {
+  const MS_PER_DAY = 86_400_000n
+  const d = new Date(Number(totalDays * MS_PER_DAY))
   if (Number.isNaN(d.getTime())) return 'ERR'
   return `D#${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`
 }


### PR DESCRIPTION
Fixes DOPE-586.

## The bug

Every DATE in the debugger read `D#1970-01-01`, whatever it actually held.

DATE is the one temporal type that is not nanoseconds. TIME is a nanosecond duration, TOD is nanoseconds since midnight, DT is nanoseconds since the epoch — but STruC++ lowers a DATE literal through a helper it named `parseDateLiteralToDays`, and `D#2026-08-26` compiles to `20691LL`. The formatter divided by a million as though the payload were nanoseconds, and 20691 nanoseconds rounds to zero milliseconds, so every date collapsed onto the epoch.

The value on the device was always correct — the generated `pou_MAIN.cpp` carries `DINIT(20691LL)`. Nothing was stored wrong and no project data is affected; only the display lied.

## Reproduction

A plain ST program, no native blocks:

```
PROGRAM main
  VAR
    dInit : DATE := D#2026-08-26;
    dAssign : DATE;
  END_VAR
  dAssign := D#2026-08-26;
END_PROGRAM
```

Before, on slm-rp4: both read `D#1970-01-01`. After: both read `D#2026-08-26`, and the `DT` beside them is unchanged.

## The test was part of the problem

The existing test wrote a nanosecond count and expected a date out, which is exactly what let the formatter look correct. It writes a day count now, and the cases around it are pinned: the epoch itself, a date before it, a count too large for a JS `Date`, and the same payload deliberately rendering differently as DATE and as DT — since reading both with one unit is the defect.

## Not affected

Forcing a DATE. `encodeByWireFormat` does not implement DATE / TOD / DT / WSTRING force at all, so there is no write path carrying the same assumption.

## How it was found

Running the end-to-end type sweep for DOPE-584 — a project with one Python block and one C++ block each declaring all 21 elementary types. DATE was the only value that came back wrong, and it came back wrong on the *input* pin, before any native-block code touched it, which is what pointed at the formatter rather than the marshalling.

`src/frontend/utils/variable-sizes.ts` is on the mirrored surface; openplc-web carries the byte-identical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaSZK4LqFWtZpERcqnZ8uQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected DATE value parsing to interpret signed days since the Unix epoch.
  * DATE values now display the correct UTC date, including dates before the Unix epoch.
  * Improved handling of invalid and out-of-range DATE values.
  * Preserved distinct parsing behavior between DATE values and nanosecond-based datetime values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->