### PR TITLE
fix(naming): validate element names against one identifier namespace (DOPE-538)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "@teamsupercell/typings-for-css-modules-loader": "^2.5.2",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^14.0.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/diff": "^7.0.2",
         "@types/eslint": "^9.6.1",
         "@types/jest": "^30.0.0",
@@ -9623,6 +9624,20 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
+      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@teamsupercell/typings-for-css-modules-loader": "^2.5.2",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/diff": "^7.0.2",
     "@types/eslint": "^9.6.1",
     "@types/jest": "^30.0.0",

--- a/src/frontend/components/_features/[workspace]/create-element/__tests__/element-card.test.tsx
+++ b/src/frontend/components/_features/[workspace]/create-element/__tests__/element-card.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { useOpenPLCStore } from '@root/frontend/store'
+import { getMemoryState } from '@root/frontend/utils/toast'
+
+import { ElementCard } from '../element-card'
+
+function seed({ pous = [], dataTypes = [] }: { pous?: string[]; dataTypes?: string[] } = {}) {
+  useOpenPLCStore.setState((state) => ({
+    ...state,
+    project: {
+      ...state.project,
+      data: { ...state.project.data, pous: [], dataTypes: [], globalVariableLists: [] },
+    },
+  }))
+  const store = useOpenPLCStore.getState()
+  for (const name of pous) store.pouActions.create({ type: 'program', name, language: 'st' })
+  for (const name of dataTypes) store.datatypeActions.create({ name, derivation: 'structure' })
+}
+
+const dataTypeNames = () => useOpenPLCStore.getState().project.data.dataTypes.map((d) => d.name)
+
+const latestToast = () => getMemoryState().toasts[0]
+
+/** Open the card, fill the form and submit it. */
+async function createDataType(name: string) {
+  const user = userEvent.setup()
+  render(<ElementCard target='data-type' closeContainer={() => undefined} />)
+
+  // The Popover trigger opens on a plain click; user-event's full pointer sequence
+  // leaves it closed. The derivation Select is the reverse — it needs the real
+  // sequence, since jsdom never delivers the pointerdown `fireEvent` synthesises.
+  fireEvent.click(screen.getByRole('button', { name: /data type/i }))
+  await user.type(screen.getByPlaceholderText('Data type name'), name)
+  await user.click(screen.getByLabelText('data-type-derivation'))
+  await user.click(await screen.findByRole('option', { name: /structure/i }))
+  await user.click(screen.getByRole('button', { name: 'Create' }))
+}
+
+describe('ElementCard — data type creation', () => {
+  beforeEach(() => seed())
+
+  it('creates the data type when the name is free', async () => {
+    await createDataType('Motor')
+
+    expect(dataTypeNames()).toEqual(['Motor'])
+  })
+
+  /**
+   * The form used to discard the action's result: on a refusal it closed with nothing
+   * created and nothing said. The reason has to reach the user, and it is often about a
+   * POU rather than another data type.
+   */
+  it('keeps the form open and shows the store reason when the name belongs to a POU', async () => {
+    seed({ pous: ['Pump'] })
+    await createDataType('pump')
+
+    expect(screen.getByText(/"pump" is already the name of a POU/)).toBeTruthy()
+    expect(latestToast()?.description).toBe('"pump" is already the name of a POU')
+    expect(dataTypeNames()).toEqual([])
+    expect(screen.getByPlaceholderText('Data type name')).toBeTruthy()
+  })
+
+  it('shows the store reason when the name belongs to another data type', async () => {
+    seed({ dataTypes: ['Motor'] })
+    await createDataType('motor')
+
+    expect(screen.getByText(/Data type name already exists/)).toBeTruthy()
+    expect(dataTypeNames()).toEqual(['Motor'])
+  })
+})

--- a/src/frontend/components/_features/[workspace]/create-element/element-card/index.tsx
+++ b/src/frontend/components/_features/[workspace]/create-element/element-card/index.tsx
@@ -103,10 +103,7 @@ const ElementCard = (props: ElementCardProps): ReactNode => {
     control: datatypeControl,
     register: datatypeRegister,
     handleSubmit: handleSubmitDatatype,
-    /**
-     * TODO: add validation
-     */
-    // setError: datatypeSetError,
+    setError: datatypeSetError,
     formState: { errors: datatypeErrors },
   } = useForm<CreateDataTypeFormProps>()
 
