### PR TITLE
fix(DOPE-585): library block naming, native variable table parity, and C++ nested autocomplete (shared surface)

### DIFF
--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -2,11 +2,28 @@ name: CI - Unit Tests
 
 on:
   workflow_dispatch:
+  # Callable from `ci.yml` so every pull request reports a test result. Until
+  # this was wired up, the only trigger was `workflow_dispatch`, which meant a
+  # green PR said "compiles and is in sync" and said nothing at all about the
+  # tests — the figures in a PR description were nobody's to check.
+  workflow_call:
 
 jobs:
   unit-tests:
     name: Unit Tests + Coverage
     runs-on: ubuntu-latest
+    # REPORTING-ONLY, deliberately. Two suites already fail to load on
+    # `development` — `frontend/store/__tests__/device-types.test.ts` and
+    # `frontend/hooks/__tests__/use-device-connect.test.ts` — and
+    # `jest --collectCoverage` also enforces coverage thresholds. Failing the
+    # job today would block every pull request on breakage none of them
+    # introduced. (No individual test fails: 7366 pass.)
+    #
+    # So the result is surfaced but not enforced: the number is visible on each
+    # PR, and a new failure shows up as a diff against a known baseline instead
+    # of being invisible. Drop this flag — and make the check required in branch
+    # protection — once those two suites load. That is its own ticket.
+    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -12,18 +12,21 @@ jobs:
   unit-tests:
     name: Unit Tests + Coverage
     runs-on: ubuntu-latest
-    # REPORTING-ONLY, deliberately. Two suites already fail to load on
-    # `development` — `frontend/store/__tests__/device-types.test.ts` and
+    # This check is EXPECTED TO BE RED for now, and that is the point: two
+    # suites already fail to load on `development` —
+    # `frontend/store/__tests__/device-types.test.ts` and
     # `frontend/hooks/__tests__/use-device-connect.test.ts` — and
-    # `jest --collectCoverage` also enforces coverage thresholds. Failing the
-    # job today would block every pull request on breakage none of them
-    # introduced. (No individual test fails: 7366 pass.)
+    # `jest --collectCoverage` also enforces coverage thresholds. No individual
+    # test fails: 7366 pass. Before this workflow was reachable from `ci.yml`, a
+    # green pull request meant "compiles and is in sync" and said nothing about
+    # the tests, so nobody had to look.
     #
-    # So the result is surfaced but not enforced: the number is visible on each
-    # PR, and a new failure shows up as a diff against a known baseline instead
-    # of being invisible. Drop this flag — and make the check required in branch
-    # protection — once those two suites load. That is its own ticket.
-    continue-on-error: true
+    # It does not block: `unit-tests / Unit Tests + Coverage` is deliberately
+    # NOT in `development`'s required-status-checks list. Add it there — which
+    # is the real switch, not anything in this file — once those two suites
+    # load. (`continue-on-error` is not the tool for this: on a job inside a
+    # reusable workflow it still surfaces the check as failed, while implying to
+    # a reader that it would not.)
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
   lint:
     uses: ./.github/workflows/ci-lint.yml
 
+  unit-tests:
+    uses: ./.github/workflows/ci-unit-tests.yml
+
   format:
     needs: [architecture, build-check, lint]
     uses: ./.github/workflows/ci-format.yml

--- a/src/backend/shared/library/__tests__/inject-library-blocks.test.ts
+++ b/src/backend/shared/library/__tests__/inject-library-blocks.test.ts
@@ -1,6 +1,6 @@
 import type { StlibArchiveDTO } from '../../../../middleware/shared/ports/library-port'
 import type { PLCProjectData } from '../../../../middleware/shared/ports/types'
-import { findLibrariesMissingNativeSources, injectLibraryBlocks, libraryBlockPouName } from '../inject-library-blocks'
+import { findLibrariesMissingNativeSources, injectLibraryBlocks } from '../inject-library-blocks'
 
 // -- helpers ------------------------------------------------------------------
 
