### PR TITLE
chore(strucpp): pin v0.6.6

### DIFF
--- a/binary-versions.json
+++ b/binary-versions.json
@@ -1,6 +1,6 @@
 {
   "strucpp": {
-    "version": "v0.6.5",
+    "version": "v0.6.6",
     "repository": "Autonomy-Logic/STruCpp"
   }
 }


### PR DESCRIPTION
Bumps the pinned STruC++ compiler from **v0.6.5** to **v0.6.6** in `binary-versions.json`.

```diff
-    "version": "v0.6.5",
+    "version": "v0.6.6",
```

`scripts/download-binaries.ts` derives the asset name from this field and resolves it to `strucpp-0.6.6.tgz`. Verified before opening: the download URL returns **HTTP 200**, a forced install under Node 22 pins `0.6.6`, and the published bundle carries the fixes below. No other change is needed — the script derives the asset name from this field, and `electron-builder.json` references the extracted `strucpp/runtime/include` and `strucpp/libs` paths, which are version-agnostic.

## What v0.6.6 brings

A single upstream PR, [STruCpp #230](https://github.com/Autonomy-Logic/STruCpp/pull/230) — two language-server resolution defects, [RTOP-247](https://autonomylogic.atlassian.net/browse/RTOP-247) and [RTOP-248](https://autonomylogic.atlassian.net/browse/RTOP-248). Compiler, codegen and the debug table are untouched; this is the LSP only.

**A STRUCT field resolved against the global scope.** Inside `TYPE ... END_TYPE` there is no enclosing POU, so the lookup scope was `globalScope` and a field name matched whatever global happened to share it. Five surfaces in this repo consumed that:

| surface | before |
| --- | --- |
| hover | showed the function block's signature |
| Ctrl/Cmd+click | navigated to the function block |
| **rename (F2)** | **rewrote the FUNCTION BLOCK and every reference to it** |
| find-all-references | listed the block's references |
| `IsWrappedTypeRequest` | misclassified the field |

The rename case is data loss rather than a cosmetic slip, and it is the reason this bump is worth taking promptly. It is also not function-block-only — any global symbol kind collided, so a field named after a FUNCTION behaved identically.

**Member access past an array subscript.** `myArray[i].` offered the generic body-completion list — keywords plus every global and library symbol — instead of the element type's members. Now covered: inline arrays, named array TYPEs, multi-dimensional arrays, an array reached through a struct field, a TYPE alias naming an array type, `ARRAY [*]`, a dot inside the index expression (`arr[s.k].`) and a subscripted index (`arr[idx[i]].`).

Deliberately unchanged upstream: hover and go-to-definition past a subscript still resolve to the base variable. They do the same for a plain non-array struct, so that is the existing behaviour of those surfaces rather than an array defect.

## Risk

Low for this repo. The `.dt` data type code view (DOPE-385/537) is the surface where the struct-field defect was found, so that path is the one worth a look during review — the change makes hover and Ctrl+click on a colliding field answer *nothing* where they previously answered wrongly.

## Verification

Upstream: full compiler suite **2322 passed / 7 skipped**, extension suite **282 passed**, both `tsc` clean, all six CI checks green on the release PR ([STruCpp #231](https://github.com/Autonomy-Logic/STruCpp/pull/231)), including a clean-checkout Extension Build & Test and the packaged Binary Smoke Test.

Both defects were also validated by hand in this editor against a purpose-built project covering every array shape and a struct whose fields are named after a FUNCTION_BLOCK and a FUNCTION.

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/725

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JAMx8mRf2ig4YFfs2gmsM

[RTOP-247]: https://autonomylogic.atlassian.net/browse/RTOP-247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RTOP-248]: https://autonomylogic.atlassian.net/browse/RTOP-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `strucpp` binary to version `v0.6.6`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->