### PR TITLE
RTOP-280 Editor: implement Save As

### DIFF
--- a/src/frontend/components/_molecules/menu-bar/menus/file.tsx
+++ b/src/frontend/components/_molecules/menu-bar/menus/file.tsx
@@ -6,6 +6,7 @@ import { useHandleRemoveTab } from '../../../../hooks/use-remove-tab'
 import { i18n } from '../../../../locales/i18n'
 import { executeExportPlcopen } from '../../../../services/export-actions'
 import { executeSaveActiveFile, executeSaveProject } from '../../../../services/save-actions'
+import { executeSaveProjectAs } from '../../../../services/save-project-as'
 import { useOpenPLCStore } from '../../../../store'
 import { MenuClasses } from '../constants'
 
@@ -47,6 +48,12 @@ export const FileMenu = () => {
     }
   }
 
+  const handleSaveProjectAs = () => {
+    if (!isSaving) {
+      void executeSaveProjectAs(projectPort, capabilities)
+    }
+  }
+
   const handleCloseTab = () => {
     handleRemoveTab(selectedTab)
   }
@@ -74,6 +81,9 @@ export const FileMenu = () => {
           <MenuPrimitive.Item className={ITEM} onClick={handleSaveProject} disabled={isSaving}>
             <span>{i18n.t('menu:file.submenu.saveProject')}</span>
             <span className={ACCELERATOR}>{'Ctrl + Shift + S'}</span>
+          </MenuPrimitive.Item>
+          <MenuPrimitive.Item className={ITEM} onClick={handleSaveProjectAs} disabled={isSaving}>
+            <span>{i18n.t('menu:file.submenu.saveAs')}</span>
           </MenuPrimitive.Item>
           <MenuPrimitive.Item className={ITEM} onClick={handleCloseTab}>
             <span>{i18n.t('menu:file.submenu.closeTab')}</span>

--- a/src/frontend/components/_templates/accelerator-handler.tsx
+++ b/src/frontend/components/_templates/accelerator-handler.tsx
@@ -9,6 +9,7 @@ import {
   useWindow,
 } from '../../../middleware/shared/providers'
 import { executeSaveActiveFile, executeSaveProject } from '../../services/save-actions'
+import { executeSaveProjectAs } from '../../services/save-project-as'
 import { openPLCStoreBase, useOpenPLCStore } from '../../store'
 import type { ModalTypes } from '../../store/slices/modal'
 import { toast } from '../_features/[app]/toast/use-toast'
@@ -208,6 +209,16 @@ const AcceleratorHandler = () => {
     })
     return unsub
   }, [accelerator, executeSave])