@@ -77,12 +77,6 @@ function archive(
 
 // -- tests --------------------------------------------------------------------
 
-describe('libraryBlockPouName', () => {
-  it('prefixes the block with its library, double-underscore separated', () => {
-    expect(libraryBlockPouName('network_tools', 'TCP_CLIENT')).toBe('network_tools__TCP_CLIENT')
-  })
-})
-
 describe('injectLibraryBlocks', () => {
   it('returns the same object when the project enables no libraries', () => {
     const data = project({ pous: ['main'] })
@@ -99,12 +93,39 @@ describe('injectLibraryBlocks', () => {
     expect(injectLibraryBlocks(data, [archive('lib', [], { stBlocks: ['ST_ADD'] })])).toBe(data)
   })
 
+  it("skips a block whose name the project's own POUs already use", () => {
+    // Same precedence the variables parser and the pin resolver apply: a POU
+    // the user wrote wins over a library block of the same name, and the
+    // library block is left out rather than shadowing it.
+    const data = project({ pous: ['main', 'TCP_CLIENT'], libraries: [{ name: 'network_tools', version: '1.0.0' }] })
+    const result = injectLibraryBlocks(data, [archive('network_tools', [{ name: 'TCP_CLIENT', language: 'cpp' }])])
+
+    expect(result).toBe(data)
+    expect(result.pous.map((p) => p.name)).toEqual(['main', 'TCP_CLIENT'])
+  })
+
+  it('grafts only the first of two libraries shipping the same block name', () => {
+    const data = project({
+      pous: ['main'],
+      libraries: [
+        { name: 'libA', version: '1.0.0' },
+        { name: 'libB', version: '1.0.0' },
+      ],
+    })
+    const result = injectLibraryBlocks(data, [
+      archive('libA', [{ name: 'DUP', language: 'cpp' }]),
+      archive('libB', [{ name: 'DUP', language: 'cpp' }]),
+    ])
+
+    expect(result.pous.map((p) => p.name)).toEqual(['main', 'DUP'])
+  })
+
   it('grafts a C++ block, parsing its interface and body from the authored file', () => {
     const data = project({ pous: ['main'], libraries: [{ name: 'network_tools', version: '1.0.0' }] })
     const result = injectLibraryBlocks(data, [archive('network_tools', [{ name: 'TCP_CLIENT', language: 'cpp' }])])
 
     expect(result).not.toBe(data)
-    expect(result.pous.map((p) => p.name)).toEqual(['main', 'network_tools__TCP_CLIENT'])
+    expect(result.pous.map((p) => p.name)).toEqual(['main', 'TCP_CLIENT'])
 
     const grafted = result.pous[1]
     expect(grafted.pouType).toBe('function-block')
@@ -127,7 +148,7 @@ describe('injectLibraryBlocks', () => {
     const result = injectLibraryBlocks(data, [archive('pylib', [{ name: 'SCALE', language: 'python' }])])
 
     expect(result.pous).toHaveLength(1)
-    expect(result.pous[0].name).toBe('pylib__SCALE')
+    expect(result.pous[0].name).toBe('SCALE')
     expect(result.pous[0].body.language).toBe('python')
     expect(result.pous[0].body.value).toContain('def block_loop()')
   })
@@ -145,7 +166,7 @@ describe('injectLibraryBlocks', () => {
       ),
     ])
 
-    expect(result.pous.map((p) => `${p.name}:${p.body.language}`)).toEqual(['mixed__C:cpp', 'mixed__P:python'])
+    expect(result.pous.map((p) => `${p.name}:${p.body.language}`)).toEqual(['C:cpp', 'P:python'])
   })
 
   it('ignores archives the project has not enabled', () => {
@@ -155,7 +176,7 @@ describe('injectLibraryBlocks', () => {
       archive('disabled', [{ name: 'No', language: 'cpp' }]),
     ])
 
-    expect(result.pous.map((p) => p.name)).toEqual(['enabled__Yes'])
+    expect(result.pous.map((p) => p.name)).toEqual(['Yes'])
   })
 
   it('ignores an archive with no manifest name', () => {
@@ -169,7 +190,7 @@ describe('injectLibraryBlocks', () => {
     const result = injectLibraryBlocks(data, [
       archive('lib', [{ name: 'Block', language: 'cpp', file: 'differently_named.cpp' }]),
     ])
-    expect(result.pous.map((p) => p.name)).toEqual(['lib__Block'])
+    expect(result.pous.map((p) => p.name)).toEqual(['Block'])
   })
 
   it('skips a native block whose manifest entry names no source file', () => {
@@ -204,7 +225,7 @@ describe('injectLibraryBlocks', () => {
         { name: 'Good', language: 'cpp' },
       ]),
     ])
-    expect(result.pous.map((p) => p.name)).toEqual(['lib__Good'])
+    expect(result.pous.map((p) => p.name)).toEqual(['Good'])
   })
 
   it('returns the project untouched when every native block fails to parse', () => {

--- a/src/backend/shared/library/inject-library-blocks.ts
+++ b/src/backend/shared/library/inject-library-blocks.ts
@@ -29,16 +29,21 @@
  * Were the lowered ST stored instead, every previously published library would
  * break on the next bridge change until rebuilt.
  *
- * ## Renaming
+ * ## Naming
  *
- * Each block's name is prefixed with the library's manifest name
- * (`<library>__<block>`) so two libraries can both ship a `Foo`, and so a
- * consumer's own POU may also be called `Foo`.  The library-tree picker
- * surfaces the prefixed name, so the user authors their ST against it directly
- * and no source rewriting is needed.
+ * The synthesized POU takes the block's own name, unprefixed — the same name
+ * the library tree offers and the same name `resolveFunctionBlockPins` looks
+ * up.  There is exactly one name for a library block across the whole system;
+ * an earlier `<library>__<block>` qualification here was a namespace nothing
+ * else spoke, which left the graphical editors unable to resolve the block
+ * they had just inserted.
  *
- * Symbol-level renames inside the synthesized POU (the `<NAME>_VARS` struct,
- * the `<name>_setup` / `<name>_loop` functions) follow automatically, because
+ * A block whose name collides with one of the project's own POUs is skipped,
+ * matching the precedence the variables parser and the pin resolver already
+ * apply: the project's definition wins.
+ *
+ * Symbol-level names inside the synthesized POU (the `<NAME>_VARS` struct, the
+ * `<name>_setup` / `<name>_loop` functions) follow automatically, because
  * `generateCppSTCode`, `generateCBlocksHeader` and `generateCBlocksCode` all
  * derive their names from `pou.name`.
  */
@@ -46,14 +51,6 @@
 import { parseHybridPouFromString } from '../../../frontend/utils/PLC/pou-text-parser'
 import type { StlibArchiveDTO } from '../../../middleware/shared/ports/library-port'
 import type { PLCPou, PLCProjectData } from '../../../middleware/shared/ports/types'
-
-/** Separator between the library name and the block name. */
-const LIBRARY_BLOCK_SEPARATOR = '__'
-
-/** Build the project-visible POU name for a library block. */
-export function libraryBlockPouName(libraryName: string, blockName: string): string {
-  return `${libraryName}${LIBRARY_BLOCK_SEPARATOR}${blockName}`
-}
 
 /** One native block an archive ships, resolved to its authored source. */
 type ResolvedNativeBlock = {
@@ -130,8 +127,13 @@ export function injectLibraryBlocks(projectData: PLCProjectData, archives: Stlib
   const { blocks } = resolveNativeBlocks(projectData, archives)
   if (blocks.length === 0) return projectData
 
+  // The project's own POUs win a name clash, so a library block that collides
+  // with one is left out rather than shadowing it.
+  const takenNames = new Set(projectData.pous.map((pou) => pou.name.toUpperCase()))
+
   const synthesized: PLCPou[] = []
   for (const block of blocks) {
+    if (takenNames.has(block.blockName.toUpperCase())) continue
     let parsed: PLCPou
     try {
       parsed = parseHybridPouFromString(block.source, block.language, 'function-block')
@@ -141,9 +143,10 @@ export function injectLibraryBlocks(projectData: PLCProjectData, archives: Stlib
       // undefined type, which names the block the user actually referenced.
       continue
     }
+    takenNames.add(block.blockName.toUpperCase())
     synthesized.push({
       ...parsed,
-      name: libraryBlockPouName(block.libraryName, block.blockName),
+      name: block.blockName,
       pouType: 'function-block',
     })
   }

--- a/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
@@ -765,10 +765,25 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
         })
         const { anchor } = splitExpression(memberChainBefore(lineBeforeCursor))
         if (anchor !== '') {
+          // Read the store at query time rather than closing over `pous` /
+          // `dataTypes` / `libraries`. Those are destructured from an
+          // unselected `useOpenPLCStore()`, and `updatePou` runs on every
+          // keystroke with no debounce, so immer hands back a fresh `pous`
+          // array per character. Naming them as deps below would dispose and
+          // re-register this provider — and the signature-help provider with
+          // it — on every keystroke, including the `.` that opens the member
+          // list while the query is still in flight. The predicate is rebuilt
+          // per query by design, so reading here is the same answer for free.
+          const {
+            project: {
+              data: { pous: currentPous, dataTypes: currentDataTypes },
+            },
+            libraries: currentLibraries,
+          } = openPLCStoreBase.getState()
           const members = await getCppMemberCompletions(
             name,
             anchor,
-            projectTypeNamePredicate(pous, dataTypes, sliceLibraries),
+            projectTypeNamePredicate(currentPous, currentDataTypes, currentLibraries),
           )
           if (members.length > 0) {
             return {
@@ -818,7 +833,7 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
       completionDisposable.dispose()
       signatureHelpDisposable.dispose()
     }
-  }, [language, deviceBoard, pouVariables, name, pous, dataTypes, sliceLibraries])
+  }, [language, deviceBoard, pouVariables, name])
 
   // -----------------------------------------------------------------------
   // AI inline completion provider (gated by hasAIAssistant)

--- a/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/index.tsx
@@ -8,10 +8,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { PLCPou } from '../../../../../../middleware/shared/ports/types'
 import { useAI, useCapabilities, useProject } from '../../../../../../middleware/shared/providers'
 import { useDebugBoolValuesMap, useDebugNonBoolValuesMap } from '../../../../../hooks/use-debug-value'
+import { getCppMemberCompletions, projectTypeNamePredicate } from '../../../../../services/cpp-scope'
 import { executeSaveActiveFile, executeSaveProject } from '../../../../../services/save-actions'
-import { pouUri } from '../../../../../services/st-lsp'
+import { pouUri, splitExpression } from '../../../../../services/st-lsp'
 import { openPLCStoreBase, useOpenPLCStore } from '../../../../../store'
 import { applyAcceptedHunks, computeHunks } from '../../../../../utils/ai-diff-review'
+import { memberChainBefore } from '../../../../../utils/cpp/member-chain'
 import { getExtensionFromLanguage, getFolderFromPouType } from '../../../../../utils/PLC/pou-file-extensions'
 import { parseHybridPouFromString, parseTextualPouFromString } from '../../../../../utils/PLC/pou-text-parser'
 import { Modal, ModalContent, ModalTitle } from '../../../../_molecules/modal'
@@ -739,13 +741,52 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
     }
 
     const completionDisposable = monaco.languages.registerCompletionItemProvider('cpp', {
-      provideCompletionItems: (model, position) => {
+      // `.` re-triggers the provider: without it Monaco only asks while a word
+      // is being typed, so `motor.` alone would never open the member list.
+      triggerCharacters: ['.'],
+      provideCompletionItems: async (model, position) => {
         const word = model.getWordUntilPosition(position)
         const range = {
           startLineNumber: position.lineNumber,
           endLineNumber: position.lineNumber,
           startColumn: word.startColumn,
           endColumn: word.endColumn,
+        }
+
+        // Member access is answered on its own: after a `.` the only valid
+        // completions are that expression's members, so offering the standard
+        // library, snippets and every in-scope name alongside them would bury
+        // the answer under a hundred irrelevant entries.
+        const lineBeforeCursor = model.getValueInRange({
+          startLineNumber: position.lineNumber,
+          startColumn: 1,
+          endLineNumber: position.lineNumber,
+          endColumn: position.column,
+        })
+        const { anchor } = splitExpression(memberChainBefore(lineBeforeCursor))
+        if (anchor !== '') {
+          const members = await getCppMemberCompletions(
+            name,
+            anchor,
+            projectTypeNamePredicate(pous, dataTypes, sliceLibraries),
+          )
+          if (members.length > 0) {
+            return {
+              suggestions: members.map((member) => ({
+                label: member.label,
+                insertText: member.label,
+                kind: monaco.languages.CompletionItemKind.Field,
+                // The IEC name is worth showing: it is what the variables
+                // table and every other language call this member, and it is
+                // not always recoverable from the C++ spelling.
+                detail: member.type ? `${member.type} — ${member.iecName}` : member.iecName,
+                range,
+              })),
+            }
+          }
+          // No members resolved (LSP not ready, or not a composite type):
+          // fall through rather than assert an empty list, which would look
+          // like "this expression has nothing" instead of "ask again later".
         }
 
         const stdLibSuggestions = cppStandardLibraryCompletion({ range }).suggestions
@@ -777,7 +818,7 @@ const MonacoEditor = (props: monacoEditorProps): ReturnType<typeof PrimitiveEdit
       completionDisposable.dispose()
       signatureHelpDisposable.dispose()
     }
-  }, [language, deviceBoard, pouVariables])
+  }, [language, deviceBoard, pouVariables, name, pous, dataTypes, sliceLibraries])
 
   // -----------------------------------------------------------------------
   // AI inline completion provider (gated by hasAIAssistant)

--- a/src/frontend/components/_molecules/variables-table/elements/array-modal.tsx
+++ b/src/frontend/components/_molecules/variables-table/elements/array-modal.tsx
@@ -19,6 +19,17 @@ type Pou = { type: string; name: string }
 type UserLibWithPous = { pous: Pou[] }
 type UserLibFunctionBlock = { type: string; name: string }
 
+/**
+ * Which shape of user library this is.
+ *
+ * A predicate rather than an inline `'pous' in userLib && …`: the two members
+ * of the union share no discriminant, so the inline form leaves the else
+ * branch un-narrowed and every access on it reads as unsafe. Written this way
+ * both branches are typed without an assertion.
+ */
+const hasPous = (lib: UserLibWithPous | UserLibFunctionBlock): lib is UserLibWithPous =>
+  'pous' in lib && Array.isArray(lib.pous)
+
 export const ArrayModal = ({
   arrayModalIsOpen,
   closeContainer,
@@ -61,14 +72,13 @@ export const ArrayModal = ({
   )
 
   const userFunctionBlocks = sliceLibraries.user.flatMap((userLib: UserLibWithPous | UserLibFunctionBlock) => {
-    if ('pous' in userLib && Array.isArray(userLib.pous)) {
+    if (hasPous(userLib)) {
       return userLib.pous
         .filter((pou) => pou?.type === 'function-block')
         .filter(hasStringName)
         .map((pou) => pou.name.toUpperCase())
     }
-    const fb = userLib as UserLibFunctionBlock
-    return fb.type === 'function-block' && typeof fb.name === 'string' ? [fb.name.toUpperCase()] : []
+    return userLib.type === 'function-block' && typeof userLib.name === 'string' ? [userLib.name.toUpperCase()] : []
   })
 
   const VariableTypes = [

--- a/src/frontend/components/_molecules/variables-table/elements/array-modal.tsx
+++ b/src/frontend/components/_molecules/variables-table/elements/array-modal.tsx
@@ -13,7 +13,6 @@ type ArrayModalProps = {
   arrayModalIsOpen: boolean
   setArrayModalIsOpen: (value: boolean) => void
   closeContainer: () => void
-  language?: string | null
 }
 
 type Pou = { type: string; name: string }
@@ -26,7 +25,6 @@ export const ArrayModal = ({
   setArrayModalIsOpen,
   variableName,
   VariableRow,
-  language,
 }: ArrayModalProps) => {
   const {
     editor: {
@@ -39,58 +37,49 @@ export const ArrayModal = ({
     libraries: sliceLibraries,
   } = useOpenPLCStore()
 
-  const isNativeLanguage = language === 'python' || language === 'cpp'
-  // Same exclusion as `selectable-cell.tsx`: native-language POUs
-  // can't yet round-trip strucpp's chrono types.
-  const excludedNativeTypes = ['TIME', 'DATE', 'TOD', 'DT']
-
+  // An array element may be any type a plain variable may be, in every
+  // language. Python and C++ blocks were once cut down to base types minus
+  // TIME/DATE/TOD/DT here, mirroring the same cut in `selectable-cell.tsx`;
+  // both bridges now carry the time and calendar types, user-defined types and
+  // function block instances, so the element picker offers the full set.
   const baseTypes = baseTypeEnum.options.filter((type) => {
     if (typeof type !== 'string') return false
     if (type.toUpperCase() === 'ARRAY') return false
-    if (isNativeLanguage && excludedNativeTypes.includes(type.toUpperCase())) return false
     return true
   })
 
-  const userDataTypes = isNativeLanguage
-    ? []
-    : dataTypes
+  const userDataTypes = dataTypes
+    .filter(hasStringName)
+    .map((type) => type.name)
+    .filter((typeName) => typeName !== name && typeName.toUpperCase() !== 'ARRAY')
+
+  const systemFunctionBlocks = sliceLibraries.system.flatMap((lib) =>
+    (lib.pous ?? [])
+      .filter((pou) => pou?.type === 'function-block')
+      .filter(hasStringName)
+      .map((pou) => pou.name.toUpperCase()),
+  )
+
+  const userFunctionBlocks = sliceLibraries.user.flatMap((userLib: UserLibWithPous | UserLibFunctionBlock) => {
+    if ('pous' in userLib && Array.isArray(userLib.pous)) {
+      return userLib.pous
+        .filter((pou) => pou?.type === 'function-block')
         .filter(hasStringName)
-        .map((type) => type.name)
-        .filter((typeName) => typeName !== name && typeName.toUpperCase() !== 'ARRAY')
-
-  const systemFunctionBlocks = isNativeLanguage
-    ? []
-    : sliceLibraries.system.flatMap((lib) =>
-        (lib.pous ?? [])
-          .filter((pou) => pou?.type === 'function-block')
-          .filter(hasStringName)
-          .map((pou) => pou.name.toUpperCase()),
-      )
-
-  const userFunctionBlocks = isNativeLanguage
-    ? []
-    : sliceLibraries.user.flatMap((userLib: UserLibWithPous | UserLibFunctionBlock) => {
-        if ('pous' in userLib && Array.isArray(userLib.pous)) {
-          return userLib.pous
-            .filter((pou) => pou?.type === 'function-block')
-            .filter(hasStringName)
-            .map((pou) => pou.name.toUpperCase())
-        }
-        const fb = userLib as UserLibFunctionBlock
-        return fb.type === 'function-block' && typeof fb.name === 'string' ? [fb.name.toUpperCase()] : []
-      })
+        .map((pou) => pou.name.toUpperCase())
+    }
+    const fb = userLib as UserLibFunctionBlock
+    return fb.type === 'function-block' && typeof fb.name === 'string' ? [fb.name.toUpperCase()] : []
+  })
 
   const VariableTypes = [
     { definition: 'base-type', values: baseTypes },
-    ...(isNativeLanguage ? [] : [{ definition: 'user-data-type', values: userDataTypes }]),
+    { definition: 'user-data-type', values: userDataTypes },
   ]
 
-  const LibraryTypes = isNativeLanguage
-    ? []
-    : [
-        { definition: 'system', values: systemFunctionBlocks },
-        { definition: 'user', values: userFunctionBlocks },
-      ]
+  const LibraryTypes = [
+    { definition: 'system', values: systemFunctionBlocks },
+    { definition: 'user', values: userFunctionBlocks },
+  ]
 
   const [selectedInput, setSelectedInput] = useState<string>('')
   const [dimensions, setDimensions] = useState<string[]>([])

--- a/src/frontend/components/_molecules/variables-table/selectable-cell.tsx
+++ b/src/frontend/components/_molecules/variables-table/selectable-cell.tsx
@@ -4,13 +4,14 @@ import _ from 'lodash'
 import { useEffect, useState } from 'react'
 
 import { baseTypeEnum } from '../../../../middleware/shared/ports/plc-schemas'
-import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import type { PLCVariable, VariableClass } from '../../../../middleware/shared/ports/types'
 import { ArrowIcon } from '../../../assets/icons/interface/Arrow'
 import { DebuggerIcon } from '../../../assets/icons/interface/Debugger'
 import { useOpenPLCStore } from '../../../store'
 import { TypeChangeValidationResult, validateTypeChange } from '../../../store/slices/project/validation/type-change'
 import { cn } from '../../../utils/cn'
 import { syncNodesWithVariables, syncNodesWithVariablesFBD } from '../../../utils/graphical/sync-nodes-with-variables'
+import { PYTHON_UNSUPPORTED_CLASSES } from '../../../utils/python/block-interface'
 import { hasStringName, safeUpper } from '../../../utils/safe-upper'
 import { InputWithRef } from '../../_atoms/input'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '../../_atoms/select'
@@ -18,6 +19,10 @@ import { TypeChangeModal } from '../type-change-modal'
 import { ArrayModal } from './elements/array-modal'
 
 type ISelectableCellProps = CellContext<PLCVariable, unknown> & { selected?: boolean }
+
+/** Declaration order shown in the Class dropdown. `global` is a
+ *  configuration-level declaration, not a POU variable, so it is not here. */
+const ALL_VARIABLE_CLASSES: readonly VariableClass[] = ['input', 'output', 'inOut', 'external', 'local', 'temp']
 
 const createVariableType = (
   definition: PLCVariable['type']['definition'],
@@ -58,8 +63,6 @@ const SelectableTypeCell = ({
     workspace: { isDebuggerVisible },
   } = useOpenPLCStore()
 
-  const language = 'language' in editor.meta ? editor.meta.language : null
-
   const VariableTypes = [
     {
       definition: 'base-type',
@@ -99,35 +102,15 @@ const SelectableTypeCell = ({
     },
   ]
 
-  // Filter available types based on language
-  const getAvailableTypes = () => {
-    if (language === 'python' || language === 'cpp') {
-      // Native-language POUs (Python / C++) don't share strucpp's
-      // chrono-backed handling for IEC time types yet, so hide them
-      // from the type dropdown.
-      const excludedTypes = ['TIME', 'DATE', 'TOD', 'DT']
-
-      // Only show Base Type for Python/C++ and filter out specific types
-      const availableTypes = VariableTypes.filter((type) => type.definition === 'base-type').map((type) => ({
-        ...type,
-        values: type.values.filter((value) => !excludedTypes.includes(safeUpper(value))),
-      }))
-
-      return availableTypes
-    }
-    return VariableTypes
-  }
-
-  const getAvailableLibraryTypes = () => {
-    if (language === 'python' || language === 'cpp') {
-      // No library types for Python/C++
-      return []
-    }
-    return LibraryTypes
-  }
-
-  const availableVariableTypes = getAvailableTypes()
-  const availableLibraryTypes = getAvailableLibraryTypes()
+  // Every language offers the same types. Python and C++ blocks used to be
+  // held to base types only, minus TIME/DATE/TOD/DT, because their bridges
+  // could not carry anything else. Both now reach IEC parity — the time and
+  // calendar types travel as 64-bit counts, arrays and user-defined types are
+  // marshalled leaf by leaf, and a variable may be a function block instance —
+  // so the table no longer has a reason to offer them less than the text
+  // editor already accepts.
+  const availableVariableTypes = VariableTypes
+  const availableLibraryTypes = LibraryTypes
 
   const { value, definition } = getValue<PLCVariable['type']>()
   // We need to keep and update the state of the cell normally
@@ -270,15 +253,13 @@ const SelectableTypeCell = ({
             />
           )
         })()}
-      {language !== 'python' && language !== 'cpp' && (
-        <ArrayModal
-          variableName={variableName}
-          VariableRow={index}
-          arrayModalIsOpen={arrayModalIsOpen}
-          setArrayModalIsOpen={setArrayModalIsOpen}
-          closeContainer={() => setPoppoverIsOpen(false)}
-        />
-      )}
+      <ArrayModal
+        variableName={variableName}
+        VariableRow={index}
+        arrayModalIsOpen={arrayModalIsOpen}
+        setArrayModalIsOpen={setArrayModalIsOpen}
+        closeContainer={() => setPoppoverIsOpen(false)}
+      />
       <PrimitiveDropdown.Root onOpenChange={setPoppoverIsOpen} open={poppoverIsOpen}>
         <PrimitiveDropdown.Trigger asChild disabled={isDebuggerVisible}>
           <div
@@ -364,17 +345,15 @@ const SelectableTypeCell = ({
               )
             })}
 
-            {language !== 'python' && language !== 'cpp' && (
-              <PrimitiveDropdown.Item
-                onSelect={() => {
-                  setArrayModalIsOpen(true)
-                  setPoppoverIsOpen(false)
-                }}
-                className='flex h-8 w-full cursor-pointer items-center justify-center py-1 outline-none hover:bg-neutral-100 data-[state=open]:bg-neutral-100 dark:hover:bg-neutral-900 data-[state=open]:dark:bg-neutral-900'
-              >
-                <span className='font-caption text-xs font-normal text-neutral-700 dark:text-neutral-500'>Array</span>
-              </PrimitiveDropdown.Item>
-            )}
+            <PrimitiveDropdown.Item
+              onSelect={() => {
+                setArrayModalIsOpen(true)
+                setPoppoverIsOpen(false)
+              }}
+              className='flex h-8 w-full cursor-pointer items-center justify-center py-1 outline-none hover:bg-neutral-100 data-[state=open]:bg-neutral-100 dark:hover:bg-neutral-900 data-[state=open]:dark:bg-neutral-900'
+            >
+              <span className='font-caption text-xs font-normal text-neutral-700 dark:text-neutral-500'>Array</span>
+            </PrimitiveDropdown.Item>
 
             {availableLibraryTypes.map((scope) => {
               const filteredValues = scope.definition === 'system' ? filteredSystemLibraries : filteredUserLibraries
@@ -447,14 +426,21 @@ const SelectableClassCell = ({
   } = useOpenPLCStore()
 
   const language = 'language' in editor.meta ? editor.meta.language : null
-  const getVariableClasses = () => {
-    if (language === 'python' || language === 'cpp') {
-      return ['input', 'output']
-    }
-    return ['input', 'output', 'inOut', 'external', 'local', 'temp']
-  }
 
-  const variableClasses = getVariableClasses()
+  /**
+   * Every class an IEC POU can declare. Python and C++ blocks were once held
+   * to `input` / `output` because their bridges carried nothing else; both now
+   * marshal the rest too, so the only exclusion left is the one the codegen
+   * itself refuses.
+   *
+   * That exclusion is read from `PYTHON_UNSUPPORTED_CLASSES` rather than
+   * restated here: the picker and the bridge must not be able to disagree
+   * about what a Python block accepts, and a class that stops being refused
+   * should reappear in the dropdown by deleting one entry, not two.
+   */
+  const variableClasses = ALL_VARIABLE_CLASSES.filter(
+    (variableClass) => language !== 'python' || !(variableClass in PYTHON_UNSUPPORTED_CLASSES),
+  )
 
   // Get the current value from the table
   const currentValue = getValue()

--- a/src/frontend/services/__tests__/cpp-scope.test.ts
+++ b/src/frontend/services/__tests__/cpp-scope.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it } from '@jest/globals'
 
 import { getCppMemberCompletions, projectTypeNamePredicate } from '../cpp-scope'
+import type { SystemLibrary, SystemLibraryPou } from '../../../middleware/shared/ports/library-types'
+import type { PLCDataType, PLCPou } from '../../../middleware/shared/ports/types'
+import type { LibraryState } from '../../store/slices/library'
 import { registerScopedQueryApi, type ScopedCompletionItem } from '../st-lsp/scoped-query'
 
 /** strucpp emits Variable(6) for instance members, Field(5) for STRUCT members. */
@@ -117,6 +120,40 @@ describe('getCppMemberCompletions', () => {
     expect(members.map((m) => m.label)).toEqual(['SPEED'])
   })
 
+  it('carries an array subscript through to the LSP', async () => {
+    // `items[0]` is one segment but two things: `items` has a C++ spelling to
+    // match, `[0]` selects an element and is strucpp's business. Comparing the
+    // whole segment against the spelling never matched, so nested completion
+    // through an array-valued member returned nothing.
+    const asked = withScopedQuery({
+      'm.': [{ label: 'items', insertText: 'items', type: 'Gear', kind: FIELD }],
+      'm.items[0].': [{ label: 'ratio', insertText: 'ratio', type: 'INT', kind: FIELD }],
+    })
+
+    const members = await getCppMemberCompletions('Probe', 'm.ITEMS[0].', isUserDefinedType)
+
+    expect(asked).toEqual(['m.', 'm.items[0].'])
+    expect(members.map((m) => m.label)).toEqual(['RATIO'])
+  })
+
+  it('carries a multi-dimensional subscript through unchanged', async () => {
+    const asked = withScopedQuery({
+      'g.': [{ label: 'grid', insertText: 'grid', type: 'Gear', kind: FIELD }],
+      'g.grid[1,2].': [{ label: 'ratio', insertText: 'ratio', type: 'INT', kind: FIELD }],
+    })
+
+    await getCppMemberCompletions('Probe', 'g.GRID[1,2].', isUserDefinedType)
+
+    expect(asked).toEqual(['g.', 'g.grid[1,2].'])
+  })
+
+  it('leaves a subscript on the root segment alone', async () => {
+    const asked = withScopedQuery({ 'bank[1].': [{ label: 'speed', insertText: 'speed', type: 'INT', kind: FIELD }] })
+    const members = await getCppMemberCompletions('Probe', 'bank[1].', isUserDefinedType)
+    expect(asked).toEqual(['bank[1].'])
+    expect(members.map((m) => m.label)).toEqual(['SPEED'])
+  })
+
   it('gives up quietly when a segment does not resolve', async () => {
     // A typo, or a chain through a scalar. Returning [] lets the provider fall
     // back to its flat list instead of asserting "this has no members".
@@ -151,23 +188,37 @@ describe('getCppMemberCompletions', () => {
 })
 
 describe('projectTypeNamePredicate', () => {
-  const pous = [
-    { name: 'Drive', pouType: 'function-block' },
-    { name: 'main', pouType: 'program' },
-    { name: 'Scale', pouType: 'function' },
-  ] as never
-  const dataTypes = [{ name: 'Motor' }, { name: 'Mode' }] as never
-  const libraries = {
-    system: [
-      {
-        pous: [
-          { name: 'TON', type: 'function-block' },
-          { name: 'ADD', type: 'function' },
-        ],
-      },
-    ],
+  const pou = (name: string, pouType: PLCPou['pouType']): PLCPou => ({
+    name,
+    pouType,
+    body: { language: 'st', value: '' },
+  })
+  const libraryPou = (name: string, type: SystemLibraryPou['type']): SystemLibraryPou => ({
+    name,
+    type,
+    language: 'st',
+    variables: [],
+    body: '',
+    documentation: '',
+  })
+  const systemLibrary = (name: string, pous: SystemLibraryPou[]): SystemLibrary => ({
+    name,
+    author: '',
+    version: '1.0.0',
+    stPath: '',
+    cPath: '',
+    pous,
+  })
+
+  const pous: PLCPou[] = [pou('Drive', 'function-block'), pou('main', 'program'), pou('Scale', 'function')]
+  const dataTypes: PLCDataType[] = [
+    { name: 'Motor', derivation: 'structure', variable: [] },
+    { name: 'Mode', derivation: 'enumerated', values: [{ description: 'IDLE' }] },
+  ]
+  const libraries: LibraryState['libraries'] = {
+    system: [systemLibrary('iec-standard-fb', [libraryPou('TON', 'function-block'), libraryPou('ADD', 'function')])],
     user: [],
-  } as never
+  }
 
   it('recognises data types, the project’s own function blocks and library blocks', () => {
     const isUdt = projectTypeNamePredicate(pous, dataTypes, libraries)

--- a/src/frontend/services/__tests__/cpp-scope.test.ts
+++ b/src/frontend/services/__tests__/cpp-scope.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it } from '@jest/globals'
+
+import { getCppMemberCompletions, projectTypeNamePredicate } from '../cpp-scope'
+import { registerScopedQueryApi, type ScopedCompletionItem } from '../st-lsp/scoped-query'
+
+/** strucpp emits Variable(6) for instance members, Field(5) for STRUCT members. */
+const VARIABLE = 6
+const FIELD = 5
+const KEYWORD = 14
+
+function withScopedQuery(items: Record<string, ScopedCompletionItem[]>) {
+  const asked: string[] = []
+  registerScopedQueryApi({
+    completeInScope: (_pou, prefix) => {
+      asked.push(prefix)
+      return Promise.resolve(items[prefix] ?? [])
+    },
+  })
+  return asked
+}
+
+const isUserDefinedType = (name: string) => ['MOTOR', 'GEAR', 'MODE'].includes(name.toUpperCase())
+
+afterEach(() => registerScopedQueryApi(null))
+
+describe('getCppMemberCompletions', () => {
+  it('spells each member the way the C++ body must write it', async () => {
+    withScopedQuery({
+      'm.': [
+        { label: 'speed', insertText: 'speed', type: 'INT', kind: FIELD },
+        { label: 'Gear', insertText: 'Gear', type: 'Gear', kind: FIELD },
+        { label: 'mode', insertText: 'mode', type: 'Mode', kind: FIELD },
+      ],
+    })
+
+    const members = await getCppMemberCompletions('Probe', 'm.', isUserDefinedType)
+
+    expect(members.map((m) => m.label)).toEqual(['SPEED', 'GEAR_', 'MODE_'])
+    // The IEC name is kept: it is what every other surface calls the member.
+    expect(members.map((m) => m.iecName)).toEqual(['speed', 'Gear', 'mode'])
+    expect(members.map((m) => m.type)).toEqual(['INT', 'Gear', 'Mode'])
+  })
+
+  it('accepts function-block instance members as well as struct fields', async () => {
+    withScopedQuery({
+      'ctl.': [
+        { label: 'T_Max', insertText: 'T_Max', type: 'TIME', kind: VARIABLE },
+        { label: 'Moisture', insertText: 'Moisture', type: 'BOOL', kind: VARIABLE },
+      ],
+    })
+
+    const members = await getCppMemberCompletions('Probe', 'ctl.', isUserDefinedType)
+    expect(members.map((m) => m.label)).toEqual(['T_MAX', 'MOISTURE'])
+  })
+
+  it('drops everything that is not a value', async () => {
+    // A bare position returns the language's keywords; after a `.` those are
+    // never valid, and offering them would bury the members.
+    withScopedQuery({
+      'm.': [
+        { label: 'speed', insertText: 'speed', type: 'INT', kind: FIELD },
+        { label: 'if', insertText: 'if', kind: KEYWORD },
+        { label: 'while', insertText: 'while', kind: KEYWORD },
+      ],
+    })
+
+    const members = await getCppMemberCompletions('Probe', 'm.', isUserDefinedType)
+    expect(members.map((m) => m.label)).toEqual(['SPEED'])
+  })
+
+  it('asks for a single-level anchor directly, with no extra round trip', async () => {
+    const asked = withScopedQuery({ 'm.': [{ label: 'speed', insertText: 'speed', type: 'INT', kind: FIELD }] })
+
+    const members = await getCppMemberCompletions('Probe', 'm.', isUserDefinedType)
+
+    expect(asked).toEqual(['m.'])
+    expect(members.map((m) => m.label)).toEqual(['SPEED'])
+  })
+
+  it('translates a mangled segment back to its IEC name before asking again', async () => {
+    // The regression that nearly shipped: having accepted `GEAR_` from this
+    // module, the user types `.` — and `m.GEAR_.` is meaningless to strucpp,
+    // whose member is `Gear`. Each segment has to be resolved back.
+    const asked = withScopedQuery({
+      'm.': [{ label: 'Gear', insertText: 'Gear', type: 'Gear', kind: FIELD }],
+      'm.Gear.': [{ label: 'ratio', insertText: 'ratio', type: 'INT', kind: FIELD }],
+    })
+
+    const members = await getCppMemberCompletions('Probe', 'm.GEAR_.', isUserDefinedType)
+
+    expect(asked).toEqual(['m.', 'm.Gear.'])
+    expect(members.map((m) => m.label)).toEqual(['RATIO'])
+  })
+
+  it('resolves a plain upper-cased segment too', async () => {
+    const asked = withScopedQuery({
+      'm.': [{ label: 'axle', insertText: 'axle', type: 'Gear', kind: FIELD }],
+      'm.axle.': [{ label: 'ratio', insertText: 'ratio', type: 'INT', kind: FIELD }],
+    })
+
+    const members = await getCppMemberCompletions('Probe', 'm.AXLE.', isUserDefinedType)
+
+    expect(asked).toEqual(['m.', 'm.axle.'])
+    expect(members.map((m) => m.label)).toEqual(['RATIO'])
+  })
+
+  it('goes three levels deep, one round trip per level', async () => {
+    const asked = withScopedQuery({
+      'a.': [{ label: 'Gear', insertText: 'Gear', type: 'Gear', kind: FIELD }],
+      'a.Gear.': [{ label: 'inner', insertText: 'inner', type: 'Motor', kind: FIELD }],
+      'a.Gear.inner.': [{ label: 'speed', insertText: 'speed', type: 'INT', kind: FIELD }],
+    })
+
+    const members = await getCppMemberCompletions('Probe', 'a.GEAR_.INNER.', isUserDefinedType)
+
+    expect(asked).toEqual(['a.', 'a.Gear.', 'a.Gear.inner.'])
+    expect(members.map((m) => m.label)).toEqual(['SPEED'])
+  })
+
+  it('gives up quietly when a segment does not resolve', async () => {
+    // A typo, or a chain through a scalar. Returning [] lets the provider fall
+    // back to its flat list instead of asserting "this has no members".
+    withScopedQuery({ 'm.': [{ label: 'speed', insertText: 'speed', type: 'INT', kind: FIELD }] })
+    expect(await getCppMemberCompletions('Probe', 'm.NOPE.', isUserDefinedType)).toEqual([])
+  })
+
+  it('leaves the root segment alone — it is a variable, never mangled', async () => {
+    // The root reaches the block through a `#define` carrying the casing the
+    // user authored, so it must not be upper-cased on the way to the LSP.
+    const asked = withScopedQuery({ 'myMotor.': [{ label: 'speed', insertText: 'speed', type: 'INT', kind: FIELD }] })
+    await getCppMemberCompletions('Probe', 'myMotor.', isUserDefinedType)
+    expect(asked).toEqual(['myMotor.'])
+  })
+
+  it('returns nothing for an empty anchor rather than listing the whole scope', async () => {
+    const asked = withScopedQuery({})
+    expect(await getCppMemberCompletions('Probe', '', isUserDefinedType)).toEqual([])
+    expect(asked).toEqual([])
+  })
+
+  it('returns nothing when the LSP is unavailable, so the caller can fall back', async () => {
+    registerScopedQueryApi(null)
+    expect(await getCppMemberCompletions('Probe', 'm.', isUserDefinedType)).toEqual([])
+  })
+
+  it('omits the type when strucpp supplied none', async () => {
+    withScopedQuery({ 'm.': [{ label: 'speed', insertText: 'speed', kind: FIELD }] })
+    const [member] = await getCppMemberCompletions('Probe', 'm.', isUserDefinedType)
+    expect(member).toEqual({ label: 'SPEED', iecName: 'speed' })
+  })
+})
+
+describe('projectTypeNamePredicate', () => {
+  const pous = [
+    { name: 'Drive', pouType: 'function-block' },
+    { name: 'main', pouType: 'program' },
+    { name: 'Scale', pouType: 'function' },
+  ] as never
+  const dataTypes = [{ name: 'Motor' }, { name: 'Mode' }] as never
+  const libraries = {
+    system: [
+      {
+        pous: [
+          { name: 'TON', type: 'function-block' },
+          { name: 'ADD', type: 'function' },
+        ],
+      },
+    ],
+    user: [],
+  } as never
+
+  it('recognises data types, the project’s own function blocks and library blocks', () => {
+    const isUdt = projectTypeNamePredicate(pous, dataTypes, libraries)
+    expect(isUdt('Motor')).toBe(true)
+    expect(isUdt('Mode')).toBe(true)
+    expect(isUdt('Drive')).toBe(true)
+    expect(isUdt('TON')).toBe(true)
+  })
+
+  it('is case-insensitive, because IEC names are', () => {
+    const isUdt = projectTypeNamePredicate(pous, dataTypes, libraries)
+    expect(isUdt('mOtOr')).toBe(true)
+    expect(isUdt('ton')).toBe(true)
+  })
+
+  it('excludes elementary types, programs and functions', () => {
+    const isUdt = projectTypeNamePredicate(pous, dataTypes, libraries)
+    expect(isUdt('INT')).toBe(false)
+    expect(isUdt('BOOL')).toBe(false)
+    // Only a function block can be a variable's type; a program or a function
+    // never is, so neither can produce the member collision.
+    expect(isUdt('main')).toBe(false)
+    expect(isUdt('Scale')).toBe(false)
+    expect(isUdt('ADD')).toBe(false)
+  })
+})

--- a/src/frontend/services/cpp-scope.ts
+++ b/src/frontend/services/cpp-scope.ts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Member resolution for the C++ editor, backed by the STruC++ LSP.
+ *
+ * C++ is the only body language with no language service of its own: ST talks
+ * to strucpp's LSP directly and Python to Pyright (through a generated
+ * preamble), but a C++ block's completion is hand-assembled in the Monaco
+ * provider. Until now that meant a flat list of the POU's own variable names —
+ * typing `motor.` re-offered the same top-level names, because
+ * `getWordUntilPosition` stops at the `.` and nothing downstream knew what a
+ * `Motor` was.
+ *
+ * It does not need to. Every POU — C++ ones included — is already published to
+ * the LSP as a signature stub (`st-lsp/project-sync`), alongside the project's
+ * data types, so strucpp can already answer "what lives under `m.Gear.` in the
+ * scope of POU X" for a C++ block. That is exactly the question
+ * {@link ScopedQueryApi.completeInScope} takes, and exactly what the graphical
+ * editors ask through `graphical-scope`. This module is the second consumer of
+ * the same API rather than a second implementation of the same idea: no type
+ * walker, no `dataTypes` traversal, no notion here of what a STRUCT is.
+ *
+ * What is C++-specific — and all this module really adds — is the *spelling*.
+ * strucpp answers in IEC terms (`speed`, typed `INT`); the C++ the block
+ * compiles against declares `SPEED`, and sometimes `GEAR_`. That translation
+ * is {@link cppMemberSpelling}, which defers to strucpp's own rule.
+ */
+
+import type { PLCDataType, PLCPou } from '../../middleware/shared/ports/types'
+import type { LibraryState } from '../store/slices/library'
+import { cppMemberSpelling } from '../utils/cpp/member-spelling'
+// Imported from the module itself rather than the `st-lsp` barrel: the barrel
+// also pulls in the LSP client, and with it `vscode-languageserver-protocol`,
+// which nothing here needs and which a plain unit test cannot load.
+import { getScopedQueryApi, isValueCompletionKind, type ScopedQueryApi } from './st-lsp/scoped-query'
+
+/** One member candidate, already spelled the way the C++ body must write it. */
+export interface CppScopeCompletion {
+  /** The C++ member name — what is inserted, e.g. `SPEED`, `GEAR_`. */
+  label: string
+  /** The IEC name as authored, shown alongside so the two are never confused. */
+  iecName: string
+  /** Resolved IEC type, when strucpp provided one. */
+  type?: string
+}
+
+/**
+ * Every type name the project defines: data types, its own function blocks,
+ * and the function blocks any enabled library ships.
+ *
+ * This is the input to the collision half of strucpp's member-mangling rule —
+ * a member is only at risk of the trailing underscore when its declared type
+ * is one of these. Built per query from the same store slices the rest of the
+ * editor reads, so a type added in the variables table is visible to the next
+ * keystroke without any cache to invalidate.
+ */
+export function projectTypeNamePredicate(
+  pous: readonly PLCPou[],
+  dataTypes: readonly PLCDataType[],
+  libraries: LibraryState['libraries'],
+): (typeName: string) => boolean {
+  const names = new Set<string>()
+  for (const dataType of dataTypes) {
+    if (typeof dataType.name === 'string') names.add(dataType.name.toUpperCase())
+  }
+  for (const pou of pous) {
+    if (pou.pouType === 'function-block') names.add(pou.name.toUpperCase())
+  }
+  for (const library of libraries.system) {
+    for (const pou of library.pous ?? []) {
+      if (pou?.type === 'function-block' && typeof pou.name === 'string') names.add(pou.name.toUpperCase())
+    }
+  }
+  return (typeName: string) => names.has(typeName.toUpperCase())
+}
+
+/**
+ * Translate a chain the user typed in C++ back into the IEC names the LSP
+ * knows, one segment at a time.
+ *
+ * This is what makes the second level work. Having accepted `GEAR_` from this
+ * very module, the user types `.` — and `m.GEAR_.` means nothing to strucpp,
+ * whose member is `Gear`. The upper-casing alone would survive (IEC names are
+ * matched case-insensitively, so `m.GEAR.` resolves), but the mangling
+ * underscore does not, and a completion that leads its user into a dead end on
+ * the next keystroke is worse than none.
+ *
+ * The inverse of the mangling rule cannot be computed — stripping a trailing
+ * `_` would corrupt a member genuinely named that way — so each segment is
+ * resolved instead: ask what lives under the chain so far, and find the
+ * candidate whose *C++ spelling* is what the user typed. One round trip per
+ * level, and chains are short.
+ *
+ * The root segment is passed through untouched. It names a variable rather
+ * than a member, so it is never mangled, and the `#define` a C++ block reaches
+ * it through carries the casing the user authored.
+ *
+ * @returns the IEC anchor, or `null` when a segment doesn't resolve — a typo,
+ *   or a chain through something with no members.
+ */
+async function toIecAnchor(
+  api: ScopedQueryApi,
+  pouName: string,
+  cppAnchor: string,
+  isUserDefinedType: (typeName: string) => boolean,
+): Promise<string | null> {
+  const segments = cppAnchor.slice(0, -1).split('.')
+  let iecAnchor = `${segments[0] ?? ''}.`
+
+  for (const segment of segments.slice(1)) {
+    const candidates = await api.completeInScope(pouName, iecAnchor)
+    const match = candidates
+      .filter((item) => isValueCompletionKind(item.kind))
+      .find((item) => cppMemberSpelling(item.label, item.type, { isUserDefinedType }) === segment)
+    if (!match) return null
+    iecAnchor += `${match.label}.`
+  }
+
+  return iecAnchor
+}
+
+/**
+ * The members reachable under `cppAnchor` in `pouName`'s scope, spelled for C++.
+ *
+ * `cppAnchor` is the expression up to and including the trailing `.` — `m.`,
+ * `m.GEAR_.`, `ctl.` — exactly as it appears in the C++ body, so it is
+ * translated to IEC names before the LSP sees it (see {@link toIecAnchor}).
+ * Filtering by whatever the user has typed after it is left to Monaco, which
+ * already does it against the completion range and does it case-insensitively
+ * (so a lower-case `s` still matches `SPEED`).
+ *
+ * Returns [] when the LSP is unavailable — during boot, in tests, or after a
+ * worker crash — so the caller falls back to its flat list rather than
+ * offering nothing.
+ */
+export async function getCppMemberCompletions(
+  pouName: string,
+  cppAnchor: string,
+  isUserDefinedType: (typeName: string) => boolean,
+): Promise<CppScopeCompletion[]> {
+  const api = getScopedQueryApi()
+  if (!api || cppAnchor === '') return []
+
+  const iecAnchor = await toIecAnchor(api, pouName, cppAnchor, isUserDefinedType)
+  if (iecAnchor === null) return []
+
+  const items = await api.completeInScope(pouName, iecAnchor)
+  return items
+    .filter((item) => isValueCompletionKind(item.kind))
+    .map((item) => ({
+      label: cppMemberSpelling(item.label, item.type, { isUserDefinedType }),
+      iecName: item.label,
+      ...(item.type ? { type: item.type } : {}),
+    }))
+}

--- a/src/frontend/services/cpp-scope.ts
+++ b/src/frontend/services/cpp-scope.ts
@@ -98,6 +98,20 @@ export function projectTypeNamePredicate(
  * @returns the IEC anchor, or `null` when a segment doesn't resolve — a typo,
  *   or a chain through something with no members.
  */
+/**
+ * Split a chain segment into the member name and any array subscript.
+ *
+ * `items[0]` is one segment but two things: the member is `items`, and `[0]`
+ * selects an element of it. Only the name half has a C++ spelling to match
+ * against; the subscript is carried through to the LSP untouched, since
+ * strucpp is what decides whether an element is addressable.
+ */
+function splitSubscript(segment: string): { name: string; subscript: string } {
+  const bracket = segment.indexOf('[')
+  if (bracket < 0) return { name: segment, subscript: '' }
+  return { name: segment.slice(0, bracket), subscript: segment.slice(bracket) }
+}
+
 async function toIecAnchor(
   api: ScopedQueryApi,
   pouName: string,
@@ -108,12 +122,13 @@ async function toIecAnchor(
   let iecAnchor = `${segments[0] ?? ''}.`
 
   for (const segment of segments.slice(1)) {
+    const { name, subscript } = splitSubscript(segment)
     const candidates = await api.completeInScope(pouName, iecAnchor)
     const match = candidates
       .filter((item) => isValueCompletionKind(item.kind))
-      .find((item) => cppMemberSpelling(item.label, item.type, { isUserDefinedType }) === segment)
+      .find((item) => cppMemberSpelling(item.label, item.type, { isUserDefinedType }) === name)
     if (!match) return null
-    iecAnchor += `${match.label}.`
+    iecAnchor += `${match.label}${subscript}.`
   }
 
   return iecAnchor

--- a/src/frontend/services/graphical-scope.ts
+++ b/src/frontend/services/graphical-scope.ts
@@ -26,19 +26,7 @@ import {
   resolveNewVariableType,
   validateVariableType,
 } from '../utils/PLC/validate-variable-type'
-import { getScopedQueryApi } from './st-lsp'
-
-/**
- * LSP `CompletionItemKind`s that denote a value symbol bindable to a box.
- * strucpp emits `Variable` (6) for in-scope variables and FUNCTION_BLOCK
- * instance members (`TON0.Q`), but `Field` (5) for STRUCT members
- * (`my_struct.field`). Both must be accepted, or struct-member access never
- * autocompletes or validates.
- */
-const LSP_KIND_VARIABLE = 6
-const LSP_KIND_FIELD = 5
-const isValueCompletionKind = (kind: number | undefined): boolean =>
-  kind === LSP_KIND_VARIABLE || kind === LSP_KIND_FIELD
+import { getScopedQueryApi, isValueCompletionKind, splitExpression } from './st-lsp'
 
 /** Max instance/struct variables to drill into when a type-filtered search has no direct hits. */
 const SCOPE_EXPAND_LIMIT = 8
@@ -68,13 +56,6 @@ export interface ScopeCompletion {
  *   - `resolved`: the expression resolves to `type`.
  */
 export type ScopeTypeResult = { status: 'unavailable' } | { status: 'unknown' } | { status: 'resolved'; type: string }
-
-/** Split `value` into the completion anchor (up to and including the last `.`) and the trailing segment. */
-function splitExpression(value: string): { anchor: string; segment: string } {
-  const lastDot = value.lastIndexOf('.')
-  if (lastDot < 0) return { anchor: '', segment: value }
-  return { anchor: value.slice(0, lastDot + 1), segment: value.slice(lastDot + 1) }
-}
 
 /**
  * Autocomplete candidates for `value` typed into a box in `pouName`'s

--- a/src/frontend/services/st-lsp/__tests__/scoped-query.test.ts
+++ b/src/frontend/services/st-lsp/__tests__/scoped-query.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from '@jest/globals'
+
+import { getScopedQueryApi, isValueCompletionKind, registerScopedQueryApi, splitExpression } from '../scoped-query'
+
+afterEach(() => registerScopedQueryApi(null))
+
+describe('splitExpression', () => {
+  it('splits on the last dot', () => {
+    expect(splitExpression('m.Gear.rat')).toEqual({ anchor: 'm.Gear.', segment: 'rat' })
+  })
+
+  it('yields an empty segment when the expression ends on the dot', () => {
+    expect(splitExpression('motor.')).toEqual({ anchor: 'motor.', segment: '' })
+  })
+
+  it('yields an empty anchor for a bare partial, which asks for the whole scope', () => {
+    expect(splitExpression('mot')).toEqual({ anchor: '', segment: 'mot' })
+    expect(splitExpression('')).toEqual({ anchor: '', segment: '' })
+  })
+
+  it('keeps a subscript inside the anchor', () => {
+    expect(splitExpression('bank[1].sp')).toEqual({ anchor: 'bank[1].', segment: 'sp' })
+  })
+})
+
+describe('isValueCompletionKind', () => {
+  it('accepts Variable(6) — in-scope variables and function-block members', () => {
+    expect(isValueCompletionKind(6)).toBe(true)
+  })
+
+  it('accepts Field(5) — STRUCT members', () => {
+    // strucpp reports these differently from instance members; rejecting
+    // Field would mean struct-member access never completes anywhere.
+    expect(isValueCompletionKind(5)).toBe(true)
+  })
+
+  it('rejects keywords and everything else', () => {
+    expect(isValueCompletionKind(14)).toBe(false)
+    expect(isValueCompletionKind(3)).toBe(false)
+    expect(isValueCompletionKind(undefined)).toBe(false)
+  })
+})
+
+describe('scoped query registration', () => {
+  it('is null until an implementation registers, so callers degrade instead of throwing', () => {
+    expect(getScopedQueryApi()).toBeNull()
+  })
+
+  it('hands back the registered implementation and clears on null', () => {
+    const api = { completeInScope: () => Promise.resolve([]) }
+    registerScopedQueryApi(api)
+    expect(getScopedQueryApi()).toBe(api)
+    registerScopedQueryApi(null)
+    expect(getScopedQueryApi()).toBeNull()
+  })
+})

--- a/src/frontend/services/st-lsp/index.ts
+++ b/src/frontend/services/st-lsp/index.ts
@@ -542,6 +542,12 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
   }
 }
 
-export { getScopedQueryApi, type ScopedCompletionItem, type ScopedQueryApi } from './scoped-query'
+export {
+  getScopedQueryApi,
+  isValueCompletionKind,
+  type ScopedCompletionItem,
+  type ScopedQueryApi,
+  splitExpression,
+} from './scoped-query'
 export type { StLspService, StLspStartOptions } from './types'
 export { parsePouUri, POU_URI_SCHEME, pouUri, stubUri } from './types'

--- a/src/frontend/services/st-lsp/scoped-query.ts
+++ b/src/frontend/services/st-lsp/scoped-query.ts
@@ -60,3 +60,40 @@ export function registerScopedQueryApi(next: ScopedQueryApi | null): void {
 export function getScopedQueryApi(): ScopedQueryApi | null {
   return api
 }
+
+/**
+ * LSP `CompletionItemKind`s that denote a value symbol — something bindable
+ * to a variable box or completable after a `.`.
+ *
+ * strucpp emits `Variable` (6) for in-scope variables and FUNCTION_BLOCK
+ * instance members (`TON0.Q`), but `Field` (5) for STRUCT members
+ * (`my_struct.field`). Both must be accepted, or struct-member access never
+ * completes. Everything else strucpp returns at a bare position — keywords,
+ * standard functions — is not a value and is filtered out.
+ */
+const LSP_KIND_VARIABLE = 6
+const LSP_KIND_FIELD = 5
+
+/** True for a completion item that names a value (variable / member / field). */
+export function isValueCompletionKind(kind: number | undefined): boolean {
+  return kind === LSP_KIND_VARIABLE || kind === LSP_KIND_FIELD
+}
+
+/**
+ * Split an expression into the completion anchor — everything up to and
+ * including the last `.` — and the trailing partial segment.
+ *
+ * `completeInScope` is anchored on the former and the caller filters by the
+ * latter: `m.Gear.rat` asks strucpp what lives under `m.Gear.` and then keeps
+ * the candidates starting `rat`. A bare partial has an empty anchor, which
+ * asks for everything in scope.
+ *
+ * Shared rather than reimplemented per consumer: the graphical boxes and the
+ * C++ editor must agree on where an anchor ends, or the same expression
+ * resolves differently depending on which one asked.
+ */
+export function splitExpression(value: string): { anchor: string; segment: string } {
+  const lastDot = value.lastIndexOf('.')
+  if (lastDot < 0) return { anchor: '', segment: value }
+  return { anchor: value.slice(0, lastDot + 1), segment: value.slice(lastDot + 1) }
+}

--- a/src/frontend/utils/__tests__/stlib-to-system-library.test.ts
+++ b/src/frontend/utils/__tests__/stlib-to-system-library.test.ts
@@ -142,7 +142,7 @@ describe('stlibToSystemLibrary — native (C/C++, Python) blocks', () => {
       sources,
     }) as unknown as StlibArchiveDTO
 
-  it('surfaces a C++ block under the prefixed name, with its authored source as the body', () => {
+  it('surfaces a C++ block under its own name, with its authored source as the body', () => {
     const lib = stlibToSystemLibrary(
       nativeArchive(
         [{ name: 'Servo', implementation: 'cpp', documentation: 'A servo motor block' }],
@@ -152,9 +152,11 @@ describe('stlibToSystemLibrary — native (C/C++, Python) blocks', () => {
 
     expect(lib.pous).toHaveLength(1)
     const block = lib.pous[0]
-    // The prefix matters: the compile-time graft produces a POU with exactly
-    // this name, so the picker must show what the user has to type.
-    expect(block.name).toBe('mylib__Servo')
+    // One name across the whole system: the graft synthesizes a POU under
+    // exactly this name and `resolveFunctionBlockPins` looks it up by it, so
+    // a block inserted from the tree resolves its pins. No library prefix —
+    // that namespace was private to the graft and broke both.
+    expect(block.name).toBe('Servo')
     expect(block.type).toBe('function-block')
     expect(block.language).toBe('cpp')
     expect(block.body).toBe('void setup(){}void loop(){}')
@@ -169,7 +171,7 @@ describe('stlibToSystemLibrary — native (C/C++, Python) blocks', () => {
         [{ fileName: 'Scale.py', source: 'def block_loop():\n    pass' }],
       ),
     )
-    expect(lib.pous[0].name).toBe('mylib__Scale')
+    expect(lib.pous[0].name).toBe('Scale')
     expect(lib.pous[0].language).toBe('python')
     expect(lib.pous[0].body).toBe('def block_loop():\n    pass')
   })

--- a/src/frontend/utils/cpp/__tests__/member-chain.test.ts
+++ b/src/frontend/utils/cpp/__tests__/member-chain.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from '@jest/globals'
+
+import { memberChainBefore } from '../member-chain'
+
+describe('memberChainBefore', () => {
+  it('returns the whole chain, not just the trailing word', () => {
+    // The bug this exists for: Monaco reports `rat` and loses `m.Gear`.
+    expect(memberChainBefore('  m.Gear.rat')).toBe('m.Gear.rat')
+  })
+
+  it('keeps a chain that ends on the dot', () => {
+    expect(memberChainBefore('  motor.')).toBe('motor.')
+  })
+
+  it('returns a bare identifier unchanged', () => {
+    expect(memberChainBefore('  mot')).toBe('mot')
+  })
+
+  it('carries an array subscript through to the LSP', () => {
+    expect(memberChainBefore('  bank[1].sp')).toBe('bank[1].sp')
+    expect(memberChainBefore('  grid[1][2].')).toBe('grid[1][2].')
+  })
+
+  it('anchors on the argument, not the call, inside a parenthesis', () => {
+    expect(memberChainBefore('  foo(bar.')).toBe('bar.')
+  })
+
+  it.each([
+    ['  a + b.', 'b.'],
+    ['  x = motor.sp', 'motor.sp'],
+    ['  if (ctl.', 'ctl.'],
+    ['  vals, other.', 'other.'],
+    ['  *ptr.', 'ptr.'],
+  ])('stops at the operator in %j', (line, expected) => {
+    expect(memberChainBefore(line)).toBe(expected)
+  })
+
+  it('returns empty when the cursor is not at the end of a chain', () => {
+    expect(memberChainBefore('')).toBe('')
+    expect(memberChainBefore('   ')).toBe('')
+    expect(memberChainBefore('  x = ')).toBe('')
+    expect(memberChainBefore('  foo(')).toBe('')
+  })
+
+  it('does not read a numeric literal as a chain', () => {
+    // Without the leading-letter guard `1.5` scans as a chain rooted at `1`,
+    // and every decimal typed in a C++ block would open a member list.
+    expect(memberChainBefore('  x = 1.5')).toBe('')
+    expect(memberChainBefore('  x = 0.')).toBe('')
+  })
+
+  it('allows an underscore-led identifier', () => {
+    expect(memberChainBefore('  _private.field')).toBe('_private.field')
+  })
+})

--- a/src/frontend/utils/cpp/__tests__/member-spelling.test.ts
+++ b/src/frontend/utils/cpp/__tests__/member-spelling.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from '@jest/globals'
+
+import { cppMemberSpelling } from '../member-spelling'
+
+/**
+ * The project types in play. `isUserDefinedType` is the precondition for
+ * strucpp's collision rule — an elementary type can never collide, because no
+ * member is declared with a type whose name it also carries.
+ */
+const isUserDefinedType = (name: string) => ['MOTOR', 'GEAR', 'MODE', 'IRRIGATION_STATE'].includes(name.toUpperCase())
+
+describe('cppMemberSpelling', () => {
+  it('upper-cases the IEC name', () => {
+    expect(cppMemberSpelling('speed', 'INT', { isUserDefinedType })).toBe('SPEED')
+    expect(cppMemberSpelling('set_point', 'REAL', { isUserDefinedType })).toBe('SET_POINT')
+    expect(cppMemberSpelling('isRunning', 'BOOL', { isUserDefinedType })).toBe('ISRUNNING')
+  })
+
+  // Verified against real strucpp output: compiling
+  //   Motor : STRUCT speed : INT; Gear : Gear; mode : Mode; END_STRUCT
+  // emits `IEC_INT SPEED{}; GEAR GEAR_{}; IEC_MODE MODE_{};`
+  it('appends the underscore when a member is named after its own type', () => {
+    expect(cppMemberSpelling('Gear', 'Gear', { isUserDefinedType })).toBe('GEAR_')
+  })
+
+  it('appends the underscore for an enum-typed member too', () => {
+    // The non-obvious one: `mode : Mode` collides just as `Gear : Gear` does,
+    // and a hand-rolled toUpperCase() would silently suggest `MODE`.
+    expect(cppMemberSpelling('mode', 'Mode', { isUserDefinedType })).toBe('MODE_')
+  })
+
+  it('does not append the underscore when the names merely resemble each other', () => {
+    expect(cppMemberSpelling('gearbox', 'Gear', { isUserDefinedType })).toBe('GEARBOX')
+    expect(cppMemberSpelling('gear_ratio', 'Gear', { isUserDefinedType })).toBe('GEAR_RATIO')
+  })
+
+  it('does not append the underscore for an elementary type of the same name', () => {
+    // A member can be called `int`; `INT` is not a user-defined type, so no
+    // collision with the class name arises.
+    expect(cppMemberSpelling('int', 'INT', { isUserDefinedType })).toBe('INT')
+  })
+
+  it('upper-cases only when the member type is unknown', () => {
+    // strucpp supplies no type for some items; the collision is then
+    // undetectable, and upper-casing is the answer for every non-UDT member.
+    expect(cppMemberSpelling('speed', undefined, { isUserDefinedType })).toBe('SPEED')
+  })
+
+  it('is case-insensitive about the collision', () => {
+    expect(cppMemberSpelling('GEAR', 'gear', { isUserDefinedType })).toBe('GEAR_')
+    expect(cppMemberSpelling('gEaR', 'GeAr', { isUserDefinedType })).toBe('GEAR_')
+  })
+})

--- a/src/frontend/utils/cpp/member-chain.ts
+++ b/src/frontend/utils/cpp/member-chain.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Recover the member-access chain the cursor sits at the end of.
+ *
+ * Monaco's `getWordUntilPosition` stops at a `.`, which is exactly right for
+ * sizing the range a completion replaces and useless for deciding *what* is
+ * being completed: at `m.Gear.rat` it reports `rat`, with no indication that it
+ * hangs off `m.Gear`. Scanning the line backwards over the characters a member
+ * path may contain recovers the whole expression, which is what the LSP needs
+ * as its anchor.
+ */
+
+/**
+ * Characters a member path can contain, anchored to the end of the line.
+ *
+ * `[` and `]` are included so an array element (`bank[1].`) survives the scan
+ * and reaches the LSP intact. Everything else — whitespace, operators,
+ * parentheses, commas — terminates the chain, which is what keeps `foo(bar.`
+ * anchored on `bar.` rather than on the call, and `a + b.` on `b.`.
+ *
+ * The first character must not be a digit: a path starts at an identifier, and
+ * without that guard `1.5` in `x = 1.5` would scan as a chain rooted at `1`.
+ */
+const MEMBER_CHAIN_AT_END = /[A-Za-z_][A-Za-z0-9_.[\]]*$/
+
+/**
+ * The member-access chain immediately before the cursor, or `''` when the
+ * cursor is not at the end of one.
+ *
+ * @param lineBeforeCursor - the current line's text up to the cursor column.
+ */
+export function memberChainBefore(lineBeforeCursor: string): string {
+  const match = MEMBER_CHAIN_AT_END.exec(lineBeforeCursor)
+  return match ? match[0] : ''
+}

--- a/src/frontend/utils/cpp/member-spelling.ts
+++ b/src/frontend/utils/cpp/member-spelling.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * How an IEC member name is spelled in the C++ a block actually compiles
+ * against.
+ *
+ * A C++ block reaches its variables through `#define`s that strucpp's header
+ * generator emits (`generateCBlocksCode`): the *top-level* name keeps the
+ * casing the user authored, because the macro is defined under that spelling
+ * (`#define motor (*(vars->MOTOR))`). Everything reached through a `.` from
+ * there is a real C++ member of a strucpp-generated struct or class, and those
+ * follow strucpp's rules — not the editor's.
+ *
+ * Two rules apply, and only the first is obvious:
+ *
+ *   1. **Upper-cased.** strucpp's parser normalises identifiers, so a STRUCT
+ *      declared `speed : INT` emits `IEC_INT SPEED{}`.
+ *
+ *   2. **A trailing underscore on a collision.** A member whose name matches
+ *      its own type's name is emitted with a `_` appended, because GCC rejects
+ *      a member that changes the meaning of its type name within the class
+ *      (`-Wchanges-meaning`). `Gear : Gear` becomes `GEAR_`, and — less
+ *      obviously — so does `mode : Mode`. The same applies to a member whose
+ *      name matches an interface method the owning function block implements.
+ *
+ * Rule 2 is imported from strucpp rather than restated here. It is the
+ * compiler's rule, it has a second condition this module cannot evaluate (see
+ * `interfaceMethods` below), and a private copy that fell behind would suggest
+ * a member name that does not compile — the failure mode is a completion the
+ * user accepts and then has to debug. `member-mangling.ts` exists in strucpp
+ * precisely because the rule had been copied five times with three different
+ * conditions; this is not the place to make that six.
+ */
+
+import { mangledMemberName } from 'strucpp/dist/backend/member-mangling.js'
+
+/**
+ * What the caller knows about the project's type names.
+ *
+ * `isUserDefinedType` decides whether a member's declared type is a project
+ * type (structure, enumeration, function block) rather than an elementary one
+ * — the precondition for the collision in rule 2.
+ */
+export interface CppMemberSpellingContext {
+  isUserDefinedType: (typeName: string) => boolean
+}
+
+/**
+ * The C++ spelling of one IEC member.
+ *
+ * `memberTypeName` is the member's declared IEC type, which is what strucpp's
+ * LSP hands back on every completion item — so the caller never has to resolve
+ * it. Pass `undefined` when the type is unknown; the collision cannot then be
+ * detected and the name is returned upper-cased only, which is the same answer
+ * for every member that isn't of a user-defined type.
+ *
+ * Note the interface-method half of rule 2 is deliberately not evaluated: the
+ * editor has no INTERFACE / METHOD model, so `interfaceMethods` is left unset
+ * and a member colliding with an implemented method is spelled without its
+ * underscore. That case needs an ST project that declares an INTERFACE, which
+ * the editor cannot currently author.
+ */
+export function cppMemberSpelling(
+  memberName: string,
+  memberTypeName: string | undefined,
+  context: CppMemberSpellingContext,
+): string {
+  return mangledMemberName(memberName.toUpperCase(), memberTypeName, {
+    isUserDefinedType: context.isUserDefinedType,
+  })
+}

--- a/src/frontend/utils/stlib-to-system-library.ts
+++ b/src/frontend/utils/stlib-to-system-library.ts
@@ -149,13 +149,17 @@ export function stlibToSystemLibrary(archive: StlibArchiveDTO): SystemLibrary {
         type: typeRef(v.type),
       })),
     ]
-    // A native (C/C++, Python) block is surfaced under the library-prefixed
-    // name (`<library>__<name>`) that the consumer's source must reference,
-    // because the compile-time graft produces a POU with exactly that name.
-    // The picker shows the prefix so the user types the right thing.
+    // A native (C/C++, Python) block is surfaced under its own name, exactly
+    // like every other library block. It briefly carried a `<library>__<name>`
+    // prefix to keep two libraries' same-named blocks apart, but nothing else
+    // in the system speaks that name: `resolveFunctionBlockPins` looks blocks
+    // up by the manifest name, so a prefixed entry resolved to no pins and the
+    // graphical editors could not build an instance for it. Name collisions
+    // are settled the way they are everywhere else — the project's own POU
+    // wins — rather than by giving native blocks a private namespace.
     const nativeLanguage = fb.implementation
     pous.push({
-      name: nativeLanguage ? `${m.name}__${fb.name}` : fb.name,
+      name: fb.name,
       type: 'function-block',
       language: nativeLanguage ?? 'st',
       variables,

--- a/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
@@ -582,7 +582,7 @@ describe('createEditorCompilerAdapter', () => {
 
     it("grafts an enabled library's C++ block into the project before preprocessing", async () => {
       // The project enables `motor_lib`, which ships a C++ FB called `Driver`.
-      // The adapter must graft a `motor_lib__Driver` POU in before building the
+      // The adapter must graft a `Driver` POU in before building the
       // IPC payload, so the program build's c_blocks.h / code.cpp generation
       // picks the C++ source up — exactly as it would for a user-authored block.
       const projectWithLib: PLCProjectData = {
@@ -592,10 +592,10 @@ describe('createEditorCompilerAdapter', () => {
       ;(window.bridge.loadAllLibraries as jest.Mock).mockResolvedValue([nativeArchive('motor_lib', 'Driver', 'cpp')])
 
       const ipcProjectData = await compileWith(projectWithLib)
-      expect(ipcProjectData.pous.map((p) => p.data.name)).toContain('motor_lib__Driver')
+      expect(ipcProjectData.pous.map((p) => p.data.name)).toContain('Driver')
       // `preprocessPous` lowered the grafted body and stamped the sidecar,
       // which is what proves it went through the user-POU path.
-      expect(ipcProjectData.originalCppPous?.map((p) => p.name)).toContain('motor_lib__Driver')
+      expect(ipcProjectData.originalCppPous?.map((p) => p.name)).toContain('Driver')
     })
 
     it("grafts an enabled library's Python block too", async () => {
@@ -609,7 +609,7 @@ describe('createEditorCompilerAdapter', () => {
       // refused before the graft can be observed — correctly, and that refusal
       // has its own tests. This one is about the graft.
       const ipcProjectData = await compileWith(projectWithLib, 'OpenPLC Runtime v4')
-      expect(ipcProjectData.pous.map((p) => p.data.name)).toContain('py_lib__Scale')
+      expect(ipcProjectData.pous.map((p) => p.data.name)).toContain('Scale')
     })
 
     it("skips native blocks from libraries that are not on the project's enabled list", async () => {
@@ -625,8 +625,8 @@ describe('createEditorCompilerAdapter', () => {
 
       const ipcProjectData = await compileWith(projectWithLib)
       const pouNames = ipcProjectData.pous.map((p) => p.data.name)
-      expect(pouNames).toContain('enabled_lib__OK')
-      expect(pouNames).not.toContain('other_lib__Leak')
+      expect(pouNames).toContain('OK')
+      expect(pouNames).not.toContain('Leak')
     })
   })
 


### PR DESCRIPTION
## Ticket

DOPE-585 — https://autonomylogic.atlassian.net/browse/DOPE-585

## Summary

Shared-surface mirror of Autonomy-Logic/openplc-web#705. Three of that PR's four fixes touch shared code and land here byte-identically; the fourth (AI chat scrolling) is web-only.

## 1. Library blocks had two different names

A native (C++/Python) library block was surfaced in the tree as `<library>__<block>` — `network-tools__TCP_CLIENT` instead of `TCP_CLIENT` — while ordinary IEC library blocks kept their bare name. The prefix was introduced so two libraries could both ship a `Foo`, assuming the picker would show it and the user would author against it.

Nothing else in the system spoke that name. `resolveFunctionBlockPins` looks blocks up by their manifest name, so a prefixed block resolved to no pins and the graphical editors could not build an instance for a block dropped into a ladder rung or an FBD sheet.

Native blocks now carry their own name everywhere — tree, pin resolution, compile-time graft. Collisions are settled the way the rest of the system already settles them rather than with a private namespace: the project's own POU wins, and a library block whose name is taken is left out instead of shadowing it.

The `.stlib` was never at fault — strucpp writes the plain block name into the manifest, which is what the graft and the tree now both use.

## 2. The variables table offered natives less than the text editor did

The table held Python and C++ POUs to `input` / `output` classes and to base types minus TIME/DATE/TOD/DT, with no user-defined types, no library function blocks and no Array option. Those limits described the old bridges. Both now reach IEC parity (DOPE-584), so the only way to declare the rest was to leave table mode and write the header by hand.

The type and class pickers now offer the same set in every language, and the array element picker with them. The one real exclusion left is Python's `VAR_TEMP`, which its bridge refuses outright — read from `PYTHON_UNSUPPORTED_CLASSES` rather than restated, so the picker and the bridge cannot disagree.

## 3. Nested members never completed in the C++ editor

Typing `motor.` re-offered the same top-level names. Monaco's `getWordUntilPosition` stops at the dot, so the provider never learned that `motor` was a `Motor`. ST and Python both have a language service behind them; C++ does not.

It does not need one. Every POU — C++ included — is already published to the STruC++ LSP as a signature stub alongside the project's data types, so strucpp can already answer *"what lives under `m.Gear.` in POU X"* for a C++ block. `cpp-scope` is a second consumer of that API, not a second implementation: no chain resolver, no type walker, no notion there of what a STRUCT is. `splitExpression` and `isValueCompletionKind` move out of `graphical-scope` into `scoped-query` so both consumers share one definition.

The only genuinely new logic is the *spelling*: strucpp answers `speed`, the generated C++ declares `SPEED`, and a member whose name matches its own type's name becomes `GEAR_` (GCC's `-Wchanges-meaning`). That rule is imported from strucpp's own `member-mangling` rather than restated — that module exists because the rule had already been copied five times with three different conditions.

The chain is translated back to IEC names one segment at a time, because the mangling cannot be inverted. Without it, accepting `GEAR_` and typing `.` led to a dead end.

## Files

Every file here is on the byte-identical shared surface:

- `src/frontend/utils/stlib-to-system-library.ts` (+ test)
- `src/backend/shared/library/inject-library-blocks.ts` (+ test)
- `src/frontend/components/_molecules/variables-table/selectable-cell.tsx`
- `src/frontend/components/_molecules/variables-table/elements/array-modal.tsx`
- `src/frontend/services/cpp-scope.ts` (+ test) — new
- `src/frontend/utils/cpp/member-spelling.ts`, `member-chain.ts` (+ tests) — new
- `src/frontend/services/st-lsp/scoped-query.ts` (+ test), `st-lsp/index.ts`, `graphical-scope.ts`
- `src/frontend/components/_features/[workspace]/editor/monaco/index.tsx`

Plus editor-only test fixtures in `src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts` that asserted the old prefixed names.

## Testing

Full Jest run on the affected suites: 276 passed, including the four new shared test files (they import from `@jest/globals`, which vitest aliases, so the same files run in both runners). `compare-surfaces.py` against the web branch: 1060 files, 0 diffs.

Merge alongside Autonomy-Logic/openplc-web#705 so the surface does not diverge between the two repos' `development`.

## Review fixes applied

CodeRabbit raised three points; all three are addressed.

- **Array subscript in a member chain.** `m.ITEMS[0].` produced the segment `ITEMS[0]`, compared against a spelling of `ITEMS`, so nested completion through an array-valued member resolved nothing. The segment is now split — name matched, subscript carried through to the LSP, which is what decides whether an element is addressable. Three regression tests.
- **`as never` fixtures.** Replaced with typed factories for `PLCPou`, `PLCDataType` and `SystemLibrary`, so they break when those definitions change instead of silently drifting.
- **Cast in `array-modal.tsx`.** Removed — but not by deleting it as suggested. Deleting compiles under `tsc` and then trips three `no-unsafe-*` lint warnings against a baseline of zero, because the union's two members share no discriminant and the inline `'pous' in lib && …` leaves the else branch un-narrowed. A `lib is UserLibWithPous` type predicate narrows both branches with no assertion and no warnings, which is what CLAUDE.md prescribes in place of `as`.

Reviewer points on the web PR that also land here: the C++ completion effect no longer names store-derived values as deps (it read a fresh `pous` array on every keystroke and re-registered the provider each character), and `ci-unit-tests.yml` is now callable and wired into `ci.yml`. That check is `continue-on-error: true` for now: two suites already fail to load on `development` — `frontend/store/__tests__/device-types.test.ts` and `frontend/hooks/__tests__/use-device-connect.test.ts` — and `jest --collectCoverage` enforces coverage thresholds, so enforcing today would block every PR on pre-existing breakage. No individual test fails: 7366 pass.

## Checklist

- [x] `npx tsc --noEmit` clean
- [x] Jest on the affected suites: 279 passed
- [x] `compare-surfaces.py` against the web branch: 0 diffs
- [ ] Full `npm test` — two pre-existing suite-load failures on `development`, unchanged by this branch
- [x] Follows `.claude/review-guidelines.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Library function blocks now appear under their authored names for clearer discovery and use.
  * Project-defined blocks take precedence over same-named library blocks, while duplicate library blocks are handled consistently.
  * Variable editors now offer the complete set of supported types, data types, function blocks, and array element options across supported languages.
  * C++ code completion now supports members across chained expressions, arrays, and project-defined types.

* **Bug Fixes**
  * Improved resolution of native library blocks and their pins during project editing and compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->