@@ -163,8 +160,13 @@ const ElementCard = (props: ElementCardProps): ReactNode => {
     if (!pouWasCreated.ok) {
       pouSetError('name', {
         type: 'already-exists',
+        message: pouWasCreated.message,
       })
-      toast({ title: 'Invalid Pou', description: "You can't create a Pou with this name.", variant: 'fail' })
+      toast({
+        title: 'Invalid Pou',
+        description: pouWasCreated.message ?? "You can't create a Pou with this name.",
+        variant: 'fail',
+      })
       return
     }
     toast({ title: 'Pou created successfully', description: 'The POU has been created', variant: 'default' })
@@ -202,35 +204,43 @@ const ElementCard = (props: ElementCardProps): ReactNode => {
   }
 
   const handleCreateDatatype: SubmitHandler<CreateDataTypeFormProps> = (data) => {
-    if (data.derivation === 'array') {
-      const draft = {
-        name: data.name,
-        derivation: data.derivation,
-        baseType: {
-          definition: 'base-type',
-          value: 'BOOL',
-        },
-        initialValue: '',
-        dimensions: [],
-      } as PLCArrayDatatype
-      createDatatype(draft)
-    }
-    if (data.derivation === 'enumerated') {
-      const draft = {
-        name: data.name,
-        derivation: data.derivation,
-        initialValue: '',
-        values: [],
-      } as PLCEnumeratedDatatype
-      createDatatype(draft)
-    }
-    if (data.derivation === 'structure') {
-      const draft = {
-        name: data.name,
-        derivation: data.derivation,
-        variable: [],
-      } as PLCStructureDatatype
-      createDatatype(draft)
+    const draft: PLCArrayDatatype | PLCEnumeratedDatatype | PLCStructureDatatype =
+      data.derivation === 'array'
+        ? {
+            name: data.name,
+            derivation: data.derivation,
+            baseType: {
+              definition: 'base-type',
+              value: 'BOOL',
+            },
+            initialValue: '',
+            dimensions: [],
+          }
+        : data.derivation === 'enumerated'
+          ? {
+              name: data.name,
+              derivation: data.derivation,
+              initialValue: '',
+              values: [],
+            }
+          : {
+              name: data.name,
+              derivation: data.derivation,
+              variable: [],
+            }
+
+    const created = createDatatype(draft)
+    if (!created.ok) {
+      // The refusal is often about a POU or a global variable list, not another data
+      // type, so the reason has to reach the user — the form used to close on failure
+      // with nothing created and nothing said.
+      datatypeSetError('name', { type: 'already-exists', message: created.message })
+      toast({
+        title: 'Invalid data type',
+        description: created.message ?? "You can't create a data type with this name.",
+        variant: 'fail',
+      })
+      return
     }
     closeContainer((prev) => !prev)
     setIsOpen(false)
@@ -330,7 +340,9 @@ const ElementCard = (props: ElementCardProps): ReactNode => {
                       />
                       {datatypeErrors.name?.type === 'already-exists' && (
                         <span className='flex-1 text-start font-caption text-cp-xs font-normal text-red-500 opacity-65'>
-                          * data type name already exists
+                          {/* The store's reason when it gave one — it names the POU or list
+                              actually in the way, which the generic wording cannot. */}
+                          * {datatypeErrors.name.message ?? 'data type name already exists'}
                         </span>
                       )}
                       {!datatypeErrors.name && (
@@ -786,7 +798,7 @@ const ElementCard = (props: ElementCardProps): ReactNode => {
                       />
                       {pouErrors.name?.type === 'already-exists' && (
                         <span className='flex-1 text-start font-caption text-cp-xs font-normal text-red-500 opacity-65'>
-                          * POU name already exists
+                          * {pouErrors.name.message ?? 'POU name already exists'}
                         </span>
                       )}
                       {pouErrors.name?.type === 'validate' && (

--- a/src/frontend/components/_features/[workspace]/create-element/element-card/index.tsx
+++ b/src/frontend/components/_features/[workspace]/create-element/element-card/index.tsx
@@ -1,21 +1,13 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 import * as Popover from '@radix-ui/react-popover'
-
-import type { PLCDataType } from '../../../../../../middleware/shared/ports/types'
-import { ArrowIcon } from '../../../../../assets/icons/interface/Arrow'
-import { DatatypeDerivationSources } from '../../../../../data/sources/data-type'
-import { CreatePouSources, PouLanguageSources } from '../../../../../data/sources/POU'
-import { useOpenPLCStore } from '../../../../../store'
-import { InputWithRef } from '../../../../_atoms/input'
-import { Select, SelectContent, SelectItem, SelectTrigger } from '../../../../_atoms/select'
-
-type PLCArrayDatatype = Extract<PLCDataType, { derivation: 'array' }>
-type PLCEnumeratedDatatype = Extract<PLCDataType, { derivation: 'enumerated' }>
-type PLCStructureDatatype = Extract<PLCDataType, { derivation: 'structure' }>
 import { startCase } from 'lodash'
 import { Dispatch, ReactNode, SetStateAction, useState } from 'react'
 import { Controller, SubmitHandler, useForm } from 'react-hook-form'
 
+import { ArrowIcon } from '../../../../../assets/icons/interface/Arrow'
+import { DatatypeDerivationSources } from '../../../../../data/sources/data-type'
+import { CreatePouSources, PouLanguageSources } from '../../../../../data/sources/POU'
+import { useOpenPLCStore } from '../../../../../store'
 import { cn } from '../../../../../utils/cn'
 import {
   isArduinoTarget as checkIsArduinoTarget,
@@ -23,6 +15,8 @@ import {
   isSimulatorTarget,
 } from '../../../../../utils/device'
 import { ConvertToLangShortenedFormat } from '../../../../../utils/formatters/POU'
+import { InputWithRef } from '../../../../_atoms/input'
+import { Select, SelectContent, SelectItem, SelectTrigger } from '../../../../_atoms/select'
 import { useToast } from '../../../[app]/toast/use-toast'
 import { validatePouOrDataTypeName } from '../hooks/use-name-validation'
 
@@ -204,32 +198,9 @@ const ElementCard = (props: ElementCardProps): ReactNode => {
   }
 
   const handleCreateDatatype: SubmitHandler<CreateDataTypeFormProps> = (data) => {
-    const draft: PLCArrayDatatype | PLCEnumeratedDatatype | PLCStructureDatatype =
-      data.derivation === 'array'
-        ? {
-            name: data.name,
-            derivation: data.derivation,
-            baseType: {
-              definition: 'base-type',
-              value: 'BOOL',
-            },
-            initialValue: '',
-            dimensions: [],
-          }
-        : data.derivation === 'enumerated'
-          ? {
-              name: data.name,
-              derivation: data.derivation,
-              initialValue: '',
-              values: [],
-            }
-          : {
-              name: data.name,
-              derivation: data.derivation,
-              variable: [],
-            }
-
-    const created = createDatatype(draft)
+    // Name and derivation only: `datatypeActions.create` builds the datatype itself
+    // through `createDatatypeObject`, so any seed passed here would be discarded.
+    const created = createDatatype({ name: data.name, derivation: data.derivation })
     if (!created.ok) {
       // The refusal is often about a POU or a global variable list, not another data
       // type, so the reason has to reach the user — the form used to close on failure

--- a/src/frontend/components/_molecules/project-tree/index.tsx
+++ b/src/frontend/components/_molecules/project-tree/index.tsx
@@ -610,12 +610,26 @@ const ProjectTreeLeaf = ({
     // No-op: user blurred or hit Enter without changing anything.
     if (newLabel === label) return
 
+    // Snapping the label back is not an explanation: element names share one
+    // namespace, so a refusal usually names a POU, data type or list the user
+    // cannot see from here. A cancelled data type rename is the user's own
+    // choice and reports nothing.
+    const reportFailedRename = (res: { message?: string; cancelled?: boolean }) => {
+      setNewLabel(label || '')
+      if (res.cancelled) return
+      toast({
+        title: 'Rename failed',
+        description: res.message ?? `"${label}" could not be renamed.`,
+        variant: 'fail',
+      })
+    }
+
     // Renames are soft, unsaved changes: renameElement flags the workspace
     // dirty and queues the old path in `pendingDeletions`. Nothing is written
     // to disk until the user saves — identical on web and desktop.
     if (isAPou) {
       const res = renamePou(label, newLabel)
-      if (!res.ok) setNewLabel(label || '')
+      if (!res.ok) reportFailedRename(res)
       return
     }
 
@@ -623,34 +637,34 @@ const ProjectTreeLeaf = ({
       // Async: a referenced type awaits the impact modal before renaming.
       void renameDatatype(label, newLabel)
         .then((res) => {
-          if (!res.ok) setNewLabel(label || '')
+          if (!res.ok) reportFailedRename(res)
         })
-        .catch(() => setNewLabel(label || ''))
+        .catch(() => reportFailedRename({}))
       return
     }
 
     if (isGlobalVariableList) {
       const res = renameGlobalVariableList(label, newLabel)
-      if (!res.ok) setNewLabel(label || '')
+      if (!res.ok) reportFailedRename(res)
       return
     }
 
     if (isServer) {
       const res = renameServer(label, newLabel)
-      if (!res.ok) setNewLabel(label || '')
+      if (!res.ok) reportFailedRename(res)
       return
     }
 
     if (isRemoteDevice) {
       const res = renameRemoteDevice(label, newLabel)
-      if (!res.ok) setNewLabel(label || '')
+      if (!res.ok) reportFailedRename(res)
       return
     }
 
     if (isEthercatDevice && busName && deviceId) {
       const res = renameEthercatDevice(busName, deviceId, newLabel)
       if (!res.ok) {
-        setNewLabel(label || '')
+        reportFailedRename(res)
       }
       // Ethercat device lives inside its parent bus file — the parent will
       // be re-serialized on the next regular save. Skipping auto-save here

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -1131,6 +1131,47 @@ describe('createSharedSlice', () => {
         expect(result.ok).toBe(false)
         expect(result.message).toBe('"Pump" is already the name of a POU')
       })
+
+      /**
+       * An unreadable `.dt` is echoed to disk verbatim on save, so the type it declares
+       * stays in the build and the list's generated struct would declare it a second time.
+       */
+      describe('with an unreadable datatypes/GVL_TYPE.dt on disk', () => {
+        const seedGhostTypeFile = () =>
+          store
+            .getState()
+            .projectActions.setUnparsedDataTypeFiles([
+              { relativePath: 'datatypes/GVL_TYPE.dt', content: 'TYPE garbage' },
+            ])
+
+        const expectedMessage = '"GVL" needs the type name "GVL_TYPE", which a data type file already uses'
+
+        it('refuses a create whose derived type name the file owns', () => {
+          seedGhostTypeFile()
+          const result = store.getState().globalVariableListActions.create('GVL')
+          expect(result.ok).toBe(false)
+          expect(result.message).toBe(expectedMessage)
+          expect(store.getState().project.data.globalVariableLists ?? []).toHaveLength(0)
+        })
+
+        it('refuses a rename whose derived type name the file owns', () => {
+          seedList('Other')
+          seedGhostTypeFile()
+          const result = store.getState().globalVariableListActions.rename('Other', 'GVL')
+          expect(result.ok).toBe(false)
+          expect(result.message).toBe(expectedMessage)
+          expect((store.getState().project.data.globalVariableLists ?? [])[0].name).toBe('Other')
+        })
+
+        it('refuses a duplicate whose derived type name the file owns', () => {
+          seedList('Other')
+          seedGhostTypeFile()
+          const result = store.getState().globalVariableListActions.duplicate('Other', 'GVL')
+          expect(result.ok).toBe(false)
+          expect(result.message).toBe(expectedMessage)
+          expect(store.getState().project.data.globalVariableLists ?? []).toHaveLength(1)
+        })
+      })
     })
   })
 

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -117,7 +117,7 @@ describe('createSharedSlice', () => {
         store.getState().pouActions.create({ type: 'program', name: 'Main', language: 'st' })
         const result = store.getState().pouActions.create({ type: 'program', name: 'Main', language: 'il' })
         expect(result.ok).toBe(false)
-        expect(result.message).toBe('POU already exists')
+        expect(result.message).toBe('POU name already exists')
       })
 
       it('rejects a POU name that is not a valid IEC identifier', () => {
@@ -483,7 +483,7 @@ describe('createSharedSlice', () => {
         store.getState().datatypeActions.create({ name: 'Motor', derivation: 'structure' })
         const result = store.getState().datatypeActions.create({ name: 'motor', derivation: 'structure' })
         expect(result.ok).toBe(false)
-        expect(result.message).toBe('Data type already exists')
+        expect(result.message).toBe('Data type name already exists')
         expect(store.getState().project.data.dataTypes).toHaveLength(1)
       })
 
@@ -497,7 +497,7 @@ describe('createSharedSlice', () => {
         store.getState().datatypeActions.create({ name: 'DT1', derivation: 'array' })
         const result = store.getState().datatypeActions.create({ name: 'DT1', derivation: 'structure' })
         expect(result.ok).toBe(false)
-        expect(result.message).toBe('Data type already exists')
+        expect(result.message).toBe('Data type name already exists')
       })
 
       it('rejects a data type name that is not a valid IEC identifier', () => {
@@ -1002,6 +1002,134 @@ describe('createSharedSlice', () => {
       it('rejects duplicating to an invalid IEC identifier', () => {
         const result = store.getState().datatypeActions.duplicate('SourceDT', 'bad name')
         expect(result.ok).toBe(false)
+      })
+    })
+  })
+
+  // =========================================================================
+  // One identifier namespace across POUs, data types and global variable lists
+  // =========================================================================
+  describe('element name namespace', () => {
+    const seedPou = (name: string) => store.getState().pouActions.create({ type: 'program', name, language: 'st' })
+    const seedDatatype = (name: string) => store.getState().datatypeActions.create({ name, derivation: 'structure' })
+    const seedList = (name: string) => store.getState().globalVariableListActions.create(name)
+
+    describe('pouActions', () => {
+      it('refuses a create taking a data type name, case-insensitively', () => {
+        seedDatatype('Motor')
+        const result = store.getState().pouActions.create({ type: 'program', name: 'motor', language: 'st' })
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('"motor" is already the name of a data type')
+        expect(store.getState().project.data.pous).toHaveLength(0)
+      })
+
+      it('refuses a create taking a global variable list name', () => {
+        seedList('GVL')
+        const result = store.getState().pouActions.create({ type: 'program', name: 'GVL', language: 'st' })
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('"GVL" is already the name of a global variable list')
+      })
+
+      it("refuses a create taking a global variable list's derived type name", () => {
+        seedList('GVL')
+        const result = store.getState().pouActions.create({ type: 'program', name: 'GVL_TYPE', language: 'st' })
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('"GVL_TYPE" is the type name of global variable list "GVL"')
+      })
+
+      it('refuses a create differing from another POU only by case', () => {
+        seedPou('Pump')
+        const result = store.getState().pouActions.create({ type: 'program', name: 'pump', language: 'st' })
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('POU name already exists')
+      })
+
+      it('refuses a rename onto a data type name', () => {
+        seedPou('Pump')
+        seedDatatype('Motor')
+        const result = store.getState().pouActions.rename('Pump', 'Motor')
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('"Motor" is already the name of a data type')
+        expect(store.getState().project.data.pous[0].name).toBe('Pump')
+      })
+
+      it('refuses a case-only rename: both names are one file on a case-folding disk', () => {
+        seedPou('Pump')
+        const result = store.getState().pouActions.rename('Pump', 'pump')
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('POU name already exists')
+        expect(store.getState().project.data.pous[0].name).toBe('Pump')
+      })
+
+      it('allows a rename onto the exact same name', () => {
+        seedPou('Pump')
+        const result = store.getState().pouActions.rename('Pump', 'Pump')
+        expect(result.ok).toBe(true)
+      })
+
+      it('refuses a duplicate taking a data type name', () => {
+        seedPou('Pump')
+        seedDatatype('Motor')
+        const result = store.getState().pouActions.duplicate('Pump', 'Motor')
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('"Motor" is already the name of a data type')
+      })
+    })
+
+    describe('datatypeActions', () => {
+      it('refuses a create taking a POU name, case-insensitively', () => {
+        seedPou('Pump')
+        const result = store.getState().datatypeActions.create({ name: 'pump', derivation: 'structure' })
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('"pump" is already the name of a POU')
+        expect(store.getState().project.data.dataTypes).toHaveLength(0)
+      })
+
+      it('refuses a create taking a global variable list name', () => {
+        seedList('GVL')
+        const result = store.getState().datatypeActions.create({ name: 'GVL', derivation: 'structure' })
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('"GVL" is already the name of a global variable list')
+      })
+
+      it("refuses a create taking a global variable list's derived type name", () => {
+        seedList('GVL')
+        const result = store.getState().datatypeActions.create({ name: 'GVL_TYPE', derivation: 'structure' })
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('"GVL_TYPE" is the type name of global variable list "GVL"')
+      })
+
+      it('refuses a rename onto a POU name', async () => {
+        seedPou('Pump')
+        seedDatatype('Motor')
+        const result = await store.getState().datatypeActions.rename('Motor', 'Pump')
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('"Pump" is already the name of a POU')
+        expect(store.getState().project.data.dataTypes[0].name).toBe('Motor')
+      })
+
+      it('refuses a duplicate taking a POU name', () => {
+        seedPou('Pump')
+        seedDatatype('Motor')
+        const result = store.getState().datatypeActions.duplicate('Motor', 'Pump')
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('"Pump" is already the name of a POU')
+      })
+    })
+
+    describe('globalVariableListActions', () => {
+      it('still allows a case-only rename: a list has no file of its own', () => {
+        seedList('GVL')
+        const result = store.getState().globalVariableListActions.rename('GVL', 'gvl')
+        expect(result.ok).toBe(true)
+      })
+
+      it('refuses a duplicate taking a POU name', () => {
+        seedPou('Pump')
+        seedList('GVL')
+        const result = store.getState().globalVariableListActions.duplicate('GVL', 'Pump')
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('"Pump" is already the name of a POU')
       })
     })
   })

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -1061,10 +1061,15 @@ describe('createSharedSlice', () => {
         expect(store.getState().project.data.pous[0].name).toBe('Pump')
       })
 
-      it('allows a rename onto the exact same name', () => {
+      /**
+       * `updatePouName` queues the old path for deletion unconditionally, so a no-op
+       * rename that reached it would mark the POU's own file deleted on the next save.
+       */
+      it('treats a rename onto the exact same name as a no-op', () => {
         seedPou('Pump')
         const result = store.getState().pouActions.rename('Pump', 'Pump')
         expect(result.ok).toBe(true)
+        expect(store.getState().pendingDeletions).toEqual([])
       })
 
       it('refuses a duplicate taking a data type name', () => {
@@ -1118,6 +1123,25 @@ describe('createSharedSlice', () => {
     })
 
     describe('globalVariableListActions', () => {
+      /**
+       * The pair collides whichever half exists first: `GVL`'s generated struct takes
+       * `GVL_TYPE`, which is already the instance name of the other list.
+       */
+      it('refuses a create whose derived type name another list already holds', () => {
+        seedList('GVL_TYPE')
+        const result = store.getState().globalVariableListActions.create('GVL')
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('"GVL" needs the type name "GVL_TYPE", which a global variable list already uses')
+        expect(store.getState().project.data.globalVariableLists ?? []).toHaveLength(1)
+      })
+
+      it('refuses the same pair in the opposite order', () => {
+        seedList('GVL')
+        const result = store.getState().globalVariableListActions.create('GVL_TYPE')
+        expect(result.ok).toBe(false)
+        expect(result.message).toBe('"GVL_TYPE" is the type name of global variable list "GVL"')
+      })
+
       it('still allows a case-only rename: a list has no file of its own', () => {
         seedList('GVL')
         const result = store.getState().globalVariableListActions.rename('GVL', 'gvl')

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -237,6 +237,11 @@ function elementNameCollision(
   if (lists.some((list) => nameMatches(globalVariableListTypeName(list.name), derived))) {
     return `"${name}" needs the type name "${derived}", which another global variable list already uses`
   }
+  // An unreadable `.dt` is echoed to disk verbatim on save, so the type it declares is
+  // still in the build — the generated struct would be a second declaration of it.
+  if (!collidesWithUnparsedDataTypeFile(state, derived).ok) {
+    return `"${name}" needs the type name "${derived}", which a data type file already uses`
+  }
   return null
 }
 

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -78,10 +78,10 @@ function validateElementName(name: string): { ok: true } | { ok: false; message:
 }
 
 /**
- * Data type names are compared case-insensitively: each one becomes a
- * `datatypes/<Name>.dt` path, and macOS/Windows fold filename case, so
- * `Foo` and `foo` would silently overwrite each other on save. IEC
- * identifiers are case-insensitive anyway.
+ * Element names are compared case-insensitively: a data type becomes a
+ * `datatypes/<Name>.dt` path and a POU a `pous/<folder>/<Name><ext>` one,
+ * and macOS/Windows fold filename case, so `Foo` and `foo` would silently
+ * overwrite each other on save. IEC identifiers are case-insensitive anyway.
  */
 const nameMatches = (a: string, b: string): boolean => a.toLowerCase() === b.toLowerCase()
 
@@ -156,51 +156,85 @@ function syncAfterDatatypePropagation(state: SharedRootState, impact: DataTypeRe
   }
 }
 
+type NamedElementKind = 'pou' | 'data-type' | 'global-variable-list'
+
+const SAME_KIND_TAKEN: Record<NamedElementKind, string> = {
+  pou: 'POU name already exists',
+  'data-type': 'Data type name already exists',
+  'global-variable-list': 'Global variable list name already exists',
+}
+
 /**
- * Why a Global Variable List may not be called `name`, or `null` when it may.
+ * Why an element of `kind` may not be called `name`, or `null` when it may.
  *
- * A list occupies TWO symbols, not one: the instance keeps the user's name, and the
- * struct backing it takes `<name>_TYPE`. Both land in the same global namespace as
- * every POU and data type — IEC gives types and variables one namespace — so a list
- * called after a POU, or one whose derived type name is already a data type, is a
- * duplicate symbol the compiler reports against a name the user never typed. Checking
- * only against other lists covered one half of a rule with two.
+ * POUs, data types and Global Variable Lists share ONE identifier namespace — IEC gives
+ * types and variables the same one — and a list occupies TWO symbols in it: the instance
+ * keeps the user's name, the struct backing it takes `<name>_TYPE`. Checking each
+ * collection only against itself covered a third of a rule with three parts.
  *
- * `ignoring` is the list being renamed: a rename onto its own name, or a case-only
- * change, must not collide with itself.
+ * The workspace makes a collision worse than the duplicate symbol the compiler would
+ * report: `files[name]`, tabs, editor models and `undoRedo[name]` are keyed by raw
+ * element name, so one entry ends up serving two elements and edits land on the wrong one.
+ *
+ * `ignoring` is the element being renamed, so it does not collide with itself. It is
+ * matched EXACTLY for POUs and data types: each owns a file path
+ * (`pous/<folder>/<Name><ext>`, `datatypes/<Name>.dt`) and macOS/Windows fold filename
+ * case, so a case-only rename writes the new file over the old one. Refusing that means
+ * the element's own entry has to stay eligible to collide. A list has no file of its
+ * own, so it matches case-insensitively and a case-only rename remains a no-op.
  */
-function globalVariableListNameCollision(state: SharedRootState, name: string, ignoring?: string): string | null {
-  if (ignoring !== undefined && nameMatches(name, ignoring)) return null
+function elementNameCollision(
+  state: SharedRootState,
+  name: string,
+  kind: NamedElementKind,
+  ignoring?: string,
+): string | null {
+  const renamedOntoItself = kind === 'global-variable-list' ? nameMatches(name, ignoring ?? '') : name === ignoring
+  if (ignoring !== undefined && renamedOntoItself) return null
 
-  const derived = globalVariableListTypeName(name)
-  const lists = state.project.data.globalVariableLists ?? []
+  const { pous, dataTypes } = state.project.data
+  const allLists = state.project.data.globalVariableLists ?? []
+  const lists =
+    kind === 'global-variable-list' ? allLists.filter((list) => !nameMatches(list.name, ignoring ?? '')) : allLists
 
-  if (lists.some((list) => !nameMatches(list.name, ignoring ?? '') && nameMatches(list.name, name))) {
-    return 'Global variable list name already exists'
-  }
-  if (state.project.data.pous.some((pou) => nameMatches(pou.name, name))) {
+  const takenBySameKind =
+    kind === 'pou'
+      ? pous.some((pou) => nameMatches(pou.name, name))
+      : kind === 'data-type'
+        ? dataTypes.some((dataType) => nameMatches(dataType.name, name))
+        : lists.some((list) => nameMatches(list.name, name))
+  if (takenBySameKind) return SAME_KIND_TAKEN[kind]
+
+  if (kind !== 'pou' && pous.some((pou) => nameMatches(pou.name, name))) {
     return `"${name}" is already the name of a POU`
   }
-  if (state.project.data.dataTypes.some((dataType) => nameMatches(dataType.name, name))) {
+  if (kind !== 'data-type' && dataTypes.some((dataType) => nameMatches(dataType.name, name))) {
     return `"${name}" is already the name of a data type`
   }
+  if (kind !== 'global-variable-list' && lists.some((list) => nameMatches(list.name, name))) {
+    return `"${name}" is already the name of a global variable list`
+  }
   // A `.dt` that failed to parse still owns its `files[name]` entry — the registry is
-  // keyed by raw name across every kind — so a list taking the same name would share
-  // that entry and misroute its save. `datatypeActions` gates on this for the same
-  // reason; the check belongs here too.
+  // keyed by raw name across every kind — so any element taking that name would share
+  // the entry and misroute its save.
   const unparsedCollision = collidesWithUnparsedDataTypeFile(state, name)
   if (!unparsedCollision.ok) return unparsedCollision.message ?? `"${name}" is already taken by a data type file`
-  if (state.project.data.dataTypes.some((dataType) => nameMatches(dataType.name, derived))) {
+
+  const listOwningTheName = lists.find((list) => nameMatches(globalVariableListTypeName(list.name), name))
+  if (listOwningTheName) {
+    return `"${name}" is the type name of global variable list "${listOwningTheName.name}"`
+  }
+
+  if (kind !== 'global-variable-list') return null
+
+  const derived = globalVariableListTypeName(name)
+  if (dataTypes.some((dataType) => nameMatches(dataType.name, derived))) {
     return `"${name}" needs the type name "${derived}", which a data type already uses`
   }
-  if (state.project.data.pous.some((pou) => nameMatches(pou.name, derived))) {
+  if (pous.some((pou) => nameMatches(pou.name, derived))) {
     return `"${name}" needs the type name "${derived}", which a POU already uses`
   }
-  if (
-    lists.some(
-      (list) => !nameMatches(list.name, ignoring ?? '') && nameMatches(globalVariableListTypeName(list.name), derived),
-    )
-  ) {
+  if (lists.some((list) => nameMatches(globalVariableListTypeName(list.name), derived))) {
     return `"${name}" needs the type name "${derived}", which another global variable list already uses`
   }
   return null
@@ -322,8 +356,8 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
   pouActions: {
     create: ({ type, name, language }) => {
       const state = getState()
-      const existing = state.project.data.pous.find((p) => p.name === name)
-      if (existing) return { ok: false, message: 'POU already exists' }
+      const collision = elementNameCollision(state, name, 'pou')
+      if (collision) return { ok: false, message: collision }
 
       const nameCheck = validateElementName(name)
       if (!nameCheck.ok) return nameCheck
@@ -379,8 +413,8 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
 
     rename: (oldName, newName) => {
       const state = getState()
-      const existing = state.project.data.pous.find((p) => p.name === newName)
-      if (existing) return { ok: false, message: 'POU name already exists' }
+      const collision = elementNameCollision(state, newName, 'pou', oldName)
+      if (collision) return { ok: false, message: collision }
 
       return renameElement(
         state,
@@ -398,8 +432,8 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const sourcePou = state.project.data.pous.find((p) => p.name === sourceName)
       if (!sourcePou) return { ok: false, message: 'Source POU not found' }
 
-      const existing = state.project.data.pous.find((p) => p.name === newName)
-      if (existing) return { ok: false, message: 'POU name already exists' }
+      const collision = elementNameCollision(state, newName, 'pou')
+      if (collision) return { ok: false, message: collision }
 
       const nameCheck = validateElementName(newName)
       if (!nameCheck.ok) return nameCheck
@@ -458,7 +492,7 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const state = getState()
       // Collision before validation, matching `datatypeActions` above: the more
       // specific message is the more useful one when a name fails both.
-      const collision = globalVariableListNameCollision(state, name)
+      const collision = elementNameCollision(state, name, 'global-variable-list')
       if (collision) return { ok: false, message: collision }
 
       const nameCheck = validateElementName(name)
@@ -498,7 +532,7 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
      */
     rename: (oldName, newName) => {
       const state = getState()
-      const collision = globalVariableListNameCollision(state, newName, oldName)
+      const collision = elementNameCollision(state, newName, 'global-variable-list', oldName)
       if (collision) return { ok: false, message: collision }
 
       const nameCheck = validateElementName(newName)
@@ -567,7 +601,7 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const source = (state.project.data.globalVariableLists ?? []).find((l) => nameMatches(l.name, sourceName))
       if (!source) return { ok: false, message: 'Global variable list not found' }
 
-      const collision = globalVariableListNameCollision(state, newName)
+      const collision = elementNameCollision(state, newName, 'global-variable-list')
       if (collision) return { ok: false, message: collision }
 
       const nameCheck = validateElementName(newName)
@@ -599,11 +633,8 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
   datatypeActions: {
     create: ({ name, derivation }) => {
       const state = getState()
-      const existing = state.project.data.dataTypes.find((d) => nameMatches(d.name, name))
-      if (existing) return { ok: false, message: 'Data type already exists' }
-
-      const fileCollision = collidesWithUnparsedDataTypeFile(state, name)
-      if (!fileCollision.ok) return fileCollision
+      const collision = elementNameCollision(state, name, 'data-type')
+      if (collision) return { ok: false, message: collision }
 
       const nameCheck = validateElementName(name)
       if (!nameCheck.ok) return nameCheck
@@ -638,14 +669,8 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
 
     rename: async (oldName, newName) => {
       const state = getState()
-      // Includes the type being renamed: a case-only change writes the
-      // new file and then deletes the old path — the same file where
-      // the filesystem folds case.
-      const collides = newName !== oldName && state.project.data.dataTypes.some((d) => nameMatches(d.name, newName))
-      if (collides) return { ok: false, message: 'Data type name already exists' }
-
-      const fileCollision = collidesWithUnparsedDataTypeFile(state, newName)
-      if (!fileCollision.ok) return fileCollision
+      const collision = elementNameCollision(state, newName, 'data-type', oldName)
+      if (collision) return { ok: false, message: collision }
 
       const datatype = state.project.data.dataTypes.find((d) => d.name === oldName)
       if (!datatype) return { ok: false, message: 'Data type not found' }
@@ -707,11 +732,8 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const source = state.project.data.dataTypes.find((d) => d.name === sourceName)
       if (!source) return { ok: false, message: 'Data type not found' }
 
-      const existing = state.project.data.dataTypes.find((d) => nameMatches(d.name, newName))
-      if (existing) return { ok: false, message: 'Data type name already exists' }
-
-      const fileCollision = collidesWithUnparsedDataTypeFile(state, newName)
-      if (!fileCollision.ok) return fileCollision
+      const collision = elementNameCollision(state, newName, 'data-type')
+      if (collision) return { ok: false, message: collision }
 
       const nameCheck = validateElementName(newName)
       if (!nameCheck.ok) return nameCheck

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -234,6 +234,11 @@ function elementNameCollision(
   if (pous.some((pou) => nameMatches(pou.name, derived))) {
     return `"${name}" needs the type name "${derived}", which a POU already uses`
   }
+  // Against the other lists' own names as well as their derived ones: the pair
+  // `GVL` / `GVL_TYPE` collides whichever of the two is created first.
+  if (lists.some((list) => nameMatches(list.name, derived))) {
+    return `"${name}" needs the type name "${derived}", which a global variable list already uses`
+  }
   if (lists.some((list) => nameMatches(globalVariableListTypeName(list.name), derived))) {
     return `"${name}" needs the type name "${derived}", which another global variable list already uses`
   }
@@ -418,6 +423,10 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
 
     rename: (oldName, newName) => {
       const state = getState()
+      // `updatePouName` queues the old path for deletion unconditionally, so letting a
+      // no-op rename through would mark the POU's own file deleted on the next save.
+      if (oldName === newName) return { ok: true }
+
       const collision = elementNameCollision(state, newName, 'pou', oldName)
       if (collision) return { ok: false, message: collision }
 


### PR DESCRIPTION
Fixes [DOPE-538](https://autonomylogic.atlassian.net/browse/DOPE-538) — sub-task of DOPE-577 (Family A: one identifier namespace).

## The bug

IEC 61131-3 gives POUs, derived types and global variable lists **one** identifier namespace, and a list occupies two symbols in it (its own name plus the `<name>_TYPE` struct backing it). The editor validated each collection only against itself:

| Path | Before |
|---|---|
| `pouActions.create` / `rename` / `duplicate` | `pous.find((p) => p.name === name)` — case-sensitive, POU-only |
| `datatypeActions.create` / `rename` / `duplicate` | data types + unparsed `.dt` only, never `pous` or lists |
| `globalVariableListActions.*` | already had the full rule, wired only to list actions |

The workspace makes a collision worse than the duplicate symbol the compiler would report: `files[name]`, tabs, editor models and `undoRedo[name]` are all keyed by raw element name, so one entry ends up serving two elements and edits land on the wrong one. And because a POU is written to `pous/<folder>/<Name><ext>`, two POUs differing only by case resolve to a single file on macOS/Windows — one silently overwrites the other on save.

## The fix

`globalVariableListNameCollision` becomes `elementNameCollision(state, name, kind, ignoring?)`, called from all nine create / rename / duplicate paths. One rule instead of three, all comparisons case-insensitive. Existing message strings are preserved; the two same-kind create messages were unified with their rename/duplicate wording (`POU already exists` → `POU name already exists`, likewise for data types).

Self-exclusion on rename differs by kind, deliberately:

- **POUs and data types** match `ignoring` **exactly**, so a case-only rename still counts as a collision — refusing it means the element's own entry has to stay eligible to collide.
- **Global variable lists** match case-insensitively, keeping today's behaviour. A list has no file of its own, so a case-only rename is a harmless no-op.

Two holes close in the other direction as well: a POU or data type can no longer take an existing list's `<name>_TYPE`, and the `GVL` / `GVL_TYPE` list pair is refused in **either** insertion order — `development` allows both today.

## Also fixed here

`handleCreateDatatype` discarded the action's result entirely: a refused create closed the modal with nothing created and nothing said. Reachable today with a plain duplicate name, independent of the gate. It now keeps the form open and surfaces the store's reason in the toast and the inline field error, matching `handleCreateGlobalVariableList`. The `TODO: add validation` on the commented-out `setError` is what this was. `handleCreatePou` and both inline error spans now carry the message instead of hardcoded generic text.

## Dependency added

`@testing-library/user-event@^14.6.1` — already in openplc-web's devDependencies, missing here, so no shared test could use it. Pinned to web's exact range. The lockfile diff is only that package; npm also wanted to correct a pre-existing `package.json` / lockfile version drift (`4.2.10` → `4.2.12`, and `4.1.4` → `4.2.2` in `release/app`) which I reverted as unrelated — worth a separate look.

Note the two repos run different runners: web on vitest, editor on jest. The shared component test therefore avoids jest-dom matchers (`toBeInTheDocument` is not registered by `jest-vi-shim.ts`) and uses `toBeTruthy()`.

## Review follow-ups

Findings from Thiago's review, all in code this branch touches, fixed in the last commit:

- The derived `<name>_TYPE` block compared only against other lists' *derived* names, so the `GVL` / `GVL_TYPE` pair was refused in one insertion order and allowed in the other.
- Rename refusals reached the user as nothing but the label snapping back. This branch adds refusal paths, so the project tree now reports the store's reason — staying quiet only for a data type rename the user cancelled.
- `pouActions.rename(x, x)` passed the gate and reached `updatePouName`, which queues the old path for deletion unconditionally. Guarded as a no-op.
- The create-element card built a data type draft that `create` discards. It now passes only `{ name, derivation }`.

Servers and remote devices are also outside the gate, and `serverActions.rename` has no duplicate check at all — pre-existing and out of scope here, filed as DOPE-600.

## Out of scope

Load-time detection of a collision already present in a project on disk. The gate is entry-point only; such a project still opens unchanged and unflagged. That is owned by DOPE-577, whose description now records it, along with two adjacent findings now carded as DOPE-598 (resource globals are not in the gate) and DOPE-599 (`checkIfGlobalVariableExists` compares case-sensitively).

## Tests

- 13 new cases in `shared-slice.test.ts` under `element name namespace` — cross-kind refusals for POU and data type create/rename/duplicate, case-insensitivity, the case-only rename refusal, the exact-name no-op, plus two list regression guards.
- New shared component test `create-element/__tests__/element-card.test.tsx` (3 cases) for the silent-failure fix. Mutation-checked: with the `if (!created.ok)` branch disabled, both refusal cases fail and the positive one still passes.

## Validation

Run on **Node 22** (Node 25 shadows jsdom's `localStorage` and fails the adapter suites for unrelated reasons).

- `jest src/frontend` — 208 suites, **4826 passed**, 0 failed
- `tsc --noEmit -p tsconfig.json` — 0 errors
- prettier + eslint clean
- Coverage: uncovered-line set for `shared/slice.ts` is identical to the baseline (28 lines, shifted by the insertion). No new gaps.

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/721

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RZ4Qs4DXQoaQy5aihwRxG


[DOPE-538]: https://autonomylogic.atlassian.net/browse/DOPE-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved creation error handling for POUs and data types, with specific messages shown in forms and notifications.
  * Prevented duplicate names across POUs, data types, and global variable lists, including case-insensitive matches.
  * Blocked global variable list names that conflict with data type files, including unreadable files.
  * Preserved valid case-only renames and added clear notifications for failed renames.

* **Tests**
  * Added coverage for creation, name collisions, rename behavior, and unreadable file conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
