### PR TITLE
feature(library): detach simulator verification from the build, add a debug harness [DOPE-597]

### DIFF
--- a/src/backend/editor/compiler/compiler-module.spec.ts
+++ b/src/backend/editor/compiler/compiler-module.spec.ts
@@ -848,4 +848,88 @@ describe('CompilerModule', () => {
       )
     })
   })
+
+  describe('compileLibrary — IPC payload validation', () => {
+    /**
+     * Collects what the module posts over the progress channel, plus whether
+     * it ever closed. A build that neither posts a result nor closes is the
+     * exact failure being guarded against: `main.ts` invokes this method with
+     * `void`, so a throw would leave the renderer's promise unsettled forever.
+     */
+    function makeChannel() {
+      const messages: Record<string, unknown>[] = []
+      let closed = false
+      return {
+        messages,
+        isClosed: () => closed,
+        channel: {
+          start: () => {},
+          postMessage: (m: Record<string, unknown>) => messages.push(m),
+          close: () => {
+            closed = true
+          },
+        },
+      }
+    }
+
+    const bridge = { loadEnabledArchives: () => ({ archives: [], missing: [] }) }
+
+    const wellFormed = {
+      pous: [],
+      dataTypes: [],
+      libraries: [],
+      configuration: { resource: { tasks: [], instances: [], globalVariables: [] } },
+    }
+
+    it('accepts the payload the editor adapter actually sends', async () => {
+      // Guards the other direction from the rejection cases below: a validator
+      // that turns away a well-formed build is a worse regression than the hole
+      // it closes. This is `IpcProjectData`'s shape — note `configuration`
+      // (singular), which is what the adapter emits and what `stubProgramFor`
+      // reads.
+      const compilerModule = new CompilerModule()
+      const { messages, channel } = makeChannel()
+
+      await compilerModule.compileLibrary(['/project', wellFormed, []], channel, bridge)
+
+      const result = messages.find((m) => m.libraryBuildResult)?.libraryBuildResult as
+        | { success: boolean; error?: string }
+        | undefined
+      // It still fails — there is no `library.json` on disk at `/project` — but
+      // it must fail on THAT, having passed the boundary check.
+      expect(result?.error ?? '').not.toMatch(
+        /malformed request|no project path|no project data|no POU list|no configuration|no resource|no task or instance list/,
+      )
+    })
+
+    it.each([
+      ['not an array', 'malformed request'],
+      [[], 'malformed request'],
+      [['/project'], 'malformed request'],
+      [['', wellFormed, []], 'no project path'],
+      [['/project', null, []], 'no project data'],
+      [['/project', {}, []], 'no POU list'],
+      [['/project', { pous: [] }, []], 'no configuration'],
+      [['/project', { pous: [], configuration: {} }, []], 'no resource'],
+      [['/project', { pous: [], configuration: { resource: {} } }, []], 'no task or instance list'],
+    ])('rejects %p with a result and a closed port', async (args, expected) => {
+      const compilerModule = new CompilerModule()
+      const { messages, isClosed, channel } = makeChannel()
+
+      await compilerModule.compileLibrary(args, channel, bridge)
+
+      const result = messages.find((m) => m.libraryBuildResult)?.libraryBuildResult as {
+        success: boolean
+        error: string
+      }
+      // A result is what settles the renderer's promise — the assertion that
+      // matters more than the wording.
+      expect(result).toBeDefined()
+      expect(result.success).toBe(false)
+      expect(result.error).toContain(expected)
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(isClosed()).toBe(true)
+    })
+  })
 })

