### PR TITLE
RTOP-274 Shared: build and parse the project snapshot archive

### DIFF
--- a/src/backend/shared/project/__tests__/project-snapshot-archive.test.ts
+++ b/src/backend/shared/project/__tests__/project-snapshot-archive.test.ts
@@ -1,0 +1,290 @@
+/**
+ * The archive stored on a device and read back from one.
+ *
+ * Two halves matter here. The round trip has to be exact, because anything the
+ * archive loses is work the user cannot get back off the device. And the parse
+ * side has to treat the archive as hostile input: it comes from a device where
+ * the stored project is neither signed nor encrypted, so anyone with
+ * filesystem access could have replaced it. Path traversal is the check that
+ * actually bites -- a bomb only exhausts disk, while `../../` writes outside
+ * the folder the user picked.
+ */
+
+import JSZip from 'jszip'
+
+import type { WriteProjectFiles } from '../../../../middleware/shared/ports/project-port'
+import {
+  buildProjectSnapshot,
+  hashText,
+  parseProjectSnapshot,
+  SNAPSHOT_FORMAT_VERSION,
+  SNAPSHOT_LIBRARY_DIR,
+  SNAPSHOT_MANIFEST_PATH,
+  assertSafeEntryPath,
+  SnapshotArchiveError,
+  toWriteProjectFiles,
+  type SnapshotLibrary,
+} from '../project-snapshot-archive'
+
+function projectFiles(overrides: Partial<WriteProjectFiles> = {}): WriteProjectFiles {
+  return {
+    projectPath: '/tmp/project',
+    projectJson: '{"meta":{"name":"Traffic Light"}}',
+    deviceConfig: '{"board":"rpi"}',
+    pinMapping: '{"pins":[]}',
+    pouFiles: [
+      { relativePath: 'pous/programs/MAIN.st', content: 'PROGRAM MAIN END_PROGRAM' },
+      { relativePath: 'pous/function-blocks/TON2.st', content: 'FUNCTION_BLOCK TON2 END_FUNCTION_BLOCK' },
+    ],
+    serverFiles: [{ relativePath: 'devices/servers/modbus.json', content: '{"port":502}' }],
+    remoteDeviceFiles: [{ relativePath: 'devices/remote/plc2.json', content: '{"ip":"10.0.0.2"}' }],
+    dataTypeFiles: [{ relativePath: 'datatypes/Color.dt', content: 'TYPE Color END_TYPE' }],
+    deletions: [],
+    ...overrides,
+  }
+}
+
+async function build(overrides: Partial<Parameters<typeof buildProjectSnapshot>[0]> = {}) {
+  return buildProjectSnapshot({
+    files: projectFiles(),
+    projectName: 'Traffic Light',
+    editorVersion: '4.2.0',
+    uploadedBy: 'op',
+    timestamp: '2026-08-31T12:00:00.000Z',
+    ...overrides,
+  })
+}
+
+async function library(name = 'Motion', version = '1.2.0'): Promise<SnapshotLibrary> {
+  const archive = JSON.stringify({ name, version, blocks: [] })
+  return { name, version, hash: await hashText(archive), archive }
+}
+
+// --- round trip ----------------------------------------------------------
+
+describe('round trip', () => {
+  it('carries every project file back unchanged', async () => {
+    const original = projectFiles()
+    const { archive } = await build({ files: original })
+    const parsed = await parseProjectSnapshot(archive)
+    const restored = toWriteProjectFiles(parsed, '/somewhere/else')
+
+    expect(restored.projectJson).toBe(original.projectJson)
+    expect(restored.deviceConfig).toBe(original.deviceConfig)
+    expect(restored.pinMapping).toBe(original.pinMapping)
+    expect(restored.pouFiles).toEqual(expect.arrayContaining(original.pouFiles))
+    expect(restored.pouFiles).toHaveLength(original.pouFiles.length)
+    expect(restored.serverFiles).toEqual(original.serverFiles)
+    expect(restored.remoteDeviceFiles).toEqual(original.remoteDeviceFiles)
+    expect(restored.dataTypeFiles).toEqual(original.dataTypeFiles)
+  })
+
+  it('writes into the destination the caller chose, not the one the archive came from', async () => {
+    const { archive } = await build()
+    const restored = toWriteProjectFiles(await parseProjectSnapshot(archive), '/new/home')
+    expect(restored.projectPath).toBe('/new/home')
+  })
+
+  it('never carries deletions across', async () => {
+    // A retrieved project is written into an empty destination. Honouring
+    // deletions from an archive would let a device name files to remove on the
+    // opening machine.
+    const { archive } = await build({ files: projectFiles({ deletions: ['pous/programs/Gone.st'] }) })
+    const restored = toWriteProjectFiles(await parseProjectSnapshot(archive), '/tmp/p')
+    expect(restored.deletions).toEqual([])
+  })
+
+  it('keeps a library project manifest', async () => {
+    const { archive } = await build({
+      files: projectFiles({ libraryManifest: '{"name":"MyLib"}' }),
+    })
+    const restored = toWriteProjectFiles(await parseProjectSnapshot(archive), '/tmp/p')
+    expect(restored.libraryManifest).toBe('{"name":"MyLib"}')
+  })
+
+  it('omits optional files a PLC project does not own rather than writing empty ones', async () => {
+    const { archive } = await build({
+      files: projectFiles({ deviceConfig: undefined, pinMapping: undefined }),
+    })
+    const restored = toWriteProjectFiles(await parseProjectSnapshot(archive), '/tmp/p')
+    expect(restored.deviceConfig).toBeUndefined()
+    expect(restored.pinMapping).toBeUndefined()
+  })
+})
+
+// --- metadata ------------------------------------------------------------
+
+describe('metadata', () => {
+  it('is returned beside the bytes so the two cannot drift', async () => {
+    // The device stores this separately and never opens the archive, so the
+    // builder producing both is what keeps them describing the same thing.
+    const { metadata } = await build()
+    expect(metadata).toEqual({
+      formatVersion: SNAPSHOT_FORMAT_VERSION,
+      projectName: 'Traffic Light',
+      editorVersion: '4.2.0',
+      uploadedBy: 'op',
+      timestamp: '2026-08-31T12:00:00.000Z',
+      libraries: [],
+    })
+  })
+
+  it('matches the manifest embedded in the archive', async () => {
+    const { archive, metadata } = await build()
+    const parsed = await parseProjectSnapshot(archive)
+    expect(parsed.metadata).toEqual(metadata)
+  })
+})
+
+// --- libraries -----------------------------------------------------------
+
+describe('libraries', () => {
+  it('bundles archives so a retrieved project still compiles elsewhere', async () => {
+    const motion = await library()
+    const { archive, metadata } = await build({ libraries: [motion] })
+
+    expect(metadata.libraries).toEqual([
+      { name: motion.name, version: motion.version, hash: motion.hash },
+    ])
+
+    const parsed = await parseProjectSnapshot(archive)
+    expect(parsed.libraries).toHaveLength(1)
+    expect(parsed.libraries[0].archive).toBe(motion.archive)
+    expect(parsed.libraries[0].name).toBe('Motion')
+    expect(parsed.libraries[0].hash).toBe(motion.hash)
+  })
+
+  it('keeps library files out of the project tree', async () => {
+    const { archive } = await build({ libraries: [await library()] })
+    const parsed = await parseProjectSnapshot(archive)
+    for (const path of parsed.files.keys()) {
+      expect(path.startsWith(SNAPSHOT_LIBRARY_DIR)).toBe(false)
+    }
+  })
+
+  it('distinguishes same name and version but different bytes', async () => {
+    // The case that silently produces a different program, so the hash has to
+    // be what identifies a library rather than the name/version pair.
+    const first = await library('Motion', '1.2.0')
+    const second: SnapshotLibrary = {
+      name: 'Motion',
+      version: '1.2.0',
+      archive: JSON.stringify({ name: 'Motion', version: '1.2.0', blocks: ['tampered'] }),
+      hash: await hashText(JSON.stringify({ name: 'Motion', version: '1.2.0', blocks: ['tampered'] })),
+    }
+    expect(first.hash).not.toBe(second.hash)
+  })
+
+  it('keeps two libraries whose names collide once sanitised', async () => {
+    const a: SnapshotLibrary = { name: 'My Lib', version: '1', archive: 'A', hash: await hashText('A') }
+    const b: SnapshotLibrary = { name: 'My/Lib', version: '1', archive: 'B', hash: await hashText('B') }
+    const { archive } = await build({ libraries: [a, b] })
+    const parsed = await parseProjectSnapshot(archive)
+    expect(parsed.libraries.map((l) => l.archive).sort()).toEqual(['A', 'B'])
+  })
+})
+
+// --- refusing hostile archives -------------------------------------------
+
+describe('untrusted input', () => {
+  async function zipWith(entries: Record<string, string>, includeManifest = true): Promise<Uint8Array> {
+    const zip = new JSZip()
+    if (includeManifest) {
+      zip.file(
+        SNAPSHOT_MANIFEST_PATH,
+        JSON.stringify({ formatVersion: SNAPSHOT_FORMAT_VERSION, projectName: 'P', libraries: [] }),
+      )
+    }
+    for (const [path, content] of Object.entries(entries)) zip.file(path, content)
+    return zip.generateAsync({ type: 'uint8array' })
+  }
+
+  it.each([
+    ['../../../etc/passwd'],
+    ['pous/../../escape.st'],
+    ['..\\..\\evil.txt'],
+    ['/etc/hosts'],
+    ['C:/Windows/System32/x'],
+    ['ok\u0000.st'],
+  ])('refuses the entry path %s', (path) => {
+    // Tested against the guard directly rather than through a built archive:
+    // JSZip normalises a leading `../` away when it writes one, so a forged
+    // traversal entry can only reach a reader from a hand-crafted archive.
+    // Nothing here relies on that normalisation for correctness.
+    expect(() => assertSafeEntryPath(path)).toThrow(SnapshotArchiveError)
+  })
+
+  it('accepts the ordinary project paths', () => {
+    for (const path of ['project.json', 'pous/programs/MAIN.st', 'devices/servers/a.json']) {
+      expect(() => assertSafeEntryPath(path)).not.toThrow()
+    }
+  })
+
+  it('refuses a backslash-escaped path a Windows archive could carry', async () => {
+    const archive = await zipWith({ 'project.json': '{}', '..\\..\\evil.txt': 'pwned' })
+    await expect(parseProjectSnapshot(archive)).rejects.toThrow(/escapes the project/)
+  })
+
+  it('refuses an absolute path', async () => {
+    const archive = await zipWith({ 'project.json': '{}', '/etc/hosts': 'pwned' })
+    await expect(parseProjectSnapshot(archive)).rejects.toThrow(/absolute path/)
+  })
+
+  it('refuses a Windows drive-letter path', async () => {
+    const archive = await zipWith({ 'project.json': '{}', 'C:/Windows/System32/x': 'pwned' })
+    await expect(parseProjectSnapshot(archive)).rejects.toThrow(/absolute path/)
+  })
+
+  it('yields nothing at all when one entry is bad', async () => {
+    // Validation completes before any content is handed back, so a rejected
+    // archive can never leave a half-written project behind.
+    const archive = await zipWith({ 'project.json': '{"real":true}', '/etc/escape.txt': 'x' })
+    await expect(parseProjectSnapshot(archive)).rejects.toThrow(SnapshotArchiveError)
+  })
+
+  it('refuses bytes that are not a ZIP', async () => {
+    await expect(parseProjectSnapshot(new TextEncoder().encode('not a zip'))).rejects.toThrow(
+      /not a readable project archive/i,
+    )
+  })
+
+  it('refuses an archive with no manifest', async () => {
+    const archive = await zipWith({ 'project.json': '{}' }, false)
+    await expect(parseProjectSnapshot(archive)).rejects.toThrow(/no project snapshot manifest/)
+  })
+
+  it('refuses an archive with no project.json', async () => {
+    const archive = await zipWith({ 'pous/programs/MAIN.st': 'x' })
+    await expect(parseProjectSnapshot(archive)).rejects.toThrow(/no project.json/)
+  })
+
+  it('refuses a manifest that is not JSON', async () => {
+    const zip = new JSZip()
+    zip.file(SNAPSHOT_MANIFEST_PATH, 'not json at all')
+    zip.file('project.json', '{}')
+    await expect(parseProjectSnapshot(await zip.generateAsync({ type: 'uint8array' }))).rejects.toThrow(
+      /not valid JSON/,
+    )
+  })
+
+  it('refuses an archive written by a newer editor rather than guessing', async () => {
+    const zip = new JSZip()
+    zip.file(
+      SNAPSHOT_MANIFEST_PATH,
+      JSON.stringify({ formatVersion: SNAPSHOT_FORMAT_VERSION + 1, projectName: 'P', libraries: [] }),
+    )
+    zip.file('project.json', '{}')
+    await expect(parseProjectSnapshot(await zip.generateAsync({ type: 'uint8array' }))).rejects.toThrow(
+      /newer editor/,
+    )
+  })
+
+  it('drops files it cannot place rather than guessing at a location', async () => {
+    // A path the writer cannot map is a file the next save would lose anyway,
+    // so surfacing it as a project file would be a lie.
+    const archive = await zipWith({ 'project.json': '{}', 'somewhere/odd/file.txt': 'x' })
+    const restored = toWriteProjectFiles(await parseProjectSnapshot(archive), '/tmp/p')
+    expect(restored.pouFiles).toHaveLength(0)
+    expect(restored.dataTypeFiles).toHaveLength(0)
+  })
+})

