### PR TITLE
RTOP-275 Editor: send the project on upload, and Retrieve Project from PLC

### DIFF
--- a/src/backend/editor/compiler/compiler-module.ts
+++ b/src/backend/editor/compiler/compiler-module.ts
@@ -8,6 +8,8 @@ import os from 'node:os'
 import path from 'node:path'
 import { join, resolve as pathResolve, sep as pathSep } from 'node:path'
 
+import { LibraryManagerModule } from '@root/backend/editor/library-manager/library-manager-module'
+import { buildUploadSnapshot } from '@root/backend/editor/project/build-upload-snapshot'
 import { RUNTIME_API_PORT } from '@root/backend/editor/runtime/runtime-api-client'
 import { resolveTrustedKeysArtifact } from '@root/backend/shared/compile/steps/generate-trusted-keys'
 import type { VppModbusScreenState } from '@root/backend/shared/compile/steps/modbus-defines'
@@ -64,8 +66,14 @@ type LibraryCompileBridge = {
     filename: string
     contentType: string
     cleanBuild: boolean
+    snapshotBuffer?: Buffer
+    snapshotMetadata?: string
     onUploadAccepted?: (responseBody: string) => void
   }) => Promise<{ success: true; data: string } | { success: false; error: string }>
+  /** Username of the live runtime session, for attributing the stored project
+   *  to whoever uploaded it. Only the username -- the password never leaves
+   *  the token authority. */
+  getRuntimeUsername?: () => string | null
   loadEnabledArchives: (enabledNames: string[]) => { archives: unknown[]; missing: string[] }
 }
 
@@ -2565,8 +2573,14 @@ class CompilerModule {
         filename: string
         contentType: string
         cleanBuild: boolean
+        snapshotBuffer?: Buffer
+        snapshotMetadata?: string
         onUploadAccepted?: (responseBody: string) => void
       }) => Promise<{ success: true; data: string } | { success: false; error: string }>
+      /** Username of the live runtime session, for attributing the stored
+       *  project to whoever uploaded it. Only the username -- the password
+       *  never leaves the token authority. */
+      getRuntimeUsername?: () => string | null
       /**
        * Resolve a list of project-enabled library names to parsed
        * `.stlib` archives.  Bundled libraries are always-on and
@@ -2950,6 +2964,19 @@ class CompilerModule {
         cleanBuild: cleanBuild ?? false,
         mainProcessBridge,
         compressSourceFolder: (folderPath: string) => this.compressSourceFolder(folderPath),
+        // The source project stored on the device beside the artifacts.
+        // Constructed per call for the same reason as getVppRuntimeFloor: the
+        // library pool is read off disk and may have changed since the last
+        // compile.
+        buildUploadSnapshot: async () => {
+          const libraryManager = new LibraryManagerModule()
+          return buildUploadSnapshot({
+            projectPath: normalizedProjectPath,
+            editorVersion: APP_VERSION,
+            uploadedBy: mainProcessBridge.getRuntimeUsername?.() ?? '',
+            readLibraryArchive: (name) => libraryManager.readArchiveText(name),
+          })
+        },
         // VPP runtime floor (DOPE-448). Constructed per call rather than
         // held on the class because the registry is read off disk and may
         // have changed since the last compile (a package installed or

--- a/src/backend/editor/compiler/editor-compiler-platform-port.ts
+++ b/src/backend/editor/compiler/editor-compiler-platform-port.ts
@@ -111,6 +111,8 @@ export interface EditorCompilerPlatformPortContext {
       filename: string
       contentType: string
       cleanBuild: boolean
+      snapshotBuffer?: Buffer
+      snapshotMetadata?: string
       onUploadAccepted?: (responseBody: string) => void
     }) => Promise<{ success: true; data: string } | { success: false; error: string }>
   }
@@ -119,6 +121,18 @@ export interface EditorCompilerPlatformPortContext {
    *  in the `archiver`-dependent compressSourceFolder method (which
    *  has its own private state on CompilerModule). */
   compressSourceFolder: (folderPath: string) => Promise<Buffer>
+  /** Build the source-project archive stored on the device so the project can
+   *  be retrieved later. Injected for the same reason as
+   *  `compressSourceFolder`: it reaches the Electron-bound library manager, and
+   *  this adapter has to stay importable outside a real Electron process.
+   *
+   *  Optional so a caller predating it stays valid — absent simply means the
+   *  upload carries no snapshot, which is what an older editor does anyway. */
+  buildUploadSnapshot?: () => Promise<{
+    archive: Buffer
+    metadata: string
+    missingLibraries: string[]
+  } | null>
   /**
    * `package.minRuntimeVersion` of the VPP providing a given board, or
    * null when the board isn't from a VPP / declares no floor
@@ -359,6 +373,28 @@ export function createEditorCompilerPlatformPort(
         // produced no artifacts.
         const fileBuffer = await context.compressSourceFolder(context.sourceTargetFolderPath)
 
+        // The source project, stored on the device beside the artifacts so it
+        // can be retrieved later. Never fatal: the device runs the new program
+        // either way, and failing an upload over the optional half of it would
+        // be a worse outcome than losing retrievability. A runtime without
+        // snapshot support ignores the extra parts, so there is nothing to
+        // probe for first.
+        let snapshot: { archive: Buffer; metadata: string; missingLibraries: string[] } | null = null
+        try {
+          snapshot = (await context.buildUploadSnapshot?.()) ?? null
+          if (snapshot && snapshot.missingLibraries.length > 0) {
+            log(
+              `Stored project will not include these libraries, which are not installed here: ${snapshot.missingLibraries.join(', ')}`,
+              'warning',
+            )
+          }
+        } catch (error) {
+          log(
+            `Could not prepare the project for storage on the device: ${error instanceof Error ? error.message : String(error)}`,
+            'warning',
+          )
+        }
+
         const deployOutcome = await deployRuntimeProgram({
           uploadProgram: () =>
             context.mainProcessBridge.makeRuntimeApiUpload({
@@ -367,6 +403,8 @@ export function createEditorCompilerPlatformPort(
               contentType: 'application/zip',
               fileBuffer,
               cleanBuild: context.cleanBuild,
+              snapshotBuffer: snapshot?.archive,
+              snapshotMetadata: snapshot?.metadata,
               onUploadAccepted: (responseBody) => {
                 try {
                   const response = JSON.parse(responseBody) as { CompilationStatus?: string }

--- a/src/backend/editor/hardware/__tests__/discover-runtimes.test.ts
+++ b/src/backend/editor/hardware/__tests__/discover-runtimes.test.ts
@@ -115,6 +115,55 @@ describe('parseAdvertisement', () => {
       apiPort: 8443,
     })
   })
+
+  it('carries the stored project name and timestamp when the device has one', () => {
+    // This is what lets the retrieve picker show something useful without
+    // logging in to every device on the network first.
+    const device = parseAdvertisement(
+      JSON.stringify({
+        service: 'openplc-runtime',
+        hostname: 'plc-1',
+        runtime_version: 'v4.2.0',
+        api_port: 8443,
+        project_name: 'Traffic Light',
+        project_timestamp: '2026-08-31T12:00:00Z',
+      }),
+      '10.0.0.5',
+    )
+    expect(device?.projectName).toBe('Traffic Light')
+    expect(device?.projectTimestamp).toBe('2026-08-31T12:00:00Z')
+  })
+
+  it('leaves the project fields undefined when the device stores nothing', () => {
+    // Absent keys are how a device says "nothing to retrieve"; turning them
+    // into empty strings would make that indistinguishable from a project
+    // whose name is blank.
+    const device = parseAdvertisement(
+      JSON.stringify({
+        service: 'openplc-runtime',
+        hostname: 'plc-1',
+        runtime_version: 'v4.2.0',
+        api_port: 8443,
+      }),
+      '10.0.0.5',
+    )
+    expect(device?.projectName).toBeUndefined()
+    expect(device?.projectTimestamp).toBeUndefined()
+  })
+
+  it('ignores an empty project name rather than showing a blank row', () => {
+    const device = parseAdvertisement(
+      JSON.stringify({
+        service: 'openplc-runtime',
+        hostname: 'plc-1',
+        runtime_version: 'v4.2.0',
+        api_port: 8443,
+        project_name: '',
+      }),
+      '10.0.0.5',
+    )
+    expect(device?.projectName).toBeUndefined()
+  })
 })
 
 describe('clampDiscoveryDuration', () => {

--- a/src/backend/editor/hardware/discover-runtimes.ts
+++ b/src/backend/editor/hardware/discover-runtimes.ts
@@ -35,6 +35,16 @@ export interface DiscoveredRuntime {
   hostname: string
   runtimeVersion: string
   apiPort: number
+  /** Name of the source project the device stores, when it has one.
+   *
+   *  Display only. It is whatever the uploading client said -- the device never
+   *  opens the archive to check -- and it rides an unauthenticated broadcast,
+   *  so nothing may depend on it being true. It exists so the retrieve picker
+   *  can be populated without logging in to every device on the network; the
+   *  authoritative name comes from the archive once retrieved. */
+  projectName?: string
+  /** When that project was stored, ISO 8601. Absent alongside `projectName`. */
+  projectTimestamp?: string
 }
 
 export interface DiscoverRuntimesOptions {
@@ -101,6 +111,15 @@ export function parseAdvertisement(payload: string, sourceAddress: string): Disc
     hostname: typeof record.hostname === 'string' ? record.hostname : '',
     runtimeVersion: typeof record.runtime_version === 'string' ? record.runtime_version : '',
     apiPort: typeof record.api_port === 'number' ? record.api_port : RUNTIME_API_PORT,
+    // Absent keys mean the device stores no project, so these stay undefined
+    // rather than becoming empty strings -- the picker distinguishes "no
+    // project" from "a project with no name".
+    ...(typeof record.project_name === 'string' && record.project_name
+      ? { projectName: record.project_name }
+      : {}),
+    ...(typeof record.project_timestamp === 'string' && record.project_timestamp
+      ? { projectTimestamp: record.project_timestamp }
+      : {}),
   }
 }
 