--- a/src/backend/editor/compiler/compiler-module.spec.ts
+++ b/src/backend/editor/compiler/compiler-module.spec.ts
@@ -857,19 +857,36 @@ describe('CompilerModule', () => {
      * `void`, so a throw would leave the renderer's promise unsettled forever.
      */
     function makeChannel() {
-      const messages: Record<string, unknown>[] = []
+      // `unknown[]`, matching `CompileProgressChannel.postMessage(message:
+      // unknown)`. Typing the sink as the shape we hope to find would assume
+      // the very thing these tests exist to check.
+      const messages: unknown[] = []
       let closed = false
       return {
         messages,
         isClosed: () => closed,
         channel: {
           start: () => {},
-          postMessage: (m: Record<string, unknown>) => messages.push(m),
+          postMessage: (m: unknown) => messages.push(m),
           close: () => {
             closed = true
           },
         },
       }
+    }
+
+    /** The build result carried by one of `messages`, or null if none does. */
+    function readBuildResult(messages: unknown[]): { success: boolean; error?: string } | null {
+      for (const message of messages) {
+        if (typeof message !== 'object' || message === null) continue
+        if (!('libraryBuildResult' in message)) continue
+        const result = message.libraryBuildResult
+        if (typeof result !== 'object' || result === null) continue
+        if (!('success' in result) || typeof result.success !== 'boolean') continue
+        const error = 'error' in result && typeof result.error === 'string' ? result.error : undefined
+        return { success: result.success, ...(error === undefined ? {} : { error }) }
+      }
+      return null
     }
 
     const bridge = { loadEnabledArchives: () => ({ archives: [], missing: [] }) }
@@ -892,9 +909,7 @@ describe('CompilerModule', () => {
 
       await compilerModule.compileLibrary(['/project', wellFormed, []], channel, bridge)
 
-      const result = messages.find((m) => m.libraryBuildResult)?.libraryBuildResult as
-        | { success: boolean; error?: string }
-        | undefined
+      const result = readBuildResult(messages)
       // It still fails — there is no `library.json` on disk at `/project` — but
       // it must fail on THAT, having passed the boundary check.
       expect(result?.error ?? '').not.toMatch(
@@ -918,15 +933,12 @@ describe('CompilerModule', () => {
 
       await compilerModule.compileLibrary(args, channel, bridge)
 
-      const result = messages.find((m) => m.libraryBuildResult)?.libraryBuildResult as {
-        success: boolean
-        error: string
-      }
+      const result = readBuildResult(messages)
       // A result is what settles the renderer's promise — the assertion that
       // matters more than the wording.
-      expect(result).toBeDefined()
-      expect(result.success).toBe(false)
-      expect(result.error).toContain(expected)
+      expect(result).not.toBeNull()
+      expect(result?.success).toBe(false)
+      expect(result?.error).toContain(expected)
 
       await new Promise((resolve) => setTimeout(resolve, 50))
       expect(isClosed()).toBe(true)

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -25,7 +25,7 @@ type StrucppCompileError = import('strucpp').CompileError
 
 import { buildArduinoCliCompileArgs } from '@root/backend/shared/firmware/build-arduino-cli-args'
 import { runLibraryBuildPipeline } from '@root/backend/shared/library/library-build-orchestrator'
-import { parseNativePouRefs } from '@root/backend/shared/library/native-pou-list'
+import { type NativePouRef, parseNativePouRefs } from '@root/backend/shared/library/native-pou-list'
 import { buildKnownPous, emitCompileErrorEvents } from '@root/backend/shared/library/program-build-helpers'
 import { runProgramBuildPipeline } from '@root/backend/shared/library/program-build-pipeline'
 import { loadStrucpp } from '@root/backend/shared/library/strucpp-runtime'
@@ -53,6 +53,82 @@ import type { KnownPou } from '@root/backend/shared/utils/PLC/split-program-st'
  */
 type LibraryCompileBridge = {
   loadEnabledArchives: (enabledNames: string[]) => { archives: unknown[]; missing: string[] }
+}
+
+/**
+ * Validated form of the `compiler:run-compile-library` payload.
+ *
+ * `CompileLibraryIpcArgs` types what OUR renderer sends; this checks what
+ * actually arrived.  The two are not the same statement — anything crossing
+ * IPC is `unknown` at runtime however the sender was typed.
+ */
+type ParsedCompileLibraryArgs = {
+  projectPath: string
+  projectData: PLCProjectData
+  nativePous: NativePouRef[]
+}
+
+/**
+ * Structural guard over the library-build IPC payload.
+ *
+ * Checks exactly the fields the pipeline dereferences before its first
+ * try/catch — `prepareXmlForLibraryBuild` -> `stubProgramFor` spreads
+ * `data.pous` and `data.configuration.resource.{tasks,instances}` with no
+ * guard of its own.  A malformed payload used to throw a TypeError out of
+ * `runLibraryBuildPipeline`, and because `main.ts` invokes this method with
+ * `void`, that rejection surfaced nowhere: the port was never closed and the
+ * renderer's promise never settled.  Failing here posts a result and closes
+ * the port like any other build failure.
+ *
+ * Deliberately structural rather than a full zod parse of `PLCProjectSchema`:
+ * what crosses this channel is `IpcProjectData`, a hand-maintained
+ * restatement of the project model that legitimately drops fields the schema
+ * requires.  Validating against the schema would reject payloads the build
+ * handles correctly today — a worse failure than the hole it closes.
+ */
+function parseCompileLibraryArgs(
+  raw: unknown,
+): { ok: true; value: ParsedCompileLibraryArgs } | { ok: false; error: string } {
+  if (!Array.isArray(raw) || raw.length < 2) {
+    return {
+      ok: false,
+      error: 'Library build failed: malformed request (expected [projectPath, projectData, nativePous]).',
+    }
+  }
+  const [projectPath, projectData, rawNativePous] = raw as unknown[]
+  if (typeof projectPath !== 'string' || projectPath === '') {
+    return { ok: false, error: 'Library build failed: request carried no project path.' }
+  }
+  if (typeof projectData !== 'object' || projectData === null) {
+    return { ok: false, error: 'Library build failed: request carried no project data.' }
+  }
+  const data = projectData as Record<string, unknown>
+  if (!Array.isArray(data.pous)) {
+    return { ok: false, error: 'Library build failed: project data has no POU list.' }
+  }
+  const configuration = data.configuration
+  if (typeof configuration !== 'object' || configuration === null) {
+    return { ok: false, error: 'Library build failed: project data has no configuration.' }
+  }
+  const resource = (configuration as Record<string, unknown>).resource
+  if (typeof resource !== 'object' || resource === null) {
+    return { ok: false, error: 'Library build failed: project configuration has no resource.' }
+  }
+  const { tasks, instances } = resource as Record<string, unknown>
+  if (!Array.isArray(tasks) || !Array.isArray(instances)) {
+    return { ok: false, error: 'Library build failed: project resource has no task or instance list.' }
+  }
+  return {
+    ok: true,
+    value: {
+      projectPath,
+      // Shape-checked above for everything the pipeline reaches for. The
+      // remaining fields are optional to it (`libraries ?? []`,
+      // `dataTypes ?? []`), so a narrower cast here would buy nothing.
+      projectData: projectData as PLCProjectData,
+      nativePous: parseNativePouRefs(rawNativePous),
+    },
+  }
 }
 
 /**
@@ -101,7 +177,7 @@ import {
 } from '@root/backend/shared/utils/vpp/generate-vendor-plugin-config'
 import { APP_VERSION } from '@root/frontend/data/constants/app-version'
 import { getErrorMessage } from '@root/frontend/utils/get-error-message'
-import { app as electronApp, dialog, MessageChannelMain } from 'electron'
+import { app as electronApp, dialog } from 'electron'
 import JSZip from 'jszip'
 
 import type { PlatformOption } from '../../../middleware/shared/ports/types'
@@ -117,34 +193,6 @@ interface MethodsResult<T> {
   data?: T
 }
 type HandleOutputDataCallback = (chunk: Buffer | string, logLevel?: 'info' | 'warning' | 'error') => void
-
-/**
- * Decode a `MessagePortMain` payload back to a string, handling the
- * forms a Node `Buffer` survives V8's structured clone as:
- *
- *   - `string` — passthrough.
- *   - `Uint8Array` / `ArrayBuffer` — typed-array decode (this is the
- *     shape Buffers ride as when the channel stays inside the main
- *     process; `.toString()` on a Uint8Array returns the comma-
- *     separated number list and was the cause of the `[verify]
- *     67,111,109,…` console flood).
- *   - `{ type: 'Buffer', data: number[] }` — Electron's IPC
- *     serialisation form, same shape `decodeMessage` in the
- *     `compiler-adapter` already handles.
- *   - anything else — `String(...)` fallback.
- */
-function decodePortMessage(raw: unknown): string {
-  if (typeof raw === 'string') return raw
-  if (raw instanceof Uint8Array) return new TextDecoder().decode(raw)
-  if (raw instanceof ArrayBuffer) return new TextDecoder().decode(new Uint8Array(raw))
-  if (raw && typeof raw === 'object' && 'type' in raw) {
-    const obj = raw as Record<string, unknown>
-    if (obj.type === 'Buffer' && Array.isArray(obj.data)) {
-      return new TextDecoder().decode(new Uint8Array(obj.data as number[]))
-    }
-  }
-  return String(raw)
-}
 
 type CompileArduinoProgramArgs = {
   boardTarget: string
@@ -382,24 +430,6 @@ class CompilerModule {
   // structure so the recipe templates resolve.
   #constructShowPropertiesDummyPath(): string {
     return join(this.sourceDirectoryPath, 'show_properties_dummy')
-  }
-
-  /**
-   * Resolve a board target to the arduino-cli core ID
-   * (`arduino-cli core install` target — e.g. `arduino:avr`).
-   *
-   * Single source of truth: reads from the shared
-   * `backend/shared/firmware/hals.json` bundle, the same file the
-   * renderer's `bridge.getAvailableBoards()` exposes via
-   * `boardInfo.core`.
-   * Used internally by the library-project verification path so a
-   * future hals.json edit (rename, new board, version bump)
-   * propagates to verification automatically — without any code
-   * change here.
-   */
-  async #getBoardCore(board: string): Promise<string | null> {
-    const halsFileContent = await readHalsFile<HalsFile>()
-    return halsFileContent[board]?.['core'] ?? null
   }
 
   /**
@@ -3317,27 +3347,29 @@ class CompilerModule {
    * `composeLibraryDebugHarness`.
    */
   async compileLibrary(
-    args: Array<string | PLCProjectData | boolean>,
+    args: unknown,
     _mainProcessPort: CompileProgressChannel,
     mainProcessBridge: LibraryCompileBridge,
   ): Promise<void> {
     _mainProcessPort.start()
 
-    // IPC args: [projectPath, projectData, nativePous?]
-    //
-    // `nativePous` is appended rather than derived here: it has to be read
-    // off the RAW project data, and by the time anything arrives over this
-    // channel `preprocessPous` has already lowered every native body to
+    // IPC args: `CompileLibraryIpcArgs` — [projectPath, projectData,
+    // nativePous]. `nativePous` is sent rather than derived here: it has to be
+    // read off the RAW project data, and by the time anything arrives over
+    // this channel `preprocessPous` has already lowered every native body to
     // bridge ST and rewritten its language tag. An older renderer omits it,
     // which degrades to "this project has no native POUs".
-    const [projectPath, projectData, rawNativePous] = args as [string, PLCProjectData, unknown]
-
-    // Validated at the boundary rather than trusted: this crosses IPC, so it
-    // arrives as `unknown` whatever the renderer intended. A malformed entry
-    // would otherwise throw inside the pipeline's read loop, and this handler
-    // is invoked with `void` — the renderer would wait for a result that never
-    // arrives. `parseNativePouRefs` drops what it cannot read.
-    const nativePous = parseNativePouRefs(rawNativePous)
+    //
+    // Validated rather than trusted — see `parseCompileLibraryArgs` for why a
+    // throw here would strand the renderer instead of failing the build.
+    const parsed = parseCompileLibraryArgs(args)
+    if (!parsed.ok) {
+      _mainProcessPort.postMessage({ logLevel: 'error', message: parsed.error })
+      _mainProcessPort.postMessage({ libraryBuildResult: { success: false, error: parsed.error } })
+      setTimeout(() => _mainProcessPort.close(), 25)
+      return
+    }
+    const { projectPath, projectData, nativePous } = parsed.value
 
     // Bridge the orchestrator's structured port API onto the desktop
     // platform's existing helpers.  This is the only desktop-specific

--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -37,39 +37,23 @@ import {
 import type { KnownPou } from '@root/backend/shared/utils/PLC/split-program-st'
 
 /**
- * Shared bridge contract between `compileLibrary` and its inner
- * `runVerificationCompile` step.  Both paths talk to the same
- * runtime API and library-resolution helper.  `loadEnabledArchives`
- * resolves project-enabled library names to parsed `.stlib`
- * archives — bundled libs are always-included, user-installed
- * subset is filtered by name, missing-but-enabled names come back
- * for the caller to surface as a pre-compile error.  The same call
- * feeds the program build (`strucpp.compile`'s `libraries:` option)
- * and the library build (`compileStlib`'s dependency list), so
- * there's exactly one resolution path and no chance of the program
- * compile seeing a different library set than the verification
- * compile.
+ * Bridge contract `compileLibrary` needs from the main process.
+ * `loadEnabledArchives` resolves project-enabled library names to
+ * parsed `.stlib` archives — bundled libs are always-included, the
+ * user-installed subset is filtered by name, and missing-but-enabled
+ * names come back for the caller to surface as a pre-compile error.
+ * The same call feeds the program build (`strucpp.compile`'s
+ * `libraries:` option) and the library build (`compileStlib`'s
+ * dependency list), so there's exactly one resolution path.
+ *
+ * It used to carry the runtime-API methods too, because the library
+ * build ran an inner verification compile through `compileProgram`.
+ * That step is gone, so the library path never touches the runtime
+ * and the contract narrows to the one call it actually makes.
  */
 type LibraryCompileBridge = {
-  makeRuntimeApiRequest: <T = void>(
-    ipAddress: string,
-    endpoint: string,
-    responseParser?: (data: string) => T,
-  ) => Promise<{ success: true; data?: T } | { success: false; error: string }>
-  // Required to satisfy compileProgram's bridge contract; never invoked on the
-  // library path (it compiles with runtimeIpAddress=null, so no upload runs).
-  makeRuntimeApiUpload: (opts: {
-    ipAddress: string
-    fileBuffer: Buffer
-    filename: string
-    contentType: string
-    cleanBuild: boolean
-    onUploadAccepted?: (responseBody: string) => void
-  }) => Promise<{ success: true; data: string } | { success: false; error: string }>
   loadEnabledArchives: (enabledNames: string[]) => { archives: unknown[]; missing: string[] }
 }
-
-type LibraryVerificationBridge = LibraryCompileBridge
 
 /**
  * Project data with the optional C++ POU sidecar attached. The base
@@ -3326,13 +3310,11 @@ class CompilerModule {
    *   5. Write the archive (same `JSON.stringify(archive, null, 2)`
    *      shape `library-manager-module` persists user-installed
    *      archives with) to `<projectPath>/build/<name>.stlib`.
-   *   6. (Phase 8) Run an end-to-end avr-gcc verification compile
-   *      against the OpenPLC Simulator target, gated by an MD5
-   *      cache keyed off the produced program.st.  Verification
-   *      failures surface as warnings on `result.verification`,
-   *      never as build errors — a legitimate user target may have
-   *      more memory than the AVR simulator.  `cleanBuild` skips
-   *      the cache and forces a re-verification.
+   *
+   * The build is target-neutral — no avr-gcc pass, no simulator.
+   * Running a library is a separate action the renderer drives
+   * through `compileProgram` with a generated harness project; see
+   * `composeLibraryDebugHarness`.
    */
   async compileLibrary(
     args: Array<string | PLCProjectData | boolean>,
@@ -3341,22 +3323,14 @@ class CompilerModule {
   ): Promise<void> {
     _mainProcessPort.start()
 
-    // IPC args:
-    //   [projectPath, projectData (build-pass), verifyProjectData,
-    //    cleanBuild?, nativePous?]
+    // IPC args: [projectPath, projectData, nativePous?]
     //
     // `nativePous` is appended rather than derived here: it has to be read
     // off the RAW project data, and by the time anything arrives over this
     // channel `preprocessPous` has already lowered every native body to
     // bridge ST and rewritten its language tag. An older renderer omits it,
     // which degrades to "this project has no native POUs".
-    const [projectPath, projectData, verifyProjectData, cleanBuild = false, rawNativePous] = args as [
-      string,
-      PLCProjectData,
-      PLCProjectData,
-      boolean | undefined,
-      unknown,
-    ]
+    const [projectPath, projectData, rawNativePous] = args as [string, PLCProjectData, unknown]
 
     // Validated at the boundary rather than trusted: this crosses IPC, so it
     // arrives as `unknown` whatever the renderer intended. A malformed entry
@@ -3371,18 +3345,12 @@ class CompilerModule {
     // the shared orchestrator from here on.
     const libraryPort = createDesktopLibraryBuildPort({
       loadEnabledArchives: (names) => mainProcessBridge.loadEnabledArchives(names),
-      runVerificationCompile: ({ projectPath: p, verifyProjectData: v, emit }) =>
-        this.runVerificationCompile(p, v as PLCProjectData, mainProcessBridge, (message, logLevel) =>
-          emit(message, logLevel),
-        ),
     })
 
     const result = await runLibraryBuildPipeline(
       {
         projectPath,
         projectData,
-        verifyProjectData,
-        cleanBuild,
         nativePous,
       },
       libraryPort,
@@ -3393,123 +3361,6 @@ class CompilerModule {
     // Same 25ms delay the pre-refactor code used so the result
     // message is delivered before the port closes.
     setTimeout(() => _mainProcessPort.close(), 25)
-  }
-
-  /**
-   * Run an end-to-end verification compile of a synthetic Library
-   * Project against the OpenPLC Simulator target.  Reuses the full
-   * `compileProgram` pipeline (strucpp → arduino-cli → bundled
-   * avr-gcc) by feeding it a private `MessageChannelMain` — verifies
-   * the same way the program build does, against the same binaries,
-   * with zero code duplication.
-   *
-   * `forwardLog` is the caller's drain for the inner pipeline's
-   * message stream.  Streaming the strucpp / arduino-cli output is
-   * the difference between "blank console for 30 seconds while
-   * arduino-cli compiles" and "user sees progress" — and crucially
-   * the difference between "the .stlib generated but verification
-   * failed silently" and "the user knows which C++ line tripped
-   * avr-gcc".  We do keep the first error message internally so the
-   * summary line at the end of the build is succinct, but every log
-   * line still flows through.
-   *
-   * Resolves with `{success, message?}` either when the inner
-   * pipeline posts `closePort: true` (happy path) or when its port
-   * closes without one (the many error paths in `compileProgram`).
-   * Never throws — matches the caller's "verification is advisory"
-   * contract.
-   */
-  private async runVerificationCompile(
-    projectPath: string,
-    verifyData: PLCProjectData,
-    bridge: LibraryVerificationBridge,
-    forwardLog: (message: string, logLevel?: 'info' | 'warning' | 'error') => void,
-  ): Promise<{ success: boolean; message?: string }> {
-    // Look up the simulator board's core ID from `hals.json` —
-    // single source of truth shared with the renderer-side
-    // `boardInfo.core` lookup.  Falls back to a sensible default
-    // only if hals.json has been mangled; the resulting compile
-    // would fail at `core install` and surface as a verification
-    // warning, which is the documented advisory behaviour.
-    const SIMULATOR_BOARD = 'OpenPLC Simulator'
-    const boardCore = (await this.#getBoardCore(SIMULATOR_BOARD)) ?? 'arduino:avr'
-
-    return new Promise((resolve) => {
-      const channel = new MessageChannelMain()
-      let firstError: string | null = null
-      let settled = false
-
-      const settle = (result: { success: boolean; message?: string }) => {
-        if (settled) return
-        settled = true
-        try {
-          channel.port1.close()
-        } catch {
-          // Already closed — fine.
-        }
-        resolve(result)
-      }
-
-      channel.port1.on('message', (event) => {
-        const data = event.data as {
-          message?: unknown
-          logLevel?: 'info' | 'warning' | 'error'
-          closePort?: boolean
-        }
-        if (data.message !== undefined) {
-          // `decodePortMessage` returns readable text from the
-          // `Uint8Array` Node `Buffer` payloads survive structured
-          // clone as.  Without it, `.toString()` on a Uint8Array
-          // would render comma-separated byte numbers in the
-          // console.
-          const text = decodePortMessage(data.message)
-          // Forward every line — the caller decides how to render
-          // them (PLC-build path would prepend `[verify]`).  Even
-          // info-level messages matter here: avr-gcc compile can
-          // take 10+ seconds on a large library and the user needs
-          // to see progress.
-          forwardLog(text, data.logLevel)
-          // Keep only the FIRST error string for the summary.  Once
-          // arduino-cli or strucpp errors, the cascade usually
-          // continues with knock-on failures; the first one names
-          // the underlying cause.
-          if (data.logLevel === 'error' && firstError === null) {
-            firstError = text
-          }
-        }
-        if (data.closePort) {
-          settle(firstError ? { success: false, message: firstError } : { success: true })
-        }
-      })
-      // `compileProgram` posts intermediate `closePort: true` messages
-      // on its happy path but jumps straight to `port.close()` on its
-      // many error paths, without an explicit close message.  Listen
-      // for the port's 'close' event so an inner-pipeline error can't
-      // leave the outer library build hanging on an unresolved promise
-      // — same convention the renderer-side adapter uses.
-      channel.port1.on('close', () => {
-        settle(firstError ? { success: false, message: firstError } : { success: true })
-      })
-      channel.port1.start()
-
-      // The boolean slots (compileOnly / cleanBuild) are runtime
-      // values the inner `compileProgram` re-casts off `args as [...]`,
-      const compileArgs: Array<string | null | boolean | undefined | object> = [
-        projectPath,
-        SIMULATOR_BOARD,
-        boardCore,
-        true,
-        verifyData,
-        null,
-        null,
-        true,
-        null,
-        undefined,
-      ]
-      void this.compileProgram(compileArgs, channel.port2, bridge).catch((err) =>
-        settle({ success: false, message: getErrorMessage(err) }),
-      )
-    })
   }
 }
 export { CompilerModule }

--- a/src/backend/editor/compiler/desktop-library-build-port.ts
+++ b/src/backend/editor/compiler/desktop-library-build-port.ts
@@ -6,13 +6,9 @@
  * Owns ONLY the platform-specific primitives the shared
  * `runLibraryBuildPipeline` cannot perform itself:
  *
- *   - MD5 hashing (Node `crypto`)
  *   - ST transpilation via the in-process JSON-fed transpiler
  *   - read / write / delete project files on the local disk
  *   - resolve library-name → `.stlib` archive via the main-process bridge
- *   - drive a verification compile through the editor's existing
- *     `compileProgram` flow (which already routes through the
- *     shared `runCompilePipeline`)
  *
  * No business logic lives here.  The orchestrator owns the build
  * sequence, cache decisions, error formatting, and the stable
@@ -20,7 +16,6 @@
  * shared with the web port impl.
  */
 
-import { createHash } from 'node:crypto'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 
@@ -47,30 +42,10 @@ export interface DesktopLibraryBuildPortDeps {
    * pointing message before any heavy step runs.
    */
   loadEnabledArchives(enabledNames: string[]): { archives: unknown[]; missing: string[] }
-
-  /**
-   * Run a verification compile against the OpenPLC Simulator board.
-   * Wraps `CompilerModule.runVerificationCompile` so the port stays
-   * decoupled from the compiler module's full surface.  Failures
-   * here are advisory — caller surfaces them as warnings, never as
-   * a fatal build error.
-   */
-  runVerificationCompile(args: {
-    projectPath: string
-    verifyProjectData: unknown
-    emit: (message: string, level?: 'info' | 'warning' | 'error') => void
-  }): Promise<{ success: boolean; message?: string }>
 }
 
 export function createDesktopLibraryBuildPort(deps: DesktopLibraryBuildPortDeps): LibraryBuildPort {
   return {
-    computeMd5(input: string): Promise<string> {
-      // Web's port impl computes the same digest via `spark-md5`.
-      // The orchestrator's verification cache keys off this value,
-      // so both platforms MUST agree byte-for-byte.
-      return Promise.resolve(createHash('md5').update(input).digest('hex'))
-    },
-
     transpileToSt(
       args: TranspileToStArgs,
       log: (message: string, level: 'info' | 'warning' | 'error') => void,
@@ -128,17 +103,6 @@ export function createDesktopLibraryBuildPort(deps: DesktopLibraryBuildPortDeps)
       // archives in one call; names that don't resolve come back
       // under `missing` for the orchestrator to fail the build on.
       return Promise.resolve(deps.loadEnabledArchives(projectLibraryRefs.map((r) => r.name)))
-    },
-
-    async verifyCompile({ projectPath, verifyProjectData, emit }) {
-      return deps.runVerificationCompile({
-        projectPath,
-        verifyProjectData,
-        // `runVerificationCompile` forwards every line off
-        // `compileProgram`'s message port; pass them straight
-        // through to the orchestrator's emit.
-        emit: (message, level) => emit(message, level ?? 'info'),
-      })
     },
   }
 }

--- a/src/backend/shared/library/__tests__/build-pipeline.test.ts
+++ b/src/backend/shared/library/__tests__/build-pipeline.test.ts
@@ -18,12 +18,7 @@ import type { StrucppRuntime } from '../strucpp-runtime'
 // ---------------------------------------------------------------------------
 
 import { __setStrucppRuntimeForTests } from '../strucpp-runtime'
-import {
-  __TESTING__,
-  composeVerificationProject,
-  libraryBuildFromTranspiledSt,
-  prepareXmlForLibraryBuild,
-} from '../build-pipeline'
+import { __TESTING__, libraryBuildFromTranspiledSt, prepareXmlForLibraryBuild } from '../build-pipeline'
 
 const STUB = __TESTING__
 const { parseLibraryManifest, stubProgramFor } = __TESTING__
@@ -268,7 +263,7 @@ describe('stubProgramFor', () => {
     expect(stubbed.data.configuration.resource.globalVariables[0]?.name).toBe('preExistingGlobal')
   })
 
-  it('keeps meta untouched (the meta type is rewritten only by composeVerificationProject)', () => {
+  it('keeps meta untouched', () => {
     const project = makeLibraryProject()
     const stubbed = stubProgramFor(project)
     expect(stubbed.meta).toEqual(project.meta)
@@ -757,22 +752,5 @@ describe('libraryBuildFromTranspiledSt', () => {
       manifest,
     )
     expect(res.errors).toEqual([])
-  })
-})
-
-// ---------------------------------------------------------------------------
-// composeVerificationProject
-// ---------------------------------------------------------------------------
-
-describe('composeVerificationProject', () => {
-  it('returns a stubbed project tagged plc-project (not plc-library)', () => {
-    const project = makeLibraryProject()
-    const verification = composeVerificationProject(project)
-
-    expect(verification.meta.type).toBe('plc-project')
-    expect(verification.meta.name).toBe(project.meta.name)
-    expect(verification.data.pous).toHaveLength(2)
-    expect(verification.data.configuration.resource.tasks).toHaveLength(1)
-    expect(verification.data.configuration.resource.instances).toHaveLength(1)
   })
 })

--- a/src/backend/shared/library/__tests__/library-build-orchestrator.test.ts
+++ b/src/backend/shared/library/__tests__/library-build-orchestrator.test.ts
@@ -1,24 +1,27 @@
 /**
  * Tests for the shared library-build orchestrator.
  *
- * The orchestrator's job is to drive the 7-stage flow through a
+ * The orchestrator's job is to drive the stage flow through a
  * `LibraryBuildPort`.  These tests mock the port + the inner shared
  * helpers (`prepareXmlForLibraryBuild`, `libraryBuildFromTranspiledSt`)
  * and verify the orchestrator's contract: stage ordering, error
- * propagation, cache hit/miss, archive feed-through, verification
- * gating.
+ * propagation, archive feed-through.
+ *
+ * The build no longer runs an avr-gcc verification compile, so there is
+ * nothing here about verify caching, `cleanBuild`, or advisory verify
+ * failures — running a library goes through the debug harness instead
+ * (`composeLibraryDebugHarness`).
  *
  * Production callers (desktop adapter and the future web adapter) get
  * exercised through their own integration paths — this file is
  * unit-level for the orchestration logic itself.
  */
 
-import type { LibraryBuildPort, VerifyCompileArgs } from '../../../../middleware/shared/ports/library-build-port'
+import type { LibraryBuildPort } from '../../../../middleware/shared/ports/library-build-port'
 import type { TranspileToStArgs, TranspileToStResult } from '../../../../middleware/shared/ports/compiler-platform-port'
 import type { PLCProjectData } from '../../types/PLC/open-plc'
 
-// ST the fake `transpileToSt` port method emits.  Fixed content so the
-// verification-cache tests can precompute the harness MD5 off it.
+// ST the fake `transpileToSt` port method emits.
 const FAKE_PROGRAM_ST = 'PROGRAM main\n(* transpiled *)\nEND_PROGRAM\n'
 
 // ---------------------------------------------------------------------------
@@ -27,16 +30,10 @@ const FAKE_PROGRAM_ST = 'PROGRAM main\n(* transpiled *)\nEND_PROGRAM\n'
 
 const mockPrepareXml = jest.fn()
 const mockLibraryBuild = jest.fn()
-const mockComposeVerify = jest.fn((project: { meta: unknown; data: unknown }) => ({
-  meta: { ...(project.meta as Record<string, unknown>), type: 'plc-project' },
-  data: project.data,
-}))
 
 jest.mock('../build-pipeline', () => ({
   prepareXmlForLibraryBuild: (...args: unknown[]) => mockPrepareXml(...args),
   libraryBuildFromTranspiledSt: (...args: unknown[]) => mockLibraryBuild(...args),
-  composeVerificationProject: (...args: unknown[]) =>
-    mockComposeVerify(...(args as [{ meta: unknown; data: unknown }])),
 }))
 
 import { runLibraryBuildPipeline } from '../library-build-orchestrator'
@@ -51,8 +48,6 @@ interface PortHarness {
   manifestContent: string | null
   archives: unknown[]
   missing: string[]
-  verifyResult: { success: boolean; message?: string }
-  verifyCalls: VerifyCompileArgs[]
   transpileResult: TranspileToStResult
   transpileCalls: TranspileToStArgs[]
   /** Programmable error for whichever method the test wants to fail. */
@@ -71,20 +66,12 @@ function makePort(): PortHarness {
     manifestContent: '{"name":"lib","version":"0.1.0","namespace":"lib"}',
     archives: [],
     missing: [],
-    verifyResult: { success: true },
-    verifyCalls: [],
     throwOnRead: new Map<string, Error>(),
     transpileResult: { ok: true, programSt: FAKE_PROGRAM_ST },
     transpileCalls: [],
     throwOn: {},
   }
   harness.port = {
-    async computeMd5(input: string) {
-      // Deterministic stand-in — same input → same hash, different
-      // inputs → different hashes.  Length-prefix makes near-duplicates
-      // distinguishable.
-      return `md5-${input.length}-${input.charCodeAt(0) ?? 0}`
-    },
     async transpileToSt(args: TranspileToStArgs, log) {
       if (harness.throwOn.transpileToSt) throw harness.throwOn.transpileToSt
       harness.transpileCalls.push(args)
@@ -113,11 +100,6 @@ function makePort(): PortHarness {
       if (harness.throwOn.loadLibraryArchives) throw harness.throwOn.loadLibraryArchives
       return { archives: harness.archives, missing: harness.missing }
     },
-    async verifyCompile(args) {
-      harness.verifyCalls.push(args)
-      args.emit('verifying...', 'info')
-      return harness.verifyResult
-    },
   }
   return harness
 }
@@ -139,7 +121,6 @@ function captureEvents() {
 beforeEach(() => {
   mockPrepareXml.mockReset()
   mockLibraryBuild.mockReset()
-  mockComposeVerify.mockClear()
 
   mockPrepareXml.mockReturnValue({
     projectData: projectDataEmpty(),
@@ -162,8 +143,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
       },
       harness.port,
       emit,
@@ -173,8 +152,9 @@ describe('runLibraryBuildPipeline', () => {
     expect(result.libraryName).toBe('lib')
     expect(result.stlibPath).toBe('build/lib.stlib')
     expect(harness.files.get('build/lib.stlib')).toMatch(/^\{[\s\S]+\}\n$/)
-    // Verification cache persisted with the MD5 the orchestrator computed.
-    expect(harness.files.has('build/.verify-cache-library.json')).toBe(true)
+    // The `.stlib` is the ONLY thing the build writes. The verification
+    // cache that used to sit beside it went out with the verify stage.
+    expect(harness.files.has('build/.verify-cache-library.json')).toBe(false)
     // Intermediates (program.st) live in memory only — the ST is
     // produced in-process by `transpileToSt` and never persisted.
     // See the path-constants comment in library-build-orchestrator.ts.
@@ -185,13 +165,16 @@ describe('runLibraryBuildPipeline', () => {
         'Starting library build...',
         'Manifest OK — building "lib" v0.1.0.',
         'Transpiling project to Structured Text',
-        'Verifying with OpenPLC Simulator (avr-gcc)...',
         'Compiling library archive...',
         'Library built successfully: build/lib.stlib',
       ]),
     )
     // The stubbed projectData from Stage 1 is what the transpiler sees.
     expect(harness.transpileCalls).toHaveLength(1)
+    // Nothing in the build talks about verification any more. Asserted on the
+    // whole event stream rather than the `arrayContaining` above, which would
+    // happily pass with an extra verify line in the middle.
+    expect(events.filter((e) => /verif/i.test(e.message))).toEqual([])
   })
 
   it('does not call deleteBuildSubtree (intermediates are no longer persisted)', async () => {
@@ -206,8 +189,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
       },
       harness.port,
       emit,
@@ -225,8 +206,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
       },
       harness.port,
       emit,
@@ -237,7 +216,6 @@ describe('runLibraryBuildPipeline', () => {
     // Should NOT have called any later stages.
     expect(mockPrepareXml).not.toHaveBeenCalled()
     expect(mockLibraryBuild).not.toHaveBeenCalled()
-    expect(harness.verifyCalls).toHaveLength(0)
   })
 
   it('feeds the resolved library archives into libraryBuildFromTranspiledSt', async () => {
@@ -256,8 +234,6 @@ describe('runLibraryBuildPipeline', () => {
           ...projectDataEmpty(),
           libraries: [{ name: 'oscat-basic', version: '1.0.0' }],
         } as PLCProjectData,
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
       },
       harness.port,
       emit,
@@ -280,8 +256,6 @@ describe('runLibraryBuildPipeline', () => {
           ...projectDataEmpty(),
           libraries: [{ name: 'ghost-lib', version: '1.0.0' }],
         } as PLCProjectData,
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
       },
       harness.port,
       emit,
@@ -290,121 +264,7 @@ describe('runLibraryBuildPipeline', () => {
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/ghost-lib/)
     expect(result.error).toMatch(/Library Manager/)
-    expect(harness.verifyCalls).toHaveLength(0)
     expect(mockLibraryBuild).not.toHaveBeenCalled()
-  })
-
-  it('skips verification when the MD5 cache matches', async () => {
-    const harness = makePort()
-    // Pre-seed the cache.  computeMd5 in the harness is deterministic
-    // off program.st length + first char; the orchestrator's value
-    // will match this when the same transpiler output replays.
-    const expectedMd5 = `md5-${FAKE_PROGRAM_ST.length}-${FAKE_PROGRAM_ST.charCodeAt(0)}`
-    harness.files.set('build/.verify-cache-library.json', JSON.stringify({ md5: expectedMd5, success: true }))
-    const { events, emit } = captureEvents()
-
-    await runLibraryBuildPipeline(
-      {
-        projectPath: '/project',
-        projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
-      },
-      harness.port,
-      emit,
-    )
-
-    expect(harness.verifyCalls).toHaveLength(0)
-    expect(events.some((e) => e.message.includes('Skipping verification'))).toBe(true)
-  })
-
-  it('cleanBuild forces a fresh verification regardless of cache', async () => {
-    const harness = makePort()
-    const expectedMd5 = `md5-${FAKE_PROGRAM_ST.length}-${FAKE_PROGRAM_ST.charCodeAt(0)}`
-    harness.files.set('build/.verify-cache-library.json', JSON.stringify({ md5: expectedMd5, success: true }))
-    const { emit } = captureEvents()
-
-    await runLibraryBuildPipeline(
-      {
-        projectPath: '/project',
-        projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: true,
-      },
-      harness.port,
-      emit,
-    )
-
-    expect(harness.verifyCalls).toHaveLength(1)
-  })
-
-  it('runs a fresh verification when the cache read throws', async () => {
-    const harness = makePort()
-    // Throw only on the cache read; the manifest read (Stage 0) must
-    // still succeed so we reach the cache-consult path.
-    const realRead = harness.port.readBuildFile.bind(harness.port)
-    harness.port.readBuildFile = async (projectPath, relPath) => {
-      if (relPath === 'build/.verify-cache-library.json') throw new Error('cache read blew up')
-      return realRead(projectPath, relPath)
-    }
-    const { emit } = captureEvents()
-
-    await runLibraryBuildPipeline(
-      {
-        projectPath: '/project',
-        projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
-      },
-      harness.port,
-      emit,
-    )
-
-    // Cache read failed → treated as a miss → fresh verification runs.
-    expect(harness.verifyCalls).toHaveLength(1)
-  })
-
-  it('runs a fresh verification when the cached file is malformed JSON', async () => {
-    const harness = makePort()
-    harness.files.set('build/.verify-cache-library.json', '{ not valid json')
-    const { emit } = captureEvents()
-
-    await runLibraryBuildPipeline(
-      {
-        projectPath: '/project',
-        projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
-      },
-      harness.port,
-      emit,
-    )
-
-    // Malformed cache → fall through to a real verification run.
-    expect(harness.verifyCalls).toHaveLength(1)
-  })
-
-  it('surfaces a verification failure as a warning but still emits the .stlib', async () => {
-    const harness = makePort()
-    harness.verifyResult = { success: false, message: 'AVR ran out of flash' }
-    const { events, emit } = captureEvents()
-
-    const result = await runLibraryBuildPipeline(
-      {
-        projectPath: '/project',
-        projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
-      },
-      harness.port,
-      emit,
-    )
-
-    expect(result.success).toBe(true) // verification failure is advisory
-    expect(result.verification?.success).toBe(false)
-    expect(result.verification?.message).toBe('AVR ran out of flash')
-    expect(harness.files.has('build/lib.stlib')).toBe(true)
-    expect(events.some((e) => e.level === 'warning' && /Verification reported issues/.test(e.message))).toBe(true)
   })
 
   it('propagates strucpp compile errors as a fatal build failure', async () => {
@@ -419,8 +279,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
       },
       harness.port,
       emit,
@@ -445,11 +303,7 @@ describe('runLibraryBuildPipeline', () => {
       dataTypes: [{ name: 'MyType', documentation: 'A type description' }],
     } as unknown as PLCProjectData
 
-    await runLibraryBuildPipeline(
-      { projectPath: '/project', projectData, verifyProjectData: projectDataEmpty(), cleanBuild: false },
-      harness.port,
-      emit,
-    )
+    await runLibraryBuildPipeline({ projectPath: '/project', projectData }, harness.port, emit)
 
     const [, , , aux] = mockLibraryBuild.mock.calls[0]
     expect(aux.pouDocs).toEqual({ MyFb: 'A docstring', MyType: 'A type description' })
@@ -484,8 +338,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData,
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
         nativePous: [
           { name: 'MyCppFb', language: 'cpp', relPath: 'pous/function-blocks/MyCppFb.cpp' },
           { name: 'MyPyFb', language: 'python', relPath: 'pous/function-blocks/MyPyFb.py' },
@@ -522,8 +374,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData,
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
         nativePous: [{ name: 'CPP_ADD', language: 'cpp', relPath: 'pous/functions/CPP_ADD.cpp' }],
       },
       harness.port,
@@ -551,8 +401,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
       },
       harness.port,
       emit,
@@ -573,8 +421,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
         nativePous: [{ name: 'Boom', language: 'cpp', relPath: 'pous/function-blocks/Boom.cpp' }],
       },
       harness.port,
@@ -595,8 +441,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
         nativePous: [{ name: 'Gone', language: 'cpp', relPath: 'pous/function-blocks/Gone.cpp' }],
       },
       harness.port,
@@ -618,8 +462,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
       },
       harness.port,
       emit,
@@ -628,7 +470,6 @@ describe('runLibraryBuildPipeline', () => {
     expect(result.success).toBe(false)
     expect(result.error).toBe('library.json is missing manifest.namespace')
     expect(mockLibraryBuild).not.toHaveBeenCalled()
-    expect(harness.verifyCalls).toHaveLength(0)
   })
 
   it('fails when reading library.json throws an IO error', async () => {
@@ -640,8 +481,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
       },
       harness.port,
       emit,
@@ -664,8 +503,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
       },
       harness.port,
       emit,
@@ -675,7 +512,6 @@ describe('runLibraryBuildPipeline', () => {
     expect(result.error).toMatch(/transpile-from-json failed: unexpected token in POU body/)
     expect(result.libraryName).toBe('lib')
     expect(mockLibraryBuild).not.toHaveBeenCalled()
-    expect(harness.verifyCalls).toHaveLength(0)
   })
 
   it('falls back to a generic message when the transpiler returns ok=true but no ST', async () => {
@@ -689,8 +525,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
       },
       harness.port,
       emit,
@@ -698,60 +532,6 @@ describe('runLibraryBuildPipeline', () => {
 
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/transpile-from-json failed: transpile-from-json failed/)
-  })
-
-  it('treats a thrown verifyCompile as a failed (advisory) verification', async () => {
-    const harness = makePort()
-    // A non-Error throwable exercises the `String(error)` fallback in
-    // `formatError`.
-    harness.port.verifyCompile = async () => {
-      throw 'avr-gcc segfaulted'
-    }
-    const { events, emit } = captureEvents()
-
-    const result = await runLibraryBuildPipeline(
-      {
-        projectPath: '/project',
-        projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
-      },
-      harness.port,
-      emit,
-    )
-
-    // Verification failures are advisory — the build still succeeds.
-    expect(result.success).toBe(true)
-    expect(result.verification?.success).toBe(false)
-    expect(result.verification?.message).toBe('avr-gcc segfaulted')
-    expect(events.some((e) => e.level === 'warning' && /Verification reported issues/.test(e.message))).toBe(true)
-  })
-
-  it('warns but still ships the .stlib when the verification cache cannot be written', async () => {
-    const harness = makePort()
-    // Fail only the cache write; the .stlib write happens later and
-    // must still succeed.
-    const realWrite = harness.port.writeBuildFile.bind(harness.port)
-    harness.port.writeBuildFile = async (projectPath, relPath, content) => {
-      if (relPath === 'build/.verify-cache-library.json') throw new Error('cache dir read-only')
-      return realWrite(projectPath, relPath, content)
-    }
-    const { events, emit } = captureEvents()
-
-    const result = await runLibraryBuildPipeline(
-      {
-        projectPath: '/project',
-        projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
-      },
-      harness.port,
-      emit,
-    )
-
-    expect(result.success).toBe(true)
-    expect(harness.files.has('build/lib.stlib')).toBe(true)
-    expect(events.some((e) => e.level === 'warning' && /Could not write verification cache/.test(e.message))).toBe(true)
   })
 
   it('fails when the .stlib archive cannot be written', async () => {
@@ -766,8 +546,6 @@ describe('runLibraryBuildPipeline', () => {
       {
         projectPath: '/project',
         projectData: projectDataEmpty(),
-        verifyProjectData: projectDataEmpty(),
-        cleanBuild: false,
       },
       harness.port,
       emit,

--- a/src/backend/shared/library/build-pipeline.ts
+++ b/src/backend/shared/library/build-pipeline.ts
@@ -23,12 +23,6 @@
  *      the archive blob + serialized bytes ready for `.stlib`
  *      write-out.
  *
- *   4. `composeVerificationProject(project)` — produces the same
- *      stubbed PLCProject the verification compile path needs
- *      (Phase 8 — feeds the existing `compileProgram` flow against
- *      the OpenPLC Simulator target to surface generated-C++
- *      compile errors).
- *
  * Everything here is pure: no fs, no spawn, no electron.  The
  * Electron compiler module and the web backend service both
  * consume this same orchestration.
@@ -512,30 +506,6 @@ function inferCategory(fileName: string): string | undefined {
   // this to group functions vs function-blocks in the manifest, but
   // accepts `undefined` and falls back to detecting from the body.
   return undefined
-}
-
-// ---------------------------------------------------------------------------
-// Stage 4: verification project (Phase 8)
-// ---------------------------------------------------------------------------
-
-/**
- * Build a transient PLCProject the verification compile path
- * consumes.  Same stub-program shape as `stubProgramFor`, but
- * tagged `plc-project` so the existing `compileProgram` flow
- * (Phase 8) doesn't try to recurse back into the library branch.
- *
- * Verification runs the resulting project through the standard
- * ST→C++→arduino-cli pipeline against the OpenPLC Simulator
- * target.  Compile failures there are surfaced as warnings — the
- * `.stlib` is still produced (the user may legitimately target a
- * platform with more memory than the AVR simulator).
- */
-export function composeVerificationProject(project: PLCProject): PLCProject {
-  const stubbed = stubProgramFor(project)
-  return {
-    meta: { ...project.meta, type: 'plc-project' },
-    data: stubbed.data,
-  }
 }
 
 // Exposed for test ergonomics only — keeps the stub-name constants

--- a/src/backend/shared/library/library-build-orchestrator.ts
+++ b/src/backend/shared/library/library-build-orchestrator.ts
@@ -6,11 +6,10 @@
  * Single source of truth for the `.stlib` compilation flow.  Both
  * desktop and web drive this function through their own
  * `LibraryBuildPort` implementation; every decision, every event,
- * every file name, every hash, every error message, every cache rule
- * is owned by this module.  The port carries only the IO primitives
- * (read / write / delete project files, resolve library archives,
- * run a verification compile) — anything that looks like business
- * logic stays here, by design.
+ * every file name, every error message is owned by this module.  The
+ * port carries only the IO primitives (read / write / delete project
+ * files, resolve library archives) — anything that looks like
+ * business logic stays here, by design.
  *
  * Stages:
  *
@@ -21,14 +20,23 @@
  *      The ST lives in memory only — no intermediate file persistence
  *      (see path-constants comment).
  *   3. Resolve project-enabled library archives + fail on missing
- *      names (one place — feeds BOTH verification and strucpp).
- *   4. Verification compile against the OpenPLC Simulator target
- *      via `LibraryBuildPort.verifyCompile`.  MD5 cache hit short-
- *      circuits.  Cache record persisted under `build/`.
- *   5. Gather `pouDocs` from the project data, and read the authored
+ *      names.
+ *   4. Gather `pouDocs` from the project data, and read the authored
  *      C/C++ / Python POU files off disk for strucpp to carry verbatim.
- *   6. strucpp compile via `libraryBuildFromTranspiledSt`.
- *   7. Write `.stlib` archive to `build/{name}.stlib`.
+ *   5. strucpp compile via `libraryBuildFromTranspiledSt`.
+ *   6. Write `.stlib` archive to `build/{name}.stlib`.
+ *
+ * The build is deliberately TARGET-NEUTRAL.  It used to end with an
+ * avr-gcc verification compile against the OpenPLC Simulator board,
+ * which meant every library was judged by whether its generated C++
+ * links on an ATmega2560 — a board most libraries never run on, and a
+ * ~30 s tax on every clean build.  Worse, the project it verified
+ * instantiated nothing (its whole body was `LocalVar := 3;`), so it
+ * never said anything about whether the library behaves.  Running a
+ * library is now its own action: `composeLibraryDebugHarness` builds
+ * a project that instantiates every block and drives it through the
+ * simulator with the debugger attached.  strucpp's `compileStlib` is
+ * what still fails a bad build.
  *
  * The orchestrator returns a structured result; the adapter wraps it
  * in whatever transport it owns (IPC port message on desktop, Promise
@@ -39,12 +47,7 @@
 import type { LibraryBuildPort } from '../../../middleware/shared/ports/library-build-port'
 import type { CompileLibraryResult } from '../../../middleware/shared/ports/types'
 import type { PLCProject, PLCProjectData } from '../types/PLC/open-plc'
-import {
-  composeVerificationProject,
-  libraryBuildFromTranspiledSt,
-  type LibraryNativeSource,
-  prepareXmlForLibraryBuild,
-} from './build-pipeline'
+import { libraryBuildFromTranspiledSt, type LibraryNativeSource, prepareXmlForLibraryBuild } from './build-pipeline'
 import type { NativePouRef } from './native-pou-list'
 
 // ---------------------------------------------------------------------------
@@ -64,11 +67,6 @@ export interface LibraryBuildArgs {
   /** Build-pass project data: Python POUs lowered to runtime ST, C/C++
    *  POUs replaced by stubs with the originals on `originalCppPous`. */
   projectData: PLCProjectData
-  /** Verification-pass project data: Python POUs lowered to no-op
-   *  stubs (the AVR simulator has no Python interpreter). */
-  verifyProjectData: PLCProjectData
-  /** Skip the MD5 verification cache and force a fresh verify run. */
-  cleanBuild: boolean
   /** Native (C/C++, Python) POUs, collected from the project data BEFORE
    *  `preprocessPous` ran — see `collectNativePous`. The pipeline cannot
    *  derive this itself: by the time it sees `projectData`, every native body
@@ -87,10 +85,9 @@ export interface LibraryBuildArgs {
 // persisted.  They're transient artifacts that exist only between
 // `prepareXmlForLibraryBuild` and `libraryBuildFromTranspiledSt` —
 // passing them through the port would force every platform to spend
-// a round-trip on data nobody reads after the build finishes.  Only
-// the user-visible `.stlib` artifact and the verification cache are
-// written to the project tree.
-const VERIFY_CACHE_REL_PATH = 'build/.verify-cache-library.json'
+// a round-trip on data nobody reads after the build finishes.  The
+// user-visible `.stlib` artifact is the only thing this pipeline
+// writes to the project tree.
 const LIBRARY_MANIFEST_REL_PATH = 'library.json'
 const STLIB_OUT_DIR = 'build'
 
@@ -101,15 +98,14 @@ const STLIB_OUT_DIR = 'build'
  * The result mirrors the existing `CompileLibraryResult` shape so the
  * desktop's MessagePort wrapper and the web adapter both surface the
  * same structure to the renderer.  `success: false` from this function
- * is a fatal build error; verification failures show up under
- * `verification.success: false` with `success: true` overall.
+ * is a fatal build error.
  */
 export async function runLibraryBuildPipeline(
   args: LibraryBuildArgs,
   port: LibraryBuildPort,
   emit: (event: LibraryBuildEvent) => void,
 ): Promise<CompileLibraryResult> {
-  const { projectPath, projectData, verifyProjectData, cleanBuild, nativePous = [] } = args
+  const { projectPath, projectData, nativePous = [] } = args
 
   emit({ message: 'Starting library build...', level: 'info' })
 
@@ -164,16 +160,14 @@ export async function runLibraryBuildPipeline(
   const programSt = transpile.programSt
 
   // -------------------------------------------------------------------------
-  // Stage 4: resolve project-enabled library archives
+  // Stage 3: resolve project-enabled library archives
   //
-  // ONE resolution path feeding both verification (so the simulator
-  // compile sees the same symbol set the user's project sees) and
-  // the strucpp library compile.  Missing names fail fast with a
-  // Library-Manager-pointing message before either heavy step runs.
-  // The bundled IEC standard set (TON, TP, CTU, etc.) is included
-  // automatically by every port impl — desktop reads it off disk,
-  // web pulls it from its bundled-stlibs asset glob.  THIS is the
-  // step whose absence on web caused the "Undefined type 'TON'" bug.
+  // Missing names fail fast with a Library-Manager-pointing message
+  // before the strucpp compile runs.  The bundled IEC standard set
+  // (TON, TP, CTU, etc.) is included automatically by every port impl
+  // — desktop reads it off disk, web pulls it from its bundled-stlibs
+  // asset glob.  THIS is the step whose absence on web caused the
+  // "Undefined type 'TON'" bug.
   // -------------------------------------------------------------------------
   const enabledLibraryRefs = (projectData.libraries ?? []).map((ref) => ({
     name: ref.name,
@@ -192,76 +186,7 @@ export async function runLibraryBuildPipeline(
   }
 
   // -------------------------------------------------------------------------
-  // Stage 5: verification compile
-  //
-  // Hash program.st and consult the cache; cache hit short-circuits
-  // the slow avr-gcc compile.  cleanBuild forces a fresh run.
-  // Verification failures are advisory: they surface as warnings on
-  // `verification.success` with the build still producing a `.stlib`.
-  //
-  // The MD5 routes through the platform port instead of `node:crypto`
-  // so the shared module ships without a host-runtime dependency.
-  // Editor's port wires it to Node's hash; web's port wires it to
-  // spark-md5 — both produce byte-identical output.
-  // -------------------------------------------------------------------------
-  const programStMd5 = await port.computeMd5(programSt)
-  let verification: CompileLibraryResult['verification']
-  let usedCache = false
-  if (!cleanBuild) {
-    const cached = await readVerificationCache(port, projectPath, programStMd5)
-    if (cached) {
-      verification = cached
-      usedCache = true
-      emit({
-        message: `Skipping verification (cached: ${cached.success ? 'pass' : 'fail'}). Use "Clean build" to force re-verification.`,
-        level: 'info',
-      })
-    }
-  }
-  if (!verification) {
-    const verifyProject = composeVerificationProject({
-      meta: { name: manifest.name, type: 'plc-library' },
-      data: verifyProjectData,
-    })
-    emit({ message: 'Verifying with OpenPLC Simulator (avr-gcc)...', level: 'info' })
-    try {
-      verification = await port.verifyCompile({
-        projectPath,
-        verifyProjectData: verifyProject.data,
-        emit: (message, logLevel) => {
-          // Demote inner errors to warnings on the way out.  `.stlib`
-          // is still produced, so an error-level `[verify]` line in
-          // the console would falsely suggest the build failed.
-          const level = logLevel === 'error' ? 'warning' : (logLevel ?? 'info')
-          emit({ message: `[verify] ${message}`, level })
-        },
-      })
-    } catch (error) {
-      verification = { success: false, message: formatError(error) }
-    }
-    if (verification.success) {
-      emit({ message: 'Verification passed.', level: 'info' })
-    } else {
-      emit({
-        message: `Verification reported issues (warning only — .stlib will still be generated): ${verification.message ?? 'see log'}`,
-        level: 'warning',
-      })
-    }
-  }
-  if (!usedCache && verification) {
-    try {
-      await port.writeBuildFile(
-        projectPath,
-        VERIFY_CACHE_REL_PATH,
-        JSON.stringify({ md5: programStMd5, ...verification }, null, 2),
-      )
-    } catch (cacheErr) {
-      emit({ message: `Could not write verification cache: ${formatError(cacheErr)}`, level: 'warning' })
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // Stage 6: gather per-symbol documentation
+  // Stage 4: gather per-symbol documentation
   //
   // POUs contribute their editor "Description" field; data types
   // contribute their own optional documentation.  Both ride through
@@ -284,7 +209,7 @@ export async function runLibraryBuildPipeline(
     }
   }
   // -------------------------------------------------------------------------
-  // Stage 6b: read the authored C/C++ and Python POU files off the project
+  // Stage 4b: read the authored C/C++ and Python POU files off the project
   //
   // Read from disk, NOT from the preprocessed project data: by this point
   // `preprocessPous` has replaced every native body with generated bridge ST,
@@ -316,33 +241,33 @@ export async function runLibraryBuildPipeline(
   }
 
   // -------------------------------------------------------------------------
-  // Stage 7: strucpp compileStlib
+  // Stage 5: strucpp compileStlib
   // -------------------------------------------------------------------------
   emit({ message: 'Compiling library archive...', level: 'info' })
-  const stage7 = libraryBuildFromTranspiledSt(programSt, knownPous, manifest, {
+  const stage5 = libraryBuildFromTranspiledSt(programSt, knownPous, manifest, {
     pouDocs,
     dependencyArchives: depArchives,
     dependencyRefs: enabledLibraryRefs,
     nativeSources,
   })
-  if (!stage7.success) {
-    for (const err of stage7.errors) {
+  if (!stage5.success) {
+    for (const err of stage5.errors) {
       const where = err.file ? `[${err.file}${err.line ? `:${err.line}` : ''}] ` : ''
       emit({ message: `${where}${err.message}`, level: 'error' })
     }
     return {
       success: false,
-      error: stage7.errors[0]?.message ?? 'Library compilation failed.',
+      error: stage5.errors[0]?.message ?? 'Library compilation failed.',
       libraryName: manifest.name,
     }
   }
 
   // -------------------------------------------------------------------------
-  // Stage 8: write .stlib archive
+  // Stage 6: write .stlib archive
   // -------------------------------------------------------------------------
   const stlibRelPath = `${STLIB_OUT_DIR}/${manifest.name}.stlib`
   try {
-    await port.writeBuildFile(projectPath, stlibRelPath, JSON.stringify(stage7.archive, null, 2) + '\n')
+    await port.writeBuildFile(projectPath, stlibRelPath, JSON.stringify(stage5.archive, null, 2) + '\n')
   } catch (error) {
     return fail(emit, `Could not write ${manifest.name}.stlib: ${formatError(error)}`, { libraryName: manifest.name })
   }
@@ -352,43 +277,12 @@ export async function runLibraryBuildPipeline(
     success: true,
     stlibPath: stlibRelPath,
     libraryName: manifest.name,
-    verification,
   }
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Read + validate the verification cache.  Returns the cached
- * `{ success, message }` only when the persisted MD5 matches the
- * current `programSt`.  Malformed cache files and missing files are
- * indistinguishable from a fresh build — both return null so the
- * caller falls through to a real verification run.
- */
-async function readVerificationCache(
-  port: LibraryBuildPort,
-  projectPath: string,
-  programStMd5: string,
-): Promise<{ success: boolean; message?: string } | null> {
-  let raw: string | null
-  try {
-    raw = await port.readBuildFile(projectPath, VERIFY_CACHE_REL_PATH)
-  } catch {
-    return null
-  }
-  if (raw === null) return null
-  try {
-    const parsed = JSON.parse(raw) as { md5?: string; success?: boolean; message?: string }
-    if (parsed?.md5 === programStMd5 && typeof parsed.success === 'boolean') {
-      return { success: parsed.success, message: parsed.message }
-    }
-  } catch {
-    /* malformed cache — fall through to fresh run */
-  }
-  return null
-}
 
 function fail(
   emit: (event: LibraryBuildEvent) => void,

--- a/src/frontend/components/_features/[workspace]/build-options/index.tsx
+++ b/src/frontend/components/_features/[workspace]/build-options/index.tsx
@@ -19,14 +19,6 @@ type BuildOptionsPopoverProps = {
   uploadAvailable: boolean
   /** Tooltip shown when an upload-bearing option is disabled. */
   uploadDisabledReason: string
-  /**
-   * Render the library-build option set instead of the program one:
-   * "Build" and "Clean build" — no upload variants.  The library
-   * build pipeline emits `build-only` for a normal build and
-   * `clean-upload` for a clean build (the enum is reused so the
-   * popover stays a single component).
-   */
-  libraryMode?: boolean
   onSelect: (option: BuildOption) => void
 }
 
@@ -85,7 +77,6 @@ export const BuildOptionsPopover = ({
   triggerTooltip,
   uploadAvailable,
   uploadDisabledReason,
-  libraryMode,
   onSelect,
 }: BuildOptionsPopoverProps): ReactNode => {
   const [open, setOpen] = useState(false)
@@ -127,48 +118,27 @@ export const BuildOptionsPopover = ({
           alignOffset={-4}
           className='box z-50 flex h-fit w-[230px] flex-col gap-1 rounded-lg bg-white p-2 dark:bg-neutral-950'
         >
-          {libraryMode ? (
-            <>
-              <OptionRow
-                label='Build'
-                description='Compile the library into a .stlib archive.'
-                disabled={false}
-                disabledReason=''
-                onClick={() => choose('build-only')}
-              />
-              <OptionRow
-                label='Clean build'
-                description='Skip the verification cache and re-verify against the simulator.'
-                disabled={false}
-                disabledReason=''
-                onClick={() => choose('clean-upload')}
-              />
-            </>
-          ) : (
-            <>
-              <OptionRow
-                label='Build only'
-                description='Compile the program without uploading.'
-                disabled={false}
-                disabledReason=''
-                onClick={() => choose('build-only')}
-              />
-              <OptionRow
-                label='Build and upload'
-                description='Compile and upload to the target device.'
-                disabled={!uploadAvailable}
-                disabledReason={uploadDisabledReason}
-                onClick={() => choose('build-upload')}
-              />
-              <OptionRow
-                label='Clean build and upload'
-                description='Invalidate the cache, fully recompile, then upload.'
-                disabled={!uploadAvailable}
-                disabledReason={uploadDisabledReason}
-                onClick={() => choose('clean-upload')}
-              />
-            </>
-          )}
+          <OptionRow
+            label='Build only'
+            description='Compile the program without uploading.'
+            disabled={false}
+            disabledReason=''
+            onClick={() => choose('build-only')}
+          />
+          <OptionRow
+            label='Build and upload'
+            description='Compile and upload to the target device.'
+            disabled={!uploadAvailable}
+            disabledReason={uploadDisabledReason}
+            onClick={() => choose('build-upload')}
+          />
+          <OptionRow
+            label='Clean build and upload'
+            description='Invalidate the cache, fully recompile, then upload.'
+            disabled={!uploadAvailable}
+            disabledReason={uploadDisabledReason}
+            onClick={() => choose('clean-upload')}
+          />
         </Popover.Content>
       </Popover.Portal>
     </Popover.Root>

--- a/src/frontend/components/_molecules/workspace-activity-bar/default/build-library.tsx
+++ b/src/frontend/components/_molecules/workspace-activity-bar/default/build-library.tsx
@@ -1,0 +1,25 @@
+import { ComponentPropsWithoutRef } from 'react'
+
+import { DownloadIcon } from '../../../../assets/icons/interface/Download'
+import { useIsNinetiesTheme } from '../../../../hooks/use-nineties-theme'
+import { ActivityBarButton } from '../../../_atoms/buttons/activity-bar'
+import { RetroBuild } from '../../../_atoms/retro-icons'
+
+/**
+ * Build a Library Project into its `.stlib`.
+ *
+ * A plain button, not the program build's options popover: a library
+ * build has exactly one thing it can do.  It used to offer a "Clean
+ * build" alongside it, whose only effect was to bypass the MD5 cache
+ * on the avr-gcc verification pass — and that pass is gone, so the
+ * second row would have been a no-op.  Same icon as the program build
+ * so the two read as the same action for the two project types.
+ */
+export const BuildLibraryButton = (props: ComponentPropsWithoutRef<typeof ActivityBarButton>) => {
+  const isNineties = useIsNinetiesTheme()
+  return (
+    <ActivityBarButton aria-label='Build Library' {...props}>
+      {isNineties ? <RetroBuild /> : <DownloadIcon />}
+    </ActivityBarButton>
+  )
+}

--- a/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
@@ -507,7 +507,7 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
     } finally {
       setIsCompiling(false)
     }
-  }, [compiler, projectData, projectMeta, addLog, isCompiling, executeSave, requestConsoleFollow])
+  }, [compiler, projectData, projectMeta, addLog, isCompiling, canEdit, executeSave, requestConsoleFollow])
 
   // ---------------------------------------------------------------------------
   // Debug Library — run the library's blocks on the simulator
@@ -567,7 +567,7 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
     // triggers can already see it.  `clearDebugState()` drops it when the
     // session ends.
     useOpenPLCStore.getState().workspaceActions.setDebugHarness({
-      programPou: harness.projectData.pous[harness.projectData.pous.length - 1],
+      programPou: harness.programPou,
       instances: harness.projectData.configurations.resource.instances,
     })
 
@@ -587,7 +587,16 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
           if (event.level === 'error' || event.stage === 'error') streamedError = true
           logCompilerEvent(event, addLog)
           if (event.firmwarePath) {
-            void simulatorRun.launch(event.firmwarePath, { attachDebugger: true })
+            // The compile succeeded — it produced firmware — so a failure to
+            // LOAD that firmware never reaches the `!result.success` branch
+            // below. Without this the harness would stay installed with no
+            // emulator behind it, and the watch list would keep showing a
+            // generated program that is not running.
+            void simulatorRun.launch(event.firmwarePath, { attachDebugger: true }).then((launched) => {
+              if (!launched) {
+                useOpenPLCStore.getState().workspaceActions.setDebugHarness(null)
+              }
+            })
           }
         },
       )

--- a/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
@@ -1,4 +1,5 @@
 import { evaluatePreBuildPlcGate } from '@root/middleware/shared/utils/build-gate/pre-build-plc-gate'
+import { composeLibraryDebugHarness } from '@root/middleware/shared/utils/library-debug/compose-library-debug-harness'
 import { resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
@@ -14,6 +15,7 @@ import {
   useSimulator,
 } from '../../../../middleware/shared/providers'
 import { StopIcon } from '../../../assets/icons/interface/Stop'
+import { useSimulatorDebugRun } from '../../../hooks/use-simulator-debug-run'
 import { useDebugPolling } from '../../../hooks/useDebugPolling'
 import { useDebugSession } from '../../../hooks/useDebugSession'
 import { buildDeviceResolverContext, showDeviceDialog } from '../../../services/device-link-resolution'
@@ -26,6 +28,7 @@ import { isOpenPLCRuntimeTarget } from '../../../utils/device'
 import { onDeviceFlashRequest } from '../../../utils/device-connect-events'
 import { getErrorMessage } from '../../../utils/get-error-message'
 import { type BuildOption, BuildOptionsPopover } from '../../_features/[workspace]/build-options'
+import { BuildLibraryButton } from '../../_molecules/workspace-activity-bar/default/build-library'
 import { ChatButton } from '../../_molecules/workspace-activity-bar/default/chat'
 import { DebuggerButton } from '../../_molecules/workspace-activity-bar/default/debugger'
 import { PlayButton } from '../../_molecules/workspace-activity-bar/default/play'
@@ -34,6 +37,15 @@ import { ZoomButton } from '../../_molecules/workspace-activity-bar/default/zoom
 import { TooltipSidebarWrapperButton } from '../../_molecules/workspace-activity-bar/tooltip-button'
 
 const disabledButtonClass = 'cursor-not-allowed opacity-50 [&>*:first-child]:hover:bg-transparent'
+
+/**
+ * Board the library debug harness is compiled for.  Pinned rather than read
+ * from the project: a library project hides the device tree entirely
+ * (`hasDevices: false`), so there is no board the author could have chosen,
+ * and the in-process simulator is the only target that runs on both the
+ * desktop and the web edition.
+ */
+const LIBRARY_DEBUG_BOARD = 'OpenPLC Simulator'
 
 type DefaultWorkspaceActivityBarProps = {
   zoom?: {
@@ -68,7 +80,6 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
 
   const [isCompiling, setIsCompiling] = useState(false)
   const [isDebuggerProcessing, setIsDebuggerProcessing] = useState(false)
-  const [simulatorRunning, setSimulatorRunning] = useState(false)
   const pendingSimulatorDebugRef = useRef(false)
   // True while a debug session is running OVER THE DEVICE CONNECTION (a baremetal
   // target, whatever transport that connection uses). Such a session shares the
@@ -129,16 +140,27 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
       ? 'Connect to the target first'
       : 'PLC is changing state...'
 
-  // The emulator stopping is a session ending, and a debug session riding it ends
-  // with it — which the drop handler below already does for every target. This
-  // only mirrors the emulator's own state into the button.
-  useEffect(() => {
-    const unsub = simulator.onStopped(() => {
+  // Emulator lifecycle — load firmware, attach the debugger, tear both down.
+  // Owned by the hook so the PLC Start button and the library Debug button
+  // cannot drift on the ordering rules it encodes.
+  const simulatorRun = useSimulatorDebugRun({
+    debugSession,
+    // The debug session rides the emulator's session, so it ends when the
+    // emulator does — through the same handler a pulled cable goes through.
+    onDebugAttached: () => {
+      debugSessionRidesDeviceRef.current = true
+    },
+    onStopped: () => {
       pendingSimulatorDebugRef.current = false
-      setSimulatorRunning(false)
-    })
-    return unsub
-  }, [simulator])
+      // The session this debug session was riding is gone, so the claim that it
+      // rides one goes with it. The drop handler cannot clear it on this path:
+      // `stopSession()` has already hidden the debugger, so the handler's
+      // `isDebuggerVisible` gate returns before it reaches the reset — leaving
+      // the ref stale-`true` for a session that no longer exists.
+      debugSessionRidesDeviceRef.current = false
+    },
+  })
+  const simulatorRunning = simulatorRun.isRunning
 
   // A serial debug session lives on the device connection: it shares that
   // client, so when the link drops (unplug, reset, liveness failure, or the user
@@ -358,27 +380,9 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
             }
             logCompilerEvent(event, addLog)
             if (event.firmwarePath && isSimulatorBoard) {
-              void simulator.loadFirmware(event.firmwarePath).then((loadResult) => {
-                if (loadResult.success) {
-                  setSimulatorRunning(true)
-                  addLog({ level: 'info', message: 'Simulator is running.' })
-                  if (pendingSimulatorDebugRef.current) {
-                    pendingSimulatorDebugRef.current = false
-                    // Rides the emulator's session, so it ends when the emulator
-                    // does — through the same handler a pulled cable goes through.
-                    debugSessionRidesDeviceRef.current = true
-                    // No config: starting the emulator opened its session, so the
-                    // connection manager already knows how to reach it.
-                    void debugSession.connectAndStart()
-                  }
-                } else {
-                  pendingSimulatorDebugRef.current = false
-                  addLog({
-                    level: 'error',
-                    message: `Failed to start simulator: ${loadResult.error ?? 'Unknown error'}`,
-                  })
-                }
-              })
+              const attachDebugger = pendingSimulatorDebugRef.current
+              pendingSimulatorDebugRef.current = false
+              void simulatorRun.launch(event.firmwarePath, { attachDebugger })
             }
           },
         )
@@ -424,8 +428,7 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
       deviceDefinitions,
       currentBoardInfo,
       isSimulatorBoard,
-      simulator,
-      debugSession,
+      simulatorRun,
       addLog,
       isCompiling,
       executeSave,
@@ -452,73 +455,165 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
   // Build Library (.stlib)
   // ---------------------------------------------------------------------------
 
-  const handleBuildLibrary = useCallback(
-    async (overrides?: { cleanBuild?: boolean }) => {
-      if (isCompiling) return
+  const handleBuildLibrary = useCallback(async () => {
+    if (isCompiling) return
 
-      // Reveal the console and re-attach to the tail (see handleBuild).
-      requestConsoleFollow()
+    // Reveal the console and re-attach to the tail (see handleBuild).
+    requestConsoleFollow()
 
-      // Always save before building.  The manifest tab and any POU
-      // bodies may have edits the workspace-level `editingState`
-      // doesn't track (each editor manages its own dirty flag against
-      // its file-slice entry), and the build pipeline reads everything
-      // off disk — `library.json`, `pous/**`, and the rest — so a
-      // stale on-disk copy would compile from the previous session's
-      // content.  `executeSaveProject` is the same full-project save
-      // the PLC build invokes; it walks every file the project owns
-      // and flushes the in-memory buffer to disk before the build
-      // starts.
+    // Always save before building.  The manifest tab and any POU
+    // bodies may have edits the workspace-level `editingState`
+    // doesn't track (each editor manages its own dirty flag against
+    // its file-slice entry), and the build pipeline reads everything
+    // off disk — `library.json`, `pous/**`, and the rest — so a
+    // stale on-disk copy would compile from the previous session's
+    // content.  `executeSaveProject` is the same full-project save
+    // the PLC build invokes; it walks every file the project owns
+    // and flushes the in-memory buffer to disk before the build
+    // starts.
+    const saved = await executeSave()
+    if (!saved) return
+
+    if (!compiler.compileLibrary) {
+      addLog({
+        level: 'error',
+        message: 'Current platform does not implement library builds.',
+      })
+      return
+    }
+
+    setIsCompiling(true)
+    addLog({ level: 'info', message: 'Library build started' })
+
+    try {
+      const result = await compiler.compileLibrary({ projectData, projectPath: projectMeta.path }, (event) => {
+        if (!event.message) return
+        addLog({
+          level: event.level === 'error' || event.stage === 'error' ? 'error' : 'info',
+          message: event.message,
+        })
+      })
+      if (!result.success) {
+        addLog({
+          level: 'error',
+          message: result.error ?? 'Library build failed.',
+        })
+      }
+    } catch (err) {
+      addLog({
+        level: 'error',
+        message: `Library build error: ${getErrorMessage(err)}`,
+      })
+    } finally {
+      setIsCompiling(false)
+    }
+  }, [compiler, projectData, projectMeta, addLog, isCompiling, executeSave, requestConsoleFollow])
+
+  // ---------------------------------------------------------------------------
+  // Debug Library — run the library's blocks on the simulator
+  // ---------------------------------------------------------------------------
+
+  /**
+   * A library has no program, so there is nothing to run and nothing to attach
+   * a debugger to.  `composeLibraryDebugHarness` synthesises the missing piece:
+   * a program declaring one instance of every block in the library.  That
+   * project compiles for the simulator exactly like any other, and the debug
+   * session that follows is the ordinary one — the harness's instances are what
+   * `buildFbInstanceMap` binds each block editor to.
+   *
+   * The harness is never written to the project: it lives in the session
+   * overlay (`workspace.debugHarness`) until the session ends.
+   */
+  const handleDebugLibrary = useCallback(async (): Promise<void> => {
+    if (simulatorRunning) {
+      await simulatorRun.stop()
+      return
+    }
+    if (isCompiling) return
+
+    requestConsoleFollow()
+
+    // Same reason the build path always saves: the compile pipeline reads the
+    // project's own files off disk, so an unflushed edit compiles stale bytes.
+    if (canEdit) {
       const saved = await executeSave()
       if (!saved) return
+    }
 
-      if (!compiler.compileLibrary) {
-        addLog({
-          level: 'error',
-          message: 'Current platform does not implement library builds.',
-        })
-        return
-      }
+    const harness = composeLibraryDebugHarness(useOpenPLCStore.getState().project.data)
 
-      setIsCompiling(true)
+    for (const skip of harness.skipped) {
+      addLog({ level: 'warning', message: `${skip.pouName}: ${skip.reason}` })
+    }
+    if (harness.blocks.length === 0) {
       addLog({
-        level: 'info',
-        message: overrides?.cleanBuild ? 'Library build started (clean)' : 'Library build started',
+        level: 'error',
+        message:
+          'Nothing to debug: this library has no function blocks the simulator can run. ' +
+          'Add a function block — to exercise a function, write one that calls it.',
       })
+      return
+    }
 
-      try {
-        const result = await compiler.compileLibrary(
-          { projectData, projectPath: projectMeta.path, cleanBuild: overrides?.cleanBuild ?? false },
-          (event) => {
-            if (!event.message) return
-            addLog({
-              level: event.level === 'error' || event.stage === 'error' ? 'error' : 'info',
-              message: event.message,
-            })
-          },
-        )
-        if (!result.success) {
-          addLog({
-            level: 'error',
-            message: result.error ?? 'Library build failed.',
-          })
-        } else if (result.verification && !result.verification.success) {
-          addLog({
-            level: 'warning',
-            message: `Library built, but verification reported: ${result.verification.message ?? 'unknown'}`,
-          })
+    setIsCompiling(true)
+    addLog({
+      level: 'info',
+      message: `Debugging ${harness.blocks.length} block(s) on the simulator: ${harness.blocks
+        .map((block) => block.pouName)
+        .join(', ')}`,
+    })
+
+    // Installed BEFORE the compile so the debug session that the firmware event
+    // triggers can already see it.  `clearDebugState()` drops it when the
+    // session ends.
+    useOpenPLCStore.getState().workspaceActions.setDebugHarness({
+      programPou: harness.projectData.pous[harness.projectData.pous.length - 1],
+      instances: harness.projectData.configurations.resource.instances,
+    })
+
+    try {
+      let streamedError = false
+      const result = await compiler.compileProgram(
+        {
+          projectData: harness.projectData,
+          boardTarget: LIBRARY_DEBUG_BOARD,
+          projectPath: projectMeta.path,
+          compileOnly: false,
+          isSimulator: true,
+          runtimeIpAddress: null,
+          runtimeJwtToken: null,
+        },
+        (event) => {
+          if (event.level === 'error' || event.stage === 'error') streamedError = true
+          logCompilerEvent(event, addLog)
+          if (event.firmwarePath) {
+            void simulatorRun.launch(event.firmwarePath, { attachDebugger: true })
+          }
+        },
+      )
+      if (!result.success) {
+        useOpenPLCStore.getState().workspaceActions.setDebugHarness(null)
+        if (!streamedError) {
+          addLog({ level: 'error', message: result.error ?? 'Harness compilation failed' })
         }
-      } catch (err) {
-        addLog({
-          level: 'error',
-          message: `Library build error: ${getErrorMessage(err)}`,
-        })
-      } finally {
-        setIsCompiling(false)
       }
-    },
-    [compiler, projectData, projectMeta, addLog, isCompiling, executeSave, requestConsoleFollow],
-  )
+    } catch (err: unknown) {
+      useOpenPLCStore.getState().workspaceActions.setDebugHarness(null)
+      addLog({ level: 'error', message: `Library debug error: ${getErrorMessage(err)}` })
+    } finally {
+      setIsCompiling(false)
+    }
+  }, [
+    compiler,
+    projectMeta,
+    addLog,
+    isCompiling,
+    canEdit,
+    executeSave,
+    requestConsoleFollow,
+    simulatorRun,
+    simulatorRunning,
+  ])
 
   // ---------------------------------------------------------------------------
   // PLC control (Start/Stop for runtime targets)
@@ -630,57 +725,17 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
   ])
 
   const handleSimulatorControl = useCallback(async (): Promise<void> => {
-    try {
-      if (simulatorRunning) {
-        // Two things end here, in this order, and the emulator's end is not
-        // conditional on the debug session's.
-        //
-        // The debug session goes first: it is a CONSUMER of the emulator, so it
-        // has to let go of the transport before the thing on the other end
-        // disappears.
-        //
-        // The emulator goes second, from a `finally`, because stopping it is
-        // this button's job and nothing else's. `stopSession()` deliberately
-        // does not do it (see its docstring: a debug session is not the owner of
-        // the thing it talks to), so with this call missing "Stop" ended the
-        // debug session, logged "Simulator stopped." and left the avr8js loop
-        // running — re-scheduling itself and burning a core for the rest of the
-        // session, unreachable because the button had flipped back to "Start".
-        //
-        // Sequencing it after a plain `await` reintroduced the same leak on the
-        // error path: anything that rejects inside the teardown (today only a
-        // throwing `onDisconnected` subscriber, which is why nothing hits it
-        // yet) skipped straight to the catch below, which only logs. The
-        // emulator kept running, `simulatorRunning` stayed true, and every
-        // retry failed identically — worse than the original bug, because
-        // nothing settled at all. `finally` keeps the order and drops the
-        // condition.
-        try {
-          await debugSession.stopSession()
-        } finally {
-          await simulator.stop()
-        }
-
-        // The session this debug session was riding is gone, so the claim that it
-        // rides one goes with it. The drop handler cannot clear it on this path:
-        // `stopSession()` has already hidden the debugger, so the handler's
-        // `isDebuggerVisible` gate returns before it reaches the reset — leaving
-        // the ref stale-`true` for a session that no longer exists.
-        debugSessionRidesDeviceRef.current = false
-
-        setSimulatorRunning(false)
-        addLog({ level: 'info', message: 'Simulator stopped.' })
-      } else {
-        pendingSimulatorDebugRef.current = true
-        handleBuildRef.current().catch(() => {
-          pendingSimulatorDebugRef.current = false
-        })
-      }
-    } catch (error: unknown) {
-      pendingSimulatorDebugRef.current = false
-      addLog({ level: 'error', message: `Simulator control error: ${getErrorMessage(error)}` })
+    if (simulatorRunning) {
+      await simulatorRun.stop()
+      return
     }
-  }, [debugSession, simulator, simulatorRunning, addLog])
+    // Starting means building first — the emulator is fed by the compile's
+    // firmware event, which `handleBuild` hands to `simulatorRun.launch`.
+    pendingSimulatorDebugRef.current = true
+    handleBuildRef.current().catch(() => {
+      pendingSimulatorDebugRef.current = false
+    })
+  }, [simulatorRun, simulatorRunning])
 
   // ---------------------------------------------------------------------------
   // MD5 verification — runs after debug compilation for non-simulator
@@ -1047,35 +1102,33 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
           </TooltipSidebarWrapperButton>
         </>
       )}
-      {/* Library-build affordance: shown only for library projects.
-          Two options surface via the `libraryMode` popover:
-            - "Build"       → fast build (verification short-
-              circuited by MD5 cache hit, when warm).
-            - "Clean build" → skip verification cache and force a
-              fresh avr-gcc verify against the simulator target. */}
+      {/* Library affordances: shown only for library projects.  Build
+          produces the `.stlib`; Debug compiles a generated harness that
+          instantiates every block once and runs it on the simulator with
+          the debugger attached — the only way to see a library actually
+          execute. */}
       {projectCaps.hasLibraryBuild && (
-        // No outer `TooltipSidebarWrapperButton`: `BuildOptionsPopover`
-        // already renders its own Radix tooltip via `triggerTooltip`,
-        // and the wrapper's tooltip persisted on top of the popover
-        // contents once the menu opened (PLC build button doesn't wrap
-        // either — same idiom here for consistency).
-        <BuildOptionsPopover
-          disabled={isCompiling}
-          triggerTooltip={isCompiling ? 'Building library…' : 'Build Library'}
-          libraryMode={true}
-          uploadAvailable={false}
-          uploadDisabledReason='library builds do not upload'
-          onSelect={(option: BuildOption) => {
-            switch (option) {
-              case 'build-only':
-                void handleBuildLibrary({ cleanBuild: false })
-                break
-              case 'clean-upload':
-                void handleBuildLibrary({ cleanBuild: true })
-                break
-            }
-          }}
-        />
+        <TooltipSidebarWrapperButton tooltipContent={isCompiling ? 'Building library…' : 'Build Library'}>
+          <BuildLibraryButton
+            onClick={() => void handleBuildLibrary()}
+            disabled={isCompiling}
+            className={cn(isCompiling && disabledButtonClass)}
+          />
+        </TooltipSidebarWrapperButton>
+      )}
+      {projectCaps.hasLibraryDebug && (
+        <TooltipSidebarWrapperButton
+          tooltipContent={
+            simulatorRunning ? 'Stop Debugging' : isCompiling ? 'Building harness…' : 'Debug Library on Simulator'
+          }
+        >
+          <DebuggerButton
+            onClick={() => void handleDebugLibrary()}
+            disabled={isCompiling}
+            isActive={isDebuggerVisible}
+            className={cn(isCompiling && disabledButtonClass)}
+          />
+        </TooltipSidebarWrapperButton>
       )}
       <TooltipSidebarWrapperButton tooltipContent='AI Chat'>
         <ChatButton />

--- a/src/frontend/hooks/use-simulator-debug-run.ts
+++ b/src/frontend/hooks/use-simulator-debug-run.ts
@@ -14,7 +14,7 @@
  * debug session hook, so editor and web share it byte-for-byte.
  */
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useSimulator } from '../../middleware/shared/providers'
 import { useOpenPLCStore } from '../store'
@@ -64,15 +64,28 @@ export function useSimulatorDebugRun(args: UseSimulatorDebugRunArgs): UseSimulat
 
   const [isRunning, setIsRunning] = useState(false)
 
+  // Callers pass these as inline arrows, so their identity changes on every
+  // render. Held in refs and read at call time so the subscription below and
+  // the callbacks in `launch` / `stop` do not churn with the caller's render
+  // cycle — the activity bar re-renders on every debug poll tick.
+  const onStoppedRef = useRef(onStopped)
+  onStoppedRef.current = onStopped
+  const onDebugAttachedRef = useRef(onDebugAttached)
+  onDebugAttachedRef.current = onDebugAttached
+
   // The emulator stopping is a session ending, and a debug session riding it
   // ends with it — which the caller's connection-drop handling already covers
   // for every target. This only mirrors the emulator's own state.
+  //
+  // Subscribed once per emulator, NOT per render: re-subscribing on every
+  // render leaves a window between unsubscribe and re-subscribe in which a
+  // stop event is dropped, stranding the button in its running state.
   useEffect(() => {
     return simulator.onStopped(() => {
       setIsRunning(false)
-      onStopped?.()
+      onStoppedRef.current?.()
     })
-  }, [simulator, onStopped])
+  }, [simulator])
 
   const launch = useCallback(
     async (firmwarePath: string, options: { attachDebugger?: boolean } = {}): Promise<boolean> => {
@@ -88,12 +101,12 @@ export function useSimulatorDebugRun(args: UseSimulatorDebugRunArgs): UseSimulat
       if (options.attachDebugger) {
         // No config: starting the emulator opened its session, so the
         // connection manager already knows how to reach it.
-        onDebugAttached?.()
+        onDebugAttachedRef.current?.()
         await debugSession.connectAndStart()
       }
       return true
     },
-    [simulator, debugSession, addLog, onDebugAttached],
+    [simulator, debugSession, addLog],
   )
 
   const stop = useCallback(async (): Promise<void> => {
@@ -127,12 +140,12 @@ export function useSimulatorDebugRun(args: UseSimulatorDebugRunArgs): UseSimulat
       }
 
       setIsRunning(false)
-      onStopped?.()
+      onStoppedRef.current?.()
       addLog({ level: 'info', message: 'Simulator stopped.' })
     } catch (error: unknown) {
       addLog({ level: 'error', message: `Simulator control error: ${getErrorMessage(error)}` })
     }
-  }, [debugSession, simulator, addLog, onStopped])
+  }, [debugSession, simulator, addLog])
 
   return { isRunning, launch, stop }
 }

--- a/src/frontend/hooks/use-simulator-debug-run.ts
+++ b/src/frontend/hooks/use-simulator-debug-run.ts
@@ -1,0 +1,138 @@
+/**
+ * Simulator run lifecycle — load firmware into the in-process emulator,
+ * optionally attach a debug session, and tear both down in the right
+ * order.
+ *
+ * Two callers drive the emulator and they must not each own a copy of
+ * this sequence: the PLC project's Start button (compile for the
+ * simulator board, run, attach) and the Library project's Debug button
+ * (compile a generated harness, run, attach).  The ordering rules here
+ * are the ones that were learned the hard way in the activity bar and
+ * are easy to get subtly wrong a second time — see `stop()`.
+ *
+ * Platform-agnostic: everything goes through `SimulatorPort` and the
+ * debug session hook, so editor and web share it byte-for-byte.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+
+import { useSimulator } from '../../middleware/shared/providers'
+import { useOpenPLCStore } from '../store'
+import { getErrorMessage } from '../utils/get-error-message'
+import type { UseDebugSessionReturn } from './useDebugSession'
+
+export interface UseSimulatorDebugRunArgs {
+  /**
+   * The caller's debug session.  Passed in rather than created here:
+   * `useDebugSession` owns a ref holding the per-POU debug trees that
+   * `useDebugPolling` reads, so a second instance would attach a
+   * session whose trees the poller never sees.
+   */
+  debugSession: UseDebugSessionReturn
+  /**
+   * Called once a debug session has been attached to a freshly started
+   * emulator.  The emulator's session IS the debug transport, so the
+   * caller uses this to record that the debug session ends when that
+   * session does.
+   */
+  onDebugAttached?: () => void
+  /**
+   * Called whenever the emulator stops — by `stop()`, by a crash, or by
+   * the program exiting.  Lets the caller drop any state that was only
+   * true while it ran.
+   */
+  onStopped?: () => void
+}
+
+export interface UseSimulatorDebugRunReturn {
+  /** True while the emulator is running. */
+  isRunning: boolean
+  /**
+   * Load `firmwarePath` into the emulator and start it.  With
+   * `attachDebugger`, opens a debug session against it once it is up.
+   * Resolves `false` (and logs) when the firmware could not be loaded.
+   */
+  launch: (firmwarePath: string, options?: { attachDebugger?: boolean }) => Promise<boolean>
+  /** End the debug session (if any) and stop the emulator. */
+  stop: () => Promise<void>
+}
+
+export function useSimulatorDebugRun(args: UseSimulatorDebugRunArgs): UseSimulatorDebugRunReturn {
+  const { debugSession, onDebugAttached, onStopped } = args
+  const simulator = useSimulator()
+  const addLog = useOpenPLCStore((state) => state.consoleActions.addLog)
+
+  const [isRunning, setIsRunning] = useState(false)
+
+  // The emulator stopping is a session ending, and a debug session riding it
+  // ends with it — which the caller's connection-drop handling already covers
+  // for every target. This only mirrors the emulator's own state.
+  useEffect(() => {
+    return simulator.onStopped(() => {
+      setIsRunning(false)
+      onStopped?.()
+    })
+  }, [simulator, onStopped])
+
+  const launch = useCallback(
+    async (firmwarePath: string, options: { attachDebugger?: boolean } = {}): Promise<boolean> => {
+      const loadResult = await simulator.loadFirmware(firmwarePath)
+      if (!loadResult.success) {
+        addLog({ level: 'error', message: `Failed to start simulator: ${loadResult.error ?? 'Unknown error'}` })
+        return false
+      }
+
+      setIsRunning(true)
+      addLog({ level: 'info', message: 'Simulator is running.' })
+
+      if (options.attachDebugger) {
+        // No config: starting the emulator opened its session, so the
+        // connection manager already knows how to reach it.
+        onDebugAttached?.()
+        await debugSession.connectAndStart()
+      }
+      return true
+    },
+    [simulator, debugSession, addLog, onDebugAttached],
+  )
+
+  const stop = useCallback(async (): Promise<void> => {
+    try {
+      // Two things end here, in this order, and the emulator's end is not
+      // conditional on the debug session's.
+      //
+      // The debug session goes first: it is a CONSUMER of the emulator, so it
+      // has to let go of the transport before the thing on the other end
+      // disappears.
+      //
+      // The emulator goes second, from a `finally`, because stopping it is
+      // this function's job and nothing else's. `stopSession()` deliberately
+      // does not do it (see its docstring: a debug session is not the owner of
+      // the thing it talks to), so with this call missing "Stop" ended the
+      // debug session, logged "Simulator stopped." and left the avr8js loop
+      // running — re-scheduling itself and burning a core for the rest of the
+      // session, unreachable because the button had flipped back to "Start".
+      //
+      // Sequencing it after a plain `await` reintroduced the same leak on the
+      // error path: anything that rejects inside the teardown (today only a
+      // throwing `onDisconnected` subscriber, which is why nothing hits it
+      // yet) skipped straight to the catch below, which only logs. The
+      // emulator kept running, `isRunning` stayed true, and every retry failed
+      // identically — worse than the original bug, because nothing settled at
+      // all. `finally` keeps the order and drops the condition.
+      try {
+        await debugSession.stopSession()
+      } finally {
+        await simulator.stop()
+      }
+
+      setIsRunning(false)
+      onStopped?.()
+      addLog({ level: 'info', message: 'Simulator stopped.' })
+    } catch (error: unknown) {
+      addLog({ level: 'error', message: `Simulator control error: ${getErrorMessage(error)}` })
+    }
+  }, [debugSession, simulator, addLog, onStopped])
+
+  return { isRunning, launch, stop }
+}

--- a/src/frontend/hooks/use-simulator-debug-run.ts
+++ b/src/frontend/hooks/use-simulator-debug-run.ts
@@ -50,7 +50,17 @@ export interface UseSimulatorDebugRunReturn {
   /**
    * Load `firmwarePath` into the emulator and start it.  With
    * `attachDebugger`, opens a debug session against it once it is up.
-   * Resolves `false` (and logs) when the firmware could not be loaded.
+   *
+   * Resolves `false` when the run did not fully come up — either the
+   * firmware would not load, or it loaded but the debug session failed
+   * to attach.  Callers that installed session state before the compile
+   * use this to tear it back down; both failures leave that state
+   * orphaned otherwise, and the compile itself reports success in both
+   * cases because it did produce firmware.
+   *
+   * Note the asymmetry with `isRunning`: a failed ATTACH still leaves
+   * the emulator running, so the caller's stop control stays live and
+   * `stop()` remains the way to end it.
    */
   launch: (firmwarePath: string, options?: { attachDebugger?: boolean }) => Promise<boolean>
   /** End the debug session (if any) and stop the emulator. */
@@ -102,7 +112,12 @@ export function useSimulatorDebugRun(args: UseSimulatorDebugRunArgs): UseSimulat
         // No config: starting the emulator opened its session, so the
         // connection manager already knows how to reach it.
         onDebugAttachedRef.current?.()
-        await debugSession.connectAndStart()
+        // `connectAndStart` reports its own failures to the console and
+        // resolves rather than throwing, so the result is the only signal
+        // that the session did not come up — discarding it told the caller
+        // the run succeeded when only half of it had.
+        const attached = await debugSession.connectAndStart()
+        if (!attached.success) return false
       }
       return true
     },

--- a/src/frontend/hooks/useDebugSession.ts
+++ b/src/frontend/hooks/useDebugSession.ts
@@ -76,7 +76,15 @@ export function useDebugSession(): UseDebugSessionReturn {
 
       wsActions.setDebugCContent(debugFileResult.content)
 
-      const instances = project.data.configurations.resource.instances
+      // A library-debug session runs against a generated harness program
+      // that instantiates every block in the library — it exists only in
+      // memory, so the POU list and instance list the debug tree is built
+      // from come from the session overlay, not from `project.data`.  An
+      // ordinary PLC project has no overlay and reads the project itself.
+      // See `composeLibraryDebugHarness`.
+      const harness = useOpenPLCStore.getState().workspace.debugHarness
+      const debugPous = harness ? [...project.data.pous, harness.programPou] : project.data.pous
+      const instances = harness?.instances ?? project.data.configurations.resource.instances
 
       const debugMap = parseDebugMap(debugFileResult.content)
       if (!debugMap) {
@@ -99,10 +107,10 @@ export function useDebugSession(): UseDebugSessionReturn {
       const pouTrees: Record<string, DebugTreeNode[]> = {}
       try {
         const treeResult = buildDebugVariableTreeMap(
-          project.data.pous,
+          debugPous,
           instances,
           entriesForTree,
-          project.data,
+          { ...project.data, pous: debugPous },
           useOpenPLCStore.getState().libraries.system,
         )
         treeMap = treeResult.treeMap
@@ -135,7 +143,7 @@ export function useDebugSession(): UseDebugSessionReturn {
       const indexMap = deriveVariableIndexMap(treeMap, debugMap)
 
       // Build FB instance map
-      const fbDebugInstancesMap = buildFbInstanceMap(project.data.pous, instances)
+      const fbDebugInstancesMap = buildFbInstanceMap(debugPous, instances)
 
       const fbTypesCount = fbDebugInstancesMap.size
       const totalFbInstances = Array.from(fbDebugInstancesMap.values()).reduce((sum, list) => sum + list.length, 0)

--- a/src/frontend/screens/workspace-screen.tsx
+++ b/src/frontend/screens/workspace-screen.tsx
@@ -86,7 +86,16 @@ const WorkspaceScreen = () => {
   // tab switches — no dispose churn, no view-state loss.
   const editors = useOpenPLCStore(useCallback((s) => s.editors, []))
   const searchResults = useOpenPLCStore(useCallback((s) => s.searchResults, []))
-  const pous = useOpenPLCStore(useCallback((s) => s.project.data.pous, []))
+  const projectPous = useOpenPLCStore(useCallback((s) => s.project.data.pous, []))
+  // A library-debug session runs a generated harness program declaring one
+  // instance of every block in the library (see `composeLibraryDebugHarness`).
+  // It is not part of the project, so it joins the POU list here — added, not
+  // substituted, so a debug flag ticked mid-session still takes effect.
+  const debugHarness = useOpenPLCStore(useCallback((s) => s.workspace.debugHarness, []))
+  const pous = useMemo(
+    () => (debugHarness ? [...projectPous, debugHarness.programPou] : projectPous),
+    [projectPous, debugHarness],
+  )
   const projectPath = useOpenPLCStore(useCallback((s) => s.project.meta.path, []))
   const projectType = useOpenPLCStore(useCallback((s) => s.project.meta.type, []))
   // Project-type capability matrix.  Combines with `capabilities`

--- a/src/frontend/store/__tests__/workspace-slice.test.ts
+++ b/src/frontend/store/__tests__/workspace-slice.test.ts
@@ -403,6 +403,26 @@ describe('createWorkspaceSlice', () => {
     expect(store.getState().workspace.fbSelectedInstance.get('TON')).toBe('PROGRAM0::timer1')
   })
 
+  it('setDebugHarness installs and clears the session overlay', () => {
+    expect(store.getState().workspace.debugHarness).toBeNull()
+
+    const harness = {
+      programPou: {
+        name: 'LIBDBG_MAIN',
+        pouType: 'program' as const,
+        interface: { variables: [] },
+        body: { language: 'st' as const, value: 'PID_I();' },
+        documentation: '',
+      },
+      instances: [{ name: 'LIBDBG_INST', program: 'LIBDBG_MAIN', task: 'LIBDBG_TASK' }],
+    }
+    store.getState().workspaceActions.setDebugHarness(harness)
+    expect(store.getState().workspace.debugHarness).toEqual(harness)
+
+    store.getState().workspaceActions.setDebugHarness(null)
+    expect(store.getState().workspace.debugHarness).toBeNull()
+  })
+
   it('setDebugLocalMd5', () => {
     store.getState().workspaceActions.setDebugLocalMd5('abc123')
     expect(store.getState().workspace.debugLocalMd5).toBe('abc123')
@@ -464,6 +484,16 @@ describe('createWorkspaceSlice', () => {
       ]),
     )
     store.getState().workspaceActions.setFbSelectedInstance('FB', 'K')
+    store.getState().workspaceActions.setDebugHarness({
+      programPou: {
+        name: 'LIBDBG_MAIN',
+        pouType: 'program',
+        interface: { variables: [] },
+        body: { language: 'st', value: 'PID_I();' },
+        documentation: '',
+      },
+      instances: [{ name: 'LIBDBG_INST', program: 'LIBDBG_MAIN', task: 'LIBDBG_TASK' }],
+    })
     store.getState().workspaceActions.setDebugLocalMd5('md5')
     store.getState().workspaceActions.setDebugGraphList(['a'])
     store.getState().workspaceActions.setDebugDataStale(true)
@@ -484,6 +514,7 @@ describe('createWorkspaceSlice', () => {
     expect(workspace.debugExpandedNodes.size).toBe(0)
     expect(workspace.fbDebugInstances.size).toBe(0)
     expect(workspace.fbSelectedInstance.size).toBe(0)
+    expect(workspace.debugHarness).toBeNull()
     expect(workspace.debugLocalMd5).toBeNull()
     expect(workspace.debugGraphList).toEqual([])
     expect(workspace.debugDataStale).toBe(false)

--- a/src/frontend/store/slices/workspace/slice.ts
+++ b/src/frontend/store/slices/workspace/slice.ts
@@ -49,6 +49,7 @@ const createWorkspaceSlice: StateCreator<WorkspaceSlice, [], [], WorkspaceSlice>
     debugExpandedNodes: new Map(),
     fbDebugInstances: new Map(),
     fbSelectedInstance: new Map(),
+    debugHarness: null,
     debugLocalMd5: null,
     debugGraphList: [],
     debugDataStale: false,
@@ -168,6 +169,7 @@ const createWorkspaceSlice: StateCreator<WorkspaceSlice, [], [], WorkspaceSlice>
           workspace.debugExpandedNodes = new Map()
           workspace.fbDebugInstances = new Map()
           workspace.fbSelectedInstance = new Map()
+          workspace.debugHarness = null
           workspace.debugLocalMd5 = null
           workspace.debugGraphList = []
           workspace.debugDataStale = false
@@ -336,6 +338,13 @@ const createWorkspaceSlice: StateCreator<WorkspaceSlice, [], [], WorkspaceSlice>
         }),
       )
     },
+    setDebugHarness: (harness) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.debugHarness = harness
+        }),
+      )
+    },
     setFbSelectedInstance: (fbTypeName: string, key: string) => {
       setState(
         produce(({ workspace }: WorkspaceSlice) => {
@@ -393,6 +402,7 @@ const createWorkspaceSlice: StateCreator<WorkspaceSlice, [], [], WorkspaceSlice>
           workspace.debugExpandedNodes = new Map()
           workspace.fbDebugInstances = new Map()
           workspace.fbSelectedInstance = new Map()
+          workspace.debugHarness = null
           workspace.debugLocalMd5 = null
           workspace.debugGraphList = []
           workspace.debugDataStale = false

--- a/src/frontend/store/slices/workspace/types.ts
+++ b/src/frontend/store/slices/workspace/types.ts
@@ -3,7 +3,9 @@ import type {
   DebugTreeNode,
   FbInstanceInfo,
   Platform,
+  PLCInstance,
   PlcLogs,
+  PLCPou,
 } from '../../../../middleware/shared/ports/types'
 
 // ---------------------------------------------------------------------------
@@ -93,6 +95,24 @@ export type WorkspaceState = {
     debugExpandedNodes: Map<string, boolean>
     fbDebugInstances: Map<string, FbInstanceInfo[]>
     fbSelectedInstance: Map<string, string>
+    /**
+     * The generated program the CURRENT debug session is running,
+     * when the session runs something the project itself does not
+     * contain.
+     *
+     * Set only by the library-debug flow, which compiles a harness
+     * program (see `composeLibraryDebugHarness`) declaring one
+     * instance of every block in the library.  That program exists
+     * only for the life of the session: writing it into `project.data`
+     * would fight each editor's dirty tracking and could be persisted
+     * to disk on the next save.
+     *
+     * Consumers ADD `programPou` to the project's own POU list rather
+     * than replacing it, so a debug flag the author ticks mid-session
+     * still takes effect.  `null` for an ordinary PLC project, whose
+     * session runs the project's own programs.
+     */
+    debugHarness: { programPou: PLCPou; instances: PLCInstance[] } | null
     debugLocalMd5: string | null
     debugGraphList: string[]
     debugDataStale: boolean
@@ -176,6 +196,8 @@ export type WorkspaceActions = {
   setDebugExpandedNodes: (expandedNodes: Map<string, boolean>) => void
   toggleDebugExpandedNode: (compositeKey: string) => void
   setFbDebugInstances: (instances: Map<string, FbInstanceInfo[]>) => void
+  /** Install (or clear, with `null`) the session's harness overlay. */
+  setDebugHarness: (harness: { programPou: PLCPou; instances: PLCInstance[] } | null) => void
   setFbSelectedInstance: (fbTypeName: string, key: string) => void
   setDebugLocalMd5: (md5: string | null) => void
   setDebugGraphList: (list: string[]) => void

--- a/src/frontend/utils/debug-polling-filter.ts
+++ b/src/frontend/utils/debug-polling-filter.ts
@@ -32,6 +32,9 @@ export interface DebugPollingState {
     debugGraphList: string[]
     fbSelectedInstance: Map<string, string>
     fbDebugInstances: Map<string, FbInstanceInfo[]>
+    /** Generated program the session is running, when it runs one the
+     *  project does not contain — see the workspace slice. */
+    debugHarness: { programPou: PLCPou } | null
   }
   editor: { meta: { name: string; [key: string]: unknown } }
   ladderFlows: Array<{
@@ -75,7 +78,6 @@ export function buildActiveIndexSet(
 ): { activeIndexes: number[]; cacheResult: VisibleVarsCache } {
   const activeKeys = new Set<string>()
 
-  const { pous } = state.project.data
   const {
     debugVariableIndexes,
     debugForcedVariables,
@@ -83,7 +85,14 @@ export function buildActiveIndexSet(
     debugGraphList,
     fbSelectedInstance,
     fbDebugInstances,
+    debugHarness,
   } = state.workspace
+  // A library-debug session runs a generated harness program that is not
+  // part of the project.  Its variables (one instance per library block,
+  // all flagged for debug) have to be polled like any other watch, so it
+  // joins the project's own POUs here rather than replacing them — a flag
+  // the author ticks mid-session must still take effect.
+  const pous = debugHarness ? [...state.project.data.pous, debugHarness.programPou] : state.project.data.pous
   const { editor } = state
 
   // -----------------------------------------------------------------------

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -13,6 +13,7 @@ import { PlcRuntimeState } from '@root/backend/shared/simulator/types'
 import { PLCProjectData } from '@root/backend/shared/types/PLC/open-plc'
 import { getErrorMessage } from '@root/frontend/utils/get-error-message'
 import type { CompileProgramIpcArgs } from '@root/middleware/adapters/editor/compile-program-flow'
+import type { CompileLibraryIpcArgs } from '@root/middleware/adapters/editor/compiler-adapter'
 import { RuntimeLogEntry } from '@root/middleware/shared/ports'
 import type { DeviceLicenseReport, DeviceLicenseRequest } from '@root/middleware/shared/ports/device-port'
 import type {
@@ -1095,7 +1096,7 @@ class MainProcessBridge implements MainIpcModule {
     void this.compilerModule.compileForDebugger(args, mainProcessPort, this)
   }
 
-  handleRunCompileLibrary = (event: IpcMainEvent, args: Array<string | PLCProjectData | boolean>) => {
+  handleRunCompileLibrary = (event: IpcMainEvent, args: CompileLibraryIpcArgs) => {
     const mainProcessPort = event.ports[0]
     void this.compilerModule.compileLibrary(args, mainProcessPort, this)
   }

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -1,4 +1,5 @@
 import type { CompileProgramIpcArgs } from '@root/middleware/adapters/editor/compile-program-flow'
+import type { CompileLibraryIpcArgs } from '@root/middleware/adapters/editor/compiler-adapter'
 import type { DiscoveredRuntimeDevice, RuntimeLogEntry } from '@root/middleware/shared/ports'
 import type {
   DeviceConnectionStatusPayload,
@@ -266,21 +267,11 @@ const rendererProcessBridge = {
   },
 
   /** Build the open Library Project into a `.stlib` archive.  Same
-   *  MessageChannel pattern as `runCompileProgram`.  Args:
-   *    [0] projectPath
-   *    [1] projectData preprocessed with `isSimulator: false` (full
-   *        Python-as-ST), used for the library build proper.
-   *    [2] projectData preprocessed with `isSimulator: true` (Python
-   *        as no-op stubs), used as input to the simulator-target
-   *        verification compile so it doesn't try to link Python
-   *        loader externs the AVR simulator runtime doesn't ship.
-   *    [3] cleanBuild flag (skips the verification cache).
-   *  Callback receives a stream of log messages and a final
-   *  `libraryBuildResult`. */
-  runCompileLibrary: (
-    compileArgs: Array<string | PLCProjectData | boolean>,
-    callback: (args: CompilerPortMessage) => void,
-  ) => {
+   *  MessageChannel pattern as `runCompileProgram`; the tuple shape
+   *  is `CompileLibraryIpcArgs`, declared next to the adapter that
+   *  fills it.  Callback receives a stream of log messages and a
+   *  final `libraryBuildResult`. */
+  runCompileLibrary: (compileArgs: CompileLibraryIpcArgs, callback: (args: CompilerPortMessage) => void) => {
     const { port1: rendererProcessPort, port2: mainProcessPort } = new MessageChannel()
     ipcRenderer.postMessage('compiler:run-compile-library', compileArgs, [mainProcessPort])
     rendererProcessPort.onmessage = (event) => callback(event.data as CompilerPortMessage)

--- a/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/compiler-adapter.test.ts
@@ -651,18 +651,16 @@ describe('createEditorCompilerAdapter', () => {
 
       const result = await promise
 
-      // Args: [projectPath, ipcDataForBuild, ipcDataForVerify, cleanBuild]
-      // 5th arg: the native-POU inventory, taken from the RAW project data
+      // Args: [projectPath, ipcDataForBuild, nativePous]
+      // 3rd arg: the native-POU inventory, taken from the RAW project data
       // before `preprocessPous` lowered every native body to bridge ST and
       // rewrote its language tag. The main process cannot derive it.
+      //
+      // There is no verify-pass project data and no `cleanBuild` flag: the
+      // build runs strucpp and nothing else, so there is no second preprocess
+      // pass to send and no verification cache to bypass.
       expect(window.bridge.runCompileLibrary).toHaveBeenCalledWith(
-        [
-          '/lib/project',
-          expect.objectContaining({ pous: expect.any(Array) }),
-          expect.objectContaining({ pous: expect.any(Array) }),
-          false,
-          expect.any(Array),
-        ],
+        ['/lib/project', expect.objectContaining({ pous: expect.any(Array) }), expect.any(Array)],
         expect.any(Function),
       )
       expect(result).toEqual({
@@ -748,23 +746,6 @@ describe('createEditorCompilerAdapter', () => {
       expect(progressEvents[0].level).toBe('info')
     })
 
-    it('propagates the cleanBuild flag through to the bridge', async () => {
-      const promise = adapter.compileLibrary!(
-        { projectData: mockProjectData, projectPath: '/lib/project', cleanBuild: true },
-        () => {},
-      )
-
-      await flushMicrotasks()
-      libraryCallback!({ libraryBuildResult: { success: true, stlibPath: '/x.stlib' } })
-      libraryCallback!({ closePort: true })
-      await promise
-
-      expect(window.bridge.runCompileLibrary).toHaveBeenCalledWith(
-        ['/lib/project', expect.any(Object), expect.any(Object), true, expect.any(Array)],
-        expect.any(Function),
-      )
-    })
-
     it('sends the native-POU inventory taken before preprocessing', async () => {
       // Regression: the pipeline used to infer this from the POU list it
       // received, which is always `st` by then — so it found none and the
@@ -789,7 +770,7 @@ describe('createEditorCompilerAdapter', () => {
       await promise
 
       const args = (window.bridge.runCompileLibrary as jest.Mock).mock.calls[0][0] as unknown[]
-      expect(args[4]).toEqual([{ name: 'CPP_SCALE', language: 'cpp', relPath: 'pous/function-blocks/CPP_SCALE.cpp' }])
+      expect(args[2]).toEqual([{ name: 'CPP_SCALE', language: 'cpp', relPath: 'pous/function-blocks/CPP_SCALE.cpp' }])
     })
 
     it('defaults non-error log levels to info when logLevel is missing', async () => {

--- a/src/middleware/adapters/editor/compiler-adapter.ts
+++ b/src/middleware/adapters/editor/compiler-adapter.ts
@@ -251,33 +251,19 @@ export function createEditorCompilerAdapter(): CompilerPort {
       args: CompileLibraryArgs,
       onProgress: (event: CompileProgressEvent) => void,
     ): Promise<CompileLibraryResult> {
-      // Two preprocess passes — the library build and the
-      // simulator-target verification want different Python
-      // treatment, and `preprocessPous` is the only place that
-      // decision lives.
+      // ONE preprocess pass, `isSimulator: false`.  Python POUs go
+      // through `injectPythonCode` + `generateSTCode`, becoming
+      // self-contained ST with the Python source embedded as strings —
+      // exactly the shape strucpp compiles for a runtime-target program
+      // build.  The `.stlib` ships real Python code, usable by any
+      // consumer that targets a Python-capable runtime.
       //
-      //   - `isSimulator: false` for the LIBRARY BUILD itself.
-      //     Python POUs go through `injectPythonCode` +
-      //     `generateSTCode`, becoming self-contained ST with the
-      //     Python source embedded as strings — exactly the shape
-      //     strucpp compiles for a runtime-target program build.
-      //     The `.stlib` ships real Python code, usable by any
-      //     consumer that targets a Python-capable runtime.
+      // There used to be a second `isSimulator: true` pass feeding an
+      // avr-gcc verification compile, which stubbed Python POUs to
+      // no-ops because the AVR simulator has no interpreter.  The
+      // verification stage is gone: the build is target-neutral, and
+      // running a library goes through the debug harness instead.
       //
-      //   - `isSimulator: true` for the VERIFICATION compile.
-      //     Python POUs become `first_run := 0;` no-op stubs.  The
-      //     AVR simulator has no Python interpreter, so passing
-      //     full-Python-as-ST through to arduino-cli would fail at
-      //     link time (the strucpp-emitted code calls into
-      //     Python loader externs the simulator runtime doesn't
-      //     ship).  Stubbing keeps the verify compile honest: it
-      //     still proves the library's ST/IL/data-types compile
-      //     cleanly to AVR — the only thing it can't prove is
-      //     that the Python POUs run, and we accept that.
-      //
-      // The renderer-side `onProgress` log channel only sees the
-      // build pass's preprocess output to avoid duplicate "Found
-      // Python POU…" lines.
       // Taken BEFORE preprocessing: that step lowers every native body to
       // bridge ST and rewrites the language tag with it, leaving nothing to
       // identify a native POU by.  Sent over IPC because the main process
@@ -311,31 +297,7 @@ export function createEditorCompilerAdapter(): CompilerPort {
             'POU validation failed. Check C/C++ code for missing setup()/loop() functions.',
         }
       }
-      const verifyResult = preprocessPous(
-        args.projectData,
-        true,
-        () => {
-          // Silent — same project gets logged once via the build
-          // pass; a second round of "Found …" lines is noise.
-        },
-        undefined,
-        fbSources,
-      )
-      // Checked rather than ignored, matching the build pass above. Both passes
-      // get the same project and the same FB pin sources, so they agree today —
-      // but handing an un-lowered project to the verify compile would fail it on
-      // `python_block_loader` instead of reporting the refusal, and that is not
-      // a difference worth leaving to luck.
-      if (verifyResult.validationFailed) {
-        return {
-          success: false,
-          error:
-            verifyResult.validationError ??
-            'POU validation failed. Check C/C++ code for missing setup()/loop() functions.',
-        }
-      }
       const ipcDataForBuild = toIpcProjectData(buildResult.projectData)
-      const ipcDataForVerify = toIpcProjectData(verifyResult.projectData)
 
       return new Promise<CompileLibraryResult>((resolve) => {
         let finalResult: CompileLibraryResult | undefined
@@ -354,13 +316,7 @@ export function createEditorCompilerAdapter(): CompilerPort {
         //     `'close'` event — that's the sole "build done"
         //     signal the adapter resolves on.
         window.bridge.runCompileLibrary(
-          [
-            args.projectPath,
-            ipcDataForBuild as never,
-            ipcDataForVerify as never,
-            args.cleanBuild ?? false,
-            nativePous as never,
-          ],
+          [args.projectPath, ipcDataForBuild as never, nativePous as never],
           (data: Record<string, unknown>) => {
             if (data.libraryBuildResult) {
               finalResult = data.libraryBuildResult as CompileLibraryResult

--- a/src/middleware/adapters/editor/compiler-adapter.ts
+++ b/src/middleware/adapters/editor/compiler-adapter.ts
@@ -15,7 +15,7 @@ import {
   findLibrariesMissingNativeSources,
   injectLibraryBlocks,
 } from '../../../backend/shared/library/inject-library-blocks'
-import { collectNativePous } from '../../../backend/shared/library/native-pou-list'
+import { collectNativePous, type NativePouRef } from '../../../backend/shared/library/native-pou-list'
 import { preprocessPous } from '../../../backend/shared/utils/PLC/preprocess-pous'
 import type {
   CompileLibraryArgs,
@@ -127,6 +127,29 @@ function inferStage(message: string): CompileProgressEvent['stage'] {
   if (lower.includes('arduino') || lower.includes('compiling') || lower.includes('uploading')) return 'arduino'
   return 'st'
 }
+
+/**
+ * Argument tuple for the `compiler:run-compile-library` channel.
+ *
+ * Declared here, beside `IpcProjectData`, for the same reason
+ * `CompileProgramIpcArgs` is: the renderer bridge and the main-process
+ * handler both name this type instead of restating a loose
+ * `Array<string | ... >`, so adding, removing or reordering a slot is a
+ * compile error on every side at once rather than a cast that silently
+ * still fits.  The main process still VALIDATES what arrives — a type is
+ * a statement about our own callers, not a guarantee about the channel.
+ */
+export type CompileLibraryIpcArgs = [
+  projectPath: string,
+  /** Build-pass project data, `preprocessPous` with `isSimulator: false`. */
+  projectData: IpcProjectData,
+  /**
+   * Native (C/C++, Python) POUs collected from the RAW project data before
+   * preprocessing lowered every native body to bridge ST — the main process
+   * cannot derive this itself.  See `collectNativePous`.
+   */
+  nativePous: NativePouRef[],
+]
 
 export function createEditorCompilerAdapter(): CompilerPort {
   return {
@@ -316,7 +339,7 @@ export function createEditorCompilerAdapter(): CompilerPort {
         //     `'close'` event — that's the sole "build done"
         //     signal the adapter resolves on.
         window.bridge.runCompileLibrary(
-          [args.projectPath, ipcDataForBuild as never, nativePous as never],
+          [args.projectPath, ipcDataForBuild, nativePous],
           (data: Record<string, unknown>) => {
             if (data.libraryBuildResult) {
               finalResult = data.libraryBuildResult as CompileLibraryResult

--- a/src/middleware/shared/ports/compiler-port.ts
+++ b/src/middleware/shared/ports/compiler-port.ts
@@ -77,17 +77,6 @@ export interface ExportXmlArgs {
 export interface CompileLibraryArgs {
   projectData: PLCProjectData
   projectPath: string
-  /**
-   * Skip the verification-result cache for this run.  The MD5 cache
-   * normally short-circuits the slow simulator-target verification
-   * when the program.st coming out of the ST transpiler hasn't changed since
-   * the last successful (or failed) verify; `cleanBuild: true`
-   * forces a fresh compile.
-   *
-   * Pure UX gate — the artefact build itself is always fresh; only
-   * the verification step is cached.
-   */
-  cleanBuild?: boolean
 }
 
 export interface CompilerPort {
@@ -126,9 +115,10 @@ export interface CompilerPort {
    * `projectCapabilities(meta).hasLibraryBuild`.
    *
    * Returns the artefact path on success, or an error string the
-   * console renders directly.  The optional `verification` field
-   * reports the Phase-8 avr-gcc verification result when wired —
-   * a verification failure does NOT fail the build.
+   * console renders directly.  The build is target-neutral: it runs
+   * strucpp and nothing else, so a library that could never link on
+   * one particular board still produces a valid archive.  Executing
+   * the library is a separate action — see `composeLibraryDebugHarness`.
    */
   compileLibrary?(
     args: CompileLibraryArgs,

--- a/src/middleware/shared/ports/library-build-port.ts
+++ b/src/middleware/shared/ports/library-build-port.ts
@@ -8,15 +8,22 @@
  * primitives the orchestrator cannot perform itself because they
  * cross the platform boundary (filesystem ↔ HTTP, etc.).
  *
+ * The port used to carry a `verifyCompile` primitive that drove the
+ * library through avr-gcc against the OpenPLC Simulator board on
+ * every build.  It is gone: the build is target-neutral, and running
+ * a library is now an explicit action driven from the renderer
+ * through `CompilerPort.compileProgram` with a generated harness
+ * project (`composeLibraryDebugHarness`).
+ *
  * Contract symmetry rule
  * ----------------------
  * Both desktop and web MUST implement every method on this interface
  * with semantically identical behaviour.  When the orchestrator calls
- * `port.readBuildFile(p, 'build/.verify-cache-library.json')`, both
- * platforms return the same content if the project tree carries the
- * same bytes.  Differences are confined to *transport* (fs vs HTTP),
- * never to logic — anything that looks like business logic belongs in
- * the shared orchestrator instead.
+ * `port.readBuildFile(p, 'library.json')`, both platforms return the
+ * same content if the project tree carries the same bytes.
+ * Differences are confined to *transport* (fs vs HTTP), never to
+ * logic — anything that looks like business logic belongs in the
+ * shared orchestrator instead.
  *
  * Web safety reminder
  * -------------------
@@ -29,20 +36,6 @@
  */
 
 import type { TranspileToStArgs, TranspileToStResult } from './compiler-platform-port'
-
-/**
- * Outcome of an attempted verification compile against the OpenPLC
- * Simulator board.  Verification is advisory: a `success: false`
- * surfaces as a warning on the build result, never as a fatal error
- * (the `.stlib` still ships).  See `runLibraryBuildPipeline` for the
- * cache + skip-on-md5-match flow that wraps this.
- */
-export interface LibraryVerificationResult {
-  success: boolean
-  /** Human-readable summary of the failure, surfaced as a console
-   *  warning when `success` is false.  Undefined on success. */
-  message?: string
-}
 
 /**
  * Library-enabled archives the project pulls in for the strucpp
@@ -61,42 +54,18 @@ export interface LibraryArchiveLookupArgs {
   projectLibraryRefs: ReadonlyArray<{ name: string; version: string }>
 }
 
-export interface VerifyCompileArgs {
-  /** Project root path on the host platform.  Same value the build
-   *  orchestrator received; the port impl knows how to interpret it. */
-  projectPath: string
-  /**
-   * Verification-pass project data — Python POUs already lowered to
-   * no-op stubs (the AVR simulator has no Python interpreter).  The
-   * orchestrator preprocesses this separately from the build pass
-   * and hands the result through.
-   *
-   * Typed as `unknown` on purpose: the architecture rule forbids the
-   * port from importing `backend/shared` types.  The orchestrator
-   * lives in `backend/shared` and produces shape-correct data; the
-   * port impl casts to its platform's expected shape (port-shape on
-   * web before invoking `runCompilePipeline`, schema-shape on editor
-   * before threading into the IPC envelope).
-   */
-  verifyProjectData: unknown
-  /** Caller log callback.  Every line the inner compile emits is
-   *  forwarded here; the orchestrator prefixes them with `[verify]`
-   *  before forwarding to its own caller. */
-  emit: (message: string, level: 'info' | 'warning' | 'error') => void
-}
-
 export interface LibraryBuildPort {
   // -------------------------------------------------------------------------
-  // Cryptography + transpile (same signatures `CompilerPlatformPort`
-  // uses for the program build — duplicated here intentionally so the
-  // orchestrator takes a single port object instead of two.  Each
-  // impl is free to delegate to whatever its program-build path uses
-  // internally; the contract is just that bytes in match bytes out.)
+  // Transpile (same signature `CompilerPlatformPort` uses for the
+  // program build — declared here too so the orchestrator takes a
+  // single port object instead of two.  Each impl is free to delegate
+  // to whatever its program-build path uses internally; the contract
+  // is just that bytes in match bytes out.)
+  //
+  // There was a `computeMd5` primitive here as well, hashing
+  // `program.st` to key the verification cache.  Both went out with
+  // the verification stage.
   // -------------------------------------------------------------------------
-
-  /** MD5 hex digest.  Editor wires it to Node's `crypto`; web wires
-   *  it to `spark-md5`.  Both byte-identical. */
-  computeMd5(input: string): Promise<string>
 
   /**
    * Transpile the project IR directly to ST via the in-process
@@ -139,8 +108,8 @@ export interface LibraryBuildPort {
   deleteBuildSubtree(projectPath: string, relPath: string): Promise<void>
 
   // -------------------------------------------------------------------------
-  // Library-resolution and verification (platform-shaped operations
-  // whose implementations differ in transport but not in semantics)
+  // Library resolution (platform-shaped operation whose implementation
+  // differs in transport but not in semantics)
   // -------------------------------------------------------------------------
 
   /**
@@ -151,15 +120,4 @@ export interface LibraryBuildPort {
    * the build with a clear "Library Manager" message.
    */
   loadLibraryArchives(args: LibraryArchiveLookupArgs): Promise<LibraryArchiveLookup>
-
-  /**
-   * Run a verification compile of `verifyProjectData` against the
-   * OpenPLC Simulator board.  Both platform impls internally drive
-   * the shared `runCompilePipeline` — the only thing they own is the
-   * platform-specific arg assembly (board entry, hals data, firmware
-   * skeleton) and the transport.  Failures are advisory: the
-   * orchestrator surfaces them as a warning on the build result,
-   * never as a fatal error.
-   */
-  verifyCompile(args: VerifyCompileArgs): Promise<LibraryVerificationResult>
 }

--- a/src/middleware/shared/ports/types.ts
+++ b/src/middleware/shared/ports/types.ts
@@ -559,6 +559,13 @@ export interface ProjectCapabilities {
   hasProgramBuild: boolean
   /** Show the Library-specific build button (produces `.stlib`). */
   hasLibraryBuild: boolean
+  /** Show the Library-specific debug button.  Compiles a synthetic
+   *  harness program that instantiates every block in the library
+   *  once, runs it on the in-process simulator, and attaches the
+   *  debugger so the author can force inputs and watch outputs.
+   *  Distinct from `hasProgramBuild`: a library has no program of its
+   *  own to build or upload, only blocks to exercise. */
+  hasLibraryDebug: boolean
   /** Show the version-control affordance. */
   hasVersionControl: boolean
   /** Show the debugger panel + watch list. */
@@ -583,6 +590,7 @@ export function projectCapabilities(
       hasVendorScreens: false,
       hasProgramBuild: false,
       hasLibraryBuild: true,
+      hasLibraryDebug: true,
       hasVersionControl: false,
       hasDebugger: false,
       hasRuntimeControls: false,
@@ -598,6 +606,7 @@ export function projectCapabilities(
     hasVendorScreens: true,
     hasProgramBuild: true,
     hasLibraryBuild: false,
+    hasLibraryDebug: false,
     hasVersionControl: true,
     hasDebugger: true,
     hasRuntimeControls: true,
@@ -1272,12 +1281,14 @@ export interface DebugCompileResult {
  * shape of `CompileResult` (success / error) plus the artefact path
  * the console surfaces so the user can find the produced archive.
  *
- * The verification step (Phase 8 — running the synthetic project
- * through avr-gcc on the simulator target) reports its outcome
- * through `verification`: missing means the step hasn't been wired
- * yet; `success: true` means it ran clean; `success: false` does NOT
- * fail the build, the warning surfaces to the console instead (a
- * legitimate target may have more memory than the AVR simulator).
+ * There is deliberately no verification field.  The build used to run
+ * the library through avr-gcc against the simulator target and report
+ * the outcome here, which judged every library by whether it links on
+ * an ATmega2560 — a target most libraries never run on.  Executing a
+ * library is now its own action: the debug harness
+ * (`composeLibraryDebugHarness`) instantiates every block and runs it
+ * on the simulator when the author asks for it.  strucpp's
+ * `compileStlib` remains the build's correctness gate.
  */
 export interface CompileLibraryResult {
   success: boolean
@@ -1286,10 +1297,6 @@ export interface CompileLibraryResult {
   /** Manifest name extracted from `library.json`. */
   libraryName?: string
   error?: string
-  verification?: {
-    success: boolean
-    message?: string
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/middleware/shared/utils/library-debug/__tests__/compose-library-debug-harness.test.ts
+++ b/src/middleware/shared/utils/library-debug/__tests__/compose-library-debug-harness.test.ts
@@ -48,12 +48,18 @@ function libraryData(pous: PLCPou[]): PLCProjectData {
     dataTypes: [],
     libraries: [],
     configurations: { resource: { tasks: [], instances: [], globalVariables: [] } },
-  } as unknown as PLCProjectData
+  }
 }
 
-/** The harness program is always appended last. */
-function harnessProgram(pous: PLCPou[]): PLCPou {
-  return pous[pous.length - 1]
+/**
+ * Locate the harness program by NAME, never by position — the tests must not
+ * encode the append order the composer happens to use, which is the same
+ * coupling `programPou` exists to spare callers.
+ */
+function harnessProgram(harness: { projectData: PLCProjectData; programName: string }): PLCPou {
+  const pou = harness.projectData.pous.find((p) => p.name === harness.programName)
+  if (!pou) throw new Error(`harness program ${harness.programName} missing from projectData.pous`)
+  return pou
 }
 
 // ---------------------------------------------------------------------------
@@ -69,7 +75,7 @@ describe('composeLibraryDebugHarness', () => {
       { pouName: 'Ramp', instanceVariable: 'RAMP_I' },
     ])
 
-    const program = harnessProgram(harness.projectData.pous)
+    const program = harnessProgram(harness)
     expect(program.name).toBe(HARNESS_PROGRAM_NAME)
     expect(program.pouType).toBe('program')
     // `derived` + the block's own name is exactly what buildFbInstanceMap
@@ -81,9 +87,16 @@ describe('composeLibraryDebugHarness', () => {
     expect(program.body).toEqual({ language: 'st', value: 'PID_I();\nRAMP_I();' })
   })
 
+  it('returns the harness program POU so callers never index into pous', () => {
+    const harness = composeLibraryDebugHarness(libraryData([functionBlock('Pid')]))
+    // Same object, not a copy — the session overlay installs this verbatim.
+    expect(harness.programPou).toBe(harnessProgram(harness))
+    expect(harness.programPou.name).toBe(harness.programName)
+  })
+
   it('flags every harness variable for debug so the watch table fills on connect', () => {
     const harness = composeLibraryDebugHarness(libraryData([functionBlock('Pid')]))
-    const program = harnessProgram(harness.projectData.pous)
+    const program = harnessProgram(harness)
     expect(program.interface?.variables.every((v) => v.debug === true)).toBe(true)
   })
 
@@ -115,7 +128,7 @@ describe('composeLibraryDebugHarness', () => {
     expect(harness.projectData.configurations.resource.globalVariables).toHaveLength(1)
   })
 
-  it('skips functions without comment — they are simply not instantiable state', () => {
+  it('skips functions — they are not instantiable state', () => {
     const fn: PLCPou = {
       name: 'Scale',
       pouType: 'function',
@@ -158,7 +171,7 @@ describe('composeLibraryDebugHarness', () => {
       ]),
     )
 
-    const program = harnessProgram(harness.projectData.pous)
+    const program = harnessProgram(harness)
     expect(program.interface?.variables).toEqual([
       expect.objectContaining({ name: 'BUF_I' }),
       expect.objectContaining({ name: 'BUF_IO_BUFFER', type: { definition: 'base-type', value: 'DINT' } }),
@@ -179,7 +192,7 @@ describe('composeLibraryDebugHarness', () => {
   it('returns no blocks for a library with nothing instantiable', () => {
     const harness = composeLibraryDebugHarness(libraryData([]))
     expect(harness.blocks).toEqual([])
-    expect(harnessProgram(harness.projectData.pous).interface?.variables).toEqual([])
+    expect(harnessProgram(harness).interface?.variables).toEqual([])
   })
 
   it('uniquifies instance names when two blocks generate the same one', () => {
@@ -192,7 +205,7 @@ describe('composeLibraryDebugHarness', () => {
   it('yields the program name when the library already owns LIBDBG_MAIN', () => {
     const harness = composeLibraryDebugHarness(libraryData([functionBlock(HARNESS_PROGRAM_NAME), functionBlock('Pid')]))
     expect(harness.programName).toBe(`${HARNESS_PROGRAM_NAME}_2`)
-    expect(harnessProgram(harness.projectData.pous).name).toBe(`${HARNESS_PROGRAM_NAME}_2`)
+    expect(harnessProgram(harness).name).toBe(`${HARNESS_PROGRAM_NAME}_2`)
     expect(harness.projectData.configurations.resource.instances[0].program).toBe(`${HARNESS_PROGRAM_NAME}_2`)
   })
 

--- a/src/middleware/shared/utils/library-debug/__tests__/compose-library-debug-harness.test.ts
+++ b/src/middleware/shared/utils/library-debug/__tests__/compose-library-debug-harness.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for the library debug harness synthesiser.
+ *
+ * The contract that matters downstream: the harness program must look
+ * like an ordinary program POU with `derived`-typed locals, because
+ * that is what `buildFbInstanceMap` recognises as a function-block
+ * instance.  Everything the debugger does for a library — instance
+ * binding, live values inside a block's editor, the watch table —
+ * follows from that shape.
+ */
+
+import type { PLCBody, PLCPou, PLCProjectData, PLCVariable } from '../../../ports/types'
+import {
+  composeLibraryDebugHarness,
+  HARNESS_INSTANCE_NAME,
+  HARNESS_PROGRAM_NAME,
+  HARNESS_TASK_NAME,
+} from '../compose-library-debug-harness'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function variable(name: string, overrides: Partial<PLCVariable> = {}): PLCVariable {
+  return {
+    name,
+    class: 'input',
+    type: { definition: 'base-type', value: 'BOOL' },
+    location: '',
+    documentation: '',
+    ...overrides,
+  }
+}
+
+function functionBlock(name: string, variables: PLCVariable[] = [], body?: Partial<PLCBody>): PLCPou {
+  return {
+    name,
+    pouType: 'function-block',
+    interface: { variables },
+    body: { language: 'st', value: '', ...body },
+    documentation: '',
+  }
+}
+
+function libraryData(pous: PLCPou[]): PLCProjectData {
+  return {
+    pous,
+    dataTypes: [],
+    libraries: [],
+    configurations: { resource: { tasks: [], instances: [], globalVariables: [] } },
+  } as unknown as PLCProjectData
+}
+
+/** The harness program is always appended last. */
+function harnessProgram(pous: PLCPou[]): PLCPou {
+  return pous[pous.length - 1]
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('composeLibraryDebugHarness', () => {
+  it('declares one instance per function block and calls each once', () => {
+    const harness = composeLibraryDebugHarness(libraryData([functionBlock('Pid'), functionBlock('Ramp')]))
+
+    expect(harness.blocks).toEqual([
+      { pouName: 'Pid', instanceVariable: 'PID_I' },
+      { pouName: 'Ramp', instanceVariable: 'RAMP_I' },
+    ])
+
+    const program = harnessProgram(harness.projectData.pous)
+    expect(program.name).toBe(HARNESS_PROGRAM_NAME)
+    expect(program.pouType).toBe('program')
+    // `derived` + the block's own name is exactly what buildFbInstanceMap
+    // matches on; anything else and no instance is discovered.
+    expect(program.interface?.variables).toEqual([
+      expect.objectContaining({ name: 'PID_I', class: 'local', type: { definition: 'derived', value: 'Pid' } }),
+      expect.objectContaining({ name: 'RAMP_I', class: 'local', type: { definition: 'derived', value: 'Ramp' } }),
+    ])
+    expect(program.body).toEqual({ language: 'st', value: 'PID_I();\nRAMP_I();' })
+  })
+
+  it('flags every harness variable for debug so the watch table fills on connect', () => {
+    const harness = composeLibraryDebugHarness(libraryData([functionBlock('Pid')]))
+    const program = harnessProgram(harness.projectData.pous)
+    expect(program.interface?.variables.every((v) => v.debug === true)).toBe(true)
+  })
+
+  it('adds the harness task and instance, replacing whatever the library carried', () => {
+    const data = libraryData([functionBlock('Pid')])
+    data.configurations.resource.tasks = [{ name: 'stale', triggering: 'Cyclic', interval: 'T#1s', priority: 9 }]
+    data.configurations.resource.instances = [{ name: 'stale', program: 'gone', task: 'stale' }]
+
+    const harness = composeLibraryDebugHarness(data)
+
+    expect(harness.projectData.configurations.resource.tasks).toEqual([
+      { name: HARNESS_TASK_NAME, triggering: 'Cyclic', interval: 'T#100ms', priority: 1 },
+    ])
+    expect(harness.projectData.configurations.resource.instances).toEqual([
+      { name: HARNESS_INSTANCE_NAME, program: HARNESS_PROGRAM_NAME, task: HARNESS_TASK_NAME },
+    ])
+    expect(harness.instanceName).toBe(HARNESS_INSTANCE_NAME)
+    expect(harness.taskName).toBe(HARNESS_TASK_NAME)
+  })
+
+  it('keeps the library POUs and everything else on the project data', () => {
+    const data = libraryData([functionBlock('Pid')])
+    data.configurations.resource.globalVariables = [variable('SHARED', { class: 'global' })]
+
+    const harness = composeLibraryDebugHarness(data)
+
+    expect(harness.projectData.pous).toHaveLength(2)
+    expect(harness.projectData.pous[0].name).toBe('Pid')
+    expect(harness.projectData.configurations.resource.globalVariables).toHaveLength(1)
+  })
+
+  it('skips functions without comment — they are simply not instantiable state', () => {
+    const fn: PLCPou = {
+      name: 'Scale',
+      pouType: 'function',
+      interface: { returnType: 'REAL', variables: [variable('IN')] },
+      body: { language: 'st', value: 'Scale := IN;' },
+      documentation: '',
+    }
+    const harness = composeLibraryDebugHarness(libraryData([fn, functionBlock('Pid')]))
+
+    expect(harness.blocks).toEqual([{ pouName: 'Pid', instanceVariable: 'PID_I' }])
+    expect(harness.skipped).toEqual([])
+  })
+
+  it('skips Python blocks and says why', () => {
+    const harness = composeLibraryDebugHarness(
+      libraryData([functionBlock('PyBlock', [], { language: 'python' }), functionBlock('Pid')]),
+    )
+
+    expect(harness.blocks).toEqual([{ pouName: 'Pid', instanceVariable: 'PID_I' }])
+    expect(harness.skipped).toEqual([
+      { pouName: 'PyBlock', reason: expect.stringContaining('Python blocks cannot run on the simulator') },
+    ])
+  })
+
+  it('instantiates C/C++ blocks — they compile into the firmware', () => {
+    const harness = composeLibraryDebugHarness(libraryData([functionBlock('CppBlock', [], { language: 'cpp' })]))
+    expect(harness.blocks).toEqual([{ pouName: 'CppBlock', instanceVariable: 'CPPBLOCK_I' }])
+    expect(harness.skipped).toEqual([])
+  })
+
+  it('binds VAR_IN_OUT members to harness locals at the call site', () => {
+    // An unbound VAR_IN_OUT is a reference with nothing behind it, so a bare
+    // `BUF_I();` would not compile.
+    const harness = composeLibraryDebugHarness(
+      libraryData([
+        functionBlock('Buf', [
+          variable('IN'),
+          variable('BUFFER', { class: 'inOut', type: { definition: 'base-type', value: 'DINT' } }),
+        ]),
+      ]),
+    )
+
+    const program = harnessProgram(harness.projectData.pous)
+    expect(program.interface?.variables).toEqual([
+      expect.objectContaining({ name: 'BUF_I' }),
+      expect.objectContaining({ name: 'BUF_IO_BUFFER', type: { definition: 'base-type', value: 'DINT' } }),
+    ])
+    expect(program.body.value).toBe('BUF_I(BUFFER := BUF_IO_BUFFER);')
+  })
+
+  it('honours the include filter, case-insensitively', () => {
+    const harness = composeLibraryDebugHarness(
+      libraryData([functionBlock('Pid'), functionBlock('Ramp'), functionBlock('Filter')]),
+      { include: ['pid', 'FILTER'] },
+    )
+    expect(harness.blocks.map((b) => b.pouName)).toEqual(['Pid', 'Filter'])
+    // A filtered-out block is a choice, not a problem — nothing to warn about.
+    expect(harness.skipped).toEqual([])
+  })
+
+  it('returns no blocks for a library with nothing instantiable', () => {
+    const harness = composeLibraryDebugHarness(libraryData([]))
+    expect(harness.blocks).toEqual([])
+    expect(harnessProgram(harness.projectData.pous).interface?.variables).toEqual([])
+  })
+
+  it('uniquifies instance names when two blocks generate the same one', () => {
+    // `Pid` and `PID` are the same identifier to IEC, so the generated
+    // instance names collide.
+    const harness = composeLibraryDebugHarness(libraryData([functionBlock('Pid'), functionBlock('PID')]))
+    expect(harness.blocks.map((b) => b.instanceVariable)).toEqual(['PID_I', 'PID_I_2'])
+  })
+
+  it('yields the program name when the library already owns LIBDBG_MAIN', () => {
+    const harness = composeLibraryDebugHarness(libraryData([functionBlock(HARNESS_PROGRAM_NAME), functionBlock('Pid')]))
+    expect(harness.programName).toBe(`${HARNESS_PROGRAM_NAME}_2`)
+    expect(harnessProgram(harness.projectData.pous).name).toBe(`${HARNESS_PROGRAM_NAME}_2`)
+    expect(harness.projectData.configurations.resource.instances[0].program).toBe(`${HARNESS_PROGRAM_NAME}_2`)
+  })
+
+  it('accepts a scan-interval override', () => {
+    const harness = composeLibraryDebugHarness(libraryData([functionBlock('Pid')]), { scanInterval: 'T#20ms' })
+    expect(harness.projectData.configurations.resource.tasks[0].interval).toBe('T#20ms')
+  })
+
+  it('does not mutate the project data it was given', () => {
+    const data = libraryData([functionBlock('Pid')])
+    const before = JSON.stringify(data)
+    composeLibraryDebugHarness(data)
+    expect(JSON.stringify(data)).toBe(before)
+  })
+})

--- a/src/middleware/shared/utils/library-debug/compose-library-debug-harness.ts
+++ b/src/middleware/shared/utils/library-debug/compose-library-debug-harness.ts
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Library debug harness — turns a Library Project into a runnable PLC
+ * Project that exercises every block the library ships.
+ *
+ * A library has no program of its own, so there is nothing to run and
+ * nothing to attach a debugger to.  This module synthesises the
+ * missing piece: a `LIBDBG_MAIN` program declaring ONE instance of
+ * every function block in the library, a task, and a configuration
+ * instance to hold it.  Compiled for the in-process simulator, that
+ * project produces exactly the artefacts a debug session already
+ * consumes — firmware plus a `debug-map.json` whose leaves are the
+ * blocks' own members.  The author then forces inputs and watches
+ * outputs through the existing debugger, per instance.
+ *
+ * Everything downstream of here is machinery that already shipped.
+ * `buildFbInstanceMap` finds these instances because they are plain
+ * `derived`-typed variables on a program POU; `useDebugCompositeKey`
+ * rewrites a block editor's variable names onto the selected
+ * instance; the watch table and the polling filter resolve through
+ * the same map.  Giving every block exactly one instance is what
+ * makes all of that work with no picker to teach.
+ *
+ * Deliberately NOT covered: standalone FUNCTIONs.  Binding a
+ * function's inputs and return value into the harness means
+ * synthesising a call site and a local per parameter, which is real
+ * complexity for a block kind that has no state to watch between
+ * scans.  An author who wants to exercise a function writes a small
+ * wrapper function block that calls it — that gives them full control
+ * over what the inputs are set to, and the results become readable
+ * through the same FB-instance path as everything else.
+ *
+ * Pure: no IPC, no electron, no disk.  Same rules as
+ * `middleware/shared/utils/iec-address` — this file is byte-identical
+ * on openplc-web.
+ */
+
+import type { PLCInstance, PLCPou, PLCProjectData, PLCTask, PLCVariable } from '../../ports/types'
+
+// ---------------------------------------------------------------------------
+// Reserved identifiers
+// ---------------------------------------------------------------------------
+
+/**
+ * The harness owns the `LIBDBG_` prefix.  These names are visible to
+ * the author — a forced input reads as `LIBDBG_INST.MY_FB_I.SETPOINT`
+ * in the debug tree — so they are a (small) UX surface, not just an
+ * internal detail.  Chosen to be obviously synthetic and unlikely to
+ * collide with a library's own identifiers; a collision is handled
+ * regardless, see `uniqueName`.
+ */
+export const HARNESS_PROGRAM_NAME = 'LIBDBG_MAIN'
+export const HARNESS_TASK_NAME = 'LIBDBG_TASK'
+export const HARNESS_INSTANCE_NAME = 'LIBDBG_INST'
+
+/** Suffix appended to a block's name to form its instance variable. */
+const INSTANCE_SUFFIX = '_I'
+/** Suffix pattern for the local backing a block's VAR_IN_OUT member. */
+const INOUT_SUFFIX = '_IO_'
+
+/**
+ * Scan interval for the harness task.  Fast enough that a forced
+ * input shows its effect on the next poll (the debugger polls on the
+ * order of 100 ms), slow enough that the emulated ATmega2560 is not
+ * spending every cycle in the scan loop.
+ */
+const DEFAULT_SCAN_INTERVAL = 'T#100ms'
+
+// ---------------------------------------------------------------------------
+// Public contract
+// ---------------------------------------------------------------------------
+
+/** One library block wired into the harness. */
+export interface LibraryDebugHarnessBlock {
+  /** Function block name exactly as the author wrote it. */
+  pouName: string
+  /** Harness variable holding this block's single instance. */
+  instanceVariable: string
+}
+
+/** One library POU the harness left out, and why. */
+export interface LibraryDebugHarnessSkip {
+  pouName: string
+  /** Sentence fragment, rendered to the console as a warning. */
+  reason: string
+}
+
+export interface LibraryDebugHarness {
+  /**
+   * Port-shape project data for the synthetic PLC project: the
+   * library's own POUs plus `LIBDBG_MAIN`, with the resource carrying
+   * the harness task and instance.  Feed this to
+   * `CompilerPort.compileProgram` with `isSimulator: true`.
+   */
+  projectData: PLCProjectData
+  /** The synthesised program POU's name (also present in `projectData.pous`). */
+  programName: string
+  /** The configuration instance holding the program. */
+  instanceName: string
+  /** The task driving the instance. */
+  taskName: string
+  /** Blocks instantiated, in the order they appear in the library. */
+  blocks: LibraryDebugHarnessBlock[]
+  /** POUs deliberately left out.  Empty when everything was eligible. */
+  skipped: LibraryDebugHarnessSkip[]
+}
+
+export interface ComposeLibraryDebugHarnessOptions {
+  /**
+   * Restrict the harness to these block names (case-insensitive).
+   * Omitted means every eligible block.  Exists for the case where a
+   * library is too large to fit the simulator and the author picks a
+   * subset; nothing drives it yet.
+   */
+  include?: readonly string[]
+  /** Override the harness task's cyclic interval.  Testing hook. */
+  scanInterval?: string
+}
+
+// ---------------------------------------------------------------------------
+// Composition
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the harness project.  Never throws and never returns a
+ * partially-formed project: when no block is eligible the result
+ * carries `blocks: []` and the caller refuses with a message rather
+ * than compiling a program that does nothing.
+ */
+export function composeLibraryDebugHarness(
+  libraryData: PLCProjectData,
+  options: ComposeLibraryDebugHarnessOptions = {},
+): LibraryDebugHarness {
+  const includeSet = options.include === undefined ? null : new Set(options.include.map((name) => name.toUpperCase()))
+
+  const skipped: LibraryDebugHarnessSkip[] = []
+  const blocks: LibraryDebugHarnessBlock[] = []
+  const variables: PLCVariable[] = []
+  const statements: string[] = []
+
+  // Every name the harness program declares, so a second block whose
+  // generated name collides gets a numeric suffix instead of silently
+  // shadowing the first.
+  const taken = new Set<string>()
+
+  for (const pou of libraryData.pous) {
+    if (pou.pouType !== 'function-block') {
+      // Functions and (impossible in a library, but cheap to state)
+      // programs are not instantiable state — see the module header.
+      continue
+    }
+    if (includeSet !== null && !includeSet.has(pou.name.toUpperCase())) continue
+
+    // The AVR simulator ships no Python interpreter.  Preprocessing
+    // for a simulator target lowers a Python POU to a `first_run := 0;`
+    // no-op, so instantiating one would put a block in the debug tree
+    // that looks live and never computes anything — worse than leaving
+    // it out and saying so.
+    if (pou.body.language === 'python') {
+      skipped.push({
+        pouName: pou.name,
+        reason: 'Python blocks cannot run on the simulator, so this block is not in the harness.',
+      })
+      continue
+    }
+
+    const instanceVariable = uniqueName(`${pou.name.toUpperCase()}${INSTANCE_SUFFIX}`, taken)
+    variables.push(harnessVariable(instanceVariable, { definition: 'derived', value: pou.name }))
+
+    // VAR_IN_OUT members are references the caller has to bind — a bare
+    // `MY_FB_I();` with one unbound fails to compile.  Give each one a
+    // harness local of the same type and bind it at the call site, so
+    // the author can force the local and watch the block read it.
+    const inOutBindings: string[] = []
+    for (const member of pou.interface?.variables ?? []) {
+      if (member.class !== 'inOut') continue
+      const backing = uniqueName(`${pou.name.toUpperCase()}${INOUT_SUFFIX}${member.name.toUpperCase()}`, taken)
+      variables.push(harnessVariable(backing, member.type))
+      inOutBindings.push(`${member.name} := ${backing}`)
+    }
+
+    statements.push(
+      inOutBindings.length > 0 ? `${instanceVariable}(${inOutBindings.join(', ')});` : `${instanceVariable}();`,
+    )
+    blocks.push({ pouName: pou.name, instanceVariable })
+  }
+
+  const programName = uniqueProgramName(libraryData.pous)
+  const harnessProgram: PLCPou = {
+    name: programName,
+    pouType: 'program',
+    interface: { variables },
+    body: {
+      language: 'st',
+      // A program with no statements is rejected by the transpiler, and
+      // an empty harness never reaches the compiler anyway — the caller
+      // refuses on `blocks.length === 0`.  The fallback keeps the body
+      // syntactically valid for that unreachable path rather than
+      // emitting an empty PROGRAM.
+      value: statements.length > 0 ? statements.join('\n') : '(* no blocks to exercise *)\n;',
+    },
+    documentation: 'Generated harness — instantiates every library block once for debugging.',
+  }
+
+  const task: PLCTask = {
+    name: HARNESS_TASK_NAME,
+    triggering: 'Cyclic',
+    interval: options.scanInterval ?? DEFAULT_SCAN_INTERVAL,
+    priority: 1,
+  }
+  const instance: PLCInstance = {
+    name: HARNESS_INSTANCE_NAME,
+    program: programName,
+    task: HARNESS_TASK_NAME,
+  }
+
+  return {
+    // The library's own tasks / instances are dropped rather than
+    // merged: a library project has none (the create flow ships empty
+    // lists for `plc-library`), and anything that did survive an import
+    // would reference a program the library cannot contain.
+    projectData: {
+      ...libraryData,
+      pous: [...libraryData.pous, harnessProgram],
+      configurations: {
+        resource: {
+          ...libraryData.configurations.resource,
+          tasks: [task],
+          instances: [instance],
+        },
+      },
+    },
+    programName,
+    instanceName: HARNESS_INSTANCE_NAME,
+    taskName: HARNESS_TASK_NAME,
+    blocks,
+    skipped,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * A harness variable is always a watched local: `debug: true` puts it
+ * in the watch table the moment the session opens, which is the whole
+ * point of the harness — the author should not have to tick a box per
+ * block before seeing anything.
+ */
+function harnessVariable(name: string, type: PLCVariable['type']): PLCVariable {
+  return {
+    name,
+    class: 'local',
+    type,
+    location: '',
+    documentation: '',
+    debug: true,
+  }
+}
+
+/**
+ * Claim `base`, or the first `base_2`, `base_3`, … that is free.
+ * Compared case-insensitively because IEC identifiers are.
+ */
+function uniqueName(base: string, taken: Set<string>): string {
+  let candidate = base
+  let counter = 2
+  while (taken.has(candidate.toUpperCase())) {
+    candidate = `${base}_${counter}`
+    counter += 1
+  }
+  taken.add(candidate.toUpperCase())
+  return candidate
+}
+
+/**
+ * `LIBDBG_MAIN`, unless the library already ships a POU by that name —
+ * in which case the harness yields and takes a suffixed one, rather
+ * than producing a project with two POUs of the same name.
+ */
+function uniqueProgramName(pous: readonly PLCPou[]): string {
+  const existing = new Set(pous.map((pou) => pou.name.toUpperCase()))
+  let candidate = HARNESS_PROGRAM_NAME
+  let counter = 2
+  while (existing.has(candidate.toUpperCase())) {
+    candidate = `${HARNESS_PROGRAM_NAME}_${counter}`
+    counter += 1
+  }
+  return candidate
+}

--- a/src/middleware/shared/utils/library-debug/compose-library-debug-harness.ts
+++ b/src/middleware/shared/utils/library-debug/compose-library-debug-harness.ts
@@ -94,6 +94,14 @@ export interface LibraryDebugHarness {
    * `CompilerPort.compileProgram` with `isSimulator: true`.
    */
   projectData: PLCProjectData
+  /**
+   * The synthesised program POU itself.  Returned rather than left for
+   * the caller to dig out of `projectData.pous`: reaching for the last
+   * element there would bind the caller to this module's append order,
+   * and a reorder would silently install a library block as the
+   * session's program.
+   */
+  programPou: PLCPou
   /** The synthesised program POU's name (also present in `projectData.pous`). */
   programName: string
   /** The configuration instance holding the program. */
@@ -231,6 +239,7 @@ export function composeLibraryDebugHarness(
         },
       },
     },
+    programPou: harnessProgram,
     programName,
     instanceName: HARNESS_INSTANCE_NAME,
     taskName: HARNESS_TASK_NAME,


### PR DESCRIPTION
[DOPE-597](https://autonomylogic.atlassian.net/browse/DOPE-597) · pairs with [openplc-web#716](https://github.com/Autonomy-Logic/openplc-web/pull/716) — **merge together**, the shared surfaces must stay byte-identical.

## Problem

Library projects could be built but never *run*. The only feedback an author got was a hidden avr-gcc pass wired into the build, and that pass judged every library against an ATmega2560 it may never target.

`runLibraryBuildPipeline` stage 5 composed a throwaway PLC project via `composeVerificationProject` → `stubProgramFor`, whose entire program body was `LocalVar := 3;`. **It instantiated nothing.** So it never said anything about whether a library *behaves* — only that its generated C++ links on AVR, at ~30 s per clean build. Libraries legitimately targeting a Linux runtime reported failures that meant nothing for their real target.

## Change A — the build no longer verifies

Deleted rather than flagged. Keeping it means two mechanisms both claiming to answer "does my library work", with the weaker one still in the default path — and, under the mirror rule, both duplicated on web.

Out: stage 5 + `readVerificationCache` + `build/.verify-cache-library.json`; `verifyCompile` / `VerifyCompileArgs` / `LibraryVerificationResult` **and `computeMd5`** from `LibraryBuildPort` (it existed only to key that cache); `composeVerificationProject`; `CompilerModule.runVerificationCompile` and its private `MessageChannelMain` plumbing; the second `preprocessPous` pass and the `verifyProjectData` IPC arg in the adapter; the `verification` field on `CompileLibraryResult`.

`cleanBuild` existed on this path *only* to bypass that cache (one read site), so the Build Library popover loses its second row and becomes a plain button — new `BuildLibraryButton` molecule, and `libraryMode` comes off `BuildOptionsPopover`.

strucpp's `compileStlib` is unchanged and remains the build's correctness gate: manifest validation, ST type errors, undefined symbols, cross-library symbol resolution. What leaves is a check on the *generated C++* against one 8 KB microcontroller.

## Change B — the debug harness

New shared pure function, `middleware/shared/utils/library-debug/compose-library-debug-harness.ts`. Port-shape `PLCProjectData` in → a runnable PLC project out: a `LIBDBG_MAIN` program declaring **one instance per function block**, plus a task and configuration instance.

```
PROGRAM LIBDBG_MAIN
  VAR
    PID_I        : PID_CONTROLLER;
    BUF_I        : RING_BUFFER;
    BUF_IO_STORE : ARRAY [1..16] OF REAL;   (* backs a VAR_IN_OUT *)
  END_VAR

  PID_I();
  BUF_I(STORE := BUF_IO_STORE);
END_PROGRAM
```

Calling each instance bare is the trick: the FB executes against whatever its inputs hold, and a forced variable stays forced across scans, so forcing `LIBDBG_INST.PID_I.SETPOINT` drives the block directly. `VAR_IN_OUT` members are the one exception — a reference the caller must bind, so each gets a harness local wired at the call site (an unbound one will not compile). Every harness variable carries `debug: true` so the watch table is populated on connect.

Python blocks are skipped with a reason (the AVR simulator has no interpreter, and `preprocessPous(isSimulator: true)` would lower them to no-ops that *look* live). C/C++ blocks are included.

**Functions are deliberately not instantiated.** Binding a function's inputs and return into the stub program is real complexity for a block kind with no state to watch between scans. An author who wants to exercise one writes a small wrapper function block that calls it — full control over the inputs, and the results readable through the same FB-instance path as everything else, with no special case anywhere in the debugger.

## Why this was cheap

The debugger is already built around function-block instances; a library project is the case it was designed for and never got pointed at. `buildFbInstanceMap` finds these instances because they are plain `derived`-typed variables on a program POU — so `useDebugCompositeKey`, the watch table and the polling filter all resolve through the existing map with **no changes**. One instance per block means it is auto-selected, and a block's own LD/FBD/ST editor paints live values for free.

The harness lives only in `workspace.debugHarness` for the life of the session; writing it into `project.data` would fight each editor's dirty tracking and could be saved to disk. Consumers **add** its program POU to the project's POU list rather than replacing it, so a debug flag ticked mid-session still takes effect.

`useSimulatorDebugRun` extracts the compile → `loadFirmware` → `connectAndStart` sequence that `handleBuild` coordinated through `pendingSimulatorDebugRef`. Both the PLC Play button and the new library Debug button drive it — a second copy is exactly the divergence this change is meant to avoid.

## Net new private code: none

Everything added is shared surface; the private changes are deletions only. `compare-surfaces.py` reports **0 diffs** across `frontend/`, `middleware/shared/`, `backend/shared/`, `__architecture__/`.

## Testing

`npm test` — 7,451 pass, 0 fail. `npm run validate:arch` clean. No new lint warnings (the 3 on `default.tsx` are pre-existing, verified by stashing).

Verified end-to-end in the browser (`openplc-web`, `npm run dev:local`) against a two-block library:

- Build emits six log lines in under a second with **no `[verify]` lines**.
- Debug Library composes the harness, compiles it onto the simulator, and attaches the debugger — watch table pre-populated with `LIBDBG_MAIN.SCALER_I` / `LATCH_I`.
- Forcing `SCALER.IN = 7` against `GAIN = 5` produced **`OUT = 35`**.
- `LATCH`: `SET = TRUE` → `Q = TRUE`; then `RESET = TRUE` → `Q = FALSE` (RESET wins, matching the ST). Its internal `SCANS` counter ticked past 3,700 — the scan loop is genuinely running.
- SCALER's editor painted `OUT = 35 := IN = 7 * GAIN = 5` inline, bound to `LIBDBG_MAIN.SCALER_I` with no picker.
- Stop tears down cleanly.
- **PLC regression check:** the refactor onto `useSimulatorDebugRun` is intact — Start built and ran the existing Irrigation project, auto-attached the debugger, painted a live wire on `Running_led`, and stopped cleanly.

## Reviewer notes

- Block selection (picking a subset when a library overflows the simulator's 63.5 KB SRAM / 256 KB flash) is deferred. The synthesizer takes an `include` option from the start so it can be wired later without a signature change.
- The IPC arg tuple for `runCompileLibrary` shrinks from 5 to 3. Main and renderer ship together, so there is no cross-version contract to keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOPE-597]: https://autonomylogic.atlassian.net/browse/DOPE-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Build Library** action for creating library files.
  * Added **Debug Library**, launching eligible library blocks in the simulator with debugger support.
  * Library debugging now provides generated harness variables and instances for monitoring.
  * Added clearer simulator start/stop handling during program and library debugging.

* **Changes**
  * Library builds no longer perform an automatic verification compile.
  * Library build options are now separate from program build and upload options.
  * Improved handling of invalid library build requests with clear failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->