### PR TITLE
fix(dev-console): a real IPC unsubscribe for accelerators, and rung bounds without xyflow's standalone helper [DOPE-507]

### DIFF
--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/body.tsx
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/body.tsx
@@ -5,7 +5,7 @@ import type {
   OnNodesChange,
   ReactFlowInstance,
 } from '@xyflow/react'
-import { applyNodeChanges, getNodesBounds } from '@xyflow/react'
+import { applyNodeChanges } from '@xyflow/react'
 import { differenceWith, isEqual, parseInt } from 'lodash'
 import { DragEvent, MouseEvent, useEffect, useMemo, useRef, useState } from 'react'
 
@@ -34,7 +34,7 @@ import {
   renderPlaceholderElements,
   searchNearestPlaceholder,
 } from './ladder-utils/elements/placeholder'
-import { findNode } from './ladder-utils/nodes'
+import { findNode, getRungNodesBounds } from './ladder-utils/nodes'
 
 /**
  * Check recursively if the related target or any of its parent elements are within the ladder area
@@ -303,18 +303,11 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
 
   /**
    * Update flow panel extent based on the bounds of the nodes
-   * To make the getNodesBounds function work, the nodes must have width and height properties set in the node data
+   * For getRungNodesBounds to work, the nodes must have width and height properties set in the node data
    * This useEffect will run every time the nodes array changes (i.e. when a node is added or removed)
    */
   const updateReactFlowPanelExtent = (rung: RungLadderState) => {
-    const zeroPositionNode: FlowNode = {
-      id: '-1',
-      position: { x: 0, y: 0 },
-      data: { label: 'Node 0' },
-      width: 150,
-      height: 40,
-    }
-    const bounds = getNodesBounds([zeroPositionNode, ...rung.nodes])
+    const bounds = getRungNodesBounds(rung.nodes)
     const [defaultWidth, defaultHeight] = rung.defaultBounds
 
     // If the bounds are less than the default extent, set the panel extent to the default extent

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/__tests__/nodes.test.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/__tests__/nodes.test.ts
@@ -1,0 +1,49 @@
+import type { Node } from '@xyflow/react'
+
+import { getRungNodesBounds } from '../nodes'
+
+const node = (overrides: Partial<Node> & Pick<Node, 'position'>): Node => ({
+  id: 'n',
+  data: {},
+  ...overrides,
+})
+
+describe('getRungNodesBounds', () => {
+  it('falls back to the origin placeholder for an empty rung', () => {
+    expect(getRungNodesBounds([])).toEqual({ width: 150, height: 40 })
+  })
+
+  it('extends the box to the far edge of each node', () => {
+    const bounds = getRungNodesBounds([
+      node({ id: 'a', position: { x: 100, y: 40 }, width: 60, height: 30 }),
+      node({ id: 'b', position: { x: 400, y: 10 }, width: 80, height: 120 }),
+    ])
+
+    expect(bounds).toEqual({ width: 480, height: 130 })
+  })
+
+  it('prefers the measured size over the declared one', () => {
+    const bounds = getRungNodesBounds([
+      node({
+        position: { x: 200, y: 0 },
+        width: 50,
+        height: 20,
+        measured: { width: 90, height: 300 },
+      }),
+    ])
+
+    expect(bounds).toEqual({ width: 290, height: 300 })
+  })
+
+  it('treats a node with no dimensions as a point', () => {
+    const bounds = getRungNodesBounds([node({ position: { x: 700, y: 500 } })])
+
+    expect(bounds).toEqual({ width: 700, height: 500 })
+  })
+
+  it('never shrinks below the origin placeholder', () => {
+    const bounds = getRungNodesBounds([node({ position: { x: 5, y: 5 }, width: 10, height: 10 })])
+
+    expect(bounds).toEqual({ width: 150, height: 40 })
+  })
+})

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/__tests__/nodes.test.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/__tests__/nodes.test.ts
@@ -35,6 +35,20 @@ describe('getRungNodesBounds', () => {
     expect(bounds).toEqual({ width: 290, height: 300 })
   })
 
+  it('falls back to the initial dimensions when nothing else is set', () => {
+    const bounds = getRungNodesBounds([node({ position: { x: 400, y: 300 }, initialWidth: 70, initialHeight: 90 })])
+
+    expect(bounds).toEqual({ width: 470, height: 390 })
+  })
+
+  it('prefers the declared size over the initial one', () => {
+    const bounds = getRungNodesBounds([
+      node({ position: { x: 400, y: 300 }, width: 100, height: 200, initialWidth: 5, initialHeight: 5 }),
+    ])
+
+    expect(bounds).toEqual({ width: 500, height: 500 })
+  })
+
   it('treats a node with no dimensions as a point', () => {
     const bounds = getRungNodesBounds([node({ position: { x: 700, y: 500 } })])
 

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/nodes.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/nodes.ts
@@ -26,6 +26,35 @@ export const getDefaultNodeStyle = ({ node, nodeType }: { node?: Node; nodeType?
   return defaultCustomNodesStyles[node?.type ?? nodeType ?? 'mockNode']
 }
 
+/** Origin placeholder inherited from the synthetic `-1` node that used to be
+ *  prepended to the `getNodesBounds` call. Dominated by `rung.defaultBounds`
+ *  ([300, 100] in production) on every real path; kept so the computation stays
+ *  numerically identical to the xyflow one it replaces. */
+const ORIGIN_NODE_SIZE = { width: 150, height: 40 }
+
+/**
+ * Bounding box of a rung's nodes, measured from the flow origin (0, 0).
+ *
+ * Replaces the standalone `getNodesBounds` from `@xyflow/react`, which warns in
+ * dev since v12 unless it is handed the internal `nodeLookup`. The hook form
+ * (`useReactFlow().getNodesBounds`) reads the store ReactFlow has already
+ * adopted, which lags the rung state this runs on by a frame — so it would swap
+ * a warning for stale numbers. Ladder rungs are flat (no subflows, no
+ * `parentId`, no node `origin`), so the box is just the node rectangles unioned
+ * with the origin, exactly what xyflow computed.
+ *
+ * The `measured ?? width` precedence mirrors xyflow's own `nodeToRect`:
+ * `applyNodeChanges` writes `measured` on dimension changes.
+ */
+export const getRungNodesBounds = (nodes: Node[]): { width: number; height: number } =>
+  nodes.reduce(
+    (bounds, node) => ({
+      width: Math.max(bounds.width, node.position.x + (node.measured?.width ?? node.width ?? 0)),
+      height: Math.max(bounds.height, node.position.y + (node.measured?.height ?? node.height ?? 0)),
+    }),
+    { ...ORIGIN_NODE_SIZE },
+  )
+
 export const buildGenericNode = <T>({
   nodeType,
   blockType,

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/nodes.ts
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/ladder-utils/nodes.ts
@@ -43,14 +43,21 @@ const ORIGIN_NODE_SIZE = { width: 150, height: 40 }
  * `parentId`, no node `origin`), so the box is just the node rectangles unioned
  * with the origin, exactly what xyflow computed.
  *
- * The `measured ?? width` precedence mirrors xyflow's own `nodeToRect`:
- * `applyNodeChanges` writes `measured` on dimension changes.
+ * The dimension precedence mirrors xyflow's own `nodeToRect`:
+ * `measured` (written by `applyNodeChanges` on dimension changes), then the
+ * declared `width`/`height`, then `initialWidth`/`initialHeight`. Every ladder
+ * builder in `_atoms/graphical-editor/ladder/node-builders.ts` sets explicit
+ * dimensions, so the initial-* step is unreachable today — it is here so the
+ * fallback chain stays honest to the helper it replaces.
  */
 export const getRungNodesBounds = (nodes: Node[]): { width: number; height: number } =>
   nodes.reduce(
     (bounds, node) => ({
-      width: Math.max(bounds.width, node.position.x + (node.measured?.width ?? node.width ?? 0)),
-      height: Math.max(bounds.height, node.position.y + (node.measured?.height ?? node.height ?? 0)),
+      width: Math.max(bounds.width, node.position.x + (node.measured?.width ?? node.width ?? node.initialWidth ?? 0)),
+      height: Math.max(
+        bounds.height,
+        node.position.y + (node.measured?.height ?? node.height ?? node.initialHeight ?? 0),
+      ),
     }),
     { ...ORIGIN_NODE_SIZE },
   )

--- a/src/main/modules/ipc/__tests__/bridge-subscriptions.test.ts
+++ b/src/main/modules/ipc/__tests__/bridge-subscriptions.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Covers the layer the accelerator listener leak actually lived in: the bridge.
+ *
+ * The adapter tests above this one run against a mocked bridge, so they prove
+ * the adapter forwards whatever disposer it is handed — but a mock that defines
+ * the contract cannot prove `renderer.ts` honours it. These tests drive the real
+ * bridge against a real EventEmitter, so a `subscribe` helper that closed over
+ * the wrong function (or went back to `removeAllListeners`) fails here.
+ */
+import { EventEmitter } from 'events'
+
+const ipc = new EventEmitter()
+
+jest.mock('electron', () => ({
+  ipcRenderer: ipc,
+  contextBridge: { exposeInMainWorld: jest.fn() },
+}))
+
+import rendererProcessBridge from '../renderer'
+
+const EXPORT_CHANNEL = 'compiler:export-project-request'
+const SAVE_CHANNEL = 'project:save-file-accelerator'
+
+beforeEach(() => {
+  ipc.removeAllListeners()
+  jest.restoreAllMocks()
+})
+
+describe('subscribe', () => {
+  it('removes the exact listener it registered', () => {
+    const on = jest.spyOn(ipc, 'on')
+    const removeListener = jest.spyOn(ipc, 'removeListener')
+
+    const unsubscribe = rendererProcessBridge.exportProjectRequest(() => {})
+    const registered = on.mock.calls[0][1]
+
+    unsubscribe()
+
+    // Same function object on both sides — a wrapper rebuilt on unsubscribe
+    // would silently leave the original listener attached.
+    expect(removeListener).toHaveBeenCalledWith(EXPORT_CHANNEL, registered)
+  })
+
+  it('leaves no listener behind across repeated mount/unmount cycles', () => {
+    // Stands in for a React effect re-running on every dependency change, which
+    // is what drove the channel past Node's ten-listener warning threshold.
+    for (let cycle = 0; cycle < 15; cycle++) {
+      const unsubscribe = rendererProcessBridge.exportProjectRequest(() => {})
+      unsubscribe()
+    }
+
+    expect(ipc.listenerCount(EXPORT_CHANNEL)).toBe(0)
+  })
+
+  it('keeps sibling subscribers on the same channel alive', () => {
+    // The reason `removeAllListeners` was never an acceptable disposer.
+    const first = jest.fn()
+    const second = jest.fn()
+
+    const unsubscribeFirst = rendererProcessBridge.saveFileAccelerator(first)
+    rendererProcessBridge.saveFileAccelerator(second)
+
+    unsubscribeFirst()
+    ipc.emit(SAVE_CHANNEL, {})
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+    expect(ipc.listenerCount(SAVE_CHANNEL)).toBe(1)
+  })
+
+  it('forwards the event and payload to the callback', () => {
+    const callback = jest.fn()
+    rendererProcessBridge.openRecentAccelerator(callback)
+
+    const event = {}
+    const payload = { projectPath: '/some/path' }
+    ipc.emit('project:open-recent-accelerator', event, payload)
+
+    expect(callback).toHaveBeenCalledWith(event, payload)
+  })
+})

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -94,10 +94,7 @@ const rendererProcessBridge = {
   openProject: (): Promise<IProjectServiceResponse> => ipcRenderer.invoke('project:open'),
   openProjectByPath: (projectPath: string): Promise<IProjectServiceResponse> =>
     ipcRenderer.invoke('project:open-by-path', projectPath),
-  openRecentAccelerator: (callback: IpcRendererCallbacks) =>
-    subscribe('project:open-recent-accelerator', (_event, ...args) =>
-      callback(_event, args[0] as IProjectServiceResponse),
-    ),
+  openRecentAccelerator: (callback: IpcRendererCallbacks) => subscribe('project:open-recent-accelerator', callback),
   pathPicker: (): Promise<{ success: boolean; error?: { title: string; description: string }; path?: string }> =>
     ipcRenderer.invoke('project:path-picker'),
   openPathPicker: (): Promise<{ success: boolean; error?: { title: string; description: string }; path?: string }> =>

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -36,6 +36,23 @@ import { ipcRenderer, IpcRendererEvent } from 'electron'
 
 type IpcRendererCallbacks = (_event: IpcRendererEvent, ...args: unknown[]) => void
 
+/**
+ * Register an IPC listener and hand back a per-listener unsubscribe.
+ *
+ * `removeAllListeners(channel)` would drop sibling subscribers on the same
+ * channel, so every `on`-style bridge method routes through here and returns
+ * the disposer instead. Callers that mount the same subscription repeatedly
+ * (React effects re-running on dependency changes) must call it on cleanup —
+ * otherwise dead listeners pile up until Node warns past ten.
+ */
+const subscribe = (channel: string, callback: IpcRendererCallbacks): (() => void) => {
+  const listener: IpcRendererCallbacks = (event, ...args) => callback(event, ...args)
+  ipcRenderer.on(channel, listener)
+  return () => {
+    ipcRenderer.removeListener(channel, listener)
+  }
+}
+
 /** Data posted through the MessagePort by the compiler module.
  *  `compileError` carries strucpp's structured `CompileError` (pouName,
  *  section, bodyLine, …) when the message is one of the per-error log
@@ -62,26 +79,25 @@ type CompilerPortMessage = {
  */
 const rendererProcessBridge = {
   // ===================== PROJECT METHODS =====================
-  aboutAccelerator: (callback: IpcRendererCallbacks) => ipcRenderer.on('website:about-accelerator', callback),
-  aboutModalAccelerator: (callback: IpcRendererCallbacks) => ipcRenderer.on('about:open-accelerator', callback),
+  aboutAccelerator: (callback: IpcRendererCallbacks) => subscribe('website:about-accelerator', callback),
+  aboutModalAccelerator: (callback: IpcRendererCallbacks) => subscribe('about:open-accelerator', callback),
   closeProjectAccelerator: (callback: IpcRendererCallbacks) =>
-    ipcRenderer.on('workspace:close-project-accelerator', callback),
-  closeTabAccelerator: (callback: IpcRendererCallbacks) => ipcRenderer.on('workspace:close-tab-accelerator', callback),
+    subscribe('workspace:close-project-accelerator', callback),
+  closeTabAccelerator: (callback: IpcRendererCallbacks) => subscribe('workspace:close-tab-accelerator', callback),
   createProject: (data: CreateProjectFileProps): Promise<IProjectServiceResponse> =>
     ipcRenderer.invoke('project:create', data),
-  createProjectAccelerator: (callback: IpcRendererCallbacks) =>
-    ipcRenderer.on('project:create-accelerator', (_event) => callback(_event)),
-  deleteFileAccelerator: (callback: IpcRendererCallbacks) =>
-    ipcRenderer.on('workspace:delete-file-accelerator', callback),
+  createProjectAccelerator: (callback: IpcRendererCallbacks) => subscribe('project:create-accelerator', callback),
+  deleteFileAccelerator: (callback: IpcRendererCallbacks) => subscribe('workspace:delete-file-accelerator', callback),
   findInProjectAccelerator: (callback: IpcRendererCallbacks) =>
-    ipcRenderer.on('project:find-in-project-accelerator', callback),
-  handleOpenProjectRequest: (callback: IpcRendererCallbacks) =>
-    ipcRenderer.on('project:open-project-request', (_event) => callback(_event)),
+    subscribe('project:find-in-project-accelerator', callback),
+  handleOpenProjectRequest: (callback: IpcRendererCallbacks) => subscribe('project:open-project-request', callback),
   openProject: (): Promise<IProjectServiceResponse> => ipcRenderer.invoke('project:open'),
   openProjectByPath: (projectPath: string): Promise<IProjectServiceResponse> =>
     ipcRenderer.invoke('project:open-by-path', projectPath),
   openRecentAccelerator: (callback: IpcRendererCallbacks) =>
-    ipcRenderer.on('project:open-recent-accelerator', (_event, val: IProjectServiceResponse) => callback(_event, val)),
+    subscribe('project:open-recent-accelerator', (_event, ...args) =>
+      callback(_event, args[0] as IProjectServiceResponse),
+    ),
   pathPicker: (): Promise<{ success: boolean; error?: { title: string; description: string }; path?: string }> =>
     ipcRenderer.invoke('project:path-picker'),
   openPathPicker: (): Promise<{ success: boolean; error?: { title: string; description: string }; path?: string }> =>
@@ -97,22 +113,14 @@ const rendererProcessBridge = {
     xml: string,
   ): Promise<{ success: boolean; error?: { title: string; description: string } }> =>
     ipcRenderer.invoke('project:export-plcopen-file', defaultFileName, xml),
-  removeCloseProjectListener: () => ipcRenderer.removeAllListeners('workspace:close-project-accelerator'),
-  removeCloseTabListener: () => ipcRenderer.removeAllListeners('workspace:close-tab-accelerator'),
-  removeCreateProjectAccelerator: () => ipcRenderer.removeAllListeners('project:create-accelerator'),
-  removeDeleteFileListener: () => ipcRenderer.removeAllListeners('workspace:delete-file-accelerator'),
-  removeOpenProjectAccelerator: () => ipcRenderer.removeAllListeners('project:open-project-request'),
-  removeOpenRecentListener: () => ipcRenderer.removeAllListeners('project:open-recent-accelerator'),
-  removeSaveFileAccelerator: () => ipcRenderer.removeAllListeners('project:save-file-accelerator'),
-  removeSaveProjectAccelerator: () => ipcRenderer.removeAllListeners('project:save-accelerator'),
   saveFile: (filePath: string, content: unknown): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('project:save-file', filePath, content),
-  saveFileAccelerator: (callback: IpcRendererCallbacks) => ipcRenderer.on('project:save-file-accelerator', callback),
+  saveFileAccelerator: (callback: IpcRendererCallbacks) => subscribe('project:save-file-accelerator', callback),
   writeProjectFiles: (files: unknown): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('project:write-files', files),
-  saveProjectAccelerator: (callback: IpcRendererCallbacks) => ipcRenderer.on('project:save-accelerator', callback),
+  saveProjectAccelerator: (callback: IpcRendererCallbacks) => subscribe('project:save-accelerator', callback),
   switchPerspective: (callback: IpcRendererCallbacks) =>
-    ipcRenderer.on('workspace:switch-perspective-accelerator', callback),
+    subscribe('workspace:switch-perspective-accelerator', callback),
 
   // ===================== POU METHODS =====================
   createPouFile: (props: CreatePouFileProps): Promise<PouServiceResponse> => ipcRenderer.invoke('pou:create', props),
@@ -124,13 +132,11 @@ const rendererProcessBridge = {
   }): Promise<PouServiceResponse> => ipcRenderer.invoke('pou:rename', data),
 
   // ===================== EDIT METHODS =====================
-  handleUndoRequest: (callback: IpcRendererCallbacks) => ipcRenderer.on('edit:undo-request', callback),
-  removeUndoRequestListener: () => ipcRenderer.removeAllListeners('edit:undo-request'),
-  handleRedoRequest: (callback: IpcRendererCallbacks) => ipcRenderer.on('edit:redo-request', callback),
-  removeRedoRequestListener: () => ipcRenderer.removeAllListeners('edit:redo-request'),
+  handleUndoRequest: (callback: IpcRendererCallbacks) => subscribe('edit:undo-request', callback),
+  handleRedoRequest: (callback: IpcRendererCallbacks) => subscribe('edit:redo-request', callback),
 
   // ===================== APP & SYSTEM METHODS =====================
-  darwinAppIsClosing: (callback: IpcRendererCallbacks) => ipcRenderer.on('app:darwin-is-closing', callback),
+  darwinAppIsClosing: (callback: IpcRendererCallbacks) => subscribe('app:darwin-is-closing', callback),
   getRecent: (): Promise<string[]> => ipcRenderer.invoke('app:store-get'),
   getStoreValue: (key: string) => ipcRenderer.invoke('app:store-get', key),
   getSystemInfo: (): Promise<{
@@ -190,8 +196,7 @@ const rendererProcessBridge = {
   handleQuitApp: () => ipcRenderer.send('app:quit'),
   openExternalLinkAccelerator: (link: string): Promise<{ success: boolean }> =>
     ipcRenderer.invoke('open-external-link', link),
-  quitAppRequest: (callback: IpcRendererCallbacks) => ipcRenderer.on('app:quit-accelerator', callback),
-  removeQuitAppListener: () => ipcRenderer.removeAllListeners('app:quit-accelerator'),
+  quitAppRequest: (callback: IpcRendererCallbacks) => subscribe('app:quit-accelerator', callback),
   retrieveRecent: (): Promise<{ name: string; path: string; lastOpenedAt: string; createdAt: string }[]> =>
     ipcRenderer.invoke('app:store-retrieve-recent'),
   /** Drop a recent-projects entry without touching disk — used by the
@@ -209,19 +214,17 @@ const rendererProcessBridge = {
   closeWindow: () => ipcRenderer.send('window-controls:closed'),
   handleCloseOrHideWindow: () => ipcRenderer.send('window-controls:close'),
   handleCloseOrHideWindowAccelerator: () =>
-    ipcRenderer.on('window-controls:request-close', () => ipcRenderer.send('window-controls:close')),
+    subscribe('window-controls:request-close', () => ipcRenderer.send('window-controls:close')),
   hideWindow: () => ipcRenderer.send('window-controls:hide'),
-  isMaximizedWindow: (callback: IpcRendererCallbacks) =>
-    ipcRenderer.on('window-controls:toggle-maximized', (_event) => callback(_event)),
+  isMaximizedWindow: (callback: IpcRendererCallbacks) => subscribe('window-controls:toggle-maximized', callback),
   maximizeWindow: () => ipcRenderer.send('window-controls:maximize'),
   minimizeWindow: () => ipcRenderer.send('window-controls:minimize'),
   rebuildMenu: () => ipcRenderer.send('window:rebuild-menu'),
   reloadWindow: () => ipcRenderer.send('window:reload'),
-  removeHandleCloseOrHideWindowAccelerator: () => ipcRenderer.removeAllListeners('window-controls:request-close'),
-  windowIsClosing: (callback: IpcRendererCallbacks) => ipcRenderer.on('window-controls:is-closing', callback),
+  windowIsClosing: (callback: IpcRendererCallbacks) => subscribe('window-controls:is-closing', callback),
 
   // ===================== THEME =====================
-  handleUpdateTheme: (callback: IpcRendererCallbacks) => ipcRenderer.on('system:update-theme', callback),
+  handleUpdateTheme: (callback: IpcRendererCallbacks) => subscribe('system:update-theme', callback),
   winHandleUpdateTheme: (theme?: 'light' | 'dark' | 'nineties') => ipcRenderer.send('system:update-theme', theme),
   winGetTheme: (): Promise<'light' | 'dark' | 'nineties' | null> => ipcRenderer.invoke('system:get-theme'),
 
@@ -307,15 +310,13 @@ const rendererProcessBridge = {
       success: boolean
       message: string
     }>,
-  exportProjectRequest: (callback: IpcRendererCallbacks) =>
-    ipcRenderer.on('compiler:export-project-request', (_event, value) => callback(_event, value)),
+  exportProjectRequest: (callback: IpcRendererCallbacks) => subscribe('compiler:export-project-request', callback),
   generateCFilesRequest: (pathToStProgram: string, callback: (args: CompilerPortMessage) => void) => {
     const { port1: rendererProcessPort, port2: mainProcessPort } = new MessageChannel()
     ipcRenderer.postMessage('compiler:generate-c-files', pathToStProgram, [mainProcessPort])
     rendererProcessPort.onmessage = (event) => callback(event.data as CompilerPortMessage)
     rendererProcessPort.addEventListener('close', () => {})
   },
-  removeExportProjectListener: () => ipcRenderer.removeAllListeners('compiler:export-project-request'),
   setupCompilerEnvironment: (callback: (args: CompilerPortMessage) => void) => {
     const { port1: rendererProcessPort, port2: mainProcessPort } = new MessageChannel()
     ipcRenderer.postMessage('compiler:setup-environment', '', [mainProcessPort])

--- a/src/middleware/adapters/editor/__tests__/accelerator-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/accelerator-adapter.test.ts
@@ -5,8 +5,20 @@ let adapter: AcceleratorPort
 
 /**
  * Each bridge method captures its callback so tests can invoke it manually.
+ * A captured handler going back to `null` stands in for the real bridge
+ * dropping the IPC listener — the adapter must return the bridge's disposer
+ * verbatim for that to happen.
  */
 const capturedHandlers: Record<string, ((...args: unknown[]) => void) | null> = {}
+
+/** Mirrors the bridge contract: register the listener, return its disposer. */
+const register = (key: string) =>
+  jest.fn().mockImplementation((cb: (...args: unknown[]) => void) => {
+    capturedHandlers[key] = cb
+    return () => {
+      capturedHandlers[key] = null
+    }
+  })
 
 beforeEach(() => {
   for (const key of Object.keys(capturedHandlers)) {
@@ -14,51 +26,21 @@ beforeEach(() => {
   }
 
   window.bridge = {
-    createProjectAccelerator: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.createProject = cb
-    }),
-    handleOpenProjectRequest: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.openProject = cb
-    }),
-    openRecentAccelerator: jest.fn().mockImplementation((cb: (...args: unknown[]) => void) => {
-      capturedHandlers.openRecent = cb
-    }),
-    saveProjectAccelerator: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.saveProject = cb
-    }),
-    saveFileAccelerator: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.saveFile = cb
-    }),
-    closeProjectAccelerator: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.closeProject = cb
-    }),
-    exportProjectRequest: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.exportProject = cb
-    }),
-    closeTabAccelerator: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.closeTab = cb
-    }),
-    deleteFileAccelerator: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.deleteFile = cb
-    }),
-    findInProjectAccelerator: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.findInProject = cb
-    }),
-    handleUndoRequest: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.undo = cb
-    }),
-    handleRedoRequest: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.redo = cb
-    }),
-    switchPerspective: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.switchPerspective = cb
-    }),
-    aboutModalAccelerator: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.about = cb
-    }),
-    quitAppRequest: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.quitApp = cb
-    }),
+    createProjectAccelerator: register('createProject'),
+    handleOpenProjectRequest: register('openProject'),
+    openRecentAccelerator: register('openRecent'),
+    saveProjectAccelerator: register('saveProject'),
+    saveFileAccelerator: register('saveFile'),
+    closeProjectAccelerator: register('closeProject'),
+    exportProjectRequest: register('exportProject'),
+    closeTabAccelerator: register('closeTab'),
+    deleteFileAccelerator: register('deleteFile'),
+    findInProjectAccelerator: register('findInProject'),
+    handleUndoRequest: register('undo'),
+    handleRedoRequest: register('redo'),
+    switchPerspective: register('switchPerspective'),
+    aboutModalAccelerator: register('about'),
+    quitAppRequest: register('quitApp'),
   } as unknown as typeof window.bridge
 
   adapter = createEditorAcceleratorAdapter()
