### PR TITLE
fix(lsp): resolve document symbols against the LSP URI (DOPE-590)

### DIFF
--- a/src/frontend/components/_features/[workspace]/editor/monaco/configs/index.ts
+++ b/src/frontend/components/_features/[workspace]/editor/monaco/configs/index.ts
@@ -4,7 +4,9 @@ import './languages/st/st.register'
 import './themes/openplc/openplc.register'
 
 import { loader } from '@monaco-editor/react'
+import { installMonacoCancellationGuard } from '@root/frontend/utils/monaco-cancellation'
 import * as monaco from 'monaco-editor'
 
 loader.config({ monaco })
 void loader.init()
+installMonacoCancellationGuard()

--- a/src/frontend/services/lsp-shared/__tests__/line-window.test.ts
+++ b/src/frontend/services/lsp-shared/__tests__/line-window.test.ts
@@ -1,9 +1,14 @@
 /**
  * @jest-environment jsdom
  */
-import type { TextEdit as LspTextEdit } from 'vscode-languageserver-protocol'
+import type { DocumentSymbol as LspDocumentSymbol, TextEdit as LspTextEdit } from 'vscode-languageserver-protocol'
 
-import { clipEditsToWindow, lspLineInWindow, modelMatchesDocumentWindow } from '../internal/line-window'
+import {
+  clipEditsToWindow,
+  clipSymbolsToWindow,
+  lspLineInWindow,
+  modelMatchesDocumentWindow,
+} from '../internal/line-window'
 
 // `Motor` occupies lines 2..4 of the aggregate datatypes document, so
 // its `.dt` view is windowed to [2, 5).
@@ -80,6 +85,67 @@ describe('clipEditsToWindow', () => {
       newText: 'anything',
     }
     expect(clipEditsToWindow([intoNextLine], MOTOR)).toEqual([])
+  })
+})
+
+describe('clipSymbolsToWindow', () => {
+  // strucpp answers DocumentSymbol[]: one top-level entry per type in the
+  // aggregate datatypes document, one per POU in a `pou://` document with
+  // its VAR declarations as children.
+  const symbol = (name: string, startLine: number, endLine: number, children?: LspDocumentSymbol[]) => {
+    const range = { start: { line: startLine, character: 0 }, end: { line: endLine, character: 0 } }
+    return { name, kind: 13, range, selectionRange: range, children } as LspDocumentSymbol
+  }
+
+  const COLORS = symbol('Colors', 1, 1)
+  const MOTOR_SYMBOL = symbol('Motor', 2, 4, [symbol('speed', 3, 3)])
+  const AGGREGATE = [COLORS, MOTOR_SYMBOL]
+
+  it('keeps every symbol when there is no window', () => {
+    expect(clipSymbolsToWindow(AGGREGATE)).toEqual(AGGREGATE)
+  })
+
+  it('keeps only the entry the .dt view renders', () => {
+    expect(clipSymbolsToWindow(AGGREGATE, MOTOR)).toEqual([MOTOR_SYMBOL])
+  })
+
+  it('keeps a matching entry whole, children included', () => {
+    expect(clipSymbolsToWindow(AGGREGATE, MOTOR)[0].children).toEqual([symbol('speed', 3, 3)])
+  })
+
+  it('lifts the children of a POU enclosing the variables window', () => {
+    const pou = symbol('main', 0, 11, [symbol('State', 2, 2), symbol('Enable', 3, 3), symbol('body_local', 7, 7)])
+    expect(clipSymbolsToWindow([pou], { startLine: 1, endLineExclusive: 5 })).toEqual([
+      symbol('State', 2, 2),
+      symbol('Enable', 3, 3),
+    ])
+  })
+
+  it('drops an enclosing symbol whose children all sit outside', () => {
+    const pou = symbol('main', 0, 11, [symbol('body_local', 7, 7)])
+    expect(clipSymbolsToWindow([pou], { startLine: 1, endLineExclusive: 5 })).toEqual([])
+  })
+
+  it('drops entries that end before the window', () => {
+    expect(clipSymbolsToWindow([COLORS], MOTOR)).toEqual([])
+  })
+
+  it('drops entries that start past the window', () => {
+    expect(clipSymbolsToWindow([symbol('Later', 6, 8)], MOTOR)).toEqual([])
+  })
+
+  it('drops a preamble symbol when the window is the body editor bound', () => {
+    // A body editor has no explicit window: the provider bounds it by the
+    // preamble the model never renders, so `lineOffset` is the window start.
+    const pou = symbol('main', 0, 11, [symbol('State', 2, 2), symbol('Enable', 3, 3)])
+    const bodyBound = { startLine: 5, endLineExclusive: Number.MAX_SAFE_INTEGER }
+    expect(clipSymbolsToWindow([pou], bodyBound)).toEqual([])
+  })
+
+  it('keeps everything when the body editor has no preamble', () => {
+    const pou = symbol('main', 0, 11, [symbol('State', 2, 2)])
+    const noPreamble = { startLine: 0, endLineExclusive: Number.MAX_SAFE_INTEGER }
+    expect(clipSymbolsToWindow([pou], noPreamble)).toEqual([pou])
   })
 })
 

