### PR TITLE
bugfix(DOPE-587): ask for a unique id only where one can be licensed

### DIFF
--- a/resources/sources/Baremetal/modbus_debug.cpp
+++ b/resources/sources/Baremetal/modbus_debug.cpp
@@ -17,9 +17,23 @@ Copyright (C) 2022 OpenPLC - Thiago Alves
 #include "openplc_version.h"
 
 // ArduinoUniqueID (ricaun) backs the DEBUG_GET_BOARD_ID (0x48) function code.
-// It supports AVR/megaAVR/SAM/SAMD/STM32/ESP/RP2040/Teensy. On a core without
-// support (or when a board intentionally opts out via OPENPLC_NO_UNIQUE_ID),
-// the board-id handler returns id_len = 0 instead of failing to compile.
+// It supports AVR/megaAVR/SAM/SAMD/STM32/ESP/RP2040/Teensy, and its header
+// `#error`s out on anything else rather than degrading — so a core it does not
+// cover has to be kept out of the translation unit, not handled at runtime.
+//
+// A UNIQUE ID IS ONLY EVER NEEDED TO BIND A PURCHASE TO A BOARD, so the build
+// asks for it only on a target whose board package declares `isLicensable`.
+// Every other target — which today is every target — gets
+// OPENPLC_NO_UNIQUE_ID from defines.h and never includes the library, so a core
+// the library rejects is a non-problem unless someone ships a paid VPP for it.
+// Note the polarity: the flag is the DEFAULT, not the exception. See
+// `generateDefinesContent` for the emitter.
+//
+// Without the library, the board-id handler answers id_len = 0. That is a
+// well-formed SUCCESS reply, and both consumers already read it as one:
+// `device-probe` treats the successful reply (not the id bytes) as proof of
+// firmware, and `resolveLicensingTarget` never asks a non-licensable board for
+// an id in the first place.
 #ifndef OPENPLC_NO_UNIQUE_ID
     #include <ArduinoUniqueID.h>
     #define OPENPLC_HAS_UNIQUE_ID

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -196,9 +196,13 @@ class CompilerModule {
     'ArduinoJson',
     'Arduino_MachineControl',
     'ArduinoMqttClient',
-    // Backs the always-on debugger's DEBUG_GET_BOARD_ID (FC 0x48). ModbusSlave.cpp
-    // includes <ArduinoUniqueID.h> unconditionally (not behind a USE_*_BLOCK gate),
-    // so the lib must be installed for every Arduino build.
+    // Backs DEBUG_GET_BOARD_ID (FC 0x48) in modbus_debug.cpp, which includes
+    // <ArduinoUniqueID.h> unless defines.h carries OPENPLC_NO_UNIQUE_ID — i.e.
+    // only on a board whose package declares `isLicensable`, since a unique id
+    // exists solely to bind a paid VPP licence to hardware. Kept in the global
+    // list rather than moved behind that gate: installing a library nothing
+    // includes costs a one-time download and changes no build, whereas a
+    // conditional install is one more way for a licensable board to fail late.
     'ArduinoUniqueID',
     'AVR_PWM',
     'CAN',

--- a/src/backend/shared/compile/__tests__/generate-defines.test.ts
+++ b/src/backend/shared/compile/__tests__/generate-defines.test.ts
@@ -33,37 +33,78 @@ const EMPTY_INPUTS = {
 }
 
 describe('generateDefinesContent — board defines section', () => {
+  // `isLicensable: true` throughout this block: it is the only input that
+  // empties the board-defines list, and these cases are about the
+  // `boardEntry.define` half.  The licensing half has its own block below.
+  const LICENSABLE = { ...EMPTY_INPUTS, isLicensable: true }
+
   it('omits the Board defines header when no boardEntry is provided', () => {
-    const out = generateDefinesContent(EMPTY_INPUTS)
+    const out = generateDefinesContent(LICENSABLE)
     expect(out).not.toContain('// Board defines')
   })
 
   it('omits the Board defines header when boardEntry has no define field', () => {
-    const out = generateDefinesContent({ ...EMPTY_INPUTS, boardEntry: {} })
+    const out = generateDefinesContent({ ...LICENSABLE, boardEntry: {} })
     expect(out).not.toContain('// Board defines')
   })
 
   it('emits a single define from a string boardEntry.define', () => {
-    const out = generateDefinesContent({ ...EMPTY_INPUTS, boardEntry: { define: 'BOARD_X' } })
+    const out = generateDefinesContent({ ...LICENSABLE, boardEntry: { define: 'BOARD_X' } })
     expect(out).toContain('// Board defines\n#define BOARD_X\n')
   })
 
   it('emits multiple defines from an array boardEntry.define', () => {
     const out = generateDefinesContent({
-      ...EMPTY_INPUTS,
+      ...LICENSABLE,
       boardEntry: { define: ['BOARD_X', 'PIN_COUNT=8', 'HAS_ANALOG'] },
     })
     expect(out).toContain('// Board defines\n#define BOARD_X\n#define PIN_COUNT=8\n#define HAS_ANALOG\n')
   })
 
   it('omits the Board defines header when boardEntry.define is an empty array', () => {
-    // Empty array is falsy-ish for the loop but the header is gated on
-    // boardEntry.define being truthy; an empty array IS truthy, so a
-    // header with no entries would be a bug.  Editor's behavior:
-    // empty-array case emits the header but no defines.  Snapshot the
-    // editor's behavior here.
-    const out = generateDefinesContent({ ...EMPTY_INPUTS, boardEntry: { define: [] } })
-    expect(out.startsWith('// Board defines\n\n\n')).toBe(true)
+    // An empty array used to emit a bare header with no defines under it
+    // (the emitter gated the header on `define` being truthy, and `[]` is).
+    // Collecting the defines into a list first means the header follows the
+    // list, so this corner now emits nothing — reachable only on a
+    // licensable board, of which there are none yet.
+    const out = generateDefinesContent({ ...LICENSABLE, boardEntry: { define: [] } })
+    expect(out).not.toContain('// Board defines')
+    expect(out.startsWith('\n\n')).toBe(true)
+  })
+})
+
+describe('generateDefinesContent — OPENPLC_NO_UNIQUE_ID', () => {
+  // The flag keeps `ArduinoUniqueID` out of the build on any board that
+  // cannot be licensed, which is what makes the library's `#error` on an
+  // uncovered core (mbed — Opta, Portenta Machine Control, Edge Control) a
+  // non-problem.  Its polarity is inverted on purpose, so the DEFAULT is
+  // tested as hard as the exception.
+  it('emits the flag when isLicensable is absent (a package that says nothing is free)', () => {
+    const out = generateDefinesContent(EMPTY_INPUTS)
+    expect(out).toContain('// Board defines\n#define OPENPLC_NO_UNIQUE_ID\n')
+  })
+
+  it('emits the flag when isLicensable is explicitly false', () => {
+    const out = generateDefinesContent({ ...EMPTY_INPUTS, isLicensable: false })
+    expect(out).toContain('#define OPENPLC_NO_UNIQUE_ID')
+  })
+
+  it('omits the flag only when isLicensable is true', () => {
+    const out = generateDefinesContent({ ...EMPTY_INPUTS, isLicensable: true })
+    expect(out).not.toContain('OPENPLC_NO_UNIQUE_ID')
+  })
+
+  it('emits the flag for the simulator, which is not licensable', () => {
+    // The avr8js simulator has real AVR silicon behind it, so
+    // ArduinoUniqueID would work there — but a simulated board cannot hold
+    // a licence, so FC 0x48 reports no id like any other free target.
+    const out = generateDefinesContent({ ...EMPTY_INPUTS, boardRuntime: 'simulator' })
+    expect(out).toContain('#define OPENPLC_NO_UNIQUE_ID')
+  })
+
+  it('appends the flag after the board`s own defines rather than replacing them', () => {
+    const out = generateDefinesContent({ ...EMPTY_INPUTS, boardEntry: { define: ['BOARD_X', 'PIN_COUNT=8'] } })
+    expect(out).toContain('// Board defines\n#define BOARD_X\n#define PIN_COUNT=8\n#define OPENPLC_NO_UNIQUE_ID\n')
   })
 })
 
@@ -452,6 +493,7 @@ describe('generateDefinesContent — full output snapshot', () => {
       [
         '// Board defines',
         '#define __AVR_ATmega2560__',
+        '#define OPENPLC_NO_UNIQUE_ID',
         '',
         '',
         '//Program MD5',
@@ -496,6 +538,7 @@ describe('generateDefinesContent — full output snapshot', () => {
       [
         '// Board defines',
         '#define PIN_LED=13',
+        '#define OPENPLC_NO_UNIQUE_ID',
         '',
         '',
         '//Program MD5',

--- a/src/backend/shared/compile/pipeline.ts
+++ b/src/backend/shared/compile/pipeline.ts
@@ -795,6 +795,10 @@ async function runCompilePipelineInner(
     stProgramFileContent: programSt,
     buildMD5Hash: md5,
     boardRuntime,
+    // Inverted polarity on purpose: this makes the build ask for
+    // `ArduinoUniqueID` only on a board whose package declares
+    // `isLicensable`, and emit `OPENPLC_NO_UNIQUE_ID` for everyone else.
+    isLicensable: targetCapabilities.isLicensable,
     ...(vppModbusState !== undefined ? { vppModbusState } : {}),
   })
 

--- a/src/backend/shared/compile/steps/generate-defines.ts
+++ b/src/backend/shared/compile/steps/generate-defines.ts
@@ -83,13 +83,31 @@ export interface GenerateDefinesInput {
    *  `defaultSerial`; `BoardInfo.defaultSerial`). Drives `DEBUG_IFACE` and the
    *  RTU "shares the debug serial" flag. Absent → `Serial`. */
   defaultSerial?: string
+  /** Whether this target's board package declares `isLicensable`
+   *  (`TargetCapabilities.isLicensable`).  Governs one define, and the
+   *  polarity is deliberately inverted: a licensable board gets nothing,
+   *  and EVERY OTHER board gets `OPENPLC_NO_UNIQUE_ID`.
+   *
+   *  A hardware unique id exists for exactly one purpose — binding a paid
+   *  VPP licence to a board — so a free target has no use for one, and
+   *  `ArduinoUniqueID` (which `#error`s on any core it doesn't cover, mbed
+   *  included) should never enter the build for one.  Absent is read as
+   *  `false`: a package that says nothing about licensing is a free
+   *  package, and the safe default is the one that compiles everywhere.
+   *
+   *  `modbus_debug.cpp` reads the flag; with it set, `FC 0x48` answers
+   *  `id_len = 0`, which `device-probe` and the licence flow already treat
+   *  as "this board has no unique id". */
+  isLicensable?: boolean
 }
 
 /**
  * Build the contents of `defines.h`.
  *
  * Output sections, in order:
- *   1. `// Board defines` — only when `boardEntry.define` is present.
+ *   1. `// Board defines` — `boardEntry.define` plus
+ *      `OPENPLC_NO_UNIQUE_ID` on every non-licensable target; omitted
+ *      entirely only when both sources are empty.
  *   2. `#define PROGRAM_MD5 "<md5>"` — always.
  *   3. `// Comms Configuration` (simulator-only) — fixed Modbus RTU
  *      over emulated USART0 so avr8js's serial bridge can drive
@@ -112,22 +130,37 @@ export function generateDefinesContent(input: GenerateDefinesInput): string {
     boardRuntime,
     vppModbusState,
     defaultSerial,
+    isLicensable,
   } = input
 
   let DEFINES_CONTENT = ''
 
-  // 1. Board defines from hals.json.  Single-string and array forms
-  //    both supported; absent `define` field means no Board defines
-  //    section header at all (the next section starts directly).
+  // 1. Board defines.  Two sources, both landing under the one
+  //    `// Board defines` header:
+  //      - `hals.json`'s per-board `define` field (single-string and
+  //        array forms both supported, emitted verbatim);
+  //      - `OPENPLC_NO_UNIQUE_ID`, emitted for every target that is NOT
+  //        licensable — see the `isLicensable` field doc for why the
+  //        default is the flag rather than its absence.
+  //    An empty list means no header at all (the next section starts
+  //    directly), which is the pre-licensing behaviour for a board with
+  //    no `define` field.
+  const boardDefines: string[] = []
   if (boardEntry && boardEntry.define) {
-    DEFINES_CONTENT = '// Board defines\n'
     if (Array.isArray(boardEntry.define)) {
-      boardEntry.define.forEach((define) => {
-        DEFINES_CONTENT += `#define ${define}\n`
-      })
+      boardDefines.push(...boardEntry.define)
     } else if (typeof boardEntry.define === 'string') {
-      DEFINES_CONTENT += `#define ${boardEntry.define}\n`
+      boardDefines.push(boardEntry.define)
     }
+  }
+  if (isLicensable !== true) {
+    boardDefines.push('OPENPLC_NO_UNIQUE_ID')
+  }
+  if (boardDefines.length > 0) {
+    DEFINES_CONTENT = '// Board defines\n'
+    boardDefines.forEach((define) => {
+      DEFINES_CONTENT += `#define ${define}\n`
+    })
   }
 
   // 2. Trailing blank-line pair after the board-defines section

--- a/src/backend/shared/simulator/__tests__/debug-e2e.test.ts
+++ b/src/backend/shared/simulator/__tests__/debug-e2e.test.ts
@@ -54,9 +54,15 @@ describeIfHex('Phase 4 debugger end-to-end (avr8js + ModbusRtuClient)', () => {
     sim?.stop()
   })
 
-  it('FC 0x45 DEBUG_GET_MD5 returns a 32-char MD5', async () => {
-    const md5 = await client.getMd5Hash()
-    expect(md5).toMatch(/^[0-9a-f]{32}$/)
+  it('FC 0x45 DEBUG_GET_MD5 returns a 32-char MD5 and the target endianness', async () => {
+    // `getMd5Hash` returns an `Md5ProbeResult`, not a bare string — the probe
+    // reads the endianness marker off the same frame. Asserting `toMatch` on
+    // the whole object silently passed for as long as it returned a string and
+    // has failed ever since; nothing caught it because this suite only runs
+    // with CHRIS_DEMO_HEX set, which CI never does.
+    const probe = await client.getMd5Hash()
+    expect(probe.md5).toMatch(/^[0-9a-f]{32}$/)
+    expect(probe.targetEndian).toBe('le')
   }, 30000)
 
   it('FC 0x42 DEBUG_SET force blink=TRUE → FC 0x44 read returns 1', async () => {
@@ -107,12 +113,21 @@ describeIfHex('Phase 4 debugger end-to-end (avr8js + ModbusRtuClient)', () => {
     expect(result.version).toMatch(/^\d+\.\d+\.\d+/)
   }, 30000)
 
-  it('FC 0x48 DEBUG_GET_BOARD_ID returns the AVR unique id (9 bytes on ATmega2560)', async () => {
+  it('FC 0x48 DEBUG_GET_BOARD_ID answers a well-formed reply with no id', async () => {
     const result = await client.getBoardId()
+    // ArduinoUniqueID would work on AVR — it reports 9 bytes on an
+    // ATmega2560 — but the simulator is not licensable, so the build defines
+    // OPENPLC_NO_UNIQUE_ID and the library never enters the firmware. A
+    // unique id exists only to bind a paid VPP licence to a board, and a
+    // simulated board cannot hold one.
+    //
+    // What matters is that the FRAME is still valid: SUCCESS status, id_len
+    // 0, no trailing bytes. `device-probe` reads the successful reply (not
+    // the id bytes) as proof of firmware, so an empty id must not look like
+    // a protocol error.
     expect(result.success).toBe(true)
-    // ArduinoUniqueID reports 9 bytes on AVR (10 on ATmega328PB). The
-    // emulated ATmega2560 yields a non-empty id; assert it round-trips.
-    expect(result.boardId!.length).toBeGreaterThan(0)
-    expect(result.boardIdHex).toMatch(/^[0-9a-f]+$/)
+    expect(result.error).toBeUndefined()
+    expect(result.boardId).toHaveLength(0)
+    expect(result.boardIdHex).toBe('')
   }, 30000)
 })


### PR DESCRIPTION
## The problem

`ArduinoUniqueID` backs `DEBUG_GET_BOARD_ID` (FC `0x48`), and its header `#error`s out on any core it does not cover rather than degrading. **mbed is such a core, and not a niche one:** Arduino Opta, Portenta Machine Control H7 and Edge Control all reach their STM32H7 through `arduino:mbed_*` rather than the STM32 core, so the library's STM32 branch never applies.

Every project for those three boards failed to compile — native blocks or not, ST or otherwise.

`OPENPLC_NO_UNIQUE_ID` already existed in `modbus_debug.cpp` as the escape hatch. Nothing in the build ever defined it, which left it unreachable.

## The fix

Define it — and invert its polarity while doing so.

A hardware unique id exists for exactly one purpose: **binding a paid VPP licence to a board.** `Baremetal.ino` is explicit that the closed licence core does *not* take the anchor from the open firmware (it reads the silicon itself, precisely so that "licensing hardware you do not own" cannot cost one edit to that file). FC `0x48` only *reports* the id so a purchase can be bound to a board.

So the build now asks for the library only on a target whose package declares `isLicensable`, and emits `OPENPLC_NO_UNIQUE_ID` for everyone else. A package that says nothing about licensing is a free package, so **absent reads as `false`** — the default is the one that compiles everywhere. Today that is every target, so no board compiles the library in at all.

## No new stub was needed

Worth stating, because it was the first thing I checked. Without the library the handler already answers a well-formed `SUCCESS` frame with `id_len = 0`, and both consumers already read that correctly:

- **`device-probe`** treats the *successful reply* — not the id bytes — as proof of firmware. Its comment notes that requiring bytes "reported those boards as having no firmware at all".
- **`resolveLicensingTarget`** short-circuits with `not-licensable` before ever asking a non-licensable board for an id.
- **`deriveIdentity`** treats a zero-length id as fatal, but only inside the licensing flow, and correctly so: `sha256(prefix ‖ ∅)` is a constant, which would licence a whole fleet from one purchase.

Only the build was misaligned.

## Deliberate non-changes

- **`ArduinoUniqueID` stays in `GLOBAL_LIBRARIES`.** Installing a library nothing includes costs a one-time download and changes no build, whereas a conditional install is one more way for a licensable board to fail late.
- **No mbed architecture guard.** An earlier revision of this branch carried `!defined(ARDUINO_ARCH_MBED)`. That fixes the wrong thing — it states a fact about the library rather than a choice a board makes. If a paid mbed VPP ever ships, that platform needs a replacement for `ArduinoUniqueID`; it is not a problem to solve here.

## Verification

All through `openplc-cli` and the real web app, not hand-driven `gcc`.

| Target | Result |
|---|---|
| Arduino Opta (mbed) | compiles, 174696 bytes |
| Portenta Machine Control H7 (mbed) | compiles |
| Arduino Edge Control (mbed) | compiles, 106024 bytes |
| Arduino Mega (AVR control) | compiles, 11516 bytes, no regression |
| OpenPLC Simulator | compiles, 15916 bytes |

All five emit `#define OPENPLC_NO_UNIQUE_ID`; no `ArduinoUniqueID.cpp.o` appears in any link line.

**FC `0x48` verified on real emulated firmware.** Booted the freshly built simulator hex on avr8js and drove it through the actual `ModbusRtuClient` stack: `SUCCESS` / `id_len 0` / no trailing bytes. The empty reply is validated against firmware, not just asserted in a test.

**Negative control.** Forced `isLicensable: true` on the Mega: the flag disappeared, `ArduinoUniqueID 1.3.0` linked in from `~/Documents/Arduino/libraries`, and the sketch compiled at 11630 bytes. The paid path still works, and the library *does* install correctly through `GLOBAL_LIBRARIES` — the original Opta failure was the header's `#error`, never a missing library. Probe reverted before committing.

**Web simulator path, in-browser** (`npm run dev:local`, Irrigation Controller project): compile → simulate → debug all work. Captured the outbound request to confirm `src/defines.h` carries `#define OPENPLC_NO_UNIQUE_ID` in the 82-file bundle. Debugger connected with 316 variables across 28 debug trees and 3 FB instances; watched the `State` enum advance `Stopped → Running` live in the FBD, then a second build/run cycle boot clean.

## Also fixed

A stale assertion in the same suite: `getMd5Hash` returns an `Md5ProbeResult`, and the test still ran `toMatch` against the whole object. It has failed for as long as that return type has been an object — nothing caught it because the suite only runs with `CHRIS_DEMO_HEX` set, which CI never does.

## One behaviour change worth flagging

A board with `define: []` **and** `isLicensable: true` now emits no `// Board defines` header, where before it emitted a bare header with nothing under it (the old code's own comment called that a bug). Unreachable today, since no package declares `isLicensable`.

## Gates

`tsc` clean · eslint clean · 402 tests passing across compile + simulator · `generate-defines.ts` at 100% statements/lines/functions · `validate:arch` passed · web build passed · `compare-surfaces.py` 1053 files / **0 diffs**.

Refs DOPE-587

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaSZK4LqFWtZpERcqnZ8uQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic handling of board identification during compilation based on target capabilities.
  * Added a compile-time marker for targets that do not support licensable hardware identification.

* **Bug Fixes**
  * Corrected board-define output when no definitions are available.
  * Improved simulator board-ID handling and debugger validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->