@@ -82,9 +64,20 @@ function testAccelerator(methodName: keyof AcceleratorPort, handlerKey: string, 
       const unsub = (adapter[methodName] as (cb: () => void) => () => void)(cb)
 
       unsub()
-      capturedHandlers[handlerKey]!()
+      capturedHandlers[handlerKey]?.()
 
       expect(cb).not.toHaveBeenCalled()
+    })
+
+    it('removes the underlying bridge listener on unsubscribe', () => {
+      const unsub = (adapter[methodName] as (cb: () => void) => () => void)(jest.fn())
+
+      expect(capturedHandlers[handlerKey]).toBeInstanceOf(Function)
+      unsub()
+
+      // Not merely flagged inactive — the listener itself is gone, so repeated
+      // mount/unmount cycles cannot pile up dead IPC listeners.
+      expect(capturedHandlers[handlerKey]).toBeNull()
     })
   })
 }
@@ -123,8 +116,17 @@ describe('onOpenRecent', () => {
     const unsub = adapter.onOpenRecent(cb)
 
     unsub()
-    capturedHandlers.openRecent!({}, { projectPath: '/x' })
+    capturedHandlers.openRecent?.({}, { projectPath: '/x' })
 
     expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('removes the underlying bridge listener on unsubscribe', () => {
+    const unsub = adapter.onOpenRecent(jest.fn())
+
+    expect(capturedHandlers.openRecent).toBeInstanceOf(Function)
+    unsub()
+
+    expect(capturedHandlers.openRecent).toBeNull()
   })
 })

