### PR TITLE
RTOP-272 follow-up: consume the projectSnapshot capability, and drop what nothing calls

### DIFF
--- a/src/backend/editor/compiler/__tests__/editor-compiler-platform-port.test.ts
+++ b/src/backend/editor/compiler/__tests__/editor-compiler-platform-port.test.ts
@@ -427,4 +427,102 @@ describe('createEditorCompilerPlatformPort', () => {
     expect(result).toEqual({ ok: true, version: null, minEditorVersion: null, supportsProjectSnapshot: false })
     expect(log).toHaveBeenCalledWith(expect.stringContaining('probe blew up'), 'warning')
   })
+
+  // ---- uploadRuntimeV4: the project-snapshot capability --------------------
+  //
+  // The capability is read by the pre-upload probe and acted on here. These pin
+  // the behaviour rather than the plumbing: whether the archive gets built at
+  // all. Building one for a runtime that discards it costs the user upload time
+  // and leaves them a device they cannot retrieve from; not building one for a
+  // runtime that would have kept it silently loses the feature.
+
+  describe('uploadRuntimeV4 — project-snapshot capability', () => {
+    const deviceContext = { kind: 'editor-https' as const, ip: '10.0.0.1', jwt: 'token' }
+
+    function makeUploadContext(overrides?: Partial<EditorCompilerPlatformPortContext>) {
+      return makeContext({
+        compressSourceFolder: jest.fn().mockResolvedValue(Buffer.from('program')),
+        mainProcessBridge: {
+          makeRuntimeApiRequest: jest.fn(),
+          makeRuntimeApiUpload: jest.fn().mockResolvedValue({ success: true, data: '{}' }),
+        },
+        ...overrides,
+      })
+    }
+
+    it('builds and sends the project when the runtime stores them', async () => {
+      const buildUploadSnapshot = jest.fn().mockResolvedValue({
+        archive: Buffer.from('zip'),
+        metadata: '{"projectName":"Demo"}',
+        missingLibraries: [],
+      })
+      const context = makeUploadContext({ buildUploadSnapshot })
+      const port = createEditorCompilerPlatformPort(makeHandlers(), context)
+
+      await port.uploadRuntimeV4({ bundle: {}, context: deviceContext, supportsProjectSnapshot: true }, () => undefined)
+
+      expect(buildUploadSnapshot).toHaveBeenCalled()
+      const upload = (context.mainProcessBridge.makeRuntimeApiUpload as jest.Mock).mock.calls[0][0] as {
+        snapshotBuffer?: Buffer
+        snapshotMetadata?: string
+      }
+      expect(upload.snapshotBuffer).toEqual(Buffer.from('zip'))
+      expect(upload.snapshotMetadata).toBe('{"projectName":"Demo"}')
+    })
+
+    it('does not build one for a runtime that would discard it', async () => {
+      const buildUploadSnapshot = jest.fn()
+      const context = makeUploadContext({ buildUploadSnapshot })
+      const port = createEditorCompilerPlatformPort(makeHandlers(), context)
+
+      await port.uploadRuntimeV4(
+        { bundle: {}, context: deviceContext, supportsProjectSnapshot: false },
+        () => undefined,
+      )
+
+      expect(buildUploadSnapshot).not.toHaveBeenCalled()
+      const upload = (context.mainProcessBridge.makeRuntimeApiUpload as jest.Mock).mock.calls[0][0] as {
+        snapshotBuffer?: Buffer
+        snapshotMetadata?: string
+      }
+      expect(upload.snapshotBuffer).toBeUndefined()
+      expect(upload.snapshotMetadata).toBeUndefined()
+    })
+
+    it('tells the user the project will not be retrievable from that device', async () => {
+      // The skip is silent otherwise, and "I uploaded it, why can I not get it
+      // back?" is the question this exists to pre-empt.
+      const log = jest.fn()
+      const port = createEditorCompilerPlatformPort(
+        makeHandlers(),
+        makeUploadContext({ buildUploadSnapshot: jest.fn() }),
+      )
+
+      await port.uploadRuntimeV4({ bundle: {}, context: deviceContext, supportsProjectSnapshot: false }, log)
+
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('does not store source projects'), 'warning')
+    })
+
+    it('still uploads the program when the project cannot be prepared', async () => {
+      // The project is the optional half. A failure preparing it must never cost
+      // the user the program upload itself.
+      const context = makeUploadContext({
+        buildUploadSnapshot: jest.fn().mockRejectedValue(new Error('disk full')),
+      })
+      const log = jest.fn()
+      const port = createEditorCompilerPlatformPort(makeHandlers(), context)
+
+      await port.uploadRuntimeV4({ bundle: {}, context: deviceContext, supportsProjectSnapshot: true }, log)
+
+      // The program still goes, just without the project beside it. (The
+      // overall result is not asserted: the deploy flow polls the device for
+      // build status afterwards, which this harness does not stand up.)
+      expect(context.mainProcessBridge.makeRuntimeApiUpload).toHaveBeenCalled()
+      const upload = (context.mainProcessBridge.makeRuntimeApiUpload as jest.Mock).mock.calls[0][0] as {
+        snapshotBuffer?: Buffer
+      }
+      expect(upload.snapshotBuffer).toBeUndefined()
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Could not prepare the project'), 'warning')
+    })
+  })
 })