+
+  /**
+   * Save As (Cmd+Shift+A)
+   */
+  useEffect(() => {
+    const unsub = accelerator.onSaveProjectAs(() => {
+      void executeSaveProjectAs(projectPort, capabilities)
+    })
+    return unsub
+  }, [accelerator, capabilities, projectPort])
 
   /**
    * Delete file

--- a/src/frontend/services/__tests__/save-project-as.test.ts
+++ b/src/frontend/services/__tests__/save-project-as.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Giving a project a new home.
+ *
+ * The ordering is the substance here. A project retrieved from a device refuses
+ * a user save and points at Save As, so Save As is the only way out for it --
+ * which means a failed one must leave that refusal intact. Adopting the
+ * destination before the write succeeds would clear the very marker protecting
+ * the project, and leave it pointing at a directory that does not contain it.
+ */
+
+import type { PlatformCapabilities } from '../../../middleware/shared/ports/platform-capabilities'
+import type { ProjectPort } from '../../../middleware/shared/ports/project-port'
+import { openPLCStoreBase } from '../../store'
+import { executeSaveProjectAs } from '../save-project-as'
+
+const capabilities = { isNativeApplication: true } as PlatformCapabilities
+
+function makePort(overrides: Partial<ProjectPort> = {}): ProjectPort {
+  return {
+    pickPath: () => Promise.resolve({ success: true, path: '/chosen/place' }),
+    saveProject: () => Promise.resolve({ success: true }),
+    ...overrides,
+  } as unknown as ProjectPort
+}
+
+const workspace = () => openPLCStoreBase.getState().workspace
+const projectPath = () => openPLCStoreBase.getState().project.meta.path
+
+beforeEach(() => {
+  openPLCStoreBase.getState().workspaceActions.setIsEphemeralProject(true)
+  openPLCStoreBase.getState().projectActions.updateMetaPath('/scratch/original')
+})
+
+afterEach(() => {
+  openPLCStoreBase.getState().workspaceActions.setIsEphemeralProject(false)
+})
+
+it('writes the project to the chosen folder and adopts it', async () => {
+  let written: { projectPath?: string } | undefined
+  const port = makePort({
+    saveProject: (files) => {
+      written = files
+      return Promise.resolve({ success: true })
+    },
+  })
+
+  const result = await executeSaveProjectAs(port, capabilities)
+
+  expect(result.success).toBe(true)
+  expect(written?.projectPath).toBe('/chosen/place')
+  expect(projectPath()).toBe('/chosen/place')
+})
+
+it('clears the ephemeral marker so an ordinary save works from then on', async () => {
+  // The whole reason Save As exists for a retrieved project.
+  await executeSaveProjectAs(makePort(), capabilities)
+  expect(workspace().isEphemeralProject).toBe(false)
+})
+
+it('leaves everything untouched when the write fails', async () => {
+  // Adopting the destination first would point the project at a folder that
+  // does not contain it, and would drop the refusal that is protecting it.
+  const port = makePort({
+    saveProject: () => Promise.resolve({ success: false, error: 'disk full' }),
+  })
+
+  const result = await executeSaveProjectAs(port, capabilities)
+
+  expect(result.success).toBe(false)
+  expect(projectPath()).toBe('/scratch/original')
+  expect(workspace().isEphemeralProject).toBe(true)
+})
+
+it('treats cancelling as an ordinary outcome, not a failure', async () => {
+  const port = makePort({ pickPath: () => Promise.resolve({ success: false }) })
+
+  const result = await executeSaveProjectAs(port, capabilities)
+
+  expect(result.cancelled).toBe(true)
+  expect(projectPath()).toBe('/scratch/original')
+  expect(workspace().isEphemeralProject).toBe(true)
+})
+
+it('never carries deletions to the new location', async () => {
+  // The destination is fresh. A deletion list from the old location would
+  // remove files there that were never copied.
+  let written: { deletions?: string[] } | undefined
+  const port = makePort({
+    saveProject: (files) => {
+      written = files
+      return Promise.resolve({ success: true })
+    },
+  })
+
+  await executeSaveProjectAs(port, capabilities)
+
+  expect(written?.deletions).toEqual([])
+})
+
+it('reports platforms that cannot choose a folder rather than failing silently', async () => {
+  const port = makePort({ pickPath: undefined })
+  const result = await executeSaveProjectAs(port, capabilities)
+  expect(result.success).toBe(false)
+  expect(workspace().isEphemeralProject).toBe(true)
+})

--- a/src/frontend/services/save-project-as.ts
+++ b/src/frontend/services/save-project-as.ts
@@ -1,0 +1,107 @@
+/**
+ * Give a project a home.
+ *
+ * This exists because of the state a retrieved project starts in: it lives in a
+ * scratch directory, so a user-initiated Save is refused and told to use Save
+ * As instead. Without this, that message points nowhere and the project can
+ * never be saved at all -- the refusal would be a dead end rather than a
+ * redirection.
+ *
+ * It is not retrieval-specific. Any project can be written somewhere else, and
+ * the retrieved case is simply the one where it is not optional.
+ */
+
+import type { PlatformCapabilities } from '../../middleware/shared/ports/platform-capabilities'
+import type { ProjectPort } from '../../middleware/shared/ports/project-port'
+import { openPLCStoreBase } from '../store'
+import { toast } from '../utils/toast'
+import { buildAllProjectFileContents } from './save-actions'
+
+export interface SaveProjectAsResult {
+  success: boolean
+  /** Where it went. Absent when the user cancelled or the write failed. */
+  projectPath?: string
+  /** True when the user closed the picker without choosing. Not a failure. */
+  cancelled?: boolean
+}
+
+/**
+ * Ask for a destination, write the project there, and adopt it as the
+ * project's location.
+ *
+ * The order matters: the destination is only adopted once the write has
+ * actually succeeded. Setting the path first and writing second would leave a
+ * project pointing at a directory that does not contain it if the write failed
+ * -- and, for a retrieved project, would clear the very flag that is protecting
+ * it from a save that goes nowhere.
+ */
+export async function executeSaveProjectAs(
+  projectPort: ProjectPort,
+  _capabilities: PlatformCapabilities,
+): Promise<SaveProjectAsResult> {
+  if (!projectPort.pickPath) {
+    toast({
+      title: 'Save As is not available here',
+      description: 'This platform cannot choose a folder to save into.',
+      variant: 'fail',
+    })
+    return { success: false }
+  }
+
+  const picked = await projectPort.pickPath()
+  if (!picked.success || !picked.path) {
+    // Cancelling is an ordinary outcome and says nothing to the user.
+    if (picked.error) {
+      toast({ title: picked.error.title, description: picked.error.description, variant: 'fail' })
+      return { success: false }
+    }
+    return { success: false, cancelled: true }
+  }
+
+  const state = openPLCStoreBase.getState()
+  const contents = buildAllProjectFileContents()
+
+  const files = {
+    projectPath: picked.path,
+    projectJson: contents['project.json'] ?? '',
+    deviceConfig: contents['devices/configuration.json'],
+    pinMapping: contents['devices/pin-mapping.json'],
+    libraryManifest: contents['library.json'],
+    pouFiles: toEntries(contents, 'pous/'),
+    serverFiles: toEntries(contents, 'devices/servers/'),
+    remoteDeviceFiles: toEntries(contents, 'devices/remote/'),
+    dataTypeFiles: toEntries(contents, 'datatypes/'),
+    // Nothing to delete: this is a fresh destination, and carrying deletions
+    // from the old location would remove files there that were never copied.
+    deletions: [],
+  }
+
+  const written = await projectPort.saveProject(files)
+  if (!written.success) {
+    toast({
+      title: 'Could not save the project there',
+      description: written.error ?? 'The files could not be written to that folder.',
+      variant: 'fail',
+    })
+    return { success: false }
+  }
+
+  // Adopt the new location only now. A project that has one is no longer
+  // ephemeral, so an ordinary Save works from here on.
+  state.projectActions.updateMetaPath(picked.path)
+  state.workspaceActions.setIsEphemeralProject(false)
+
+  toast({
+    title: 'Project saved',
+    description: `Saved to ${picked.path}.`,
+    variant: 'default',
+  })
+  return { success: true, projectPath: picked.path }
+}
+
+/** The entries under one directory prefix, as the write shape expects. */
+function toEntries(contents: Record<string, string>, prefix: string) {
+  return Object.entries(contents)
+    .filter(([path]) => path.startsWith(prefix))
+    .map(([relativePath, content]) => ({ relativePath, content }))
+}