--- a/src/middleware/adapters/editor/__tests__/accelerator-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/accelerator-adapter.test.ts
@@ -11,6 +11,21 @@ let adapter: AcceleratorPort
  */
 const capturedHandlers: Record<string, ((...args: unknown[]) => void) | null> = {}
 
+/** Invokes a captured bridge listener, failing loudly if none was registered.
+ *  CLAUDE.md forbids non-null assertions, and a bare `?.()` would let a missing
+ *  registration pass the test silently. */
+const fire = (key: string, ...args: unknown[]): void => {
+  const handler = capturedHandlers[key]
+  if (!handler) throw new Error(`no listener captured for "${key}"`)
+  handler(...args)
+}
+
+/** Emits on a channel whose listener may already be gone — used after an
+ *  unsubscribe to show the callback stays silent. */
+const fireIfRegistered = (key: string, ...args: unknown[]): void => {
+  capturedHandlers[key]?.(...args)
+}
+
 /** Mirrors the bridge contract: register the listener, return its disposer. */
 const register = (key: string) =>
   jest.fn().mockImplementation((cb: (...args: unknown[]) => void) => {
@@ -55,7 +70,7 @@ function testAccelerator(methodName: keyof AcceleratorPort, handlerKey: string, 
 
       expect((window.bridge as unknown as Record<string, jest.Mock>)[bridgeMethodName]).toHaveBeenCalledTimes(1)
 
-      capturedHandlers[handlerKey]!()
+      fire(handlerKey)
       expect(cb).toHaveBeenCalledTimes(1)
     })
 
@@ -64,7 +79,7 @@ function testAccelerator(methodName: keyof AcceleratorPort, handlerKey: string, 
       const unsub = (adapter[methodName] as (cb: () => void) => () => void)(cb)
 
       unsub()
-      capturedHandlers[handlerKey]?.()
+      fireIfRegistered(handlerKey)
 
       expect(cb).not.toHaveBeenCalled()
     })