--- a/src/backend/editor/compiler/__tests__/editor-compiler-platform-port.test.ts
+++ b/src/backend/editor/compiler/__tests__/editor-compiler-platform-port.test.ts
@@ -352,7 +352,7 @@ describe('createEditorCompilerPlatformPort', () => {
     // This stub answers every endpoint with a `/api/version` body, so
     // `/api/capabilities` yields no usable `runtimeVersion` and the probe
     // falls back — the exact shape of a runtime predating the endpoint.
-    expect(result).toEqual({ ok: true, version: '4.1.2', minEditorVersion: null })
+    expect(result).toEqual({ ok: true, version: '4.1.2', minEditorVersion: null, supportsProjectSnapshot: false })
   })
 
   it('checkRuntimeVersion reads the editor floor from /api/capabilities when the device serves it', async () => {
@@ -370,7 +370,7 @@ describe('createEditorCompilerPlatformPort', () => {
       { context: { kind: 'editor-https', ip: '10.0.0.1', jwt: 'token' } },
       () => undefined,
     )
-    expect(result).toEqual({ ok: true, version: 'v4.2.0', minEditorVersion: '4.2.1' })
+    expect(result).toEqual({ ok: true, version: 'v4.2.0', minEditorVersion: '4.2.1', supportsProjectSnapshot: false })
   })
 
   it('checkRuntimeVersion falls back to /api/version when capabilities 404s', async () => {
@@ -387,7 +387,7 @@ describe('createEditorCompilerPlatformPort', () => {
       { context: { kind: 'editor-https', ip: '10.0.0.1', jwt: 'token' } },
       log,
     )
-    expect(result).toEqual({ ok: true, version: 'v4.1.7', minEditorVersion: null })
+    expect(result).toEqual({ ok: true, version: 'v4.1.7', minEditorVersion: null, supportsProjectSnapshot: false })
     // The 404 is the normal answer from every deployed runtime — it must not
     // nag the user on every upload.
     expect(log).not.toHaveBeenCalled()
@@ -407,7 +407,7 @@ describe('createEditorCompilerPlatformPort', () => {
       { context: { kind: 'editor-https', ip: '10.0.0.1', jwt: 'token' } },
       log,
     )
-    expect(result).toEqual({ ok: true, version: null, minEditorVersion: null })
+    expect(result).toEqual({ ok: true, version: null, minEditorVersion: null, supportsProjectSnapshot: false })
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Could not reach runtime'), 'warning')
   })
 
@@ -424,7 +424,7 @@ describe('createEditorCompilerPlatformPort', () => {
       { context: { kind: 'editor-https', ip: '10.0.0.1', jwt: 'token' } },
       log,
     )
-    expect(result).toEqual({ ok: true, version: null, minEditorVersion: null })
+    expect(result).toEqual({ ok: true, version: null, minEditorVersion: null, supportsProjectSnapshot: false })
     expect(log).toHaveBeenCalledWith(expect.stringContaining('probe blew up'), 'warning')
   })
 })