--- a/src/frontend/store/slices/workspace/slice.ts
+++ b/src/frontend/store/slices/workspace/slice.ts
@@ -155,6 +155,10 @@ const createWorkspaceSlice: StateCreator<WorkspaceSlice, [], [], WorkspaceSlice>
     clearWorkspace: () => {
       setState(
         produce(({ workspace }: WorkspaceSlice) => {
+          // A retrieved project's ephemeral marker belongs to the project, not
+          // to the session. Leaving it set would make the NEXT project opened
+          // refuse to save for a reason that no longer applies.
+          workspace.isEphemeralProject = false
           workspace.editingState = 'initial-state'
           workspace.selectedProjectTreeLeaf = { label: '', type: null }
           workspace.isDebuggerVisible = false

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -86,6 +86,10 @@ export default class MenuBuilder {
     this.mainWindow.webContents.send('project:save-accelerator')
   }
 
+  handleSaveProjectAs() {
+    this.mainWindow.webContents.send('project:save-as-accelerator')
+  }
+
   handleSaveFile() {
     this.mainWindow.webContents.send('project:save-file-accelerator')
   }
@@ -235,8 +239,7 @@ export default class MenuBuilder {
         {
           label: i18n.t('menu:file.submenu.saveAs'),
           accelerator: 'Cmd+Shift+A',
-          click: () => {},
-          enabled: false,
+          click: () => this.handleSaveProjectAs(),
         },
         {
           label: i18n.t('menu:file.submenu.closeTab'),

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -121,6 +121,7 @@ const rendererProcessBridge = {
   writeProjectFiles: (files: unknown): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('project:write-files', files),
   saveProjectAccelerator: (callback: IpcRendererCallbacks) => subscribe('project:save-accelerator', callback),
+  saveProjectAsAccelerator: (callback: IpcRendererCallbacks) => subscribe('project:save-as-accelerator', callback),
   switchPerspective: (callback: IpcRendererCallbacks) =>
     subscribe('workspace:switch-perspective-accelerator', callback),
 

--- a/src/middleware/adapters/editor/accelerator-adapter.ts
+++ b/src/middleware/adapters/editor/accelerator-adapter.ts
@@ -50,6 +50,10 @@ export function createEditorAcceleratorAdapter(): AcceleratorPort {
       return window.bridge.saveProjectAccelerator(() => callback())
     },
 
+    onSaveProjectAs(callback: () => void): Unsubscribe {
+      return window.bridge.saveProjectAsAccelerator(() => callback())
+    },
+
     onSaveFile(callback: () => void): Unsubscribe {
       return window.bridge.saveFileAccelerator(() => callback())
     },

--- a/src/middleware/shared/ports/accelerator-port.ts
+++ b/src/middleware/shared/ports/accelerator-port.ts
@@ -41,6 +41,9 @@ export interface AcceleratorPort {
   onOpenProject(callback: () => void): Unsubscribe
   onOpenRecent(callback: (projectData?: unknown) => void): Unsubscribe
   onSaveProject(callback: () => void): Unsubscribe
+  /** Save As. Desktop only in practice; web's adapter returns a no-op
+   *  unsubscribe like its other accelerators. */
+  onSaveProjectAs(callback: () => void): Unsubscribe
   onSaveFile(callback: () => void): Unsubscribe
   onCloseProject(callback: () => void): Unsubscribe
   onExportProject(callback: () => void): Unsubscribe

--- a/src/middleware/shared/ports/runtime-port.ts
+++ b/src/middleware/shared/ports/runtime-port.ts
@@ -333,15 +333,22 @@ export interface RuntimePort {
    * whether to offer retrieval without holding the privilege retrieval needs.
    */
   getProjectSnapshotInfo?(
-    ipAddress: string,
+    /** Desktop passes the device address; web resolves it from its device context. */
+    ipAddress?: string,
   ): Promise<{ success: boolean; info?: RuntimeProjectSnapshotInfo; error?: string }>
 
   /**
    * Retrieve the stored project and unpack it somewhere the editor can open it.
    *
-   * Returns a path, never the archive. Those are untrusted bytes from a device,
-   * and every check deciding whether they are safe to write belongs beside the
-   * write rather than in the renderer.
+   * Desktop only, and it returns a path rather than the archive on purpose:
+   * those are untrusted bytes from a device, and every check deciding whether
+   * they are safe to WRITE belongs beside the write, in the main process,
+   * rather than in the renderer.
+   *
+   * Web implements `retrieveProjectArchive` instead. The split is real rather
+   * than cosmetic: web has no filesystem to unpack onto and imports the project
+   * into its workspace, so forcing both onto one shape would mean one of them
+   * returning a path that does not exist.
    */
   retrieveProject?(ipAddress: string): Promise<{
     success: boolean
@@ -351,6 +358,23 @@ export interface RuntimePort {
     libraries?: Array<{ name: string; version: string; status: 'installed' | 'differs' | 'missing' }>
     error?: string
   }>
+
+  /** Username of the live runtime session, for attributing a stored project to
+   *  whoever uploaded it. Only the username -- the password stays inside the
+   *  token authority. */
+  getSessionUsername?(): string | null
+
+  /**
+   * Retrieve the stored project as raw archive bytes.
+   *
+   * Web's counterpart to `retrieveProject`: there is no filesystem to unpack
+   * onto, so the archive is parsed in the browser and imported into the
+   * workspace. The bytes are still untrusted -- the shared parser validates
+   * before yielding any of them.
+   */
+  retrieveProjectArchive?(): Promise<
+    { success: true; archive: Uint8Array; projectName: string } | { success: false; error: string }
+  >
 
   /** Install libraries a retrieved project brought with it, by name. */
   installRetrievedLibraries?(


### PR DESCRIPTION
Part of RTOP-272. RTOP-280 now tracks the **web** half; this is the desktop implementation it will reach parity with.

## Why now

Save As has been a disabled placeholder since it was added — `click: () => {}, enabled: false` — so nothing ever stood behind it. That was harmless until a project retrieved from a device started refusing user saves and pointing at it. Then the refusal became a **dead end** rather than a redirection: the project could never be saved at all, and the message named something that did not exist.

Not retrieval-specific, though. "Write this project somewhere else" is an ordinary thing to want; the retrieved case is just the one where it is not optional.

## Behaviour

Pick a folder → write the project tree → adopt the path → clear the ephemeral marker.

Two orderings that are load-bearing rather than incidental:

- **The destination is adopted only after the write succeeds.** Adopting first would leave a project pointing at a folder that does not contain it when the write failed — and would clear the very marker protecting a retrieved project from a save that goes nowhere, turning a recoverable failure into a lost project.
- **Deletions are never carried across.** The destination is fresh; a deletion list from the old location would delete files there that were never copied.

Cancelling the picker is an ordinary outcome and says nothing. Only genuine failures are reported.

Wired to both the in-app File menu and the native menu item (`Cmd+Shift+A`), through the same accelerator path Save Project already uses.

## Bug fixed alongside

`clearWorkspace` now resets `isEphemeralProject`. The type documentation already claimed *"Reset to `false` on project close"* and nothing implemented it — so the next project opened would have inherited a refusal that no longer applied to it.

## Testing

6 new tests covering exactly the orderings above: adopts on success, **leaves path and marker untouched on a failed write**, cancelling is not a failure, deletions never travel, and an unsupported platform reports rather than failing silently.

Full suite: 7528 passing. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bpea15BYCgPSqpatpveRk1