### PR TITLE
RTOP-276 Editor: identify a library by canonical content, not raw bytes

### DIFF
--- a/src/backend/editor/project/build-upload-snapshot.ts
+++ b/src/backend/editor/project/build-upload-snapshot.ts
@@ -18,7 +18,7 @@ import { join, relative, sep } from 'path'
 
 import {
   buildProjectSnapshot,
-  hashText,
+  hashLibraryArchive,
   type SnapshotLibrary,
 } from '../../shared/project/project-snapshot-archive'
 
@@ -133,7 +133,7 @@ export async function buildUploadSnapshot(
       libraries.push({
         name,
         version: readLibraryVersion(archive),
-        hash: await hashText(archive),
+        hash: await hashLibraryArchive(archive),
         archive,
       })
     }

--- a/src/backend/editor/project/describe-retrieved-libraries.ts
+++ b/src/backend/editor/project/describe-retrieved-libraries.ts
@@ -17,7 +17,7 @@
  * Electron-bound; this keeps the rule testable without standing up an app.
  */
 
-import { hashText, type SnapshotLibrary } from '../../shared/project/project-snapshot-archive'
+import { hashLibraryArchive, type SnapshotLibrary } from '../../shared/project/project-snapshot-archive'
 
 export type RetrievedLibraryStatus = 'installed' | 'differs' | 'missing'
 
@@ -42,7 +42,7 @@ export async function describeRetrievedLibraries(
       described.push({ name: library.name, version: library.version, status: 'missing' })
       continue
     }
-    const localHash = await hashText(local)
+    const localHash = await hashLibraryArchive(local)
     described.push({
       name: library.name,
       version: library.version,

--- a/src/backend/shared/project/__tests__/project-snapshot-archive.test.ts
+++ b/src/backend/shared/project/__tests__/project-snapshot-archive.test.ts
@@ -15,6 +15,7 @@ import JSZip from 'jszip'
 import type { WriteProjectFiles } from '../../../../middleware/shared/ports/project-port'
 import {
   buildProjectSnapshot,
+  hashLibraryArchive,
   hashText,
   parseProjectSnapshot,
   SNAPSHOT_FORMAT_VERSION,
@@ -185,6 +186,29 @@ describe('libraries', () => {
     const { archive } = await build({ libraries: [a, b] })
     const parsed = await parseProjectSnapshot(archive)
     expect(parsed.libraries.map((l) => l.archive).sort()).toEqual(['A', 'B'])
+  })
+})
+
+describe('library identity', () => {
+  it('ignores formatting so the two clients agree on the same library', async () => {
+    // The editor holds an installed FILE; web holds the same archive parsed in
+    // memory and never sees a file. Hashing raw text would make every project
+    // uploaded from one and opened in the other report as differing -- the
+    // exact false alarm the comparison exists to avoid.
+    const pretty = JSON.stringify({ manifest: { name: 'Motion', version: '1' } }, null, 2)
+    const compact = JSON.stringify({ manifest: { name: 'Motion', version: '1' } })
+    expect(await hashLibraryArchive(pretty)).toBe(await hashLibraryArchive(compact))
+  })
+
+  it('still distinguishes a genuinely different archive', async () => {
+    const theirs = JSON.stringify({ manifest: { name: 'Motion', version: '1' }, body: 'a' })
+    const mine = JSON.stringify({ manifest: { name: 'Motion', version: '1' }, body: 'b' })
+    expect(await hashLibraryArchive(theirs)).not.toBe(await hashLibraryArchive(mine))
+  })
+
+  it('falls back to hashing the bytes when the archive is not JSON', async () => {
+    // No canonical form exists, and a stable hash of the bytes beats none.
+    expect(await hashLibraryArchive('not json')).toBe(await hashText('not json'))
   })
 })
 

--- a/src/backend/shared/project/project-snapshot-archive.ts
+++ b/src/backend/shared/project/project-snapshot-archive.ts
@@ -137,6 +137,29 @@ export async function hashText(text: string): Promise<string> {
 }
 
 /**
+ * Identity of a `.stlib` archive, for telling "same library" from "same name
+ * and version, different bytes".
+ *
+ * Hashes a canonical re-serialisation rather than the raw text, because the two
+ * clients do not have the same bytes to offer. The editor holds the file it
+ * installed; web holds the archive parsed into memory and never sees a file at
+ * all. Hashing raw text would make every project uploaded from one and opened
+ * in the other report as differing, which is precisely the false alarm this
+ * comparison exists to avoid raising.
+ *
+ * Unparseable text falls back to hashing it verbatim: an archive that is not
+ * JSON has no canonical form, and a stable hash of the bytes is still better
+ * than none.
+ */
+export async function hashLibraryArchive(archiveText: string): Promise<string> {
+  try {
+    return await hashText(JSON.stringify(JSON.parse(archiveText)))
+  } catch {
+    return hashText(archiveText)
+  }
+}
+
+/**
  * Reject anything that would escape the destination directory when written.
  *
  * Path traversal is the check that actually matters here: a bomb only exhausts

--- a/src/middleware/shared/ports/runtime-port.ts
+++ b/src/middleware/shared/ports/runtime-port.ts
@@ -261,7 +261,13 @@ export interface RuntimePort {
    * Web adapter: sends zip as base64.
    * Editor adapter: sends via file path or streamed content.
    */
-  uploadProgram?(programData: string | ArrayBuffer): Promise<{ success: boolean; error?: string }>
+  uploadProgram?(
+    programData: string | ArrayBuffer,
+    /** The source project to store on the device alongside the program, so it
+     *  can be retrieved later. Optional: a runtime without snapshot support
+     *  ignores it, and an upload is complete without one. */
+    snapshot?: { archiveBase64: string; metadata: string },
+  ): Promise<{ success: boolean; error?: string }>
 
   /**
    * Subscribe to token refresh events (e.g., JWT auto-renewal).


### PR DESCRIPTION
Part of RTOP-272, and a prerequisite for the web half.

The editor holds the `.stlib` **file** it installed. Web holds the same archive **parsed in memory** and never sees a file at all. Hashing raw text made those two disagree about every library, so a project uploaded from one and opened in the other would report each library as "same name, different bytes" — precisely the false alarm this comparison exists to raise only when it is real.

Hashes a canonical re-serialisation instead. That also stops a difference in whitespace between two copies of the same library reading as a difference in the library.

Text that will not parse falls back to hashing the bytes: there is no canonical form for it, and a stable hash still beats none.

Found while building the web mirror — the two platforms simply do not have the same bytes to offer, and nothing in the editor-only tests could have surfaced it.

## Testing

Editor suite: 7522 passing. Three new cases: formatting-insensitive, genuinely-different still differs, non-JSON falls back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bpea15BYCgPSqpatpveRk1