@@ -106,7 +121,7 @@ describe('onOpenRecent', () => {
 
     const mockEvent = {}
     const mockResponse = { projectPath: '/some/path' }
-    capturedHandlers.openRecent!(mockEvent, mockResponse)
+    fire('openRecent', mockEvent, mockResponse)
 
     expect(cb).toHaveBeenCalledWith(mockResponse)
   })
@@ -116,7 +131,7 @@ describe('onOpenRecent', () => {
     const unsub = adapter.onOpenRecent(cb)
 
     unsub()
-    capturedHandlers.openRecent?.({}, { projectPath: '/x' })
+    fireIfRegistered('openRecent', {}, { projectPath: '/x' })
 
     expect(cb).not.toHaveBeenCalled()
   })

--- a/src/middleware/adapters/editor/__tests__/window-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/window-adapter.test.ts
@@ -10,6 +10,29 @@ let adapter: WindowPort
  */
 const capturedHandlers: Record<string, ((...args: unknown[]) => void) | null> = {}
 
+/**
+ * Narrows an optional `WindowPort` member. CLAUDE.md forbids non-null
+ * assertions, and a bare `?.()` would let a missing implementation pass the
+ * test silently — this fails loudly instead.
+ */
+function implemented<T>(member: T | undefined, name: string): T {
+  if (!member) throw new Error(`WindowPort.${name} is not implemented by the editor adapter`)
+  return member
+}
+
+/** Invokes a captured bridge listener, failing loudly if none was registered. */
+const fire = (key: string, ...args: unknown[]): void => {
+  const handler = capturedHandlers[key]
+  if (!handler) throw new Error(`no listener captured for "${key}"`)
+  handler(...args)
+}
+
+/** Emits on a channel whose listener may already be gone — used after an
+ *  unsubscribe to show the callback stays silent. */
+const fireIfRegistered = (key: string, ...args: unknown[]): void => {
+  capturedHandlers[key]?.(...args)
+}
+
 /** Mirrors the bridge contract: register the listener, return its disposer. */
 const register = (key: string) =>
   jest.fn().mockImplementation((cb: (...args: unknown[]) => void) => {
@@ -103,7 +126,7 @@ describe('onCloseRequested', () => {
     adapter.onCloseRequested(cb)
 
     expect(window.bridge.windowIsClosing).toHaveBeenCalledTimes(1)
-    capturedHandlers.closeRequested!()
+    fire('closeRequested')
 
     expect(cb).toHaveBeenCalledTimes(1)
   })
@@ -113,7 +136,7 @@ describe('onCloseRequested', () => {
     const unsub = adapter.onCloseRequested(cb)
 
     unsub()
-    capturedHandlers.closeRequested?.()
+    fireIfRegistered('closeRequested')
 
     expect(cb).not.toHaveBeenCalled()
     expect(capturedHandlers.closeRequested).toBeNull()
@@ -123,20 +146,20 @@ describe('onCloseRequested', () => {
 describe('onDarwinAppQuitting', () => {
   it('registers a bridge listener and fires callback', () => {
     const cb = jest.fn()
-    adapter.onDarwinAppQuitting!(cb)
+    implemented(adapter.onDarwinAppQuitting, 'onDarwinAppQuitting')(cb)
 
     expect(window.bridge.darwinAppIsClosing).toHaveBeenCalledTimes(1)
-    capturedHandlers.darwinQuitting!()
+    fire('darwinQuitting')
 
     expect(cb).toHaveBeenCalledTimes(1)
   })
 
   it('returns an unsubscribe function that removes the bridge listener', () => {
     const cb = jest.fn()
-    const unsub = adapter.onDarwinAppQuitting!(cb)
+    const unsub = implemented(adapter.onDarwinAppQuitting, 'onDarwinAppQuitting')(cb)
 
     unsub()
-    capturedHandlers.darwinQuitting?.()
+    fireIfRegistered('darwinQuitting')
 
     expect(cb).not.toHaveBeenCalled()
     expect(capturedHandlers.darwinQuitting).toBeNull()
@@ -145,7 +168,7 @@ describe('onDarwinAppQuitting', () => {
 
 describe('enableAutoCloseHandshake', () => {
   it('registers handshake and returns unsubscribe that removes it', () => {
-    const unsub = adapter.enableAutoCloseHandshake!()
+    const unsub = implemented(adapter.enableAutoCloseHandshake, 'enableAutoCloseHandshake')()
 
     expect(window.bridge.handleCloseOrHideWindowAccelerator).toHaveBeenCalledTimes(1)
     expect(capturedHandlers.autoCloseHandshake).toBeInstanceOf(Function)
@@ -158,23 +181,23 @@ describe('enableAutoCloseHandshake', () => {
 describe('onMaximizedChanged', () => {
   it('registers a bridge listener and toggles maximized state', () => {
     const cb = jest.fn()
-    adapter.onMaximizedChanged!(cb)
+    implemented(adapter.onMaximizedChanged, 'onMaximizedChanged')(cb)
 
     expect(window.bridge.isMaximizedWindow).toHaveBeenCalledTimes(1)
 
-    capturedHandlers.maximized!()
+    fire('maximized')
     expect(cb).toHaveBeenCalledWith(true)
 
-    capturedHandlers.maximized!()
+    fire('maximized')
     expect(cb).toHaveBeenCalledWith(false)
   })
 
   it('returns an unsubscribe function that removes the bridge listener', () => {
     const cb = jest.fn()
-    const unsub = adapter.onMaximizedChanged!(cb)
+    const unsub = implemented(adapter.onMaximizedChanged, 'onMaximizedChanged')(cb)
 
     unsub()
-    capturedHandlers.maximized?.()
+    fireIfRegistered('maximized')
 
     expect(cb).not.toHaveBeenCalled()
     expect(capturedHandlers.maximized).toBeNull()

--- a/src/middleware/adapters/editor/__tests__/window-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/window-adapter.test.ts
@@ -2,7 +2,22 @@ import type { WindowPort } from '../../../shared/ports/window-port'
 import { createEditorWindowAdapter } from '../window-adapter'
 
 let adapter: WindowPort
+
+/**
+ * A captured handler going back to `null` stands in for the real bridge
+ * dropping the IPC listener — the adapter must return the bridge's disposer
+ * verbatim for that to happen.
+ */
 const capturedHandlers: Record<string, ((...args: unknown[]) => void) | null> = {}
+
+/** Mirrors the bridge contract: register the listener, return its disposer. */
+const register = (key: string) =>
+  jest.fn().mockImplementation((cb: (...args: unknown[]) => void) => {
+    capturedHandlers[key] = cb
+    return () => {
+      capturedHandlers[key] = null
+    }
+  })
 
 beforeEach(() => {
   for (const key of Object.keys(capturedHandlers)) {
@@ -17,17 +32,17 @@ beforeEach(() => {
     reloadWindow: jest.fn(),
     handleQuitApp: jest.fn(),
     rebuildMenu: jest.fn(),
-    windowIsClosing: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.closeRequested = cb
+    windowIsClosing: register('closeRequested'),
+    darwinAppIsClosing: register('darwinQuitting'),
+    // Takes no callback of its own — the main process echoes the close back —
+    // but still hands out a disposer for the listener it registered.
+    handleCloseOrHideWindowAccelerator: jest.fn().mockImplementation(() => {
+      capturedHandlers.autoCloseHandshake = () => {}
+      return () => {
+        capturedHandlers.autoCloseHandshake = null
+      }
     }),
-    darwinAppIsClosing: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.darwinQuitting = cb
-    }),
-    handleCloseOrHideWindowAccelerator: jest.fn(),
-    removeHandleCloseOrHideWindowAccelerator: jest.fn(),
-    isMaximizedWindow: jest.fn().mockImplementation((cb: () => void) => {
-      capturedHandlers.maximized = cb
-    }),
+    isMaximizedWindow: register('maximized'),
   } as unknown as typeof window.bridge
 
   adapter = createEditorWindowAdapter()
@@ -93,14 +108,15 @@ describe('onCloseRequested', () => {
     expect(cb).toHaveBeenCalledTimes(1)
   })
 
-  it('returns an unsubscribe function that deactivates the callback', () => {
+  it('returns an unsubscribe function that removes the bridge listener', () => {
     const cb = jest.fn()
     const unsub = adapter.onCloseRequested(cb)
 
     unsub()
-    capturedHandlers.closeRequested!()
+    capturedHandlers.closeRequested?.()
 
     expect(cb).not.toHaveBeenCalled()
+    expect(capturedHandlers.closeRequested).toBeNull()
   })
 })
 
@@ -115,14 +131,15 @@ describe('onDarwinAppQuitting', () => {
     expect(cb).toHaveBeenCalledTimes(1)
   })
 
-  it('returns an unsubscribe function that deactivates the callback', () => {
+  it('returns an unsubscribe function that removes the bridge listener', () => {
     const cb = jest.fn()
     const unsub = adapter.onDarwinAppQuitting!(cb)
 
     unsub()
-    capturedHandlers.darwinQuitting!()
+    capturedHandlers.darwinQuitting?.()
 
     expect(cb).not.toHaveBeenCalled()
+    expect(capturedHandlers.darwinQuitting).toBeNull()
   })
 })
 
@@ -131,9 +148,10 @@ describe('enableAutoCloseHandshake', () => {
     const unsub = adapter.enableAutoCloseHandshake!()
 
     expect(window.bridge.handleCloseOrHideWindowAccelerator).toHaveBeenCalledTimes(1)
+    expect(capturedHandlers.autoCloseHandshake).toBeInstanceOf(Function)
 
     unsub()
-    expect(window.bridge.removeHandleCloseOrHideWindowAccelerator).toHaveBeenCalledTimes(1)
+    expect(capturedHandlers.autoCloseHandshake).toBeNull()
   })
 })
 
@@ -151,12 +169,14 @@ describe('onMaximizedChanged', () => {
     expect(cb).toHaveBeenCalledWith(false)
   })
 
-  it('returns an unsubscribe function (no-op)', () => {
+  it('returns an unsubscribe function that removes the bridge listener', () => {
     const cb = jest.fn()
     const unsub = adapter.onMaximizedChanged!(cb)
 
-    expect(typeof unsub).toBe('function')
-    // The unsubscribe is a no-op for this channel, but should not throw
     unsub()
+    capturedHandlers.maximized?.()
+
+    expect(cb).not.toHaveBeenCalled()
+    expect(capturedHandlers.maximized).toBeNull()
   })
 })

--- a/src/middleware/adapters/editor/accelerator-adapter.ts
+++ b/src/middleware/adapters/editor/accelerator-adapter.ts
@@ -3,11 +3,14 @@
  *
  * Each accelerator fires an IPC event from the main process menu when the user
  * presses a keyboard shortcut. This adapter wraps `window.bridge.*` listener
- * registrations and returns an Unsubscribe function that deactivates the callback.
+ * registrations and returns the bridge's own Unsubscribe.
  *
- * Note: Electron's `ipcRenderer.on` only supports `removeAllListeners(channel)`,
- * not per-listener removal. We use an active flag so that unsubscribing prevents
- * the callback from firing without removing all listeners on the channel.
+ * Note: every `window.bridge.*Accelerator` registration returns a real
+ * per-listener disposer (`ipcRenderer.removeListener` with the exact wrapped
+ * function — see the `subscribe` helper in `src/main/modules/ipc/renderer.ts`).
+ * Returning it verbatim is what keeps the IPC listener count flat: the
+ * subscribing effects in `accelerator-handler.tsx` re-run on every dependency
+ * change, so a no-op unsubscribe would leak one listener per re-run.
  *
  * IPC channels:
  *   project:create-accelerator
@@ -32,153 +35,63 @@ import type { Unsubscribe } from '../../shared/ports/types'
 export function createEditorAcceleratorAdapter(): AcceleratorPort {
   return {
     onCreateProject(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.createProjectAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.createProjectAccelerator(() => callback())
     },
 
     onOpenProject(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.handleOpenProjectRequest(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.handleOpenProjectRequest(() => callback())
     },
 
     onOpenRecent(callback: (projectData?: unknown) => void): Unsubscribe {
-      let active = true
-      window.bridge.openRecentAccelerator((_event: unknown, response: unknown) => {
-        if (active) callback(response)
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.openRecentAccelerator((_event: unknown, response: unknown) => callback(response))
     },
 
     onSaveProject(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.saveProjectAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.saveProjectAccelerator(() => callback())
     },
 
     onSaveFile(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.saveFileAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.saveFileAccelerator(() => callback())
     },
 
     onCloseProject(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.closeProjectAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.closeProjectAccelerator(() => callback())
     },
 
     onExportProject(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.exportProjectRequest(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.exportProjectRequest(() => callback())
     },
 
     onCloseTab(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.closeTabAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.closeTabAccelerator(() => callback())
     },
 
     onDeleteFile(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.deleteFileAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.deleteFileAccelerator(() => callback())
     },
 
     onFindInProject(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.findInProjectAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.findInProjectAccelerator(() => callback())
     },
 
     onUndo(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.handleUndoRequest(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.handleUndoRequest(() => callback())
     },
 
     onRedo(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.handleRedoRequest(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.handleRedoRequest(() => callback())
     },
 
     onSwitchPerspective(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.switchPerspective(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.switchPerspective(() => callback())
     },
 
     onAbout(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.aboutModalAccelerator(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.aboutModalAccelerator(() => callback())
     },
 
     onQuitApp(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.quitAppRequest(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.quitAppRequest(() => callback())
     },
   }
 }

--- a/src/middleware/adapters/editor/window-adapter.ts
+++ b/src/middleware/adapters/editor/window-adapter.ts
@@ -53,45 +53,24 @@ export function createEditorWindowAdapter(): WindowPort {
     },
 
     onCloseRequested(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.windowIsClosing(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.windowIsClosing(() => callback())
     },
 
     onDarwinAppQuitting(callback: () => void): Unsubscribe {
-      let active = true
-      window.bridge.darwinAppIsClosing(() => {
-        if (active) callback()
-      })
-      return () => {
-        active = false
-      }
+      return window.bridge.darwinAppIsClosing(() => callback())
     },
 
     enableAutoCloseHandshake(): Unsubscribe {
-      window.bridge.handleCloseOrHideWindowAccelerator()
-      return () => {
-        window.bridge.removeHandleCloseOrHideWindowAccelerator()
-      }
+      return window.bridge.handleCloseOrHideWindowAccelerator()
     },
 
     onMaximizedChanged(callback: (isMaximized: boolean) => void): Unsubscribe {
       let maximized = false
 
-      const handler = () => {
+      return window.bridge.isMaximizedWindow(() => {
         maximized = !maximized
         callback(maximized)
-      }
-
-      window.bridge.isMaximizedWindow(handler)
-
-      return () => {
-        // Electron IPC does not expose per-listener unsubscribe for this channel.
-      }
+      })
     },
   }
 }


### PR DESCRIPTION
DOPE-507 — https://autonomylogic.atlassian.net/browse/DOPE-507

Mirror PR: **Autonomy-Logic/openplc-web#703** (shared frontend surface, byte-identical).

Bug fix: no Requirements Gathering document; the Jira issue carries the full diagnosis.
No cybersecurity risk assessment — the change opens no IPC channel and adds no capability;
it removes 13 methods from the exposed bridge surface.

## Why

Two dev-console warnings, both observed during DOPE-492 validation (that is where the xyflow
one came from — the demand this PR closes is DOPE-507). Neither is user-visible in
production, but both bury real diagnostics in noise.

1. `MaxListenersExceededWarning: 11 compiler:export-project-request listeners` — an actual
   IPC listener leak, pre-existing.
2. `Please use getNodesBounds from useReactFlow…` × N — introduced by the xyflow 12.11.2
   upgrade.

## What — the listener leak (editor-only)

Every accelerator subscription in `accelerator-adapter.ts` registered a live `ipcRenderer.on`
listener but handed back an unsubscribe that only flipped a local `active = false` flag. The
IPC listener itself never came off. The subscribing effects in `accelerator-handler.tsx`
re-run on dependency changes (tab switch, `editingState`, HMR), so each re-run left one
permanent dead listener behind — Node warns past ten. Dead callbacks were active-guarded, so
no double-fires: a slow leak plus warning noise, loudest in long dev sessions.

The workaround existed because `renderer.ts` only exposed `removeAllListeners(channel)` for
these channels, which would drop sibling subscribers. So the fix is at the bridge:

- **`renderer.ts`** — new `subscribe(channel, callback)` helper that keeps the wrapped
  function and returns `ipcRenderer.removeListener` bound to it. This is the pattern the same
  file already used for `libraries:changed`, `packages:*`, `device:*`, `simulator:stopped` and
  `file:external-change`; the accelerator channels were simply the ones that never got it. All
  21 `on`-style bridge methods now route through it.
- **Dropped the 13 dead `remove*Listener` methods** built on `removeAllListeners`. Twelve had
  no callers at all; the thirteenth (`removeHandleCloseOrHideWindowAccelerator`) is replaced
  by the real disposer.
- **`accelerator-adapter.ts`** — all 15 methods return the bridge's unsubscribe; the `active`
  flag is gone. The header doc claimed the opposite of what is now true ("Electron's
  `ipcRenderer.on` only supports `removeAllListeners`, not per-listener removal") — that false
  premise is what produced the workaround, so it is rewritten.
- **`window-adapter.ts`** — same conversion for `onCloseRequested`, `onDarwinAppQuitting`,
  `onMaximizedChanged` and `enableAutoCloseHandshake`, which carried an identical workaround.

`AcceleratorPort` / `WindowPort` are unchanged (`(cb) => Unsubscribe`), so the web adapters
are untouched.

### Behaviour note: the argument contract widened

`createProjectAccelerator`, `handleOpenProjectRequest` and `isMaximizedWindow` previously
truncated arguments (`(_event) => callback(_event)`); routing them through `subscribe` means
they now forward `(event, ...args)` like the other eighteen. Harmless today — every adapter
callback ignores the arguments — but it is a real behaviour change in a helper serving 21
methods, so it is called out rather than left implicit.

## What — the rung bounds warning (shared surface)

xyflow ≥12 warns in dev whenever the standalone `getNodesBounds(nodes)` is called without a
`nodeLookup`, and `updateReactFlowPanelExtent` in `ladder/rung/body.tsx` did exactly that on
every rung node change. The computed values were correct for us — no subflows, no `parentId`
— so this is pure console noise, absent from prod builds.

The docs-recommended `useReactFlow().getNodesBounds` is **not** usable here:
`updateReactFlowPanelExtent(rung)` runs in the same effect that feeds ReactFlow via
`setRungLocal`, so the adopted store lags the rung state by a frame, and the synthetic `-1`
node isn't in the lookup at all. It would trade a warning for stale numbers.

So: new `getRungNodesBounds` in `ladder-utils/nodes.ts`, computing the box directly from
`position` plus xyflow's own fallback chain (`measured → width → initialWidth → 0`, matching
`nodeToRect`). This is also what the rest of the ladder already does (see `changeRailBounds`).
The 150×40 origin placeholder is carried over from the synthetic node; it is dominated by
`rung.defaultBounds` (`[300, 100]` in production) on every real path.

Bounds are measured **from the origin** rather than as `maxX - minX`, which is equivalent
here because `body.tsx` pins the `CoordinateExtent` to `[[0, 0], […]]` and so structurally
prevents negative positions. Same numbers for every reachable input, not by coincidence.

## Review follow-up (second round)

- **Bridge-level tests added.** The adapter tests run against a mocked bridge whose own mock
  defines the disposer contract, so the layer the leak actually lived in had no net under it —
  a `subscribe` closing over the wrong function would have kept the suite green. The new
  `bridge-subscriptions.test.ts` drives the real `renderer.ts` against a real `EventEmitter`:
  `removeListener` is called with the exact function `on` received, 15 mount/unmount cycles
  leave zero listeners, and a sibling subscriber survives an unsubscribe. Verified against two
  mutants — reverting to `removeAllListeners` (2 of 4 fail) and a no-op disposer, i.e. the
  original bug (3 of 4 fail).
- **Dropped the IPC payload cast** in `openRecentAccelerator`, per the CLAUDE.md rule on
  assertions at IPC boundaries. It cast `unknown` to `IProjectServiceResponse` only to pass it
  to a parameter typed `unknown`; since `subscribe` already forwards `(event, ...args)`, the
  wrapper was redundant and the method now reads like the other twenty.
- **Completed the `nodeToRect` fallback chain** (`initialWidth`/`initialHeight`). Unreachable
  today — every ladder builder sets explicit dimensions — so no number moves; it makes the
  comment's claim true, and the comment now names the unreachable step. Two regression tests.
- **Removed the non-null assertions** from both adapter test suites (CLAUDE.md forbids `!`):
  optional port members narrow through a helper that fails loudly, and captured listeners fire
  through one that distinguishes "never registered" from "already unsubscribed".

## Verification

- 386 tests green across `middleware/adapters/editor` + the new bridge suite; 7
  `getRungNodesBounds` tests green under **jest** (editor) and **vitest** (web).
- `tsc --noEmit` clean in both repos. Prettier clean. ESLint: no errors — the three
  `exhaustive-deps` warnings in `body.tsx` are pre-existing (verified against `HEAD`; they
  only shifted line numbers).
- Mirror gate: `match: true`, 1053 files, 0 diffs.

**Manual validation is still outstanding** and is the acceptance criterion — it needs a
running app, so it is not something CI or the unit suite can stand in for:

- open/close a project and switch tabs ~15 times → no `MaxListenersExceededWarning`
- grow and shrink a rung → no `Please use getNodesBounds from useReactFlow`, and the panel
  extent still tracks as before

## Mirror

`ladder/rung/body.tsx` and `ladder-utils/nodes.ts` are byte-identical to
Autonomy-Logic/openplc-web#703 on the same branch name
`chore/dev-console-warning-cleanup`. Everything else (`src/main/modules/ipc`,
`middleware/adapters/editor`) is editor-only and mirror-exempt.

## Process note (not for this PR)

Neither pipeline runs unit tests, so the green results above are a local claim CI never
re-checks. Worth raising separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ladder editor panel sizing for empty, measured, and dimensionless nodes.
  * Ensured window and accelerator event listeners are fully removed when unsubscribed.
  * Preserved event payloads for recent-project shortcuts.

* **Refactor**
  * Updated event subscriptions to return dedicated unsubscribe controls.
  * Simplified editor window and accelerator event handling.

* **Tests**
  * Added coverage for ladder node bounds and event listener cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->