### PR TITLE
chore(ci): trim stale commentary from the unit-tests workflow

### DIFF
--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -2,31 +2,14 @@ name: CI - Unit Tests
 
 on:
   workflow_dispatch:
-  # Callable from `ci.yml` so every pull request reports a test result. Until
-  # this was wired up, the only trigger was `workflow_dispatch`, which meant a
-  # green PR said "compiles and is in sync" and said nothing at all about the
-  # tests — the figures in a PR description were nobody's to check.
+  # Called from `ci.yml` on every pull request.
   workflow_call:
 
 jobs:
   unit-tests:
     name: Unit Tests + Coverage
     runs-on: ubuntu-latest
-    # This check is EXPECTED TO BE RED for now, and that is the point: two
-    # suites already fail to load on `development` —
-    # `frontend/store/__tests__/device-types.test.ts` and
-    # `frontend/hooks/__tests__/use-device-connect.test.ts` — and
-    # `jest --collectCoverage` also enforces coverage thresholds. No individual
-    # test fails: 7366 pass. Before this workflow was reachable from `ci.yml`, a
-    # green pull request meant "compiles and is in sync" and said nothing about
-    # the tests, so nobody had to look.
-    #
-    # It does not block: `unit-tests / Unit Tests + Coverage` is deliberately
-    # NOT in `development`'s required-status-checks list. Add it there — which
-    # is the real switch, not anything in this file — once those two suites
-    # load. (`continue-on-error` is not the tool for this: on a job inside a
-    # reusable workflow it still surfaces the check as failed, while implying to
-    # a reader that it would not.)
+    # Required check on `development` — a red suite blocks the merge.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## What

Comment-only change to `.github/workflows/ci-unit-tests.yml`. The workflow itself is untouched — same triggers, same job name, same six steps.

## Why

The job carried a 15-line comment block declaring the check **"EXPECTED TO BE RED"**, naming two suites that failed to load on `development`, and telling the reader that `unit-tests / Unit Tests + Coverage` was deliberately left out of the branch's required-status-checks list.

Every part of that is now wrong:

- The suites pass. Fresh dispatch on `development`: [run 33251508485](https://github.com/Autonomy-Logic/openplc-editor/actions/runs/33251508485), `Test Suites: 2 skipped, 349 passed`, `Tests: 20 skipped, 7445 passed`. (The two skipped suites are the pre-existing `describe.skip` simulator e2e pair.)
- The check **is** required on `development` as of today, so a red suite blocks the merge.

A reader of the file today would draw the opposite conclusion on both points.

The `on:` block's four-line account of why `workflow_call` was added goes too. That history belongs in Jira and in the commit message, not in a config file.

## Result

```yaml
on:
  workflow_dispatch:
  # Called from `ci.yml` on every pull request.
  workflow_call:

jobs:
  unit-tests:
    name: Unit Tests + Coverage
    runs-on: ubuntu-latest
    # Required check on `development` — a red suite blocks the merge.
```

The `--ignore-scripts` / strucpp comment further down is left as is: it documents a real trap (the skipped postinstall never fetches strucpp, which the sources import).

## Notes for the reviewer

- `.github/workflows/` is outside the shared-surface sync gate, and the two repos' copies legitimately differ (npm vs pnpm), so this is not a byte-identical mirror. The wording is aligned by hand.
- The job name `Unit Tests + Coverage` is load-bearing — it is the required-check context. Unchanged here, and it should stay that way.

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/714

Closes the follow-through on DOPE-549 / DOPE-550 / DOPE-582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JAMx8mRf2ig4YFfs2gmsM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comments describing when unit tests run and their role in the development merge process.
  * Removed outdated historical notes and references to previous test and coverage issues.
* **Chores**
  * No changes to workflow behavior or test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->