--- a/src/backend/editor/library-manager/library-manager-module.ts
+++ b/src/backend/editor/library-manager/library-manager-module.ts
@@ -388,6 +388,28 @@ export class LibraryManagerModule {
   // Install paths
   // -------------------------------------------------------------------------
 
+  /**
+   * Install a `.stlib` from text rather than a file on disk.
+   *
+   * The archives bundled with a retrieved project arrive as text -- they came
+   * out of a ZIP fetched from a device, never touching the filesystem. Writing
+   * them to a temp file just to read them back would add a failure mode and an
+   * exposure window for no benefit: `installStlib` already reduces to
+   * `prepareStlibUpload(text)` plus the shared persist step.
+   *
+   * The text is validated by the same strucpp preparer as any other install,
+   * so an archive from a device gets no more trust than one a user picked.
+   */
+  async installFromText(archiveText: string): Promise<LibraryInstallResult> {
+    let prepared: PreparedLibrary
+    try {
+      prepared = prepareStlibUpload(archiveText)
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) }
+    }
+    return this.persistPrepared(prepared)
+  }
+
   private async installStlib(filePath: string): Promise<LibraryInstallResult> {
     let prepared: PreparedLibrary
     try {

--- a/src/backend/editor/library-manager/library-manager-module.ts
+++ b/src/backend/editor/library-manager/library-manager-module.ts
@@ -218,6 +218,44 @@ export class LibraryManagerModule {
   }
 
   /**
+   * The raw `.stlib` text for one library, or null when this machine does not
+   * have it.
+   *
+   * Text rather than the parsed archive on purpose: this feeds the project
+   * snapshot stored on a device, which bundles libraries verbatim and hashes
+   * them so the opening client can tell "same library" from "same name and
+   * version, different bytes". Re-serialising a parsed archive would hash a
+   * representation of the artifact rather than the artifact.
+   *
+   * User-installed wins over bundled, matching `loadAll`'s precedence: a
+   * library someone installed deliberately is the one the project means.
+   */
+  readArchiveText(name: string): string | null {
+    const entry = this.readRegistry().libraries[name]
+    if (entry) {
+      try {
+        assertPathContained(this.librariesDir, entry.stlibPath, `library[${name}].stlibPath`)
+        if (existsSync(entry.stlibPath)) return readFileSync(entry.stlibPath, 'utf-8')
+      } catch {
+        // Fall through to the bundled copy. A registry entry pointing outside
+        // the libraries directory is exactly what that guard exists to stop.
+      }
+    }
+
+    if (!existsSync(this.bundledDir)) return null
+    for (const file of readdirSync(this.bundledDir).filter((f) => f.endsWith('.stlib'))) {
+      try {
+        const text = readFileSync(join(this.bundledDir, file), 'utf-8')
+        const parsed = JSON.parse(text) as { manifest?: { name?: unknown } }
+        if (parsed.manifest?.name === name) return text
+      } catch {
+        // Skip a malformed bundled archive, as readBundledArchives does.
+      }
+    }
+    return null
+  }
+
+  /**
    * Return every installed archive's parsed contents — bundled then
    * user-installed alphabetical.  Used by the renderer to hydrate
    * the in-memory library state at startup and after install/uninstall

--- a/src/backend/editor/project/__tests__/build-upload-snapshot.test.ts
+++ b/src/backend/editor/project/__tests__/build-upload-snapshot.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Assembling the archive that travels with a program upload.
+ *
+ * The two things that matter: `build/` never travels (it is the bulk of a
+ * project and the device already has the artifacts), and a project that
+ * references a library the machine cannot supply is still worth storing.
+ * Refusing to store anything because one library is missing would lose the
+ * whole project to protect a detail the opening client can warn about.
+ */
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { parseProjectSnapshot } from '../../../shared/project/project-snapshot-archive'
+import {
+  buildUploadSnapshot,
+  readProjectDirectory,
+  referencedLibraryNames,
+} from '../build-upload-snapshot'
+
+let projectPath: string
+
+beforeEach(() => {
+  projectPath = mkdtempSync(join(tmpdir(), 'openplc-snapshot-'))
+})
+
+afterEach(() => {
+  rmSync(projectPath, { recursive: true, force: true })
+})
+
+function write(relativePath: string, content: string): void {
+  const absolute = join(projectPath, relativePath)
+  mkdirSync(join(absolute, '..'), { recursive: true })
+  writeFileSync(absolute, content, 'utf-8')
+}
+
+function seedProject(projectJson = '{"meta":{"name":"Traffic Light"},"data":{}}'): void {
+  write('project.json', projectJson)
+  write('devices/configuration.json', '{"board":"rpi"}')
+  write('pous/programs/MAIN.st', 'PROGRAM MAIN END_PROGRAM')
+  write('datatypes/Color.dt', 'TYPE Color END_TYPE')
+}
+
+// --- the disk walk -------------------------------------------------------
+
+describe('readProjectDirectory', () => {
+  it('collects the project tree by root-relative path', async () => {
+    seedProject()
+    const files = await readProjectDirectory(projectPath)
+    expect([...files.keys()].sort()).toEqual([
+      'datatypes/Color.dt',
+      'devices/configuration.json',
+      'pous/programs/MAIN.st',
+      'project.json',
+    ])
+  })
+
+  it('never carries build/', async () => {
+    // The whole point. It is the bulk of a project, and the device already has
+    // the artifacts -- it is what the upload beside this one is made of.
+    seedProject()
+    write('build/rpi/src/pou_MAIN.cpp', 'generated')
+    write('build/rpi/src/configuration.cpp', 'generated')
+    const files = await readProjectDirectory(projectPath)
+    expect([...files.keys()].some((path) => path.startsWith('build/'))).toBe(false)
+  })
+
+  it('skips local noise that would otherwise travel to a device and back', async () => {
+    seedProject()
+    write('.DS_Store', 'junk')
+    write('.git/config', '[core]')
+    write('node_modules/pkg/index.js', 'module.exports = {}')
+    const files = await readProjectDirectory(projectPath)
+    expect([...files.keys()].sort()).toEqual([
+      'datatypes/Color.dt',
+      'devices/configuration.json',
+      'pous/programs/MAIN.st',
+      'project.json',
+    ])
+  })
+
+  it('uses forward slashes so an archive reads the same on every host', async () => {
+    seedProject()
+    const files = await readProjectDirectory(projectPath)
+    expect([...files.keys()].every((path) => !path.includes('\\'))).toBe(true)
+  })
+})
+
+// --- library references --------------------------------------------------
+
+describe('referencedLibraryNames', () => {
+  it('reads the names a project declares', () => {
+    const json = '{"data":{"libraries":[{"name":"Motion","version":"1.0"},{"name":"Vision"}]}}'
+    expect(referencedLibraryNames(json)).toEqual(['Motion', 'Vision'])
+  })
+
+  it('treats an unparseable project.json as declaring none', () => {
+    // A project.json that will not parse is a project that will not open. Still
+    // worth storing; just without libraries we cannot identify.
+    expect(referencedLibraryNames('not json')).toEqual([])
+  })
+
+  it('ignores entries with no usable name', () => {
+    expect(referencedLibraryNames('{"data":{"libraries":[{"version":"1"},{"name":""}]}}')).toEqual([])
+  })
+})
+
+// --- the assembled archive ----------------------------------------------
+
+describe('buildUploadSnapshot', () => {
+  it('produces an archive the shared reader accepts', async () => {
+    seedProject()
+    const snapshot = await buildUploadSnapshot({
+      projectPath,
+      editorVersion: '4.2.0',
+      uploadedBy: 'op',
+      timestamp: '2026-08-31T12:00:00.000Z',
+    })
+
+    const parsed = await parseProjectSnapshot(new Uint8Array(snapshot.archive))
+    expect(parsed.metadata.projectName).toBe('Traffic Light')
+    expect(parsed.metadata.editorVersion).toBe('4.2.0')
+    expect(parsed.metadata.uploadedBy).toBe('op')
+    expect(parsed.files.get('pous/programs/MAIN.st')).toBe('PROGRAM MAIN END_PROGRAM')
+  })
+
+  it('hands back metadata matching the archive, as one JSON string', async () => {
+    // The device stores these separately and never opens the archive, so they
+    // are the only description of the stored project that exists.
+    seedProject()
+    const snapshot = await buildUploadSnapshot({
+      projectPath,
+      editorVersion: '4.2.0',
+      uploadedBy: 'op',
+    })
+    const metadata = JSON.parse(snapshot.metadata) as { projectName: string; formatVersion: number }
+    expect(metadata.projectName).toBe('Traffic Light')
+    expect(metadata.formatVersion).toBe(1)
+  })
+
+  it('bundles the libraries the project references', async () => {
+    seedProject('{"meta":{"name":"P"},"data":{"libraries":[{"name":"Motion","version":"1.2.0"}]}}')
+    const archiveText = JSON.stringify({ manifest: { name: 'Motion', version: '1.2.0' } })
+
+    const snapshot = await buildUploadSnapshot({
+      projectPath,
+      editorVersion: '4.2.0',
+      uploadedBy: 'op',
+      readLibraryArchive: () => archiveText,
+    })
+
+    expect(snapshot.missingLibraries).toEqual([])
+    const parsed = await parseProjectSnapshot(new Uint8Array(snapshot.archive))
+    expect(parsed.libraries).toHaveLength(1)
+    expect(parsed.libraries[0].archive).toBe(archiveText)
+    expect(parsed.metadata.libraries[0]).toEqual({
+      name: 'Motion',
+      version: '1.2.0',
+      hash: expect.any(String),
+    })
+  })
+
+  it('still stores the project when a library cannot be read', async () => {
+    // Losing the whole project to protect a detail the opening client can warn
+    // about would be the wrong trade.
+    seedProject('{"meta":{"name":"P"},"data":{"libraries":[{"name":"Gone"}]}}')
+    const snapshot = await buildUploadSnapshot({
+      projectPath,
+      editorVersion: '4.2.0',
+      uploadedBy: 'op',
+      readLibraryArchive: () => null,
+    })
+
+    expect(snapshot.missingLibraries).toEqual(['Gone'])
+    const parsed = await parseProjectSnapshot(new Uint8Array(snapshot.archive))
+    expect(parsed.files.get('project.json')).toBeDefined()
+    expect(parsed.libraries).toHaveLength(0)
+  })
+
+  it('falls back to the directory name when the project has no name', async () => {
+    // The device shows this in its discovery reply and in the retrieve picker.
+    // An empty name there reads as a broken device.
+    seedProject('{"meta":{},"data":{}}')
+    const snapshot = await buildUploadSnapshot({
+      projectPath,
+      editorVersion: '4.2.0',
+      uploadedBy: 'op',
+    })
+    const metadata = JSON.parse(snapshot.metadata) as { projectName: string }
+    expect(metadata.projectName).toBe(projectPath.split(/[\\/]/).pop())
+  })
+})

--- a/src/backend/editor/project/__tests__/describe-retrieved-libraries.test.ts
+++ b/src/backend/editor/project/__tests__/describe-retrieved-libraries.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Classifying the libraries a retrieved project brought with it.
+ *
+ * The case that matters is `differs`: a library with the same name but
+ * different bytes builds a different program, silently. Reporting that as
+ * "already installed" would be worse than saying nothing, which is why status
+ * is decided by content hash and not by the version label.
+ */
+
+import { hashText, type SnapshotLibrary } from '../../../shared/project/project-snapshot-archive'
+import { describeRetrievedLibraries } from '../describe-retrieved-libraries'
+
+async function library(name: string, version: string, body: string): Promise<SnapshotLibrary> {
+  const archive = JSON.stringify({ manifest: { name, version }, body })
+  return { name, version, hash: await hashText(archive), archive }
+}
+
+it('reports a library this machine does not have as missing', async () => {
+  const motion = await library('Motion', '1.0.0', 'a')
+  const described = await describeRetrievedLibraries([motion], () => null)
+  expect(described).toEqual([{ name: 'Motion', version: '1.0.0', status: 'missing' }])
+})
+
+it('reports an identical library as installed', async () => {
+  const motion = await library('Motion', '1.0.0', 'a')
+  const described = await describeRetrievedLibraries([motion], () => motion.archive)
+  expect(described[0].status).toBe('installed')
+})
+
+it('reports the same name with different bytes as differing', async () => {
+  // Same name, same version, different contents -- the silent-wrong-program
+  // case. Version alone cannot distinguish these.
+  const theirs = await library('Motion', '1.0.0', 'built-against-this')
+  const mine = await library('Motion', '1.0.0', 'something-else')
+  const described = await describeRetrievedLibraries([theirs], () => mine.archive)
+  expect(described[0].status).toBe('differs')
+})
+
+it('does not treat a matching version as a matching library', async () => {
+  // Stated separately because it is the assumption the hash exists to replace.
+  const theirs = await library('Motion', '1.0.0', 'x')
+  const mine = await library('Motion', '1.0.0', 'y')
+  expect(theirs.version).toBe(mine.version)
+  const described = await describeRetrievedLibraries([theirs], () => mine.archive)
+  expect(described[0].status).not.toBe('installed')
+})
+
+it('classifies each library independently', async () => {
+  const present = await library('Present', '1', 'same')
+  const absent = await library('Absent', '1', 'x')
+  const changed = await library('Changed', '1', 'theirs')
+  const local: Record<string, string> = {
+    Present: present.archive,
+    Changed: (await library('Changed', '1', 'mine')).archive,
+  }
+  const described = await describeRetrievedLibraries(
+    [present, absent, changed],
+    (name) => local[name] ?? null,
+  )
+  expect(described.map((entry) => entry.status)).toEqual(['installed', 'missing', 'differs'])
+})
+
+it('handles a project with no libraries', async () => {
+  expect(await describeRetrievedLibraries([], () => null)).toEqual([])
+})

--- a/src/backend/editor/project/__tests__/materialize-retrieved-project.test.ts
+++ b/src/backend/editor/project/__tests__/materialize-retrieved-project.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Writing a retrieved project to disk.
+ *
+ * The archive comes from a device where the stored project is neither signed
+ * nor encrypted, so anyone with filesystem access could have replaced it. It is
+ * untrusted input all the way to the write, and a rejected archive has to leave
+ * nothing behind -- a partially written project would be worse than none, since
+ * it looks openable.
+ *
+ * The project name is part of that: it lands in a filesystem path here, so it
+ * gets the same treatment as any other untrusted path segment.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import JSZip from 'jszip'
+
+import {
+  SNAPSHOT_FORMAT_VERSION,
+  SNAPSHOT_MANIFEST_PATH,
+  SnapshotArchiveError,
+  buildProjectSnapshot,
+  hashText,
+} from '../../../shared/project/project-snapshot-archive'
+import { materializeRetrievedProject, safeFolderName } from '../materialize-retrieved-project'
+
+let scratchRoot: string
+
+beforeEach(() => {
+  scratchRoot = mkdtempSync(join(tmpdir(), 'openplc-retrieve-'))
+})
+
+afterEach(() => {
+  rmSync(scratchRoot, { recursive: true, force: true })
+})
+
+async function makeArchive(
+  files: Record<string, string> = {
+    'project.json': '{"meta":{"name":"Traffic Light"}}',
+    'pous/programs/MAIN.st': 'PROGRAM MAIN END_PROGRAM',
+  },
+  projectName = 'Traffic Light',
+): Promise<Uint8Array> {
+  const built = await buildProjectSnapshot({
+    files: new Map(Object.entries(files)),
+    projectName,
+    editorVersion: '4.2.0',
+    uploadedBy: 'op',
+    timestamp: '2026-08-31T12:00:00.000Z',
+  })
+  return built.archive
+}
+
+// --- the happy path ------------------------------------------------------
+
+describe('materializeRetrievedProject', () => {
+  it('writes the project tree into a fresh directory', async () => {
+    const result = await materializeRetrievedProject(await makeArchive(), {
+      scratchRoot,
+      folderName: 'proj',
+    })
+
+    expect(result.projectPath).toBe(join(scratchRoot, 'proj'))
+    expect(result.projectName).toBe('Traffic Light')
+    expect(readFileSync(join(result.projectPath, 'project.json'), 'utf-8')).toContain('Traffic Light')
+    expect(readFileSync(join(result.projectPath, 'pous/programs/MAIN.st'), 'utf-8')).toBe(
+      'PROGRAM MAIN END_PROGRAM',
+    )
+  })
+
+  it('never writes into the caller directory itself', async () => {
+    // The retrieved project has to be its own directory: dropping it into the
+    // scratch root would mix two retrievals together.
+    await materializeRetrievedProject(await makeArchive(), { scratchRoot, folderName: 'proj' })
+    expect(readdirSync(scratchRoot)).toEqual(['proj'])
+  })
+
+  it('hands back the metadata and bundled libraries for the caller to act on', async () => {
+    const archiveText = JSON.stringify({ manifest: { name: 'Motion', version: '1.2.0' } })
+    const built = await buildProjectSnapshot({
+      files: new Map([['project.json', '{}']]),
+      projectName: 'P',
+      editorVersion: '4.2.0',
+      uploadedBy: 'op',
+      libraries: [
+        { name: 'Motion', version: '1.2.0', hash: await hashText(archiveText), archive: archiveText },
+      ],
+    })
+
+    const result = await materializeRetrievedProject(built.archive, { scratchRoot, folderName: 'p' })
+    expect(result.metadata.editorVersion).toBe('4.2.0')
+    expect(result.libraries.map((library) => library.name)).toEqual(['Motion'])
+  })
+
+  it('keeps bundled libraries out of the written project tree', async () => {
+    // They are the caller's to install, not files the project owns.
+    const archiveText = JSON.stringify({ manifest: { name: 'Motion', version: '1' } })
+    const built = await buildProjectSnapshot({
+      files: new Map([['project.json', '{}']]),
+      projectName: 'P',
+      editorVersion: '4.2.0',
+      uploadedBy: 'op',
+      libraries: [{ name: 'Motion', version: '1', hash: await hashText(archiveText), archive: archiveText }],
+    })
+
+    const result = await materializeRetrievedProject(built.archive, { scratchRoot, folderName: 'p' })
+    expect(existsSync(join(result.projectPath, '.openplc-snapshot'))).toBe(false)
+  })
+})
+
+// --- refusing what should not be written --------------------------------
+
+describe('untrusted archives', () => {
+  it('writes nothing at all when the archive is rejected', async () => {
+    // A partially written project is worse than none: it looks openable.
+    const notAZip = new TextEncoder().encode('definitely not a zip')
+    await expect(
+      materializeRetrievedProject(notAZip, { scratchRoot, folderName: 'proj' }),
+    ).rejects.toThrow(SnapshotArchiveError)
+    expect(existsSync(join(scratchRoot, 'proj'))).toBe(false)
+  })
+
+  it('refuses an archive with an absolute path before creating the directory', async () => {
+    const zip = new JSZip()
+    zip.file(
+      SNAPSHOT_MANIFEST_PATH,
+      JSON.stringify({ formatVersion: SNAPSHOT_FORMAT_VERSION, projectName: 'P', libraries: [] }),
+    )
+    zip.file('project.json', '{}')
+    zip.file('/etc/passwd', 'pwned')
+
+    await expect(
+      materializeRetrievedProject(await zip.generateAsync({ type: 'uint8array' }), {
+        scratchRoot,
+        folderName: 'proj',
+      }),
+    ).rejects.toThrow(SnapshotArchiveError)
+    expect(existsSync(join(scratchRoot, 'proj'))).toBe(false)
+  })
+})
+
+// --- the project name as a path segment ---------------------------------
+
+describe('safeFolderName', () => {
+  it('keeps an ordinary name readable', () => {
+    expect(safeFolderName('Traffic Light')).toBe('Traffic Light')
+  })
+
+  it('flattens separators instead of creating directories', () => {
+    expect(safeFolderName('a/b')).toBe('a-b')
+    expect(safeFolderName('a\\b')).toBe('a-b')
+  })
+
+  it('refuses to produce a relative directory reference', () => {
+    // "..", or a name starting with one, would resolve somewhere other than
+    // inside the scratch root.
+    expect(safeFolderName('..')).toBe('retrieved-project')
+    expect(safeFolderName('../../etc')).toBe('-..-etc')
+    // The property that actually matters, stated directly rather than left to
+    // be inferred from the expected strings above: whatever comes out, it
+    // cannot resolve anywhere but inside the destination.
+    for (const hostile of ['..', '../..', './../x', '....//..']) {
+      const folder = safeFolderName(hostile)
+      expect(folder.startsWith('.')).toBe(false)
+      expect(folder.includes('/')).toBe(false)
+      expect(folder.includes('\\')).toBe(false)
+    }
+  })
+
+  it('drops control characters and the characters Windows reserves', () => {
+    expect(safeFolderName('bad\u0000name')).toBe('badname')
+    expect(safeFolderName('a:b*c?d"e<f>g|h')).toBe('abcdefgh')
+  })
+
+  it('falls back rather than producing an unnamed directory', () => {
+    expect(safeFolderName('')).toBe('retrieved-project')
+    expect(safeFolderName('   ')).toBe('retrieved-project')
+    expect(safeFolderName('...')).toBe('retrieved-project')
+  })
+
+  it('bounds the length so a hostile name cannot blow the path limit', () => {
+    expect(safeFolderName('x'.repeat(500)).length).toBe(80)
+  })
+})

--- a/src/backend/editor/project/build-upload-snapshot.ts
+++ b/src/backend/editor/project/build-upload-snapshot.ts
@@ -1,0 +1,184 @@
+/**
+ * Assemble the source-project archive that rides along with a program upload.
+ *
+ * The device stores it untouched so the project can be retrieved later. This
+ * module is the editor's side of that: read the project off disk, gather the
+ * `.stlib` archives it references, and hand both to the shared archive builder.
+ *
+ * Reading from disk rather than from the renderer's store is deliberate. The
+ * build path already saves the whole project before compiling -- the compiler
+ * reads its source from disk, so it has to -- which means the tree on disk is
+ * the exact project the artifacts were built from. Serialising the store again
+ * here would introduce a second source of truth that could disagree with what
+ * was actually compiled.
+ */
+
+import { promises as fs } from 'fs'
+import { join, relative, sep } from 'path'
+
+import {
+  buildProjectSnapshot,
+  hashText,
+  type SnapshotLibrary,
+} from '../../shared/project/project-snapshot-archive'
+
+/**
+ * Directories and files never worth storing.
+ *
+ * `build/` is the point: it holds the compiled artifacts, which the device
+ * already has, and it is far larger than the source. The rest is local noise
+ * that would otherwise travel to a device and back onto someone else's machine.
+ */
+const EXCLUDED_DIRECTORIES = new Set(['build', '.git', 'node_modules'])
+const EXCLUDED_FILES = new Set(['.DS_Store', 'Thumbs.db'])
+
+/** How a caller supplies the `.stlib` text for a library the project uses. */
+export type ReadLibraryArchive = (name: string) => Promise<string | null> | (string | null)
+
+export interface BuildUploadSnapshotOptions {
+  projectPath: string
+  editorVersion: string
+  /** Runtime account performing the upload. Informational only. */
+  uploadedBy: string
+  /** Injected rather than imported: the library manager is Electron-bound, and
+   *  this module is otherwise plain filesystem work that can be tested without
+   *  standing up an app. */
+  readLibraryArchive?: ReadLibraryArchive
+  timestamp?: string
+}
+
+export interface UploadSnapshot {
+  archive: Buffer
+  /** JSON, sent as the upload's `snapshot_metadata` field. */
+  metadata: string
+  /** Libraries the project references that could not be read. Reported rather
+   *  than fatal: a project missing a library is still worth storing, and the
+   *  alternative is refusing to store anything at all. */
+  missingLibraries: string[]
+}
+
+/**
+ * Every file under `projectPath`, keyed by project-root-relative path.
+ *
+ * Paths are normalised to forward slashes so an archive written on Windows
+ * reads identically everywhere -- ZIP entry names use `/` regardless of host,
+ * and a backslash in an entry name is a literal character rather than a
+ * separator to anything unpacking it.
+ */
+export async function readProjectDirectory(projectPath: string): Promise<Map<string, string>> {
+  const files = new Map<string, string>()
+
+  async function walk(directory: string): Promise<void> {
+    const entries = await fs.readdir(directory, { withFileTypes: true })
+    for (const entry of entries) {
+      const absolute = join(directory, entry.name)
+      if (entry.isDirectory()) {
+        if (EXCLUDED_DIRECTORIES.has(entry.name)) continue
+        await walk(absolute)
+        continue
+      }
+      if (!entry.isFile() || EXCLUDED_FILES.has(entry.name)) continue
+
+      const relativePath = relative(projectPath, absolute).split(sep).join('/')
+      files.set(relativePath, await fs.readFile(absolute, 'utf-8'))
+    }
+  }
+
+  await walk(projectPath)
+  return files
+}
+
+/** The library names a project declares, read straight from its `project.json`. */
+export function referencedLibraryNames(projectJson: string): string[] {
+  try {
+    const parsed = JSON.parse(projectJson) as { data?: { libraries?: Array<{ name?: unknown }> } }
+    const libraries = parsed.data?.libraries
+    if (!Array.isArray(libraries)) return []
+    return libraries
+      .map((library) => (typeof library?.name === 'string' ? library.name : ''))
+      .filter((name) => name.length > 0)
+  } catch {
+    // A project.json we cannot parse is a project that will not open anyway.
+    // Storing it without its libraries is strictly better than storing nothing.
+    return []
+  }
+}
+
+/**
+ * Build the archive and its metadata for an upload.
+ *
+ * Bundling the libraries is what makes a retrieved project compile on a machine
+ * whose pool has never seen them. A library that cannot be read is reported and
+ * skipped rather than failing the build: the project is still worth storing,
+ * and the opening client warns about what is missing.
+ */
+export async function buildUploadSnapshot(
+  options: BuildUploadSnapshotOptions,
+): Promise<UploadSnapshot> {
+  const files = await readProjectDirectory(options.projectPath)
+
+  const projectJson = files.get('project.json') ?? ''
+  const projectName = readProjectName(projectJson, options.projectPath)
+
+  const libraries: SnapshotLibrary[] = []
+  const missingLibraries: string[] = []
+
+  if (options.readLibraryArchive) {
+    for (const name of referencedLibraryNames(projectJson)) {
+      const archive = await options.readLibraryArchive(name)
+      if (!archive) {
+        missingLibraries.push(name)
+        continue
+      }
+      libraries.push({
+        name,
+        version: readLibraryVersion(archive),
+        hash: await hashText(archive),
+        archive,
+      })
+    }
+  }
+
+  const built = await buildProjectSnapshot({
+    files,
+    projectName,
+    editorVersion: options.editorVersion,
+    uploadedBy: options.uploadedBy,
+    libraries,
+    timestamp: options.timestamp,
+  })
+
+  return {
+    archive: Buffer.from(built.archive),
+    metadata: JSON.stringify(built.metadata),
+    missingLibraries,
+  }
+}
+
+/**
+ * The project's display name.
+ *
+ * Falls back to the directory name, because the device shows this in its
+ * discovery reply and in the retrieve picker -- an empty name there reads as a
+ * broken device rather than as a project that never set one.
+ */
+function readProjectName(projectJson: string, projectPath: string): string {
+  try {
+    const parsed = JSON.parse(projectJson) as { meta?: { name?: unknown } }
+    if (typeof parsed.meta?.name === 'string' && parsed.meta.name.trim()) {
+      return parsed.meta.name.trim()
+    }
+  } catch {
+    // Fall through to the directory name.
+  }
+  return projectPath.split(sep).filter(Boolean).pop() ?? 'Untitled project'
+}
+
+function readLibraryVersion(archive: string): string {
+  try {
+    const parsed = JSON.parse(archive) as { manifest?: { version?: unknown } }
+    return typeof parsed.manifest?.version === 'string' ? parsed.manifest.version : ''
+  } catch {
+    return ''
+  }
+}

--- a/src/backend/editor/project/describe-retrieved-libraries.ts
+++ b/src/backend/editor/project/describe-retrieved-libraries.ts
@@ -1,0 +1,54 @@
+/**
+ * Compare the libraries a retrieved project carries against this machine's pool.
+ *
+ * Three outcomes, and the middle one is why this exists:
+ *
+ *   - `installed` -- same name, same bytes. Nothing to do.
+ *   - `differs`   -- same name, DIFFERENT bytes. The project was built against
+ *     something this machine does not have. Building it here would silently
+ *     produce a different program, so this cannot be reported as "already
+ *     installed" -- that phrasing would actively mislead.
+ *   - `missing`   -- not here at all.
+ *
+ * Compared by content hash rather than by version: a version is a label someone
+ * types, and two different builds can carry the same one.
+ *
+ * Takes a reader callback rather than the library manager itself, which is
+ * Electron-bound; this keeps the rule testable without standing up an app.
+ */
+
+import { hashText, type SnapshotLibrary } from '../../shared/project/project-snapshot-archive'
+
+export type RetrievedLibraryStatus = 'installed' | 'differs' | 'missing'
+
+export interface DescribedLibrary {
+  name: string
+  version: string
+  status: RetrievedLibraryStatus
+}
+
+/** Returns the local `.stlib` text for a library, or null when absent. */
+export type ReadLocalArchive = (name: string) => Promise<string | null> | (string | null)
+
+export async function describeRetrievedLibraries(
+  libraries: SnapshotLibrary[],
+  readLocalArchive: ReadLocalArchive,
+): Promise<DescribedLibrary[]> {
+  const described: DescribedLibrary[] = []
+
+  for (const library of libraries) {
+    const local = await readLocalArchive(library.name)
+    if (local === null) {
+      described.push({ name: library.name, version: library.version, status: 'missing' })
+      continue
+    }
+    const localHash = await hashText(local)
+    described.push({
+      name: library.name,
+      version: library.version,
+      status: localHash === library.hash ? 'installed' : 'differs',
+    })
+  }
+
+  return described
+}

--- a/src/backend/editor/project/materialize-retrieved-project.ts
+++ b/src/backend/editor/project/materialize-retrieved-project.ts
@@ -1,0 +1,127 @@
+/**
+ * Write a project retrieved from a device onto disk.
+ *
+ * It lands in a scratch directory, not a location the user picked, and the
+ * project is marked ephemeral until they choose one. That is what makes the
+ * rest of the editor work unchanged:
+ *
+ *   - `meta.path` is always a real, writable directory, and never the
+ *     previously open project's path. Every write in `save-actions` derives
+ *     from `meta.path`, so a retrieved project loaded while the store still
+ *     pointed at the old one would save its contents over the user's actual
+ *     work.
+ *
+ *   - The compile pipeline reads source from disk. A project with no location
+ *     could not be built at all, so "no location" is not a state worth
+ *     supporting -- a scratch location is.
+ *
+ * The user-facing Save is refused for an ephemeral project and points at Save
+ * As; the pre-build flush still writes here, which is why the build path needs
+ * no change. Blocking every save would break compilation instead of protecting
+ * anything.
+ *
+ * Everything in the archive is untrusted: it came from a device where the
+ * stored project is neither signed nor encrypted, so anyone with filesystem
+ * access could have replaced it. `parseProjectSnapshot` validates before
+ * yielding content, and every path is re-checked here against the destination
+ * before a single byte is written.
+ */
+
+import { promises as fs } from 'fs'
+import { join, resolve, sep } from 'path'
+
+import {
+  parseProjectSnapshot,
+  SnapshotArchiveError,
+  type SnapshotLibrary,
+  type SnapshotMetadata,
+} from '../../shared/project/project-snapshot-archive'
+
+export interface MaterializedProject {
+  /** Scratch directory holding the project tree. */
+  projectPath: string
+  projectName: string
+  metadata: SnapshotMetadata
+  /** Bundled `.stlib` archives, for the caller to offer to install. */
+  libraries: SnapshotLibrary[]
+}
+
+export interface MaterializeOptions {
+  /** Directory to create the project folder inside. */
+  scratchRoot: string
+  /** Overridden in tests; defaults to a timestamp so two retrievals of the same
+   *  project in one session do not collide. */
+  folderName?: string
+}
+
+/**
+ * A project name reduced to something safe to use as a directory name.
+ *
+ * The name comes from a device and is echoed straight into a path here, so it
+ * gets the same treatment as any other untrusted path segment: separators,
+ * traversal and control characters out. An empty result falls back rather than
+ * producing a directory called "".
+ */
+export function safeFolderName(projectName: string): string {
+  const cleaned = projectName
+    // Separators first, so "a/b" becomes one segment rather than two directories.
+    .replace(/[\\/]/g, '-')
+    // Control characters (the NUL truncates a path in some syscalls) plus the
+    // characters Windows reserves, including the colon that names an alternate
+    // data stream.
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f:*?"<>|]/g, '')
+    // A leading dot gives a hidden directory, and a name of "." or ".." gives
+    // the wrong directory entirely.
+    .replace(/^\.+/, '')
+    .trim()
+    .slice(0, 80)
+  return cleaned || 'retrieved-project'
+}
+
+/**
+ * Unpack `archive` into a fresh directory under `scratchRoot`.
+ *
+ * Throws `SnapshotArchiveError` for an archive that cannot be trusted or read;
+ * nothing is written in that case, so a rejected archive never leaves a partial
+ * project behind.
+ */
+export async function materializeRetrievedProject(
+  archive: Uint8Array,
+  options: MaterializeOptions,
+): Promise<MaterializedProject> {
+  const parsed = await parseProjectSnapshot(archive)
+
+  const projectName = parsed.metadata.projectName || 'Retrieved project'
+  const folder = options.folderName ?? `${safeFolderName(projectName)}-${Date.now()}`
+  const projectPath = join(options.scratchRoot, folder)
+
+  // Resolve every destination and confirm containment BEFORE writing anything.
+  // parseProjectSnapshot already refuses escaping entries, but the guard that
+  // matters is the one next to the write: this is the only place that knows
+  // what the destination actually is.
+  const destinationRoot = resolve(projectPath)
+  const writes: Array<{ absolute: string; content: string }> = []
+  for (const [relativePath, content] of parsed.files) {
+    const absolute = resolve(destinationRoot, relativePath)
+    if (absolute !== destinationRoot && !absolute.startsWith(destinationRoot + sep)) {
+      throw new SnapshotArchiveError(
+        `The device sent a project containing a file that would be written outside the destination: ${relativePath}`,
+      )
+    }
+    writes.push({ absolute, content })
+  }
+
+  await fs.mkdir(destinationRoot, { recursive: true })
+  for (const { absolute, content } of writes) {
+    await fs.mkdir(join(absolute, '..'), { recursive: true })
+    await fs.writeFile(absolute, content, 'utf-8')
+  }
+
+  return {
+    projectPath: destinationRoot,
+    projectName,
+    metadata: parsed.metadata,
+    libraries: parsed.libraries,
+  }
+}

--- a/src/backend/editor/runtime/runtime-api-client.ts
+++ b/src/backend/editor/runtime/runtime-api-client.ts
@@ -63,6 +63,61 @@ const PlcStatusResponseSchema = z.object({
 })
 
 /**
+ * What a device reports about the source project it stores.
+ *
+ * Every field but `present` is optional because a device with nothing stored
+ * answers `{present: false}` alone, and because these values come from whoever
+ * uploaded -- the runtime never opens the archive to check them.
+ */
+const ProjectSnapshotInfoSchema = z.object({
+  present: z.boolean(),
+  projectName: z.string().optional(),
+  editorVersion: z.string().optional(),
+  uploadedBy: z.string().optional(),
+  timestamp: z.string().optional(),
+  sizeBytes: z.number().optional(),
+  formatVersion: z.number().optional(),
+  libraries: z
+    .array(
+      z.object({
+        name: z.string(),
+        version: z.string().optional(),
+        hash: z.string().optional(),
+      }),
+    )
+    .optional(),
+})
+
+export type ProjectSnapshotInfo = z.infer<typeof ProjectSnapshotInfoSchema>
+
+const ProjectSnapshotBodySchema = z.object({
+  projectName: z.string(),
+  contentBase64: z.string(),
+})
+
+type ProjectSnapshotBody = z.infer<typeof ProjectSnapshotBodySchema>
+
+/**
+ * Turn a failed snapshot fetch into something a user can act on.
+ *
+ * The two interesting outcomes are indistinguishable from a transport error in
+ * the raw text: a device with nothing stored (404) and an account without the
+ * privilege to read it (403). Both are real answers, and reporting either as a
+ * broken connection sends people looking for a network problem that is not
+ * there.
+ */
+function describeSnapshotFetchFailure(raw: string): string {
+  const lower = raw.toLowerCase()
+  if (lower.includes('admin privileges required')) {
+    return 'This account is not an administrator on that device. Only administrators can retrieve a stored project.'
+  }
+  if (lower.includes('no project is stored')) {
+    return 'That device is not storing a project.'
+  }
+  return raw
+}
+
+/**
  * One header value, whatever the wire gave us.
  *
  * `IncomingHttpHeaders` values are `string | string[] | undefined`: a header sent
@@ -491,6 +546,66 @@ export class RuntimeApiClient {
         (r) => !r.success && r.statusCode === 401,
       )
       .then((r) => (r.success ? { success: true, data: r.data } : { success: false, error: r.error }))
+  }
+
+  /**
+   * What the device says about the source project it is storing, if any.
+   *
+   * Authenticated but not admin-gated, so the UI can decide whether to OFFER
+   * retrieval without needing the privilege that retrieval itself requires.
+   */
+  async getProjectSnapshotInfo(
+    ipAddress: string,
+  ): Promise<{ success: true; info: ProjectSnapshotInfo } | { success: false; error: string }> {
+    const result = await this.makeRuntimeApiRequest<ProjectSnapshotInfo | null>(
+      ipAddress,
+      '/api/project-snapshot/info',
+      (data) => ProjectSnapshotInfoSchema.safeParse(parseJsonOrNull(data)).data ?? null,
+    )
+    if (!result.success) return { success: false, error: result.error }
+    if (!result.data) return { success: false, error: 'The device sent an unreadable snapshot description' }
+    return { success: true, info: result.data }
+  }
+
+  /**
+   * Fetch the stored source project.
+   *
+   * Admin only on the device: the archive is not encrypted there, so that role
+   * check is the whole of the access control rather than a layer behind one. A
+   * non-admin account gets a 403, which is a real answer and not a transport
+   * failure — the caller says so rather than reporting a broken connection.
+   *
+   * The body is base64 in JSON rather than a binary download because
+   * openplc-web reaches devices through the orchestrator's HTTP proxy, which
+   * decodes as JSON or falls back to text. Editor and web therefore read the
+   * same shape off the same endpoint.
+   */
+  async retrieveProjectSnapshot(
+    ipAddress: string,
+  ): Promise<
+    { success: true; archive: Buffer; projectName: string } | { success: false; error: string }
+  > {
+    const result = await this.makeRuntimeApiRequest<ProjectSnapshotBody | null>(
+      ipAddress,
+      '/api/project-snapshot',
+      (data) => ProjectSnapshotBodySchema.safeParse(parseJsonOrNull(data)).data ?? null,
+    )
+
+    if (!result.success) {
+      return { success: false, error: describeSnapshotFetchFailure(result.error) }
+    }
+    if (!result.data) {
+      return { success: false, error: 'The device sent an unreadable project archive' }
+    }
+
+    let archive: Buffer
+    try {
+      archive = Buffer.from(result.data.contentBase64, 'base64')
+    } catch {
+      return { success: false, error: 'The device sent a project archive that is not valid base64' }
+    }
+
+    return { success: true, archive, projectName: result.data.projectName }
   }
 
   /**

--- a/src/backend/editor/runtime/runtime-api-client.ts
+++ b/src/backend/editor/runtime/runtime-api-client.ts
@@ -506,6 +506,16 @@ export class RuntimeApiClient {
     filename: string
     contentType: string
     cleanBuild: boolean
+    /** Optional source-project archive, stored on the device so the project can
+     *  be retrieved later. Its own multipart part rather than something inside
+     *  `program.zip`: in there the runtime would extract it into
+     *  `core/generated` and hand it to the compiler. A runtime without snapshot
+     *  support ignores the extra parts, so sending them is always safe. */
+    snapshotBuffer?: Buffer
+    /** JSON metadata describing `snapshotBuffer`. The runtime never opens the
+     *  archive, so this is the only thing it can report about the stored
+     *  project — the two travel together or not at all. */
+    snapshotMetadata?: string
     onUploadAccepted?: (responseBody: string) => void
   }): Promise<{ success: true; data: string } | { success: false; error: string }> {
     type UploadResult = { success: true; data: string } | { success: false; error: string; statusCode?: number }
@@ -515,13 +525,46 @@ export class RuntimeApiClient {
         `Content-Disposition: form-data; name="file"; filename="${headerSafe(opts.filename)}"\r\n` +
         `Content-Type: ${headerSafe(opts.contentType)}\r\n\r\n`,
     )
+
+    // Both parts or neither. A snapshot the device cannot describe is one it
+    // refuses anyway, and it would surface as a warning the user then has to
+    // make sense of.
+    const snapshotBuffer = opts.snapshotBuffer
+    const snapshotMetadata = opts.snapshotMetadata
+    const snapshotParts: Uint8Array[] =
+      snapshotBuffer !== undefined && snapshotMetadata !== undefined
+        ? [
+            asBytes(
+              Buffer.from(
+                `\r\n--${boundary}\r\n` +
+                  `Content-Disposition: form-data; name="snapshot"; filename="project.zip"\r\n` +
+                  `Content-Type: application/zip\r\n\r\n`,
+              ),
+            ),
+            asBytes(snapshotBuffer),
+            asBytes(
+              Buffer.from(
+                `\r\n--${boundary}\r\n` +
+                  `Content-Disposition: form-data; name="snapshot_metadata"\r\n` +
+                  `Content-Type: application/json\r\n\r\n` +
+                  snapshotMetadata,
+              ),
+            ),
+          ]
+        : []
+
     const footer = Buffer.from(`\r\n--${boundary}--\r\n`)
     // `Buffer.concat` is typed as taking `Uint8Array`s, and this project's
     // TS/@types/node pairing does not accept a `Buffer` there (their iterator
     // types differ). A zero-copy view over the same memory satisfies the
     // signature honestly — the previous `as unknown as` hid the mismatch, and
     // copying a firmware bundle to appease a type would be worse than both.
-    const reqBody = Buffer.concat([asBytes(header), asBytes(opts.fileBuffer), asBytes(footer)])
+    const reqBody = Buffer.concat([
+      asBytes(header),
+      asBytes(opts.fileBuffer),
+      ...snapshotParts,
+      asBytes(footer),
+    ])
     const path = opts.cleanBuild ? '/api/upload-file?clean=1' : '/api/upload-file'
 
     const doRequest = (token: string): Promise<UploadResult> =>

--- a/src/backend/shared/project/__tests__/project-snapshot-archive.test.ts
+++ b/src/backend/shared/project/__tests__/project-snapshot-archive.test.ts
@@ -24,6 +24,7 @@ import {
   assertSafeEntryPath,
   SnapshotArchiveError,
   toWriteProjectFiles,
+  writeProjectFilesToMap,
   type SnapshotLibrary,
 } from '../project-snapshot-archive'
 
@@ -47,7 +48,7 @@ function projectFiles(overrides: Partial<WriteProjectFiles> = {}): WriteProjectF
 
 async function build(overrides: Partial<Parameters<typeof buildProjectSnapshot>[0]> = {}) {
   return buildProjectSnapshot({
-    files: projectFiles(),
+    files: writeProjectFilesToMap(projectFiles()),
     projectName: 'Traffic Light',
     editorVersion: '4.2.0',
     uploadedBy: 'op',
@@ -66,7 +67,7 @@ async function library(name = 'Motion', version = '1.2.0'): Promise<SnapshotLibr
 describe('round trip', () => {
   it('carries every project file back unchanged', async () => {
     const original = projectFiles()
-    const { archive } = await build({ files: original })
+    const { archive } = await build({ files: writeProjectFilesToMap(original) })
     const parsed = await parseProjectSnapshot(archive)
     const restored = toWriteProjectFiles(parsed, '/somewhere/else')
 
@@ -90,14 +91,16 @@ describe('round trip', () => {
     // A retrieved project is written into an empty destination. Honouring
     // deletions from an archive would let a device name files to remove on the
     // opening machine.
-    const { archive } = await build({ files: projectFiles({ deletions: ['pous/programs/Gone.st'] }) })
+    const { archive } = await build({
+      files: writeProjectFilesToMap(projectFiles({ deletions: ['pous/programs/Gone.st'] })),
+    })
     const restored = toWriteProjectFiles(await parseProjectSnapshot(archive), '/tmp/p')
     expect(restored.deletions).toEqual([])
   })
 
   it('keeps a library project manifest', async () => {
     const { archive } = await build({
-      files: projectFiles({ libraryManifest: '{"name":"MyLib"}' }),
+      files: writeProjectFilesToMap(projectFiles({ libraryManifest: '{"name":"MyLib"}' })),
     })
     const restored = toWriteProjectFiles(await parseProjectSnapshot(archive), '/tmp/p')
     expect(restored.libraryManifest).toBe('{"name":"MyLib"}')
@@ -105,7 +108,7 @@ describe('round trip', () => {
 
   it('omits optional files a PLC project does not own rather than writing empty ones', async () => {
     const { archive } = await build({
-      files: projectFiles({ deviceConfig: undefined, pinMapping: undefined }),
+      files: writeProjectFilesToMap(projectFiles({ deviceConfig: undefined, pinMapping: undefined })),
     })
     const restored = toWriteProjectFiles(await parseProjectSnapshot(archive), '/tmp/p')
     expect(restored.deviceConfig).toBeUndefined()

--- a/src/backend/shared/project/project-snapshot-archive.ts
+++ b/src/backend/shared/project/project-snapshot-archive.ts
@@ -92,7 +92,12 @@ export interface SnapshotMetadata {
 }
 
 export interface BuildProjectSnapshotOptions {
-  files: WriteProjectFiles
+  /** Project-root-relative path to file content, for everything except
+   *  `build/`. A Map rather than `WriteProjectFiles` because the two callers
+   *  have genuinely different sources: the editor walks the project directory
+   *  on disk, web holds the files in memory. `writeProjectFilesToMap` converts
+   *  when a caller already has the structured shape. */
+  files: Map<string, string>
   projectName: string
   editorVersion: string
   /** Runtime account performing the upload. Informational only. */
@@ -188,11 +193,12 @@ export async function buildProjectSnapshot(
   const zip = new JSZip()
   zip.file(SNAPSHOT_MANIFEST_PATH, JSON.stringify(metadata, null, 2))
 
-  // The project's own relative paths, straight from the canonical iterator.
-  // Imported lazily-by-shape rather than by calling the generator directly so
-  // this module stays usable with a plain file map in tests.
-  for (const entry of iterateProjectEntries(files)) {
-    zip.file(entry.relativePath, entry.content)
+  for (const [relativePath, content] of files) {
+    // Refuse to WRITE what we would refuse to read, so a project that somehow
+    // holds an escaping path cannot be handed to a device and blamed on the
+    // device later.
+    assertSafeEntryPath(relativePath)
+    zip.file(relativePath, content)
   }
 
   for (const library of libraries) {
@@ -215,32 +221,24 @@ function libraryFileName(library: SnapshotLibrary): string {
 }
 
 /**
- * Every project file as a relative path plus content.
+ * A structured `WriteProjectFiles` flattened to the path/content map the
+ * archive stores.
  *
- * Deliberately a local walk of `WriteProjectFiles` rather than a call into
- * `iterateWriteProjectFiles`: that generator's entries are typed to a fixed
- * set of literal paths, and this module only needs the path/content pair.
- * Both walk the same shape, so a new file category has to be added in both --
- * the round-trip test is what catches it.
+ * Deliberately a local walk rather than a call into `iterateWriteProjectFiles`:
+ * that generator's entries are typed to a fixed set of literal paths and this
+ * needs only the pair. Both walk the same shape, so a new file category has to
+ * be added in both -- the round-trip test is what catches a miss.
  */
-function* iterateProjectEntries(
-  files: WriteProjectFiles,
-): Generator<{ relativePath: string; content: string }> {
-  yield { relativePath: 'project.json', content: files.projectJson }
-  if (files.deviceConfig !== undefined) {
-    yield { relativePath: 'devices/configuration.json', content: files.deviceConfig }
-  }
-  if (files.pinMapping !== undefined) {
-    yield { relativePath: 'devices/pin-mapping.json', content: files.pinMapping }
-  }
-  if (files.libraryManifest !== undefined) {
-    yield { relativePath: 'library.json', content: files.libraryManifest }
-  }
+export function writeProjectFilesToMap(files: WriteProjectFiles): Map<string, string> {
+  const map = new Map<string, string>()
+  map.set('project.json', files.projectJson)
+  if (files.deviceConfig !== undefined) map.set('devices/configuration.json', files.deviceConfig)
+  if (files.pinMapping !== undefined) map.set('devices/pin-mapping.json', files.pinMapping)
+  if (files.libraryManifest !== undefined) map.set('library.json', files.libraryManifest)
   for (const group of [files.pouFiles, files.serverFiles, files.remoteDeviceFiles, files.dataTypeFiles]) {
-    for (const file of group) {
-      yield { relativePath: file.relativePath, content: file.content }
-    }
+    for (const file of group) map.set(file.relativePath, file.content)
   }
+  return map
 }
 
 /**

--- a/src/cli/compile/headless-bridge.ts
+++ b/src/cli/compile/headless-bridge.ts
@@ -54,8 +54,15 @@ export interface HeadlessCompileBridge {
     filename: string
     contentType: string
     cleanBuild: boolean
+    snapshotBuffer?: Buffer
+    snapshotMetadata?: string
     onUploadAccepted?: (responseBody: string) => void
   }) => Promise<{ success: true; data: string } | { success: false; error: string }>
+  /** Username of the live runtime session, so an uploaded project records who
+   *  stored it. Without this the CLI would store projects attributed to nobody
+   *  while the GUI attributed them correctly -- the kind of difference between
+   *  the two front ends this bridge exists to prevent. */
+  getRuntimeUsername: () => string | null
   loadEnabledArchives: (enabledNames: string[]) => { archives: unknown[]; missing: string[] }
 }
 
@@ -86,6 +93,8 @@ export function createHeadlessCompileBridge(runtime: RuntimeApiClient | null): H
       if (!runtime) return Promise.resolve(noRuntime())
       return runtime.makeRuntimeApiUpload(opts)
     },
+
+    getRuntimeUsername: () => runtime?.tokens.getUsername() ?? null,
 
     loadEnabledArchives: (enabledNames) => libraries.loadEnabledArchives(enabledNames),
   }

--- a/src/frontend/components/_molecules/menu-bar/menus/file.tsx
+++ b/src/frontend/components/_molecules/menu-bar/menus/file.tsx
@@ -55,6 +55,13 @@ export const FileMenu = () => {
     closeProject()
   }
 
+  // Reachable whether or not a device is connected: the modal owns the
+  // connection handling, including the case where retrieving means
+  // disconnecting from the device currently in use.
+  const handleRetrieveProject = () => {
+    openModal('retrieve-project', null)
+  }
+
   return (
     <MenuPrimitive.Menu>
       <MenuPrimitive.Trigger className={TRIGGER}>{i18n.t('menu:file.label')}</MenuPrimitive.Trigger>
@@ -72,6 +79,10 @@ export const FileMenu = () => {
             <span>{i18n.t('menu:file.submenu.closeTab')}</span>
             <span className={ACCELERATOR}>{'Ctrl + W'}</span>
           </MenuPrimitive.Item>
+          <MenuPrimitive.Item className={ITEM} onClick={handleRetrieveProject}>
+            <span>{i18n.t('menu:file.submenu.retrieveProject')}</span>
+          </MenuPrimitive.Item>
+          <MenuPrimitive.Separator className={SEPARATOR} />
           <MenuPrimitive.Item className={ITEM} onClick={handleCloseProject}>
             <span>{i18n.t('menu:file.submenu.closeProject')}</span>
             <span className={ACCELERATOR}>{'Ctrl + Shift + W'}</span>

--- a/src/frontend/components/_organisms/modals/index.ts
+++ b/src/frontend/components/_organisms/modals/index.ts
@@ -1,3 +1,4 @@
 export { RuntimeCreateUserModal } from './runtime-create-user-modal'
+export { RetrieveProjectModal } from './retrieve-project-modal'
 export { RuntimeDiscoverDevicesModal } from './runtime-discover-devices-modal'
 export { RuntimeLoginModal } from './runtime-login-modal'

--- a/src/frontend/components/_organisms/modals/retrieve-project-modal.tsx
+++ b/src/frontend/components/_organisms/modals/retrieve-project-modal.tsx
@@ -25,9 +25,9 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { DiscoveredRuntimeDevice } from '../../../../middleware/shared/ports'
 import { useProject, useRuntime } from '../../../../middleware/shared/providers'
+import { nextStepForDevice } from '../../../services/retrieve-project-connection'
 import { useOpenPLCStore } from '../../../store'
 import { cn } from '../../../utils/cn'
-import { nextStepForDevice } from '../../../services/retrieve-project-connection'
 import { toast } from '../../../utils/toast'
 import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'
 
@@ -150,12 +150,43 @@ const RetrieveProjectModal = () => {
       // flush still runs -- the compiler reads source from disk.
       workspaceActions.setIsEphemeralProject(true)
 
-      const missing = retrieved.libraries ?? []
+      // Anything this machine cannot supply, or supplies differently. The
+      // second case is the one worth separating: a library with the same name
+      // but different bytes builds a DIFFERENT program, silently, and reading
+      // "already installed" would be actively misleading.
+      const libraries = retrieved.libraries ?? []
+      const installable = libraries.filter((library) => library.status !== 'installed')
+
+      if (installable.length > 0 && runtime.installRetrievedLibraries) {
+        const differing = installable.filter((library) => library.status === 'differs')
+        const missing = installable.filter((library) => library.status === 'missing')
+        const lines = [
+          missing.length ? `Not installed here: ${missing.map((l) => l.name).join(', ')}.` : '',
+          differing.length
+            ? `Installed but different from what this project was built with: ${differing
+                .map((l) => l.name)
+                .join(', ')}. Building without updating them produces a different program.`
+            : '',
+        ].filter(Boolean)
+
+        const result = await runtime.installRetrievedLibraries(
+          retrieved.projectPath,
+          installable.map((library) => library.name),
+        )
+        toast({
+          title: result.success
+            ? `Installed ${result.installed.length} librar${result.installed.length === 1 ? 'y' : 'ies'}`
+            : 'Some libraries could not be installed',
+          description: result.success
+            ? lines.join(' ')
+            : result.failed.map((failure) => `${failure.name}: ${failure.error}`).join('; '),
+          variant: result.success ? 'default' : 'fail',
+        })
+      }
+
       toast({
         title: `Retrieved "${retrieved.projectName ?? 'project'}"`,
-        description: missing.length
-          ? `Use Save As to keep it. It uses these libraries: ${missing.map((library) => library.name).join(', ')}.`
-          : 'This project has no location yet — use Save As to keep it.',
+        description: 'This project has no location yet — use Save As to keep it.',
         variant: 'default',
       })
       close()

--- a/src/frontend/components/_organisms/modals/retrieve-project-modal.tsx
+++ b/src/frontend/components/_organisms/modals/retrieve-project-modal.tsx
@@ -1,0 +1,368 @@
+/**
+ * Retrieve Project from PLC.
+ *
+ * Picks a device off the LAN scan, authenticates if needed, pulls the stored
+ * source project down and opens it.
+ *
+ * The connection handling is the part worth reading. `RuntimeApiClient` is
+ * deliberately single-device: one address, one token authority, and `login`
+ * replaces the session. That is a good property, so this respects it rather
+ * than working around it:
+ *
+ *   - target is the device already connected -> retrieve straight away, no
+ *     prompt and no re-login, because the session in hand is already the right
+ *     one;
+ *   - connected to a DIFFERENT device -> say plainly that continuing
+ *     disconnects, then ask for the target's credentials;
+ *   - not connected -> just ask for credentials.
+ *
+ * Browsing another device must never quietly log someone out of the one they
+ * are working on, which is why the middle case is a prompt rather than a
+ * silent switch.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { DiscoveredRuntimeDevice } from '../../../../middleware/shared/ports'
+import { useProject, useRuntime } from '../../../../middleware/shared/providers'
+import { useOpenPLCStore } from '../../../store'
+import { cn } from '../../../utils/cn'
+import { nextStepForDevice } from '../../../services/retrieve-project-connection'
+import { toast } from '../../../utils/toast'
+import { Modal, ModalContent, ModalTitle } from '../../_molecules/modal'
+
+type Step = 'pick' | 'confirm-disconnect' | 'credentials' | 'working'
+
+const RetrieveProjectModal = () => {
+  const {
+    modals,
+    modalActions,
+    deviceActions,
+    workspaceActions,
+    sharedWorkspaceActions: { closeProject },
+  } = useOpenPLCStore()
+  const runtime = useRuntime()
+  const projectPort = useProject()
+  const runtimeIpAddress = useOpenPLCStore(
+    (state) => state.deviceDefinitions.configuration.runtimeIpAddress || '',
+  )
+
+  const isOpen = modals['retrieve-project']?.open || false
+
+  const [step, setStep] = useState<Step>('pick')
+  const [scanning, setScanning] = useState(false)
+  const [devices, setDevices] = useState<DiscoveredRuntimeDevice[]>([])
+  const [selected, setSelected] = useState<DiscoveredRuntimeDevice | null>(null)
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [busyMessage, setBusyMessage] = useState('')
+  const scanIdRef = useRef(0)
+
+  const close = useCallback(() => {
+    modalActions.onOpenChange('retrieve-project', false)
+    setStep('pick')
+    setDevices([])
+    setSelected(null)
+    setUsername('')
+    setPassword('')
+    setError('')
+    setBusyMessage('')
+  }, [modalActions])
+
+  const runScan = useCallback(async () => {
+    if (!runtime.discoverDevices) {
+      setError('Device discovery is not available on this platform.')
+      return
+    }
+    setError('')
+    setDevices([])
+    setSelected(null)
+    setScanning(true)
+
+    const scanId = ++scanIdRef.current
+    const result = await runtime.discoverDevices({ durationMs: 3000 })
+    if (scanId !== scanIdRef.current) return
+
+    if (!result.success) {
+      setError(result.error || 'Could not search the network.')
+    } else {
+      setDevices((previous) => {
+        const merged = new Map(previous.map((device) => [device.ipAddress, device]))
+        for (const device of result.devices ?? []) merged.set(device.ipAddress, device)
+        return Array.from(merged.values())
+      })
+    }
+    setScanning(false)
+  }, [runtime])
+
+  useEffect(() => {
+    if (!isOpen) return
+    if (!runtime.onDeviceDiscovered) {
+      void runScan()
+      return
+    }
+    // Subscribe before scanning so the first replies are not dropped.
+    const unsubscribe = runtime.onDeviceDiscovered((device) => {
+      setDevices((previous) =>
+        previous.some((existing) => existing.ipAddress === device.ipAddress)
+          ? previous
+          : [...previous, device],
+      )
+    })
+    void runScan()
+    return unsubscribe
+  }, [isOpen, runScan, runtime])
+
+  /** Fetch, unpack and open. Everything before this is about getting a session. */
+  const retrieveAndOpen = useCallback(
+    async (device: DiscoveredRuntimeDevice) => {
+      if (!runtime.retrieveProject) {
+        setError('Retrieving a project is not available on this platform.')
+        setStep('pick')
+        return
+      }
+
+      setStep('working')
+      setBusyMessage(`Retrieving ${device.projectName ?? 'the project'} from ${device.ipAddress}...`)
+
+      const retrieved = await runtime.retrieveProject(device.ipAddress)
+      if (!retrieved.success || !retrieved.projectPath) {
+        setError(retrieved.error || 'The device did not return a project.')
+        setStep('pick')
+        return
+      }
+
+      setBusyMessage('Opening the project...')
+      // Close the current project first so its unsaved-changes prompt runs
+      // before anything is replaced, exactly as File -> Close Project does.
+      closeProject()
+
+      const opened = await projectPort.openProjectByPath(retrieved.projectPath)
+      if (!opened.success) {
+        setError(opened.error?.description || 'The retrieved project could not be opened.')
+        setStep('pick')
+        return
+      }
+
+      // It lives in a scratch directory until the user picks a location, so the
+      // user-facing Save is refused and points at Save As. The build's own
+      // flush still runs -- the compiler reads source from disk.
+      workspaceActions.setIsEphemeralProject(true)
+
+      const missing = retrieved.libraries ?? []
+      toast({
+        title: `Retrieved "${retrieved.projectName ?? 'project'}"`,
+        description: missing.length
+          ? `Use Save As to keep it. It uses these libraries: ${missing.map((library) => library.name).join(', ')}.`
+          : 'This project has no location yet — use Save As to keep it.',
+        variant: 'default',
+      })
+      close()
+    },
+    [close, closeProject, projectPort, runtime, workspaceActions],
+  )
+
+  const handleContinueFromPick = useCallback(() => {
+    if (!selected) return
+    setError('')
+
+    const next = nextStepForDevice(runtimeIpAddress, selected.ipAddress)
+    if (next === 'retrieve') {
+      void retrieveAndOpen(selected)
+      return
+    }
+    setStep(next)
+  }, [retrieveAndOpen, runtimeIpAddress, selected])
+
+  const handleLogin = useCallback(async () => {
+    if (!selected) return
+    setError('')
+    setStep('working')
+    setBusyMessage(`Signing in to ${selected.ipAddress}...`)
+
+    // The address has to move BEFORE the login: the adapter reads it from the
+    // store to know which device to authenticate against. The user has already
+    // agreed to leave the previous device at this point, so a failed sign-in
+    // leaving the address changed is the outcome they asked for, not a
+    // surprise.
+    deviceActions.setRuntimeIpAddress(selected.ipAddress)
+
+    const result = await runtime.login({ username, password })
+    if (!result.success) {
+      setError(result.error || 'Could not sign in to that device.')
+      setStep('credentials')
+      return
+    }
+    await retrieveAndOpen(selected)
+  }, [deviceActions, password, retrieveAndOpen, runtime, selected, username])
+
+  const retrievable = (device: DiscoveredRuntimeDevice) => Boolean(device.projectName)
+
+  return (
+    <Modal open={isOpen} onOpenChange={(open) => !open && close()}>
+      <ModalContent className='flex h-[520px] w-[520px] select-none flex-col rounded-lg p-6'>
+        <ModalTitle className='mb-2 text-xl font-semibold'>Retrieve Project from PLC</ModalTitle>
+
+        {step === 'pick' && (
+          <>
+            <p className='mb-4 text-sm text-neutral-600 dark:text-neutral-400'>
+              Choose a device to retrieve its stored project. Devices that are not storing one cannot be
+              selected.
+            </p>
+
+            <div className='mb-3 flex items-center justify-between'>
+              <span className='text-sm font-medium text-neutral-850 dark:text-neutral-300'>
+                {scanning && (
+                  <span className='mr-2 inline-block h-3 w-3 animate-pulse rounded-full bg-brand align-middle' />
+                )}
+                {scanning ? 'Searching devices...' : `Found ${devices.length} device${devices.length === 1 ? '' : 's'}`}
+              </span>
+              <button
+                type='button'
+                onClick={() => void runScan()}
+                disabled={scanning}
+                className='rounded-md bg-neutral-100 px-3 py-1 text-xs font-medium text-neutral-1000 hover:bg-neutral-200 disabled:opacity-50 dark:bg-neutral-850 dark:text-neutral-100'
+              >
+                Rescan
+              </button>
+            </div>
+
+            <div className='flex-1 overflow-auto rounded-md border border-neutral-200 dark:border-neutral-800'>
+              {devices.length === 0 ? (
+                <div className='flex h-full items-center justify-center text-sm text-neutral-500 dark:text-neutral-400'>
+                  {scanning ? 'Waiting for responses...' : 'No devices replied.'}
+                </div>
+              ) : (
+                <ul className='divide-y divide-neutral-200 dark:divide-neutral-800'>
+                  {devices.map((device) => {
+                    const isSelected = selected?.ipAddress === device.ipAddress
+                    const canRetrieve = retrievable(device)
+                    return (
+                      <li key={device.ipAddress}>
+                        <button
+                          type='button'
+                          disabled={!canRetrieve}
+                          onClick={() => setSelected(device)}
+                          aria-selected={isSelected}
+                          className={cn(
+                            'flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-sm',
+                            !canRetrieve && 'cursor-not-allowed opacity-50',
+                            isSelected
+                              ? 'bg-brand/20 dark:bg-brand/30 font-bold shadow-[inset_3px_0_0_var(--primary-default)]'
+                              : 'text-neutral-850 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-850',
+                          )}
+                        >
+                          <span className='font-medium text-neutral-950 dark:text-white'>
+                            {device.projectName ?? 'No project stored'}
+                          </span>
+                          <span className='text-xs text-neutral-600 dark:text-neutral-400'>
+                            {device.hostname || '(unknown host)'} · {device.ipAddress}
+                            {device.runtimeVersion ? ` · ${device.runtimeVersion}` : ''}
+                            {device.projectTimestamp ? ` · ${formatTimestamp(device.projectTimestamp)}` : ''}
+                          </span>
+                        </button>
+                      </li>
+                    )
+                  })}
+                </ul>
+              )}
+            </div>
+          </>
+        )}
+
+        {step === 'confirm-disconnect' && selected && (
+          <div className='flex flex-1 flex-col justify-center gap-4 text-sm'>
+            <p className='text-neutral-850 dark:text-neutral-300'>
+              Retrieving a project from <strong>{selected.hostname || selected.ipAddress}</strong> requires
+              disconnecting from <strong>{runtimeIpAddress}</strong>.
+            </p>
+            <p className='text-neutral-600 dark:text-neutral-400'>
+              You will be signed in to the new device instead. Disconnect and continue?
+            </p>
+          </div>
+        )}
+
+        {step === 'credentials' && selected && (
+          <div className='flex flex-1 flex-col justify-center gap-3 text-sm'>
+            <p className='text-neutral-600 dark:text-neutral-400'>
+              Sign in to <strong>{selected.hostname || selected.ipAddress}</strong>. Retrieving a project
+              requires an administrator account on that device.
+            </p>
+            <input
+              autoFocus
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              placeholder='Username'
+              className='rounded-md border border-neutral-200 px-3 py-2 dark:border-neutral-800 dark:bg-neutral-900'
+            />
+            <input
+              type='password'
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              onKeyDown={(event) => event.key === 'Enter' && void handleLogin()}
+              placeholder='Password'
+              className='rounded-md border border-neutral-200 px-3 py-2 dark:border-neutral-800 dark:bg-neutral-900'
+            />
+          </div>
+        )}
+
+        {step === 'working' && (
+          <div className='flex flex-1 items-center justify-center text-sm text-neutral-600 dark:text-neutral-400'>
+            {busyMessage}
+          </div>
+        )}
+
+        {error && <p className='mt-3 text-sm text-red-600 dark:text-red-400'>{error}</p>}
+
+        <div className='mt-4 flex gap-3'>
+          {step === 'pick' && (
+            <button
+              type='button'
+              onClick={handleContinueFromPick}
+              disabled={!selected}
+              className='flex-1 rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-medium-dark disabled:opacity-50'
+            >
+              Retrieve
+            </button>
+          )}
+          {step === 'confirm-disconnect' && (
+            <button
+              type='button'
+              onClick={() => setStep('credentials')}
+              className='flex-1 rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-medium-dark'
+            >
+              Disconnect and continue
+            </button>
+          )}
+          {step === 'credentials' && (
+            <button
+              type='button'
+              onClick={() => void handleLogin()}
+              disabled={!username || !password}
+              className='flex-1 rounded-md bg-brand px-4 py-2 text-sm font-medium text-white hover:bg-brand-medium-dark disabled:opacity-50'
+            >
+              Sign in and retrieve
+            </button>
+          )}
+          <button
+            type='button'
+            onClick={close}
+            disabled={step === 'working'}
+            className='flex-1 rounded-md bg-neutral-100 px-4 py-2 text-sm font-medium text-neutral-1000 hover:bg-neutral-200 disabled:opacity-50 dark:bg-neutral-850 dark:text-neutral-100'
+          >
+            Cancel
+          </button>
+        </div>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+/** A device timestamp, shown as local time. Falls back to the raw string. */
+function formatTimestamp(value: string): string {
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleString()
+}
+
+export { RetrieveProjectModal }

--- a/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
+++ b/src/frontend/components/_organisms/workspace-activity-bar/default.tsx
@@ -187,9 +187,14 @@ export const DefaultWorkspaceActivityBar = ({ zoom }: DefaultWorkspaceActivityBa
   }, [isSimulatorBoard, isDebuggerVisible, simulator, addLog])
 
   const executeSave = useCallback(async (): Promise<boolean> => {
-    const result = await executeSaveProject(projectPort, capabilities)
+    // 'pre-build', not a user save: the compiler reads source from disk, so
+    // this flush has to run even for a project retrieved from a device that has
+    // no chosen location yet. Refusing it would not protect that project, it
+    // would just stop it compiling. The user-facing Save is the one that is
+    // gated, in executeSaveProject.
+    const result = await executeSaveProject(projectPort, capabilities, 'pre-build')
     return result.success
-  }, [projectPort])
+  }, [projectPort, capabilities])
 
   // ---------------------------------------------------------------------------
   // Build (Compile)

--- a/src/frontend/components/_templates/app-layout.tsx
+++ b/src/frontend/components/_templates/app-layout.tsx
@@ -11,7 +11,12 @@ import { ProjectModal } from '../_features/[start]/new-project/project-modal'
 import { AIConsentModal } from '../_features/[workspace]/editor/monaco/ai-consent-modal'
 import { DataTypeRenameImpactModal } from '../_molecules/rename-impact-modal/data-type-rename-impact-modal'
 import AboutModal from '../_organisms/about-modal'
-import { RuntimeCreateUserModal, RuntimeDiscoverDevicesModal, RuntimeLoginModal } from '../_organisms/modals'
+import {
+  RetrieveProjectModal,
+  RuntimeCreateUserModal,
+  RuntimeDiscoverDevicesModal,
+  RuntimeLoginModal,
+} from '../_organisms/modals'
 import { ConfirmDeleteProjectModal } from '../_organisms/modals/confirm-delete-project-modal'
 import { ConfirmInstallLibrariesModal } from '../_organisms/modals/confirm-install-libraries-modal'
 import { ConfirmPlcopenImportModal } from '../_organisms/modals/confirm-plcopen-import-modal'
@@ -162,6 +167,7 @@ const AppLayout = ({ children, ...rest }: AppLayoutProps): ReactNode => {
           {modals?.['runtime-login']?.open === true && <RuntimeLoginModal />}
           {modals?.['runtime-create-user']?.open === true && <RuntimeCreateUserModal />}
           {modals?.['runtime-discover-devices']?.open === true && <RuntimeDiscoverDevicesModal />}
+          {modals?.['retrieve-project']?.open === true && <RetrieveProjectModal />}
           {modals?.['ai-consent']?.open === true && <AIConsentModal />}
           <AboutModal />
           <AcceleratorHandler />

--- a/src/frontend/locales/en/menu.json
+++ b/src/frontend/locales/en/menu.json
@@ -18,6 +18,7 @@
       },
       "save": "Save File",
       "saveProject": "Save Project",
+      "retrieveProject": "Retrieve Project from PLC…",
       "saveAs": "Save As",
       "closeTab": "Close Tab",
       "closeProject": "Close Project",

--- a/src/frontend/services/__tests__/retrieve-project-connection.test.ts
+++ b/src/frontend/services/__tests__/retrieve-project-connection.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The three connection cases for Retrieve Project from PLC.
+ *
+ * The rule exists because `RuntimeApiClient` is single-device: signing in to
+ * another device replaces the session. That is a property worth keeping, so
+ * retrieving from elsewhere costs the current connection -- and the cost has to
+ * be visible. Browsing another device must never quietly sign someone out of
+ * the one they are working on.
+ */
+
+import { nextStepForDevice } from '../retrieve-project-connection'
+
+describe('nextStepForDevice', () => {
+  it('retrieves straight away from the device already connected', () => {
+    // Nothing to ask and nothing to disconnect: the session in hand is already
+    // authenticated against this device.
+    expect(nextStepForDevice('192.168.2.4', '192.168.2.4')).toBe('retrieve')
+  })
+
+  it('asks before giving up a session on a different device', () => {
+    expect(nextStepForDevice('192.168.2.4', '192.168.2.9')).toBe('confirm-disconnect')
+  })
+
+  it('goes straight to credentials when there is no session to lose', () => {
+    expect(nextStepForDevice('', '192.168.2.4')).toBe('credentials')
+  })
+
+  it('never silently switches devices', () => {
+    // The property, stated directly: any target that is not the connected
+    // device stops for the user before the session moves.
+    for (const target of ['192.168.2.9', '10.0.0.1', 'plc.local']) {
+      expect(nextStepForDevice('192.168.2.4', target)).not.toBe('retrieve')
+    }
+  })
+
+  it('treats an unknown connection as no connection rather than as a match', () => {
+    // An empty address must not accidentally equal an empty target and let a
+    // retrieve through with no session at all.
+    expect(nextStepForDevice('', '')).toBe('credentials')
+  })
+})

--- a/src/frontend/services/__tests__/save-actions.test.ts
+++ b/src/frontend/services/__tests__/save-actions.test.ts
@@ -65,6 +65,46 @@ describe('save-actions', () => {
   })
 
   describe('executeSaveProject', () => {
+    describe('a project retrieved from a device', () => {
+      // It lives in a scratch directory until the user picks a location.
+      // Writing there and reporting success would tell someone their work is
+      // safe when it is somewhere temporary.
+      afterEach(() => {
+        openPLCStoreBase.getState().workspaceActions.setIsEphemeralProject(false)
+      })
+
+      it('refuses a user save and says what to do instead', async () => {
+        openPLCStoreBase.getState().workspaceActions.setIsEphemeralProject(true)
+        const projectPort = makeProjectPort()
+
+        const result = await executeSaveProject(projectPort, capabilities)
+
+        expect(result.success).toBe(false)
+        expect(projectPort.saveProject).not.toHaveBeenCalled()
+        expect(lastToast()).toMatchObject({ title: 'This project has no location yet' })
+      })
+
+      it('still lets the build flush the project to disk', async () => {
+        // The compiler reads its source from disk, so refusing this would not
+        // protect the project -- it would stop it compiling. This is the whole
+        // reason the two saves are distinguishable.
+        openPLCStoreBase.getState().workspaceActions.setIsEphemeralProject(true)
+        const projectPort = makeProjectPort()
+
+        const result = await executeSaveProject(projectPort, capabilities, 'pre-build')
+
+        expect(result.success).toBe(true)
+        expect(projectPort.saveProject).toHaveBeenCalled()
+      })
+
+      it('leaves an ordinary project untouched', async () => {
+        const projectPort = makeProjectPort()
+        const result = await executeSaveProject(projectPort, capabilities)
+        expect(result.success).toBe(true)
+        expect(projectPort.saveProject).toHaveBeenCalled()
+      })
+    })
+
     it('reports success and clears the updated flag for a valid flow', async () => {
       createLadderPou('ValidPou')
 

--- a/src/frontend/services/retrieve-project-connection.ts
+++ b/src/frontend/services/retrieve-project-connection.ts
@@ -1,0 +1,29 @@
+/**
+ * What has to happen before a project can be retrieved from a device.
+ *
+ * `RuntimeApiClient` is deliberately single-device: one address, one token
+ * authority, and signing in replaces the session. Retrieving from somewhere
+ * else therefore costs the current connection, and the one thing that must
+ * never happen is that cost being paid silently -- browsing another device
+ * cannot quietly log someone out of the one they are working on.
+ *
+ * Kept out of the modal because this rule is the feature, not presentation.
+ */
+
+export type RetrieveConnectionStep =
+  /** Already signed in to this exact device; the session in hand is the right one. */
+  | 'retrieve'
+  /** Signed in elsewhere; say what continuing costs before taking it. */
+  | 'confirm-disconnect'
+  /** No session to lose; just ask who to sign in as. */
+  | 'credentials'
+
+/**
+ * `connectedIp` is the device the editor currently holds a session for, empty
+ * when there is none. `targetIp` is the device the user picked.
+ */
+export function nextStepForDevice(connectedIp: string, targetIp: string): RetrieveConnectionStep {
+  if (!connectedIp) return 'credentials'
+  if (connectedIp === targetIp) return 'retrieve'
+  return 'confirm-disconnect'
+}

--- a/src/frontend/services/save-actions.ts
+++ b/src/frontend/services/save-actions.ts
@@ -388,9 +388,25 @@ export function buildAllProjectFileContents(): Record<string, string> {
  * server error are all routine — so the success toast is load-bearing
  * confirmation the user needs.  Failure toasts fire on both builds.
  */
+/**
+ * Why a save is happening.
+ *
+ * The distinction exists for one case: a project retrieved from a device lives
+ * in a scratch directory until the user picks a location. A USER save there
+ * would report success for work written somewhere temporary, so it is refused
+ * and points at Save As. The build's own flush must still run, because the
+ * compiler reads its source from disk -- refusing it would not protect
+ * anything, it would just stop the project compiling.
+ *
+ * Defaults to `'user'` so every existing call site keeps the stricter meaning;
+ * only the build path opts out.
+ */
+export type SaveReason = 'user' | 'pre-build'
+
 export async function executeSaveProject(
   projectPort: ProjectPort,
   capabilities: PlatformCapabilities,
+  reason: SaveReason = 'user',
 ): Promise<{ success: boolean }> {
   // Run any pending debounced graphical write-backs before reading state:
   // a save landing inside the debounce window must serialize the fresh
@@ -413,6 +429,21 @@ export async function executeSaveProject(
     notifyNoWritePermission('save changes to')
     return { success: false }
   }
+
+  // A retrieved project has no location the user chose. Writing to the scratch
+  // directory and reporting success would tell someone their work is safe when
+  // it is somewhere temporary. The build's flush is exempt: it needs the tree
+  // on disk to compile, and scratch is a perfectly good place for that.
+  if (state.workspace.isEphemeralProject && reason === 'user') {
+    toast({
+      title: 'This project has no location yet',
+      description:
+        'It was retrieved from a device. Use Save As to choose where to keep it, then saving works as usual.',
+      variant: 'warn',
+    })
+    return { success: false }
+  }
+
   const { project, pendingDeletions } = state
   const { setEditingState } = state.workspaceActions
   const { setAllToSaved, updateFile } = state.fileActions

--- a/src/frontend/store/slices/modal/slice.ts
+++ b/src/frontend/store/slices/modal/slice.ts
@@ -18,6 +18,7 @@ const ALL_MODAL_TYPES: ModalTypes[] = [
   'quit-application',
   'runtime-create-user',
   'runtime-discover-devices',
+  'retrieve-project',
   'runtime-login',
   'server-ip-mismatch',
   'runtime-connection-lost',

--- a/src/frontend/store/slices/modal/types.ts
+++ b/src/frontend/store/slices/modal/types.ts
@@ -23,6 +23,7 @@ export type ModalTypes =
   | 'quit-application'
   | 'runtime-create-user'
   | 'runtime-discover-devices'
+  | 'retrieve-project'
   | 'runtime-login'
   | 'server-ip-mismatch'
   | 'runtime-connection-lost'

--- a/src/frontend/store/slices/workspace/slice.ts
+++ b/src/frontend/store/slices/workspace/slice.ts
@@ -59,6 +59,7 @@ const createWorkspaceSlice: StateCreator<WorkspaceSlice, [], [], WorkspaceSlice>
     projectLoadingMessage: '',
     // Persist-permission flag (backend write access on the open project)
     canEdit: true,
+    isEphemeralProject: false,
   },
 
   workspaceActions: {
@@ -433,6 +434,13 @@ const createWorkspaceSlice: StateCreator<WorkspaceSlice, [], [], WorkspaceSlice>
       setState(
         produce(({ workspace }: WorkspaceSlice) => {
           workspace.canEdit = value
+        }),
+      )
+    },
+    setIsEphemeralProject: (value: boolean) => {
+      setState(
+        produce(({ workspace }: WorkspaceSlice) => {
+          workspace.isEphemeralProject = value
         }),
       )
     },

--- a/src/frontend/store/slices/workspace/types.ts
+++ b/src/frontend/store/slices/workspace/types.ts
@@ -123,6 +123,20 @@ export type WorkspaceState = {
      * on project close.
      */
     canEdit: boolean
+    /**
+     * Whether the open project was retrieved from a device and has no location
+     * the user chose yet.
+     *
+     * It lives in a scratch directory, so `meta.path` is a real writable
+     * directory and everything that derives a path from it keeps working --
+     * including the pre-build flush, which is why a retrieved project can still
+     * be compiled and uploaded. What this gates is the USER-initiated save:
+     * writing to scratch and calling it saved would tell someone their work is
+     * safe when it is somewhere temporary. Save As clears the flag.
+     *
+     * Reset to `false` on project close and on any normally opened project.
+     */
+    isEphemeralProject: boolean
   }
 }
 
@@ -189,6 +203,7 @@ export type WorkspaceActions = {
   setProjectLoading: (isLoading: boolean, message?: string) => void
   // Persist-permission flag (backend write access on the open project)
   setCanEdit: (value: boolean) => void
+  setIsEphemeralProject: (value: boolean) => void
 }
 
 export type WorkspaceSlice = WorkspaceState & {

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -1,5 +1,8 @@
 import { ESIService } from '@root/backend/editor/ethercat'
 import { createDesktopCatalogTransport } from '@root/backend/editor/library-manager/desktop-catalog-transport'
+import { describeRetrievedLibraries } from '@root/backend/editor/project/describe-retrieved-libraries'
+import { materializeRetrievedProject } from '@root/backend/editor/project/materialize-retrieved-project'
+import type { ProjectSnapshotInfo } from '@root/backend/editor/runtime/runtime-api-client'
 import type {
   DebugBoardIdResult,
   DebugStatusResult,
@@ -9,11 +12,9 @@ import type {
 } from '@root/backend/shared/debug/types'
 import { parseESIDeviceFull } from '@root/backend/shared/ethercat/esi-parser-main'
 import { listPublicLibraries, PublicLibrarySchema } from '@root/backend/shared/library/public-catalog-client'
+import type { SnapshotMetadata } from '@root/backend/shared/project/project-snapshot-archive'
 import { PlcRuntimeState } from '@root/backend/shared/simulator/types'
 import { PLCProjectData } from '@root/backend/shared/types/PLC/open-plc'
-import { materializeRetrievedProject } from '@root/backend/editor/project/materialize-retrieved-project'
-import type { ProjectSnapshotInfo } from '@root/backend/editor/runtime/runtime-api-client'
-import type { SnapshotMetadata } from '@root/backend/shared/project/project-snapshot-archive'
 import { getErrorMessage } from '@root/frontend/utils/get-error-message'
 import type { CompileProgramIpcArgs } from '@root/middleware/adapters/editor/compile-program-flow'
 import { RuntimeLogEntry } from '@root/middleware/shared/ports'
@@ -529,6 +530,34 @@ class MainProcessBridge implements MainIpcModule {
   getRuntimeUsername = (): string | null => this.runtimeApi.tokens.getUsername()
 
   /**
+   * Install the libraries a retrieved project brought with it.
+   *
+   * The archives are re-read from the project's own archive rather than kept
+   * in memory between calls, so installing is always installing what that
+   * project actually carries. Each goes through the same strucpp validation as
+   * a library the user picked by hand -- an archive off a device earns no extra
+   * trust.
+   */
+  handleInstallRetrievedLibraries = async (
+    _event: IpcMainInvokeEvent,
+    projectPath: string,
+    names: string[],
+  ): Promise<{ success: boolean; installed: string[]; failed: Array<{ name: string; error: string }> }> => {
+    const archives = this.retrievedLibraries.get(projectPath) ?? []
+    const manager = new LibraryManagerModule()
+    const installed: string[] = []
+    const failed: Array<{ name: string; error: string }> = []
+
+    for (const library of archives) {
+      if (!names.includes(library.name)) continue
+      const result = await manager.installFromText(library.archive)
+      if (result.success) installed.push(library.name)
+      else failed.push({ name: library.name, error: result.error ?? 'Install failed' })
+    }
+    return { success: failed.length === 0, installed, failed }
+  }
+
+  /**
    * What a device says about the source project it stores.
    *
    * Authenticated but not admin-gated on the device, so the UI can decide
@@ -554,6 +583,17 @@ class MainProcessBridge implements MainIpcModule {
    * `materialize-retrieved-project` for what depends on the project having a
    * real path from the moment it is opened.
    */
+  /**
+   * Bundled library archives from the most recent retrievals, keyed by the
+   * project they came with.
+   *
+   * Kept here rather than sent to the renderer so the bytes never leave the
+   * process that validates them, and keyed by project path so installing
+   * always installs what THAT project carried rather than whatever was
+   * retrieved most recently.
+   */
+  private retrievedLibraries = new Map<string, Array<{ name: string; archive: string }>>()
+
   handleRuntimeRetrieveProject = async (
     _event: IpcMainInvokeEvent,
     ipAddress: string,
@@ -562,7 +602,7 @@ class MainProcessBridge implements MainIpcModule {
     projectPath?: string
     projectName?: string
     metadata?: SnapshotMetadata
-    libraries?: Array<{ name: string; version: string; hash: string }>
+    libraries?: Array<{ name: string; version: string; status: 'installed' | 'differs' | 'missing' }>
     error?: string
   }> => {
     const fetched = await this.runtimeApi.retrieveProjectSnapshot(ipAddress)
@@ -572,15 +612,21 @@ class MainProcessBridge implements MainIpcModule {
       const materialized = await materializeRetrievedProject(new Uint8Array(fetched.archive), {
         scratchRoot: join(app.getPath('userData'), 'retrieved-projects'),
       })
+      this.retrievedLibraries.set(
+        materialized.projectPath,
+        materialized.libraries.map(({ name, archive }) => ({ name, archive })),
+      )
       return {
         success: true,
         projectPath: materialized.projectPath,
         projectName: materialized.projectName,
         metadata: materialized.metadata,
-        // Names only: the renderer decides what to offer installing, and the
-        // archives themselves stay in the main process where the library
-        // manager can write them.
-        libraries: materialized.libraries.map(({ name, version, hash }) => ({ name, version, hash })),
+        // Status, not archives. The renderer decides what to offer; the bytes
+        // stay in the main process where the library manager can write them,
+        // and are re-read from the same archive when the user says yes.
+        libraries: await describeRetrievedLibraries(materialized.libraries, (name) =>
+          new LibraryManagerModule().readArchiveText(name),
+        ),
       }
     } catch (error) {
       return { success: false, error: getErrorMessage(error) }
@@ -747,6 +793,7 @@ class MainProcessBridge implements MainIpcModule {
     this.registerHandle('runtime:discover-devices', this.handleRuntimeDiscoverDevices)
     this.registerHandle('runtime:project-snapshot-info', this.handleRuntimeProjectSnapshotInfo)
     this.registerHandle('runtime:retrieve-project', this.handleRuntimeRetrieveProject)
+    this.registerHandle('runtime:install-retrieved-libraries', this.handleInstallRetrievedLibraries)
 
     // ===================== ETHERCAT DISCOVERY =====================
     this.registerHandle('ethercat:get-interfaces', this.handleEtherCATGetInterfaces)

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -515,9 +515,15 @@ class MainProcessBridge implements MainIpcModule {
     filename: string
     contentType: string
     cleanBuild: boolean
+    snapshotBuffer?: Buffer
+    snapshotMetadata?: string
     onUploadAccepted?: (responseBody: string) => void
   }): Promise<{ success: true; data: string } | { success: false; error: string }> =>
     this.runtimeApi.makeRuntimeApiUpload(opts)
+
+  /** Username of the live runtime session, so an uploaded project can record
+   *  who stored it. Only the username crosses this boundary. */
+  getRuntimeUsername = (): string | null => this.runtimeApi.tokens.getUsername()
 
   private makeRuntimeApiMutation = (
     method: 'POST' | 'PUT' | 'DELETE',

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -11,6 +11,9 @@ import { parseESIDeviceFull } from '@root/backend/shared/ethercat/esi-parser-mai
 import { listPublicLibraries, PublicLibrarySchema } from '@root/backend/shared/library/public-catalog-client'
 import { PlcRuntimeState } from '@root/backend/shared/simulator/types'
 import { PLCProjectData } from '@root/backend/shared/types/PLC/open-plc'
+import { materializeRetrievedProject } from '@root/backend/editor/project/materialize-retrieved-project'
+import type { ProjectSnapshotInfo } from '@root/backend/editor/runtime/runtime-api-client'
+import type { SnapshotMetadata } from '@root/backend/shared/project/project-snapshot-archive'
 import { getErrorMessage } from '@root/frontend/utils/get-error-message'
 import type { CompileProgramIpcArgs } from '@root/middleware/adapters/editor/compile-program-flow'
 import { RuntimeLogEntry } from '@root/middleware/shared/ports'
@@ -525,6 +528,65 @@ class MainProcessBridge implements MainIpcModule {
    *  who stored it. Only the username crosses this boundary. */
   getRuntimeUsername = (): string | null => this.runtimeApi.tokens.getUsername()
 
+  /**
+   * What a device says about the source project it stores.
+   *
+   * Authenticated but not admin-gated on the device, so the UI can decide
+   * whether to offer retrieval without holding the privilege retrieval needs.
+   */
+  handleRuntimeProjectSnapshotInfo = async (
+    _event: IpcMainInvokeEvent,
+    ipAddress: string,
+  ): Promise<{ success: boolean; info?: ProjectSnapshotInfo; error?: string }> => {
+    const result = await this.runtimeApi.getProjectSnapshotInfo(ipAddress)
+    return result.success ? { success: true, info: result.info } : { success: false, error: result.error }
+  }
+
+  /**
+   * Retrieve the stored project and write it to a scratch directory.
+   *
+   * Fetch and unpack are one IPC call because the archive should not sit in the
+   * renderer at all: it is untrusted bytes from a device, and every check that
+   * decides whether it is safe to write lives next to the write. The renderer
+   * gets back a path and a description, never the archive.
+   *
+   * The scratch location is why this works at all -- see
+   * `materialize-retrieved-project` for what depends on the project having a
+   * real path from the moment it is opened.
+   */
+  handleRuntimeRetrieveProject = async (
+    _event: IpcMainInvokeEvent,
+    ipAddress: string,
+  ): Promise<{
+    success: boolean
+    projectPath?: string
+    projectName?: string
+    metadata?: SnapshotMetadata
+    libraries?: Array<{ name: string; version: string; hash: string }>
+    error?: string
+  }> => {
+    const fetched = await this.runtimeApi.retrieveProjectSnapshot(ipAddress)
+    if (!fetched.success) return { success: false, error: fetched.error }
+
+    try {
+      const materialized = await materializeRetrievedProject(new Uint8Array(fetched.archive), {
+        scratchRoot: join(app.getPath('userData'), 'retrieved-projects'),
+      })
+      return {
+        success: true,
+        projectPath: materialized.projectPath,
+        projectName: materialized.projectName,
+        metadata: materialized.metadata,
+        // Names only: the renderer decides what to offer installing, and the
+        // archives themselves stay in the main process where the library
+        // manager can write them.
+        libraries: materialized.libraries.map(({ name, version, hash }) => ({ name, version, hash })),
+      }
+    } catch (error) {
+      return { success: false, error: getErrorMessage(error) }
+    }
+  }
+
   private makeRuntimeApiMutation = (
     method: 'POST' | 'PUT' | 'DELETE',
     ipAddress: string,
@@ -683,6 +745,8 @@ class MainProcessBridge implements MainIpcModule {
     this.registerHandle('runtime:clear-credentials', this.handleRuntimeClearCredentials)
     this.registerHandle('runtime:get-serial-ports', this.handleRuntimeGetSerialPorts)
     this.registerHandle('runtime:discover-devices', this.handleRuntimeDiscoverDevices)
+    this.registerHandle('runtime:project-snapshot-info', this.handleRuntimeProjectSnapshotInfo)
+    this.registerHandle('runtime:retrieve-project', this.handleRuntimeRetrieveProject)
 
     // ===================== ETHERCAT DISCOVERY =====================
     this.registerHandle('ethercat:get-interfaces', this.handleEtherCATGetInterfaces)

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -618,9 +618,15 @@ const rendererProcessBridge = {
     projectPath?: string
     projectName?: string
     metadata?: RuntimeProjectSnapshotMetadata
-    libraries?: Array<{ name: string; version: string; hash: string }>
+    libraries?: Array<{ name: string; version: string; status: 'installed' | 'differs' | 'missing' }>
     error?: string
   }> => ipcRenderer.invoke('runtime:retrieve-project', ipAddress),
+  /** Install libraries a retrieved project brought with it, by name. */
+  runtimeInstallRetrievedLibraries: (
+    projectPath: string,
+    names: string[],
+  ): Promise<{ success: boolean; installed: string[]; failed: Array<{ name: string; error: string }> }> =>
+    ipcRenderer.invoke('runtime:install-retrieved-libraries', projectPath, names),
   onRuntimeDeviceDiscovered: (callback: (_event: IpcRendererEvent, device: DiscoveredRuntimeDevice) => void) => {
     ipcRenderer.on('runtime:device-discovered', callback)
     return () => ipcRenderer.removeListener('runtime:device-discovered', callback)

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -1,5 +1,10 @@
 import type { CompileProgramIpcArgs } from '@root/middleware/adapters/editor/compile-program-flow'
-import type { DiscoveredRuntimeDevice, RuntimeLogEntry } from '@root/middleware/shared/ports'
+import type {
+  DiscoveredRuntimeDevice,
+  RuntimeLogEntry,
+  RuntimeProjectSnapshotInfo,
+  RuntimeProjectSnapshotMetadata,
+} from '@root/middleware/shared/ports'
 import type {
   DeviceConnectionStatusPayload,
   DeviceLicenseReport,
@@ -594,6 +599,28 @@ const rendererProcessBridge = {
     durationMs?: number
   }): Promise<{ success: boolean; devices?: DiscoveredRuntimeDevice[]; error?: string }> =>
     ipcRenderer.invoke('runtime:discover-devices', opts),
+  /** What a device says about the project it stores; `present: false` when none. */
+  runtimeProjectSnapshotInfo: (
+    ipAddress: string,
+  ): Promise<{ success: boolean; info?: RuntimeProjectSnapshotInfo; error?: string }> =>
+    ipcRenderer.invoke('runtime:project-snapshot-info', ipAddress),
+  /**
+   * Retrieve the stored project and unpack it to a scratch directory.
+   *
+   * Returns a path, never the archive: those are untrusted bytes from a device,
+   * and every check deciding whether they are safe to write lives beside the
+   * write in the main process.
+   */
+  runtimeRetrieveProject: (
+    ipAddress: string,
+  ): Promise<{
+    success: boolean
+    projectPath?: string
+    projectName?: string
+    metadata?: RuntimeProjectSnapshotMetadata
+    libraries?: Array<{ name: string; version: string; hash: string }>
+    error?: string
+  }> => ipcRenderer.invoke('runtime:retrieve-project', ipAddress),
   onRuntimeDeviceDiscovered: (callback: (_event: IpcRendererEvent, device: DiscoveredRuntimeDevice) => void) => {
     ipcRenderer.on('runtime:device-discovered', callback)
     return () => ipcRenderer.removeListener('runtime:device-discovered', callback)

--- a/src/middleware/adapters/editor/runtime-adapter.ts
+++ b/src/middleware/adapters/editor/runtime-adapter.ts
@@ -250,5 +250,23 @@ export function createEditorRuntimeAdapter(getIpAddress: () => string): RuntimeP
       const handler = (_event: unknown, device: DiscoveredRuntimeDevice) => callback(device)
       return window.bridge.onRuntimeDeviceDiscovered(handler)
     },
+
+    // --- stored source project ---
+
+    async getProjectSnapshotInfo(ipAddress: string) {
+      try {
+        return await window.bridge.runtimeProjectSnapshotInfo(ipAddress)
+      } catch (err) {
+        return { success: false, error: getErrorMessage(err) }
+      }
+    },
+
+    async retrieveProject(ipAddress: string) {
+      try {
+        return await window.bridge.runtimeRetrieveProject(ipAddress)
+      } catch (err) {
+        return { success: false, error: getErrorMessage(err) }
+      }
+    },
   }
 }

--- a/src/middleware/adapters/editor/runtime-adapter.ts
+++ b/src/middleware/adapters/editor/runtime-adapter.ts
@@ -268,5 +268,13 @@ export function createEditorRuntimeAdapter(getIpAddress: () => string): RuntimeP
         return { success: false, error: getErrorMessage(err) }
       }
     },
+
+    async installRetrievedLibraries(projectPath: string, names: string[]) {
+      try {
+        return await window.bridge.runtimeInstallRetrievedLibraries(projectPath, names)
+      } catch (err) {
+        return { success: false, installed: [], failed: [{ name: '', error: getErrorMessage(err) }] }
+      }
+    },
   }
 }

--- a/src/middleware/shared/ports/index.ts
+++ b/src/middleware/shared/ports/index.ts
@@ -156,6 +156,8 @@ export type {
   DiscoverDevicesOptions,
   DiscoverDevicesResult,
   DiscoveredRuntimeDevice,
+  RuntimeProjectSnapshotInfo,
+  RuntimeProjectSnapshotMetadata,
   LoginParams,
   LoginResult,
   RuntimeLogsResult,

--- a/src/middleware/shared/ports/runtime-port.ts
+++ b/src/middleware/shared/ports/runtime-port.ts
@@ -152,6 +152,38 @@ export interface DiscoveredRuntimeDevice {
   hostname: string
   runtimeVersion: string
   apiPort: number
+  /** Name of the source project the device is storing, when it has one.
+   *
+   *  Carried on the unauthenticated discovery reply so the retrieve picker can
+   *  be populated without logging in to every device on the network. Display
+   *  only: it is whatever the uploading client said, the device never opened
+   *  the archive to check, and the authoritative name comes from the archive
+   *  itself once retrieved. Absent means the device stores no project. */
+  projectName?: string
+  /** When that project was stored, ISO 8601. Absent alongside `projectName`. */
+  projectTimestamp?: string
+}
+
+/** What a device reports about the project it stores, once authenticated. */
+export interface RuntimeProjectSnapshotInfo {
+  present: boolean
+  projectName?: string
+  editorVersion?: string
+  uploadedBy?: string
+  timestamp?: string
+  sizeBytes?: number
+  formatVersion?: number
+  libraries?: Array<{ name: string; version?: string; hash?: string }>
+}
+
+/** The manifest carried inside a retrieved archive. */
+export interface RuntimeProjectSnapshotMetadata {
+  formatVersion: number
+  projectName: string
+  editorVersion: string
+  uploadedBy: string
+  timestamp: string
+  libraries: Array<{ name: string; version: string; hash: string }>
 }
 
 export interface DiscoverDevicesOptions {

--- a/src/middleware/shared/ports/runtime-port.ts
+++ b/src/middleware/shared/ports/runtime-port.ts
@@ -317,4 +317,32 @@ export interface RuntimePort {
 
   /** Get EtherCAT runtime status (plugin state, slave status, cycle metrics). */
   getEthercatRuntimeStatus?(): Promise<{ success: boolean; data?: EtherCATRuntimeStatusResponse; error?: string }>
+
+  // --- stored source project ---
+
+  /**
+   * What a device says about the source project it stores.
+   *
+   * Authenticated but not admin-gated on the device, so the UI can decide
+   * whether to offer retrieval without holding the privilege retrieval needs.
+   */
+  getProjectSnapshotInfo?(
+    ipAddress: string,
+  ): Promise<{ success: boolean; info?: RuntimeProjectSnapshotInfo; error?: string }>
+
+  /**
+   * Retrieve the stored project and unpack it somewhere the editor can open it.
+   *
+   * Returns a path, never the archive. Those are untrusted bytes from a device,
+   * and every check deciding whether they are safe to write belongs beside the
+   * write rather than in the renderer.
+   */
+  retrieveProject?(ipAddress: string): Promise<{
+    success: boolean
+    projectPath?: string
+    projectName?: string
+    metadata?: RuntimeProjectSnapshotMetadata
+    libraries?: Array<{ name: string; version: string; hash: string }>
+    error?: string
+  }>
 }

--- a/src/middleware/shared/ports/runtime-port.ts
+++ b/src/middleware/shared/ports/runtime-port.ts
@@ -342,7 +342,13 @@ export interface RuntimePort {
     projectPath?: string
     projectName?: string
     metadata?: RuntimeProjectSnapshotMetadata
-    libraries?: Array<{ name: string; version: string; hash: string }>
+    libraries?: Array<{ name: string; version: string; status: 'installed' | 'differs' | 'missing' }>
     error?: string
   }>
+
+  /** Install libraries a retrieved project brought with it, by name. */
+  installRetrievedLibraries?(
+    projectPath: string,
+    names: string[],
+  ): Promise<{ success: boolean; installed: string[]; failed: Array<{ name: string; error: string }> }>
 }

--- a/src/middleware/shared/runtime-auth/runtime-token-manager.ts
+++ b/src/middleware/shared/runtime-auth/runtime-token-manager.ts
@@ -45,6 +45,12 @@ export interface RuntimeTokenManager {
   getToken(): string | null
   /** Whether a usable token is currently held. */
   hasToken(): boolean
+  /** Username of the live session, or null when there is none.
+   *
+   *  Only the username: the password stays private to this module. Callers
+   *  want it to attribute an action to an account -- the project snapshot
+   *  records who uploaded -- not to authenticate with it. */
+  getUsername(): string | null
   /** Adopt a token + the credentials that produced it (called on login). */
   setSession(token: string, credentials: RuntimeCredentials): void
   /** Forget the token and credentials (called on logout). */
@@ -79,6 +85,10 @@ export function createRuntimeTokenManager(transport: TokenLoginTransport): Runti
 
   function getToken(): string | null {
     return token
+  }
+
+  function getUsername(): string | null {
+    return credentials?.username ?? null
   }
 
   function hasToken(): boolean {
@@ -139,5 +149,5 @@ export function createRuntimeTokenManager(transport: TokenLoginTransport): Runti
     }
   }
 
-  return { getToken, hasToken, setSession, clear, refresh, withAuth, onTokenChanged }
+  return { getToken, getUsername, hasToken, setSession, clear, refresh, withAuth, onTokenChanged }
 }


### PR DESCRIPTION
Part of RTOP-272. The editor half: every upload now carries the source project, and there is a File menu entry to pull one back off a device.

## Upload

The archive is assembled **from the project on disk**, not from the renderer's store. The build path already saves everything before compiling — the compiler reads its source from disk, so it must — which means the on-disk tree *is* the project the artifacts were built from. Serialising the store again would create a second source of truth that could disagree with what was actually compiled.

`build/` never travels: it is the bulk of a project and the device already has the artifacts, since they are the other half of the same upload.

Nothing on this path can fail an upload. A runtime without snapshot support ignores the extra multipart parts, so there is no capability probe.

## Retrieve

Fetch and unpack are **one IPC call**. The archive is untrusted bytes from a device, and every check deciding whether it is safe to write lives beside the write. The renderer gets a path and a description, never the bytes.

A rejected archive writes nothing — destinations are resolved and checked for containment before the first byte, so there is no half-written project left looking openable. The project name is treated as the untrusted path segment it is.

403 and 404 are translated rather than passed through: "this account is not an administrator there" and "that device stores no project" are real answers, and reporting either as a raw transport error sends people hunting a network problem that does not exist.

## The three connection cases

`RuntimeApiClient` is deliberately single-device, so retrieving from elsewhere costs the current connection. That cost is never paid silently:

- **same device already connected** → retrieve straight away, no prompt, no re-login
- **a different device** → say plainly what continuing disconnects, then ask for credentials
- **not connected** → just ask for credentials

The rule lives in `retrieve-project-connection.ts` with its own tests, because it is the feature rather than presentation.

## Opening a retrieved project

It lands in a scratch directory and is marked ephemeral. `meta.path` is then always a real writable directory and never the previously open project's path — every write in `save-actions` derives from `meta.path`, so loading a retrieved project while the store still pointed at the old one would save its contents over the user's actual work.

The user-facing Save is refused and points at Save As. **The build's pre-build flush is exempt**, and that split is the whole trick: the compiler reads source from disk, so blocking every save would not protect the project, it would stop it compiling and take upload with it. `executeSaveProject` takes a reason defaulting to `'user'`, so every existing call site keeps the stricter meaning.

## Libraries

Each bundled library is classified against the local pool as `installed`, `missing`, or `differs`, and the ones that are not already here are offered for install.

`differs` is why the comparison exists: same name, different bytes, silently different program. Reporting that as "already installed" would actively mislead. Status is decided by **content hash, not version** — a version is a label someone types, and two builds can share one. Archives install through the same strucpp validation as a hand-picked library.

## Testing

Editor suite: **7519 passing**, typecheck and lint clean, no raw control bytes in any changed file.

Verified on the hardware device via the real CLI (`openplc-cli create` → `upload` → retrieve):

| Check | Result |
|---|---|
| CLI upload stores the snapshot; `uploadedBy: "op"` | pass |
| `main.st` byte-identical to the project on disk | pass |
| `build/` present locally, **absent** from the archive | pass |
| Retrieve → materialize produces exactly the project tree | pass |
| Non-admin account: `info` works, `retrieve` refused with the plain-language message | pass |
| Discovery advertises project name + timestamp | pass |

**The CLI needed no upload code of its own** — it inherited the path, which is the property the headless bridge exists to preserve. One gap that testing caught: `uploadedBy` came back empty from the CLI because its bridge is a separate implementation and lacked the username accessor, so it would have stored projects attributed to nobody while the GUI attributed them correctly. Wired and re-verified.

Two other things caught in my own work: staging a snapshot before the extract could strand it for the *next* build to promote (fixed, with a regression test), and the size limits in the shared archive module had no test proving they fire — the first attempt at one passed vacuously against a STORE-mode fixture with no compression ratio to judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bpea15BYCgPSqpatpveRk1