--- a/src/backend/shared/project/__tests__/project-snapshot-archive.test.ts
+++ b/src/backend/shared/project/__tests__/project-snapshot-archive.test.ts
@@ -19,6 +19,7 @@ import {
   parseProjectSnapshot,
   SNAPSHOT_FORMAT_VERSION,
   SNAPSHOT_LIBRARY_DIR,
+  SNAPSHOT_LIMITS,
   SNAPSHOT_MANIFEST_PATH,
   assertSafeEntryPath,
   SnapshotArchiveError,
@@ -187,7 +188,11 @@ describe('libraries', () => {
 // --- refusing hostile archives -------------------------------------------
 
 describe('untrusted input', () => {
-  async function zipWith(entries: Record<string, string>, includeManifest = true): Promise<Uint8Array> {
+  async function zipWith(
+    entries: Record<string, string>,
+    includeManifest = true,
+    compress = false,
+  ): Promise<Uint8Array> {
     const zip = new JSZip()
     if (includeManifest) {
       zip.file(
@@ -196,7 +201,11 @@ describe('untrusted input', () => {
       )
     }
     for (const [path, content] of Object.entries(entries)) zip.file(path, content)
-    return zip.generateAsync({ type: 'uint8array' })
+    // STORE by default so a fixture's declared sizes are predictable; the
+    // ratio check needs a genuinely DEFLATEd entry to have a ratio at all.
+    return zip.generateAsync(
+      compress ? { type: 'uint8array', compression: 'DEFLATE' } : { type: 'uint8array' },
+    )
   }
 
   it.each([
@@ -277,6 +286,48 @@ describe('untrusted input', () => {
     await expect(parseProjectSnapshot(await zip.generateAsync({ type: 'uint8array' }))).rejects.toThrow(
       /newer editor/,
     )
+  })
+
+  it('refuses an archive with too many entries', async () => {
+    const entries: Record<string, string> = { 'project.json': '{}' }
+    for (let i = 0; i < 10; i += 1) entries[`pous/programs/P${i}.st`] = 'x'
+    const archive = await zipWith(entries)
+    await expect(
+      parseProjectSnapshot(archive, { ...SNAPSHOT_LIMITS, maxEntries: 5 }),
+    ).rejects.toThrow(/too many files/)
+  })
+
+  it('refuses an archive larger than the total limit', async () => {
+    const archive = await zipWith({ 'project.json': '{}', 'pous/programs/Big.st': 'x'.repeat(5_000) })
+    await expect(
+      parseProjectSnapshot(archive, { ...SNAPSHOT_LIMITS, maxTotalBytes: 100 }),
+    ).rejects.toThrow(/too large uncompressed|beyond the size limit/)
+  })
+
+  it('refuses a single entry larger than the per-entry limit', async () => {
+    const archive = await zipWith({ 'project.json': '{}', 'pous/programs/Big.st': 'x'.repeat(5_000) })
+    await expect(
+      parseProjectSnapshot(archive, { ...SNAPSHOT_LIMITS, maxEntryBytes: 100 }),
+    ).rejects.toThrow(/entry is too large/)
+  })
+
+  it('refuses an entry whose compression ratio looks like a bomb', async () => {
+    // Highly compressible filler stands in for the real thing: what matters is
+    // that the ratio is judged from the DECLARED sizes, before anything is
+    // decompressed, because decompressing is the part that hurts.
+    const archive = await zipWith(
+      { 'project.json': '{}', 'pous/programs/Bomb.st': 'a'.repeat(200_000) },
+      true,
+      true,
+    )
+    await expect(
+      parseProjectSnapshot(archive, { ...SNAPSHOT_LIMITS, maxCompressionRatio: 2 }),
+    ).rejects.toThrow(/compression ratio/)
+  })
+
+  it('accepts a normal project under the real limits', async () => {
+    const { archive } = await build()
+    await expect(parseProjectSnapshot(archive)).resolves.toBeDefined()
   })
 
   it('drops files it cannot place rather than guessing at a location', async () => {

--- a/src/backend/shared/project/project-snapshot-archive.ts
+++ b/src/backend/shared/project/project-snapshot-archive.ts
@@ -49,8 +49,19 @@ export const SNAPSHOT_LIBRARY_DIR = '.openplc-snapshot/libraries'
 /**
  * Limits applied when READING an archive. Generous enough that no real project
  * trips them and tight enough that a hostile device cannot exhaust the client.
+ *
+ * Injectable into `parseProjectSnapshot` so the refusal paths can be tested
+ * without building a 100 MB fixture -- a limit with no test proving it fires
+ * is a limit nobody knows is wired up.
  */
-export const SNAPSHOT_LIMITS = {
+export interface SnapshotLimits {
+  maxEntries: number
+  maxEntryBytes: number
+  maxTotalBytes: number
+  maxCompressionRatio: number
+}
+
+export const SNAPSHOT_LIMITS: SnapshotLimits = {
   maxEntries: 20_000,
   maxEntryBytes: 32 * 1024 * 1024,
   maxTotalBytes: 100 * 1024 * 1024,
@@ -238,7 +249,10 @@ function* iterateProjectEntries(
  * Validates the whole archive before returning any of it, so a rejected
  * archive never leaves a partially written project behind.
  */
-export async function parseProjectSnapshot(bytes: Uint8Array): Promise<ParsedProjectSnapshot> {
+export async function parseProjectSnapshot(
+  bytes: Uint8Array,
+  limits: SnapshotLimits = SNAPSHOT_LIMITS,
+): Promise<ParsedProjectSnapshot> {
   let zip: JSZip
   try {
     zip = await JSZip.loadAsync(bytes)
@@ -250,9 +264,9 @@ export async function parseProjectSnapshot(bytes: Uint8Array): Promise<ParsedPro
 
   const entries = Object.values(zip.files).filter((entry) => !entry.dir)
 
-  if (entries.length > SNAPSHOT_LIMITS.maxEntries) {
+  if (entries.length > limits.maxEntries) {
     throw new SnapshotArchiveError(
-      `Archive has too many files (${entries.length}, limit ${SNAPSHOT_LIMITS.maxEntries})`,
+      `Archive has too many files (${entries.length}, limit ${limits.maxEntries})`,
     )
   }
 
@@ -268,17 +282,17 @@ export async function parseProjectSnapshot(bytes: Uint8Array): Promise<ParsedPro
     const uncompressed = meta?.uncompressedSize ?? 0
     const compressed = meta?.compressedSize ?? 0
 
-    if (uncompressed > SNAPSHOT_LIMITS.maxEntryBytes) {
+    if (uncompressed > limits.maxEntryBytes) {
       throw new SnapshotArchiveError(`Archive entry is too large: ${entry.name}`)
     }
-    if (compressed > 0 && uncompressed / compressed > SNAPSHOT_LIMITS.maxCompressionRatio) {
+    if (compressed > 0 && uncompressed / compressed > limits.maxCompressionRatio) {
       throw new SnapshotArchiveError(`Archive entry has a suspicious compression ratio: ${entry.name}`)
     }
     declaredTotal += uncompressed
   }
-  if (declaredTotal > SNAPSHOT_LIMITS.maxTotalBytes) {
+  if (declaredTotal > limits.maxTotalBytes) {
     throw new SnapshotArchiveError(
-      `Archive is too large uncompressed (${declaredTotal} bytes, limit ${SNAPSHOT_LIMITS.maxTotalBytes})`,
+      `Archive is too large uncompressed (${declaredTotal} bytes, limit ${limits.maxTotalBytes})`,
     )
   }
 
@@ -299,7 +313,7 @@ export async function parseProjectSnapshot(bytes: Uint8Array): Promise<ParsedPro
     const content = await entry.async('string')
     readTotal += content.length
     // Backstop for an archive that lied about, or omitted, its declared sizes.
-    if (readTotal > SNAPSHOT_LIMITS.maxTotalBytes) {
+    if (readTotal > limits.maxTotalBytes) {
       throw new SnapshotArchiveError('Archive expanded beyond the size limit while reading')
     }
 

--- a/src/backend/shared/project/project-snapshot-archive.ts
+++ b/src/backend/shared/project/project-snapshot-archive.ts
@@ -1,0 +1,450 @@
+/**
+ * Build and parse the source-project archive stored on a runtime device.
+ *
+ * The editor uploads only build artifacts, so a device has never recorded the
+ * project they came from. This module produces the archive that closes that
+ * gap ("Retrieve Project from PLC") and reads one back.
+ *
+ * Three things shape it:
+ *
+ *   - **The archive is the project's own on-disk shape.** Entries use the same
+ *     project-root-relative paths `iterateWriteProjectFiles` yields, so a
+ *     retrieved archive maps straight onto the existing project-open path
+ *     rather than needing a translation layer. `toWriteProjectFiles` below is
+ *     the explicit inverse of that generator and has to move with it.
+ *
+ *   - **The device never opens it.** The runtime stores these bytes untouched
+ *     and takes its metadata from a separate field, so the format here can
+ *     change without touching the device. `buildProjectSnapshot` returns that
+ *     metadata alongside the bytes precisely so the two cannot drift.
+ *
+ *   - **A retrieved archive is untrusted input.** It arrives from a device
+ *     that may not be the one that wrote it, and the stored project is not
+ *     signed or encrypted -- anyone with filesystem access to the device can
+ *     replace it. `parseProjectSnapshot` therefore validates before it yields
+ *     anything, with the same class of checks the runtime applies to uploads.
+ *
+ * No filesystem, no HTTP, no DOM: callers own reading and writing. Built on
+ * JSZip and WebCrypto only, so the identical file runs in the Electron main
+ * process and in the browser.
+ */
+
+import JSZip from 'jszip'
+
+import type { RawProjectFile, WriteProjectFiles } from '../../../middleware/shared/ports/project-port'
+
+/**
+ * Bumped when the archive layout changes in a way an older reader would
+ * misread. A reader that does not recognise the version refuses the archive
+ * outright rather than guessing at a partial parse.
+ */
+export const SNAPSHOT_FORMAT_VERSION = 1
+
+/** Manifest entry, kept out of the project tree so it can never collide with a real file. */
+export const SNAPSHOT_MANIFEST_PATH = '.openplc-snapshot/manifest.json'
+
+/** Bundled `.stlib` archives live here, one JSON text file each. */
+export const SNAPSHOT_LIBRARY_DIR = '.openplc-snapshot/libraries'
+
+/**
+ * Limits applied when READING an archive. Generous enough that no real project
+ * trips them and tight enough that a hostile device cannot exhaust the client.
+ */
+export const SNAPSHOT_LIMITS = {
+  maxEntries: 20_000,
+  maxEntryBytes: 32 * 1024 * 1024,
+  maxTotalBytes: 100 * 1024 * 1024,
+  /** A legitimately compressible project of source text sits far below this. */
+  maxCompressionRatio: 1_000,
+} as const
+
+/** One library bundled with the project. `archive` is the `.stlib` JSON text. */
+export interface SnapshotLibrary {
+  name: string
+  version: string
+  /** SHA-256 of `archive`, hex. Lets the opening client tell "same library" from
+   *  "same name and version, different bytes" -- the case that silently
+   *  produces a different program. */
+  hash: string
+  archive: string
+}
+
+/** What the device stores beside the archive and reports without opening it. */
+export interface SnapshotMetadata {
+  formatVersion: number
+  projectName: string
+  editorVersion: string
+  uploadedBy: string
+  /** ISO 8601, UTC. */
+  timestamp: string
+  libraries: Array<{ name: string; version: string; hash: string }>
+}
+
+export interface BuildProjectSnapshotOptions {
+  files: WriteProjectFiles
+  projectName: string
+  editorVersion: string
+  /** Runtime account performing the upload. Informational only. */
+  uploadedBy: string
+  libraries?: SnapshotLibrary[]
+  /** Injectable so tests get a stable manifest; defaults to now. */
+  timestamp?: string
+}
+
+export interface BuiltProjectSnapshot {
+  /** The archive to send as the upload's `snapshot` field. */
+  archive: Uint8Array
+  /** The same values, to send as the `snapshot_metadata` field. */
+  metadata: SnapshotMetadata
+}
+
+export interface ParsedProjectSnapshot {
+  metadata: SnapshotMetadata
+  /** Project-root-relative path to file content, exactly as stored. */
+  files: Map<string, string>
+  libraries: SnapshotLibrary[]
+}
+
+export class SnapshotArchiveError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SnapshotArchiveError'
+  }
+}
+
+/** SHA-256 hex, via WebCrypto so the one implementation covers Node and the browser. */
+export async function hashText(text: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(text))
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/**
+ * Reject anything that would escape the destination directory when written.
+ *
+ * Path traversal is the check that actually matters here: a bomb only exhausts
+ * disk, while a `../../` entry writes outside the folder the user chose. Called
+ * before any content is handed back, so a bad archive yields nothing at all
+ * rather than a half-written tree.
+ *
+ * Exported so it can be tested directly: JSZip quietly normalises a leading
+ * `../` away when it BUILDS an archive, so a test cannot forge that entry
+ * through the library -- only a hand-crafted archive carries it. The guard
+ * still has to exist and still has to be tested, because nothing here should
+ * depend on JSZip's sanitising for correctness.
+ */
+export function assertSafeEntryPath(rawPath: string): void {
+  // Windows-authored archives can carry backslashes; normalise before judging
+  // so `..\\..\\x` is not waved through as a single innocent-looking segment.
+  const path = rawPath.replace(/\\/g, '/')
+
+  if (path.startsWith('/') || /^[a-zA-Z]:/.test(path)) {
+    throw new SnapshotArchiveError(`Archive contains an absolute path: ${rawPath}`)
+  }
+  if (path.split('/').some((segment) => segment === '..')) {
+    throw new SnapshotArchiveError(`Archive contains a path that escapes the project: ${rawPath}`)
+  }
+  if (path.includes('\0')) {
+    throw new SnapshotArchiveError(`Archive contains a path with a null byte: ${rawPath}`)
+  }
+}
+
+/**
+ * Build the archive for an upload.
+ *
+ * Everything except `build/` -- which is exactly what `WriteProjectFiles`
+ * already carries, since that is the set the editor persists. Bundled
+ * libraries ride alongside so a retrieved project can still compile on a
+ * machine whose library pool has never seen them.
+ */
+export async function buildProjectSnapshot(
+  options: BuildProjectSnapshotOptions,
+): Promise<BuiltProjectSnapshot> {
+  const { files, projectName, editorVersion, uploadedBy } = options
+  const libraries = options.libraries ?? []
+  const timestamp = options.timestamp ?? new Date().toISOString()
+
+  const metadata: SnapshotMetadata = {
+    formatVersion: SNAPSHOT_FORMAT_VERSION,
+    projectName,
+    editorVersion,
+    uploadedBy,
+    timestamp,
+    libraries: libraries.map(({ name, version, hash }) => ({ name, version, hash })),
+  }
+
+  const zip = new JSZip()
+  zip.file(SNAPSHOT_MANIFEST_PATH, JSON.stringify(metadata, null, 2))
+
+  // The project's own relative paths, straight from the canonical iterator.
+  // Imported lazily-by-shape rather than by calling the generator directly so
+  // this module stays usable with a plain file map in tests.
+  for (const entry of iterateProjectEntries(files)) {
+    zip.file(entry.relativePath, entry.content)
+  }
+
+  for (const library of libraries) {
+    zip.file(`${SNAPSHOT_LIBRARY_DIR}/${libraryFileName(library)}`, library.archive)
+  }
+
+  const archive = await zip.generateAsync({
+    type: 'uint8array',
+    compression: 'DEFLATE',
+    compressionOptions: { level: 6 },
+  })
+
+  return { archive, metadata }
+}
+
+/** Stable, collision-resistant, and safe as a path segment. */
+function libraryFileName(library: SnapshotLibrary): string {
+  const safeName = library.name.replace(/[^A-Za-z0-9._-]/g, '_')
+  return `${safeName}-${library.hash.slice(0, 12)}.stlib`
+}
+
+/**
+ * Every project file as a relative path plus content.
+ *
+ * Deliberately a local walk of `WriteProjectFiles` rather than a call into
+ * `iterateWriteProjectFiles`: that generator's entries are typed to a fixed
+ * set of literal paths, and this module only needs the path/content pair.
+ * Both walk the same shape, so a new file category has to be added in both --
+ * the round-trip test is what catches it.
+ */
+function* iterateProjectEntries(
+  files: WriteProjectFiles,
+): Generator<{ relativePath: string; content: string }> {
+  yield { relativePath: 'project.json', content: files.projectJson }
+  if (files.deviceConfig !== undefined) {
+    yield { relativePath: 'devices/configuration.json', content: files.deviceConfig }
+  }
+  if (files.pinMapping !== undefined) {
+    yield { relativePath: 'devices/pin-mapping.json', content: files.pinMapping }
+  }
+  if (files.libraryManifest !== undefined) {
+    yield { relativePath: 'library.json', content: files.libraryManifest }
+  }
+  for (const group of [files.pouFiles, files.serverFiles, files.remoteDeviceFiles, files.dataTypeFiles]) {
+    for (const file of group) {
+      yield { relativePath: file.relativePath, content: file.content }
+    }
+  }
+}
+
+/**
+ * Read an archive retrieved from a device.
+ *
+ * Validates the whole archive before returning any of it, so a rejected
+ * archive never leaves a partially written project behind.
+ */
+export async function parseProjectSnapshot(bytes: Uint8Array): Promise<ParsedProjectSnapshot> {
+  let zip: JSZip
+  try {
+    zip = await JSZip.loadAsync(bytes)
+  } catch (error) {
+    throw new SnapshotArchiveError(
+      `Not a readable project archive: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+
+  const entries = Object.values(zip.files).filter((entry) => !entry.dir)
+
+  if (entries.length > SNAPSHOT_LIMITS.maxEntries) {
+    throw new SnapshotArchiveError(
+      `Archive has too many files (${entries.length}, limit ${SNAPSHOT_LIMITS.maxEntries})`,
+    )
+  }
+
+  // Check declared sizes before reading anything: the point of a zip bomb is
+  // that decompressing it is what hurts, so the refusal has to come first.
+  let declaredTotal = 0
+  for (const entry of entries) {
+    assertSafeEntryPath(entry.name)
+
+    // JSZip exposes these on the internal record; absent for archives it built
+    // in memory, in which case the post-read total below is the backstop.
+    const meta = (entry as unknown as { _data?: { uncompressedSize?: number; compressedSize?: number } })._data
+    const uncompressed = meta?.uncompressedSize ?? 0
+    const compressed = meta?.compressedSize ?? 0
+
+    if (uncompressed > SNAPSHOT_LIMITS.maxEntryBytes) {
+      throw new SnapshotArchiveError(`Archive entry is too large: ${entry.name}`)
+    }
+    if (compressed > 0 && uncompressed / compressed > SNAPSHOT_LIMITS.maxCompressionRatio) {
+      throw new SnapshotArchiveError(`Archive entry has a suspicious compression ratio: ${entry.name}`)
+    }
+    declaredTotal += uncompressed
+  }
+  if (declaredTotal > SNAPSHOT_LIMITS.maxTotalBytes) {
+    throw new SnapshotArchiveError(
+      `Archive is too large uncompressed (${declaredTotal} bytes, limit ${SNAPSHOT_LIMITS.maxTotalBytes})`,
+    )
+  }
+
+  const manifestEntry = zip.file(SNAPSHOT_MANIFEST_PATH)
+  if (!manifestEntry) {
+    throw new SnapshotArchiveError('Archive has no project snapshot manifest')
+  }
+  const metadata = parseManifest(await manifestEntry.async('string'))
+
+  const files = new Map<string, string>()
+  const libraries: SnapshotLibrary[] = []
+  let readTotal = 0
+
+  for (const entry of entries) {
+    const path = entry.name.replace(/\\/g, '/')
+    if (path === SNAPSHOT_MANIFEST_PATH) continue
+
+    const content = await entry.async('string')
+    readTotal += content.length
+    // Backstop for an archive that lied about, or omitted, its declared sizes.
+    if (readTotal > SNAPSHOT_LIMITS.maxTotalBytes) {
+      throw new SnapshotArchiveError('Archive expanded beyond the size limit while reading')
+    }
+
+    if (path.startsWith(`${SNAPSHOT_LIBRARY_DIR}/`)) {
+      libraries.push({
+        ...matchLibraryMetadata(metadata, path),
+        archive: content,
+      })
+      continue
+    }
+
+    files.set(path, content)
+  }
+
+  if (!files.has('project.json')) {
+    throw new SnapshotArchiveError('Archive has no project.json')
+  }
+
+  return { metadata, files, libraries }
+}
+
+/**
+ * Pair a bundled library file with its manifest entry.
+ *
+ * The manifest is the authority on name and version; the file name only has to
+ * be unique. An entry with no manifest match still comes back -- dropping it
+ * silently would turn a malformed archive into a project that compiles against
+ * a library the user was never told about.
+ */
+function matchLibraryMetadata(
+  metadata: SnapshotMetadata,
+  path: string,
+): { name: string; version: string; hash: string } {
+  const fileName = path.slice(`${SNAPSHOT_LIBRARY_DIR}/`.length)
+  const match = metadata.libraries.find(
+    (library) => libraryFileName({ ...library, archive: '' }) === fileName,
+  )
+  return match ?? { name: fileName.replace(/\.stlib$/, ''), version: '', hash: '' }
+}
+
+function parseManifest(text: string): SnapshotMetadata {
+  let raw: unknown
+  try {
+    raw = JSON.parse(text)
+  } catch (error) {
+    throw new SnapshotArchiveError(
+      `Project snapshot manifest is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+
+  if (typeof raw !== 'object' || raw === null) {
+    throw new SnapshotArchiveError('Project snapshot manifest is not an object')
+  }
+  const record = raw as Record<string, unknown>
+
+  const formatVersion = record.formatVersion
+  if (typeof formatVersion !== 'number' || !Number.isInteger(formatVersion)) {
+    throw new SnapshotArchiveError('Project snapshot manifest has no formatVersion')
+  }
+  if (formatVersion > SNAPSHOT_FORMAT_VERSION) {
+    throw new SnapshotArchiveError(
+      `This project was stored by a newer editor (archive format ${formatVersion}, this editor reads ${SNAPSHOT_FORMAT_VERSION}). Update the editor to open it.`,
+    )
+  }
+
+  const libraries = Array.isArray(record.libraries)
+    ? record.libraries.flatMap((entry) => {
+        if (typeof entry !== 'object' || entry === null) return []
+        const library = entry as Record<string, unknown>
+        if (typeof library.name !== 'string' || !library.name) return []
+        return [
+          {
+            name: library.name,
+            version: typeof library.version === 'string' ? library.version : '',
+            hash: typeof library.hash === 'string' ? library.hash : '',
+          },
+        ]
+      })
+    : []
+
+  return {
+    formatVersion,
+    projectName: typeof record.projectName === 'string' ? record.projectName : '',
+    editorVersion: typeof record.editorVersion === 'string' ? record.editorVersion : '',
+    uploadedBy: typeof record.uploadedBy === 'string' ? record.uploadedBy : '',
+    timestamp: typeof record.timestamp === 'string' ? record.timestamp : '',
+    libraries,
+  }
+}
+
+/**
+ * Turn a parsed archive back into the shape the project-open path consumes.
+ *
+ * The explicit inverse of `iterateProjectEntries`. Anything under a known
+ * directory goes to its bucket; anything else is dropped rather than guessed
+ * at, because a file the writer cannot place is a file the next save would
+ * lose anyway.
+ */
+export function toWriteProjectFiles(
+  parsed: ParsedProjectSnapshot,
+  projectPath: string,
+): WriteProjectFiles {
+  const pouFiles: RawProjectFile[] = []
+  const serverFiles: RawProjectFile[] = []
+  const remoteDeviceFiles: RawProjectFile[] = []
+  const dataTypeFiles: RawProjectFile[] = []
+
+  let projectJson = ''
+  let deviceConfig: string | undefined
+  let pinMapping: string | undefined
+  let libraryManifest: string | undefined
+
+  for (const [relativePath, content] of parsed.files) {
+    if (relativePath === 'project.json') {
+      projectJson = content
+    } else if (relativePath === 'devices/configuration.json') {
+      deviceConfig = content
+    } else if (relativePath === 'devices/pin-mapping.json') {
+      pinMapping = content
+    } else if (relativePath === 'library.json') {
+      libraryManifest = content
+    } else if (relativePath.startsWith('pous/')) {
+      pouFiles.push({ relativePath, content })
+    } else if (relativePath.startsWith('devices/servers/')) {
+      serverFiles.push({ relativePath, content })
+    } else if (relativePath.startsWith('devices/remote/')) {
+      remoteDeviceFiles.push({ relativePath, content })
+    } else if (relativePath.startsWith('datatypes/')) {
+      dataTypeFiles.push({ relativePath, content })
+    }
+  }
+
+  return {
+    projectPath,
+    projectJson,
+    deviceConfig,
+    pinMapping,
+    libraryManifest,
+    pouFiles,
+    serverFiles,
+    remoteDeviceFiles,
+    dataTypeFiles,
+    // A retrieved project is written into an empty destination, so there is
+    // nothing to delete. Carrying deletions from the archive would let a
+    // hostile device name files to remove on the opening machine.
+    deletions: [],
+  }
+}

--- a/src/jest-vi-shim.ts
+++ b/src/jest-vi-shim.ts
@@ -1,3 +1,6 @@
+import { webcrypto } from 'node:crypto'
+import { TextDecoder, TextEncoder } from 'node:util'
+
 // Alias `vi` to `jest` so shared test files can use `vi.spyOn()` in both Jest and Vitest
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ;(globalThis as any).vi = jest
@@ -71,4 +74,26 @@ try {
   openPLCStoreBase.getState().libraryActions.setSystemLibraries(stlibsToSystemLibraries(archives))
 } catch (err) {
   console.warn(`[jest-setup] could not pre-load bundled .stlibs from ${stlibsDir}:`, err)
+}
+
+// jsdom ships neither the TextEncoder/TextDecoder pair nor WebCrypto, both of
+// which Node has had for years and browsers provide as a matter of course.
+// The project-snapshot archive is written against those platform APIs on
+// purpose, so that one implementation runs unchanged in the Electron main
+// process and in the browser; without these it would be untestable here purely
+// because of the environment.
+{
+  const scope = globalThis as unknown as Record<string, unknown>
+
+  if (typeof scope.TextEncoder === 'undefined') scope.TextEncoder = TextEncoder
+  if (typeof scope.TextDecoder === 'undefined') scope.TextDecoder = TextDecoder
+
+  const existing = scope.crypto as { subtle?: unknown } | undefined
+  if (!existing || typeof existing.subtle === 'undefined') {
+    Object.defineProperty(globalThis, 'crypto', {
+      value: webcrypto,
+      writable: true,
+      configurable: true,
+    })
+  }
 }


### PR DESCRIPTION
Part of RTOP-272. The archive a device stores and hands back, and the reader for one that comes back.

Mirrored byte-identically into openplc-web (Autonomy-Logic/openplc-web#PR). Nothing consumes it yet — the editor and web upload/retrieve paths are the follow-ups.

## Shape

Entries use the project's own root-relative paths, the same set `iterateWriteProjectFiles` yields, so a retrieved archive maps straight onto the existing project-open path rather than needing a translation layer. `toWriteProjectFiles` is the explicit inverse of that walk and has to move with it — the round-trip test is what catches a new file category added to one and not the other.

`.stlib` archives ride along under `.openplc-snapshot/libraries/`, so a retrieved project still compiles on a machine whose library pool has never seen them. Each carries a SHA-256 of its contents, which is what lets the opening client tell "same library" from "same name and version, different bytes" — the case that silently produces a different program.

## One implementation, deliberately

Built on JSZip and WebCrypto only, so the identical file runs in the Electron main process and in the browser. The web mirror is byte-identical and its test passes under Vitest with no changes at all. Two implementations of one archive format is the drift this exists to avoid.

`buildProjectSnapshot` returns the device metadata *alongside* the bytes rather than leaving callers to assemble it separately. The runtime never opens the archive, so those two are the only description of the stored project that exists; producing them together is what stops them describing different things.

## Treating a retrieved archive as hostile

It comes from a device where the stored project is neither signed nor encrypted — anyone with filesystem access could have replaced it. So: entry-count, per-entry and total size caps, a compression-ratio check, and containment of every resolved path. Validation completes before any content is returned, so a rejected archive leaves nothing half-written.

Two things worth a reviewer's attention:

- **The path guard is exported and tested directly.** JSZip normalises a leading `../` away when it *builds* an archive, so a forged traversal entry can only reach a reader from a hand-crafted one — a test that goes through JSZip is testing JSZip, not the guard. Absolute paths and Windows drive letters *are* preserved by JSZip, and those are covered end to end. Nothing here relies on JSZip's sanitising for correctness.
- **Deletions are never carried across.** A retrieved project is written into an empty destination; honouring an archive's deletion list would let a device name files to remove on the opening machine.

An archive whose `formatVersion` is newer than this reader is refused with a message telling the user to update, rather than partially parsed.

## Incidental

jsdom ships neither `TextEncoder`/`TextDecoder` nor WebCrypto. `jest.setup.js` looked like the place to polyfill them but is referenced by nothing in this repo — `src/jest-vi-shim.ts` is the file the config actually loads, and it already polyfills jsdom gaps for the same reason.

`jszip` is imported here as it already is in `compiler-module.ts`, i.e. as a transitive dependency rather than a declared one. Pre-existing and left alone, but worth knowing it is not in `package.json`.

## Testing

28 tests, covering the round trip, metadata/manifest agreement, library bundling and hash identity, and the refusal paths. Full suites green in both repos: editor 7473 passed / 350 suites, web 7505 passed / 354 suites. Typecheck clean in both; lint clean on the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bpea15BYCgPSqpatpveRk1