--- a/src/frontend/services/lsp-shared/__tests__/line-window.test.ts
+++ b/src/frontend/services/lsp-shared/__tests__/line-window.test.ts
@@ -92,9 +92,14 @@ describe('clipSymbolsToWindow', () => {
   // strucpp answers DocumentSymbol[]: one top-level entry per type in the
   // aggregate datatypes document, one per POU in a `pou://` document with
   // its VAR declarations as children.
-  const symbol = (name: string, startLine: number, endLine: number, children?: LspDocumentSymbol[]) => {
+  const symbol = (
+    name: string,
+    startLine: number,
+    endLine: number,
+    children?: LspDocumentSymbol[],
+  ): LspDocumentSymbol => {
     const range = { start: { line: startLine, character: 0 }, end: { line: endLine, character: 0 } }
-    return { name, kind: 13, range, selectionRange: range, children } as LspDocumentSymbol
+    return { name, kind: 13, range, selectionRange: range, children }
   }
 
   const COLORS = symbol('Colors', 1, 1)

--- a/src/frontend/services/lsp-shared/internal/line-window.ts
+++ b/src/frontend/services/lsp-shared/internal/line-window.ts
@@ -6,7 +6,7 @@
  * the model owns the whole document, as every body editor does.
  */
 
-import type { TextEdit as LspTextEdit } from 'vscode-languageserver-protocol'
+import type { DocumentSymbol as LspDocumentSymbol, TextEdit as LspTextEdit } from 'vscode-languageserver-protocol'
 
 export interface LspLineWindow {
   startLine: number
@@ -47,6 +47,28 @@ export function clipEditsToWindow(edits: LspTextEdit[], lineWindow?: LspLineWind
     }
   }
   return clipped
+}
+
+/**
+ * Symbols the window actually shows. A symbol starting inside it is kept
+ * whole — its children sit within its own range. A symbol that merely
+ * encloses the window (the POU wrapping the VAR blocks a `pouvars://`
+ * view renders) is not itself in view, so its matching children are
+ * lifted in its place.
+ */
+export function clipSymbolsToWindow(symbols: LspDocumentSymbol[], lineWindow?: LspLineWindow): LspDocumentSymbol[] {
+  if (!lineWindow) return symbols
+  const kept: LspDocumentSymbol[] = []
+  for (const sym of symbols) {
+    if (sym.range.start.line >= lineWindow.endLineExclusive) continue
+    if (sym.range.end.line < lineWindow.startLine) continue
+    if (lspLineInWindow(sym.range.start.line, lineWindow)) {
+      kept.push(sym)
+      continue
+    }
+    kept.push(...clipSymbolsToWindow(sym.children ?? [], lineWindow))
+  }
+  return kept
 }
 
 /**

--- a/src/frontend/services/lsp-shared/providers.ts
+++ b/src/frontend/services/lsp-shared/providers.ts
@@ -53,6 +53,7 @@ import {
 } from './converters'
 import {
   clipEditsToWindow,
+  clipSymbolsToWindow,
   lspLineInWindow,
   type LspLineWindow,
   modelMatchesDocumentWindow,
@@ -284,20 +285,28 @@ export function registerLspProviders(opts: RegisterLspProvidersOptions): monaco.
   disposables.push(
     monacoApi.languages.registerDocumentSymbolProvider(languageId, {
       provideDocumentSymbols: async (model) => {
-        const { lineOffset } = resolveLspContext(model.uri.toString())
+        const { lspUri, lineOffset, lineWindow } = resolveLspContext(model.uri.toString())
         const result = await connection.sendRequest(DocumentSymbolRequest.type, {
-          textDocument: { uri: model.uri.toString() },
+          textDocument: { uri: lspUri },
         })
         if (!result) return []
         if (result.length === 0) return []
+        // A body editor renders the document from `lineOffset` down, so a
+        // preamble symbol converts to a line Monaco rejects the moment the
+        // outline navigates to it.
+        const visible = lineWindow ?? { startLine: lineOffset, endLineExclusive: Number.MAX_SAFE_INTEGER }
         // The handler can return either DocumentSymbol[] (nested
         // hierarchy) or SymbolInformation[] (flat list with
         // containerName).  Monaco's outline view wants
         // DocumentSymbol[] — flat lists get rewrapped.
         if ('range' in result[0]) {
-          return (result as DocumentSymbol[]).map((s) => lspDocumentSymbolToMonaco(s, lineOffset))
+          return clipSymbolsToWindow(result as DocumentSymbol[], visible).map((s) =>
+            lspDocumentSymbolToMonaco(s, lineOffset),
+          )
         }
-        return (result as SymbolInformation[]).map((s) => symbolInformationToDocumentSymbol(s, lineOffset))
+        return (result as SymbolInformation[])
+          .filter((s) => lspLineInWindow(s.location.range.start.line, visible))
+          .map((s) => symbolInformationToDocumentSymbol(s, lineOffset))
       },
     }),
   )

--- a/src/frontend/services/st-lsp/__tests__/dtview-context.test.ts
+++ b/src/frontend/services/st-lsp/__tests__/dtview-context.test.ts
@@ -126,9 +126,14 @@ describe('dt view request window', () => {
 describe('dt view outline', () => {
   // strucpp answers the aggregate document with one top-level symbol per
   // type, its fields as children.
-  const symbol = (name: string, startLine: number, endLine: number, children?: LspDocumentSymbol[]) => {
+  const symbol = (
+    name: string,
+    startLine: number,
+    endLine: number,
+    children?: LspDocumentSymbol[],
+  ): LspDocumentSymbol => {
     const range = { start: { line: startLine, character: 0 }, end: { line: endLine, character: 0 } }
-    return { name, kind: 13, range, selectionRange: range, children } as LspDocumentSymbol
+    return { name, kind: 13, range, selectionRange: range, children }
   }
   const AGGREGATE_SYMBOLS = [symbol('Colors', 1, 1), symbol('Motor', 2, 4, [symbol('speed', 3, 3)])]
 

--- a/src/frontend/services/st-lsp/__tests__/dtview-context.test.ts
+++ b/src/frontend/services/st-lsp/__tests__/dtview-context.test.ts
@@ -1,11 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-import type { Diagnostic } from 'vscode-languageserver-protocol'
+import type { Diagnostic, DocumentSymbol as LspDocumentSymbol } from 'vscode-languageserver-protocol'
 
 import type { PLCDataType } from '../../../../middleware/shared/ports/types'
 import { monacoPositionToLsp } from '../../lsp-shared/converters'
-import { lspLineInWindow } from '../../lsp-shared/internal/line-window'
+import { clipSymbolsToWindow, lspLineInWindow } from '../../lsp-shared/internal/line-window'
 import { diagnosticsInSpan, dtViewLineOffset, dtViewSpan, dtViewWindow } from '../dtview-context'
 
 const enumType = (name: string): PLCDataType => ({
@@ -120,5 +120,30 @@ describe('dt view request window', () => {
 
   it('rejects both frame lines of the first entry, whose offset is zero', () => {
     expect(reach('Colors', [1, 2, 3])).toEqual([false, true, false])
+  })
+})
+
+describe('dt view outline', () => {
+  // strucpp answers the aggregate document with one top-level symbol per
+  // type, its fields as children.
+  const symbol = (name: string, startLine: number, endLine: number, children?: LspDocumentSymbol[]) => {
+    const range = { start: { line: startLine, character: 0 }, end: { line: endLine, character: 0 } }
+    return { name, kind: 13, range, selectionRange: range, children } as LspDocumentSymbol
+  }
+  const AGGREGATE_SYMBOLS = [symbol('Colors', 1, 1), symbol('Motor', 2, 4, [symbol('speed', 3, 3)])]
+
+  const outline = (dtName: string) => {
+    const span = dtViewSpan(DATA_TYPES, dtName)
+    if (!span) throw new Error(`no span for ${dtName}`)
+    return clipSymbolsToWindow(AGGREGATE_SYMBOLS, dtViewWindow(span))
+  }
+
+  it('shows only the entry the view renders', () => {
+    expect(outline('Motor').map((s) => s.name)).toEqual(['Motor'])
+    expect(outline('Colors').map((s) => s.name)).toEqual(['Colors'])
+  })
+
+  it('keeps the entry fields', () => {
+    expect(outline('Motor')[0].children?.map((s) => s.name)).toEqual(['speed'])
   })
 })

--- a/src/frontend/utils/__tests__/monaco-cancellation.test.ts
+++ b/src/frontend/utils/__tests__/monaco-cancellation.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { installMonacoCancellationGuard, isMonacoCancellation } from '../monaco-cancellation'
+
+const canceled = () => {
+  const error = new Error('Canceled')
+  error.name = 'Canceled'
+  return error
+}
+
+const rejectionEvent = (reason: unknown) => {
+  const event = new Event('unhandledrejection', { cancelable: true })
+  Object.defineProperty(event, 'reason', { value: reason })
+  return event
+}
+
+describe('isMonacoCancellation', () => {
+  it('accepts the error Monaco rejects cancelled work with', () => {
+    expect(isMonacoCancellation(canceled())).toBe(true)
+  })
+
+  it('rejects an error that only borrows the name', () => {
+    const error = new Error('Request cancelled by the user')
+    error.name = 'Canceled'
+    expect(isMonacoCancellation(error)).toBe(false)
+  })
+
+  it('rejects a real failure', () => {
+    expect(isMonacoCancellation(new Error('Canceled the wrong way'))).toBe(false)
+    expect(isMonacoCancellation(new TypeError('Canceled'))).toBe(false)
+  })
+
+  it('rejects a non-error reason', () => {
+    expect(isMonacoCancellation('Canceled')).toBe(false)
+    expect(isMonacoCancellation(undefined)).toBe(false)
+  })
+})
+
+describe('installMonacoCancellationGuard', () => {
+  it('swallows a cancellation rejection', () => {
+    const uninstall = installMonacoCancellationGuard()
+    const event = rejectionEvent(canceled())
+    window.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+    uninstall()
+  })
+
+  it('leaves a real rejection to be reported', () => {
+    const uninstall = installMonacoCancellationGuard()
+    const event = rejectionEvent(new Error('worker died'))
+    window.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(false)
+    uninstall()
+  })
+
+  it('stops swallowing once uninstalled', () => {
+    installMonacoCancellationGuard()()
+    const event = rejectionEvent(canceled())
+    window.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(false)
+  })
+})

--- a/src/frontend/utils/monaco-cancellation.ts
+++ b/src/frontend/utils/monaco-cancellation.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+
+const CANCELED = 'Canceled'
+
+/**
+ * Monaco's own cancellation signal: `CancellationError` and the legacy
+ * `canceled()` helper both set name and message to `Canceled`.
+ */
+export function isMonacoCancellation(reason: unknown): boolean {
+  return reason instanceof Error && reason.name === CANCELED && reason.message === CANCELED
+}
+
+/**
+ * Dismissing a quick pick cancels its token, and the delayers unwound by
+ * that cancellation reject with no `catch` behind them. Nothing is wrong,
+ * but the renderer reports every one as an unhandled rejection.
+ */
+export function installMonacoCancellationGuard(): () => void {
+  const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+    if (isMonacoCancellation(event.reason)) event.preventDefault()
+  }
+  window.addEventListener('unhandledrejection', onUnhandledRejection)
+  return () => window.removeEventListener('unhandledrejection', onUnhandledRejection)
+}


### PR DESCRIPTION
Closes DOPE-590.

## The bug

Every LSP provider resolves the Monaco model URI to an LSP context and requests against the resolved `lspUri`. The document-symbols provider was the one exception — it requested `model.uri` directly:

```ts
const { lineOffset } = resolveLspContext(model.uri.toString())
const result = await connection.sendRequest(DocumentSymbolRequest.type, {
  textDocument: { uri: model.uri.toString() },   // model URI, not lspUri
})
```

For a partial code view that URI is synthetic and the worker never indexed it. Confirmed in strucpp's own handler — `docManager.getState(uri)` misses, and it returns `[]`. So `dtview://` and `pouvars://` had **no outline at all**.

## Why the URI swap alone isn't enough

The answer covers the whole document; the model renders a slice of it. Symbols are clipped to that slice:

- A symbol starting inside the window is kept whole — its children sit within its own range.
- A symbol that merely **encloses** the window is not itself in view, so its matching children are lifted in its place. This is the `pouvars://` case: strucpp answers a `pou://` document with one top-level POU symbol spanning the file and the VAR declarations as children. The card proposed filtering top-level symbols by start line, which drops that POU (it starts at line 0, outside the VAR window) and takes the declarations with it, leaving the outline empty.
- A body editor has no explicit window, so it is bounded by `lineOffset` — the preamble the model never renders.

That last bound fixes a **renderer crash** that predates this card. `converters.ts:64` maps LSP line 0 to `1 - lineOffset`, a non-positive line, and `editorNavigationQuickAccess.js:93` calls `model.getLineContent` on it the moment the outline navigates:

```
Error: Illegal value for lineNumber
  at TextModel.getLineContent
  at StandaloneGotoSymbolQuickAccessProvider.gotoLocation
```

## Consequence worth reviewing

**The ST body editor's outline is now empty.** That is the honest answer — strucpp emits no symbols for statements, and the declarations it does emit genuinely are not in that editor, which is why picking one could never work. It contradicts the card's original AC ("body outline unchanged"), which assumed the body path was already correct; it wasn't.

DOPE-551 carries the follow-up: list the declarations again and bind accepting one to the preamble redirect that already opens the variables panel. Its description and acceptance criteria were extended for this.

**Python gains an outline it never had** — its `lspUri` is `<modelUri>.py`, the URI basedpyright indexes, while the request went out with the extensionless model URI.

## Validation

Run in this desktop editor against a real project, all four surfaces:

| surface | before | after |
| --- | --- | --- |
| `.dt` code view | empty | only that type and its fields |
| POU variables code view | empty | the VAR declarations |
| POU body editor | listed, crashed on Enter | empty, no crash |
| Python POU | empty | populated |

Automated: 25 tests in `line-window.test.ts`, 15 in `dtview-context.test.ts` walking the real `dtViewSpan`/`dtViewWindow` arithmetic. Full suites green in both repos — editor 350/350 suites and 7463 tests with coverage above every threshold, web 351/354 files (the 3 failures are the known local-only jsdom/localStorage adapter suites, identical on clean `development`, green in CI).

## Second commit: Monaco cancellation noise

Dismissing a quick pick cancels its token, unwinding delayers that reject with no `catch` behind them. Nothing is broken, but each one reports as an unhandled rejection. A guard at renderer bootstrap marks them handled, with a deliberately narrow predicate — an error merely *named* `Canceled` with a different message still reports, and two tests pin that.

**Known dev-only noise, accepted:** webpack-dev-server registers its own `unhandledrejection` listener before any app code runs, and listeners fire in registration order, so its overlay still appears intermittently in dev (trigger: Esc landing while `WordHighlighter`'s delayer is mid-flight). Filtering it through `client.overlay.runtimeErrors` is not open to us — the option is serialized and rebuilt client-side with `new Function`, which our CSP (`script-src 'self' 'unsafe-inline'`, `src/index.ejs:13`) refuses, taking the whole dev-server client down with an `EvalError`. The remaining options are relaxing that CSP or disabling the runtime-error overlay wholesale; neither is worth it for a cosmetic dev-only message. The console stays clean regardless, and a packaged build has no such listener.

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/715

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JAMx8mRf2ig4YFfs2gmsM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor stability by preventing expected Monaco cancellation events from appearing as unhandled errors.
  * Updated code outlines to show only symbols within the visible editor window.
  * Preserved relevant child symbols when enclosing symbols fall outside the visible window.

* **Tests**
  * Added coverage for editor cancellation handling and visible-window symbol filtering, including data type views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->