--- a/src/backend/editor/compiler/editor-compiler-platform-port.ts
+++ b/src/backend/editor/compiler/editor-compiler-platform-port.ts
@@ -380,23 +380,32 @@ export function createEditorCompilerPlatformPort(
         // The source project, stored on the device beside the artifacts so it
         // can be retrieved later. Never fatal: the device runs the new program
         // either way, and failing an upload over the optional half of it would
-        // be a worse outcome than losing retrievability. A runtime without
-        // snapshot support ignores the extra parts, so there is nothing to
-        // probe for first.
+        // be a worse outcome than losing retrievability.
         let snapshot: { archive: Buffer; metadata: string; missingLibraries: string[] } | null = null
-        try {
-          snapshot = (await context.buildUploadSnapshot?.()) ?? null
-          if (snapshot && snapshot.missingLibraries.length > 0) {
+        if (!args.supportsProjectSnapshot) {
+          // Asked and answered by the pre-upload capability check. Building one
+          // anyway would spend the user's time compressing a project this
+          // device discards on arrival, and leave them a device they cannot
+          // retrieve from with nothing said about why.
+          log(
+            'This runtime does not store source projects, so the project will not be sent with the program and cannot be retrieved from this device later.',
+            'warning',
+          )
+        } else {
+          try {
+            snapshot = (await context.buildUploadSnapshot?.()) ?? null
+            if (snapshot && snapshot.missingLibraries.length > 0) {
+              log(
+                `Stored project will not include these libraries, which are not installed here: ${snapshot.missingLibraries.join(', ')}`,
+                'warning',
+              )
+            }
+          } catch (error) {
             log(
-              `Stored project will not include these libraries, which are not installed here: ${snapshot.missingLibraries.join(', ')}`,
+              `Could not prepare the project for storage on the device: ${error instanceof Error ? error.message : String(error)}`,
               'warning',
             )
           }
-        } catch (error) {
-          log(
-            `Could not prepare the project for storage on the device: ${error instanceof Error ? error.message : String(error)}`,
-            'warning',
-          )
         }
 
         const deployOutcome = await deployRuntimeProgram({
@@ -602,12 +611,12 @@ export function createEditorCompilerPlatformPort(
         if (!result.success) return { success: false as const, error: result.error }
         return { success: true as const, body: result.data }
       }
-      const { version, minEditorVersion } = await probeRuntimeVersion({
+      const { version, minEditorVersion, supportsProjectSnapshot } = await probeRuntimeVersion({
         fetchCapabilities: () => getJson('/api/capabilities'),
         fetchVersion: () => getJson('/api/version'),
         log,
       })
-      return { ok: true, version, minEditorVersion }
+      return { ok: true, version, minEditorVersion, supportsProjectSnapshot }
     },
 
     /**

--- a/src/backend/editor/runtime/runtime-api-client.ts
+++ b/src/backend/editor/runtime/runtime-api-client.ts
@@ -63,34 +63,6 @@ const PlcStatusResponseSchema = z.object({
   switchPosition: z.string().optional(),
 })
 
-/**
- * What a device reports about the source project it stores.
- *
- * Every field but `present` is optional because a device with nothing stored
- * answers `{present: false}` alone, and because these values come from whoever
- * uploaded -- the runtime never opens the archive to check them.
- */
-const ProjectSnapshotInfoSchema = z.object({
-  present: z.boolean(),
-  projectName: z.string().optional(),
-  editorVersion: z.string().optional(),
-  uploadedBy: z.string().optional(),
-  timestamp: z.string().optional(),
-  sizeBytes: z.number().optional(),
-  formatVersion: z.number().optional(),
-  libraries: z
-    .array(
-      z.object({
-        name: z.string(),
-        version: z.string().optional(),
-        hash: z.string().optional(),
-      }),
-    )
-    .optional(),
-})
-
-export type ProjectSnapshotInfo = z.infer<typeof ProjectSnapshotInfoSchema>
-
 const ProjectSnapshotBodySchema = z.object({
   projectName: z.string(),
   contentBase64: z.string(),

--- a/src/backend/editor/runtime/runtime-api-client.ts
+++ b/src/backend/editor/runtime/runtime-api-client.ts
@@ -592,25 +592,6 @@ export class RuntimeApiClient {
   }
 
   /**
-   * What the device says about the source project it is storing, if any.
-   *
-   * Authenticated but not admin-gated, so the UI can decide whether to OFFER
-   * retrieval without needing the privilege that retrieval itself requires.
-   */
-  async getProjectSnapshotInfo(
-    ipAddress: string,
-  ): Promise<{ success: true; info: ProjectSnapshotInfo } | { success: false; error: string }> {
-    const result = await this.makeRuntimeApiRequest<ProjectSnapshotInfo | null>(
-      ipAddress,
-      '/api/project-snapshot/info',
-      (data) => ProjectSnapshotInfoSchema.safeParse(parseJsonOrNull(data)).data ?? null,
-    )
-    if (!result.success) return { success: false, error: result.error }
-    if (!result.data) return { success: false, error: 'The device sent an unreadable snapshot description' }
-    return { success: true, info: result.data }
-  }
-
-  /**
    * Fetch the stored source project.
    *
    * Admin only on the device: the archive is not encrypted there, so that role

--- a/src/backend/shared/compile/__tests__/pipeline.test.ts
+++ b/src/backend/shared/compile/__tests__/pipeline.test.ts
@@ -1312,3 +1312,60 @@ describe('runCompilePipeline — side effects', () => {
     expect(stEvents.some((e) => e.message === 'transpiler: parsed 5 POUs' && e.level === 'info')).toBe(true)
   })
 })
+
+// --- the project-snapshot capability reaches the upload ----------------------
+//
+// The runtime advertises `projectSnapshot` at `/api/capabilities` and the
+// pre-upload probe already reads it. The upload step is what acts on it, so the
+// value has to survive the trip: without this the flag is read and dropped, and
+// the editor builds an archive for a device that discards it.
+
+describe('project-snapshot capability', () => {
+  it('tells the upload step when the runtime stores source projects', async () => {
+    const port = makePort({
+      checkRuntimeVersion: jest.fn().mockResolvedValue({ ok: true, version: '4.2.0', supportsProjectSnapshot: true }),
+    })
+
+    const { emit } = captureEvents()
+    await runCompilePipeline(
+      makeArgs({
+        isSimulator: false,
+        isRuntimeV4: true,
+        boardRuntime: 'openplc-compiler',
+        deviceContext: deviceContextFixture,
+      }),
+      port,
+      emit,
+    )
+
+    expect(port.uploadRuntimeV4).toHaveBeenCalledWith(
+      expect.objectContaining({ supportsProjectSnapshot: true }),
+      expect.anything(),
+    )
+  })
+
+  it('tells the upload step when it does not', async () => {
+    // Every runtime predating the feature. The upload step skips building the
+    // archive and says why, rather than sending one into a device that drops it.
+    const port = makePort({
+      checkRuntimeVersion: jest.fn().mockResolvedValue({ ok: true, version: '4.1.0', supportsProjectSnapshot: false }),
+    })
+
+    const { emit } = captureEvents()
+    await runCompilePipeline(
+      makeArgs({
+        isSimulator: false,
+        isRuntimeV4: true,
+        boardRuntime: 'openplc-compiler',
+        deviceContext: deviceContextFixture,
+      }),
+      port,
+      emit,
+    )
+
+    expect(port.uploadRuntimeV4).toHaveBeenCalledWith(
+      expect.objectContaining({ supportsProjectSnapshot: false }),
+      expect.anything(),
+    )
+  })
+})

--- a/src/backend/shared/compile/pipeline.ts
+++ b/src/backend/shared/compile/pipeline.ts
@@ -681,7 +681,17 @@ async function runCompilePipelineInner(
     }
 
     emit({ stage: 'upload', message: 'Uploading Runtime v4 bundle...', level: 'info' })
-    const uploadResult = await port.uploadRuntimeV4({ bundle, context: deviceContext }, makePlatformLog(emit, 'upload'))
+    const uploadResult = await port.uploadRuntimeV4(
+      {
+        bundle,
+        context: deviceContext,
+        // Answered by the capability probe above, so the upload step does not
+        // have to ask the device a second time -- and does not build a project
+        // archive for a runtime that will discard it.
+        supportsProjectSnapshot: versionCheck.supportsProjectSnapshot,
+      },
+      makePlatformLog(emit, 'upload'),
+    )
     if (!uploadResult.ok) {
       return bailError(emit, 'upload', 'Failed to upload to runtime.', uploadResult.errors)
     }

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -6,7 +6,6 @@ import {
   pruneRetrievedProjects,
   RETAINED_RETRIEVALS,
 } from '@root/backend/editor/project/materialize-retrieved-project'
-import type { ProjectSnapshotInfo } from '@root/backend/editor/runtime/runtime-api-client'
 import type {
   DebugBoardIdResult,
   DebugStatusResult,

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -563,20 +563,6 @@ class MainProcessBridge implements MainIpcModule {
   }
 
   /**
-   * What a device says about the source project it stores.
-   *
-   * Authenticated but not admin-gated on the device, so the UI can decide
-   * whether to offer retrieval without holding the privilege retrieval needs.
-   */
-  handleRuntimeProjectSnapshotInfo = async (
-    _event: IpcMainInvokeEvent,
-    ipAddress: string,
-  ): Promise<{ success: boolean; info?: ProjectSnapshotInfo; error?: string }> => {
-    const result = await this.runtimeApi.getProjectSnapshotInfo(ipAddress)
-    return result.success ? { success: true, info: result.info } : { success: false, error: result.error }
-  }
-
-  /**
    * Retrieve the stored project and write it to a scratch directory.
    *
    * Fetch and unpack are one IPC call because the archive should not sit in the
@@ -820,7 +806,6 @@ class MainProcessBridge implements MainIpcModule {
     this.registerHandle('runtime:clear-credentials', this.handleRuntimeClearCredentials)
     this.registerHandle('runtime:get-serial-ports', this.handleRuntimeGetSerialPorts)
     this.registerHandle('runtime:discover-devices', this.handleRuntimeDiscoverDevices)
-    this.registerHandle('runtime:project-snapshot-info', this.handleRuntimeProjectSnapshotInfo)
     this.registerHandle('runtime:retrieve-project', this.handleRuntimeRetrieveProject)
     this.registerHandle('runtime:install-retrieved-libraries', this.handleInstallRetrievedLibraries)
 

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -3,7 +3,6 @@ import type { CompileLibraryIpcArgs } from '@root/middleware/adapters/editor/com
 import type {
   DiscoveredRuntimeDevice,
   RuntimeLogEntry,
-  RuntimeProjectSnapshotInfo,
   RuntimeProjectSnapshotMetadata,
 } from '@root/middleware/shared/ports'
 import type {
@@ -591,11 +590,6 @@ const rendererProcessBridge = {
     durationMs?: number
   }): Promise<{ success: boolean; devices?: DiscoveredRuntimeDevice[]; error?: string }> =>
     ipcRenderer.invoke('runtime:discover-devices', opts),
-  /** What a device says about the project it stores; `present: false` when none. */
-  runtimeProjectSnapshotInfo: (
-    ipAddress: string,
-  ): Promise<{ success: boolean; info?: RuntimeProjectSnapshotInfo; error?: string }> =>
-    ipcRenderer.invoke('runtime:project-snapshot-info', ipAddress),
   /**
    * Retrieve the stored project and unpack it to a scratch directory.
    *

--- a/src/middleware/adapters/editor/__tests__/runtime-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/runtime-adapter.test.ts
@@ -31,10 +31,6 @@ beforeEach(() => {
     onRuntimeTokenRefreshed: jest.fn().mockImplementation(() => jest.fn()),
     runtimeDiscoverDevices: jest.fn().mockResolvedValue({ success: true, devices: [] }),
     onRuntimeDeviceDiscovered: jest.fn().mockImplementation(() => jest.fn()),
-    runtimeProjectSnapshotInfo: jest.fn().mockResolvedValue({
-      success: true,
-      info: { present: true, projectName: 'Traffic Light' },
-    }),
     runtimeRetrieveProject: jest.fn().mockResolvedValue({
       success: true,
       projectName: 'Traffic Light',
@@ -639,22 +635,6 @@ describe('isReadyForDebug', () => {
 // ---------------------------------------------------------------------------
 // stored source project
 // ---------------------------------------------------------------------------
-
-describe('getProjectSnapshotInfo', () => {
-  it('delegates to bridge with the device address', async () => {
-    const result = await adapter.getProjectSnapshotInfo!('192.168.1.100')
-
-    expect(window.bridge.runtimeProjectSnapshotInfo).toHaveBeenCalledWith('192.168.1.100')
-    expect(result).toEqual({ success: true, info: { present: true, projectName: 'Traffic Light' } })
-  })
-
-  it('reports a failed IPC call rather than throwing at the caller', async () => {
-    ;(window.bridge.runtimeProjectSnapshotInfo as jest.Mock).mockRejectedValue(new Error('info failed'))
-    const result = await adapter.getProjectSnapshotInfo!('192.168.1.100')
-
-    expect(result).toEqual({ success: false, error: 'info failed' })
-  })
-})
 
 describe('retrieveProject', () => {
   it('delegates to bridge with the device address', async () => {

--- a/src/middleware/adapters/editor/runtime-adapter.ts
+++ b/src/middleware/adapters/editor/runtime-adapter.ts
@@ -256,14 +256,6 @@ export function createEditorRuntimeAdapter(getIpAddress: () => string): RuntimeP
 
     // --- stored source project ---
 
-    async getProjectSnapshotInfo(ipAddress: string) {
-      try {
-        return await window.bridge.runtimeProjectSnapshotInfo(ipAddress)
-      } catch (err) {
-        return { success: false, error: getErrorMessage(err) }
-      }
-    },
-
     async retrieveProject(ipAddress: string) {
       try {
         return await window.bridge.runtimeRetrieveProject(ipAddress)

--- a/src/middleware/shared/ports/compiler-platform-port.ts
+++ b/src/middleware/shared/ports/compiler-platform-port.ts
@@ -152,6 +152,17 @@ export interface UploadRuntimeV4Args {
   bundle: Record<string, string>
   /** Discriminated device context; see `PlatformDeviceContext`. */
   context: PlatformDeviceContext
+  /**
+   * Whether this runtime stores the source project sent beside a program, as
+   * declared at `GET /api/capabilities` and read by the pre-upload version
+   * check.
+   *
+   * `false` means do not build one: a runtime that does not support snapshots
+   * discards the extra parts silently, so sending one costs the user upload
+   * time for an archive that is thrown away, and leaves them a device they
+   * cannot retrieve from with nothing said about why.
+   */
+  supportsProjectSnapshot: boolean
 }
 
 export interface UploadResult {
@@ -246,6 +257,13 @@ export interface CheckRuntimeVersionResult {
    *  when the runtime is unreachable or doesn't expose the
    *  endpoint (very old v3 runtimes). */
   version: string | null
+  /**
+   * Whether this runtime stores the source project an upload carries, from
+   * `projectSnapshot` at `GET /api/capabilities`. `false` for every runtime
+   * predating the feature or the endpoint, which is the honest default: one
+   * that stores snapshots says so.
+   */
+  supportsProjectSnapshot: boolean
   /**
    * Oldest editor this runtime accepts programs from, declared at
    * `GET /api/capabilities` (DOPE-448).  `null` means the runtime

--- a/src/middleware/shared/ports/index.ts
+++ b/src/middleware/shared/ports/index.ts
@@ -159,7 +159,6 @@ export type {
   LoginParams,
   LoginResult,
   RuntimeLogsResult,
-  RuntimeProjectSnapshotInfo,
   RuntimeProjectSnapshotMetadata,
   RuntimeStatusResult,
   UsersInfoResult,

--- a/src/middleware/shared/ports/runtime-port.ts
+++ b/src/middleware/shared/ports/runtime-port.ts
@@ -164,18 +164,6 @@ export interface DiscoveredRuntimeDevice {
   projectTimestamp?: string
 }
 
-/** What a device reports about the project it stores, once authenticated. */
-export interface RuntimeProjectSnapshotInfo {
-  present: boolean
-  projectName?: string
-  editorVersion?: string
-  uploadedBy?: string
-  timestamp?: string
-  sizeBytes?: number
-  formatVersion?: number
-  libraries?: Array<{ name: string; version?: string; hash?: string }>
-}
-
 /** The manifest carried inside a retrieved archive. */
 export interface RuntimeProjectSnapshotMetadata {
   formatVersion: number
@@ -376,17 +364,6 @@ export interface RuntimePort {
   // --- stored source project ---
 
   /**
-   * What a device says about the source project it stores.
-   *
-   * Authenticated but not admin-gated on the device, so the UI can decide
-   * whether to offer retrieval without holding the privilege retrieval needs.
-   */
-  getProjectSnapshotInfo?(
-    /** Desktop passes the device address; web resolves it from its device context. */
-    ipAddress?: string,
-  ): Promise<{ success: boolean; info?: RuntimeProjectSnapshotInfo; error?: string }>
-
-  /**
    * Retrieve the stored project and unpack it somewhere the editor can open it.
    *
    * Desktop only, and it returns a path rather than the archive on purpose:
@@ -412,12 +389,6 @@ export interface RuntimePort {
    *  whoever uploaded it. Only the username -- the password stays inside the
    *  token authority. */
   getSessionUsername?(): string | null
-
-  /** The device this session is authenticated against, or null when there is no
-   *  session. A device context alone is not one: selecting a device points the
-   *  adapter at it without signing in, so both have to hold before a caller may
-   *  skip asking for credentials. */
-  getAuthenticatedDevice?(): { agentId: string; deviceId: string } | null
 
   /**
    * Retrieve the stored project as raw archive bytes.


### PR DESCRIPTION
Follow-up to #1070. That PR merged at its then-head; this commit was pushed minutes later and did not make it in, so `development` is currently carrying the exact state the review objected to.

**Must land together with openplc-web's sibling PR.** Both change shared files (`runtime-port.ts`, `compiler-platform-port.ts`, `pipeline.ts` and its test), so landing one alone turns `ci-sync` red. (`probe-runtime-version.ts` was listed here in error -- it already carries `supportsProjectSnapshot` on `development` and is untouched by either PR.) Surfaces compare clean between the two branches right now (0 diffs), and `development` vs `development` is also clean — because neither side landed, both are equally behind.

## What this fixes

**`capabilities.projectSnapshot` is finally consumed** (review finding #2 on openplc-runtime #183, which was never actually closed). My earlier commit made it worse rather than better: it added `supportsProjectSnapshot` to the version probe with a doc comment claiming *"The upload path uses this to skip building one and to say why"* — and nothing read the field. That comment is in `development` today, and it is false.

The flag now travels probe → pipeline → `uploadRuntimeV4`. An upload to a runtime that does not store source projects skips building the archive and says so in the build log, instead of spending the user's time compressing a project the device discards on arrival and leaving them a device they cannot retrieve from with nothing said about why. Two tests assert the value reaches the upload step in both directions, so the plumbing cannot silently break again.

**Two pieces of dead surface are removed rather than left unused** (review finding #5):

- `getProjectSnapshotInfo` was plumbed through four layers with no caller. It cannot usefully serve the picker either — the endpoint is authenticated, so it cannot be asked about a device before signing in, which is why nothing ever called it. Better re-added when something needs it than kept as a shape people assume is load-bearing.
- `getAuthenticatedDevice` was left callerless by the picker unification in #1070. Its one remaining use moved into the web adapter as `connectedRetrievableDeviceKey`, where the device context and the token are both local — which also takes the web-shaped signature out of the shared port, closing a nit from the same review.

## Testing

**Correction to an earlier version of this body,** which claimed lint was clean when it was red. It was not: deleting `getProjectSnapshotInfo` orphaned `ProjectSnapshotInfoSchema`, the type it inferred, and an import in `main.ts`, and CI's `lint` failed on all three. Fixed in a follow-up commit.

The claim was wrong because `npm run lint` uses an unquoted glob that matches a handful of files on macOS while CI's shell expands it across the tree -- so a clean local run means very little here. `npx eslint src` is the invocation that matches CI, and is what these numbers now come from.

Current state: 7595 tests passing, `npx eslint src` 0 errors, `npx tsc --build` clean, prettier clean, shared surfaces at 0 diffs. `development` is merged in and conflict-free.

One flake to be honest about: across three full runs of the suite, one run reported a single failure that I could not reproduce on the two subsequent runs and that the reporter did not name. Worth watching in CI rather than assuming it is nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bpea15BYCgPSqpatpveRk1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects whether connected runtimes support project snapshots before uploading.
  * Avoids creating project archives when snapshots are unsupported and warns when projects cannot be stored.
  * Adds support for viewing and updating runtime retain settings.

* **Bug Fixes**
  * Prevents unnecessary snapshot processing and avoids uploading project data that would be discarded.

* **Removed**
  * Removed the previous project snapshot information lookup and related bridge functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
