### PR TITLE
fix(save): stop queueing a save no sign-in can ever replay (mirror of openplc-web#726)

### DIFF
--- a/src/frontend/services/__tests__/save-actions.test.ts
+++ b/src/frontend/services/__tests__/save-actions.test.ts
@@ -15,7 +15,13 @@ import type { LadderFlowType } from '../../store/slices/ladder'
 import { getMemoryState } from '../../utils/toast'
 import { buildAllProjectFileContentsPure, executeSaveFile, executeSaveProject } from '../save-actions'
 
-const capabilities = { isNativeApplication: true } as PlatformCapabilities
+/**
+ * `hasEdgeAccount` is declared, not left off. The shared save path asks it to
+ * decide whether a session that ended can be signed back into, and the desktop
+ * always has an account surface. Nothing here exercises that branch today, but a
+ * fixture that omits the field would send a future case down the wrong one.
+ */
+const capabilities = { isNativeApplication: true, hasEdgeAccount: true } as PlatformCapabilities
 
 const lastToast = () => getMemoryState().toasts[0]
 

--- a/src/frontend/services/save-actions.ts
+++ b/src/frontend/services/save-actions.ts
@@ -403,6 +403,37 @@ export function buildAllProjectFileContents(): Record<string, string> {
  */
 export type SaveReason = 'user' | 'pre-build'
 
+/**
+ * A session that ended with no way back, and what to say about it.
+ *
+ * Both the resume queue and the "sign in again" message assume a sign-in exists
+ * to wait for. Where the build has no account surface they are worse than
+ * useless: a partner-integration launch authenticates its visitor by an
+ * ephemeral session, that person has no Autonomy account and no sign-in is on
+ * screen, so `onRestored` can never fire. The save would sit in the queue
+ * forever while the toast named an action that does not exist, and they would
+ * keep typing into a tab where nothing more is ever written.
+ *
+ * `hasEdgeAccount` is the right question because it is exactly "is there an
+ * account surface here". It stays true on the desktop editor, so this branch is
+ * dead there and the queue keeps working for a real signed-out user.
+ */
+function endedSessionCanBeRestored(capabilities: PlatformCapabilities): boolean {
+  return capabilities.hasEdgeAccount
+}
+
+/**
+ * Deliberately the same words as the `/unauthorized` panel for the same
+ * situation: someone who meets both should not have to work out that they are
+ * being told one thing. It promises nothing about unsaved work surviving,
+ * because reopening starts a new session from the last save.
+ */
+const ENDED_SESSION_NO_RETURN = {
+  title: 'Your editing session has ended',
+  description:
+    'Editing sessions are temporary and this one has run out, so nothing further can be saved from this tab. Open the project again from the application you came from to carry on.',
+} as const
+
 export async function executeSaveProject(
   projectPort: ProjectPort,
   capabilities: PlatformCapabilities,
@@ -607,6 +638,12 @@ export async function executeSaveProject(
       // happened, say the work is safe, and queue the save so signing in finishes
       // it — the user should not have to remember to press save a second time.
       setEditingState('unsaved')
+
+      if (!endedSessionCanBeRestored(capabilities)) {
+        toast({ ...ENDED_SESSION_NO_RETURN, variant: 'fail' })
+        return { success: false }
+      }
+
       resumeSaveAfterEdgeSignIn(() => executeSaveProject(projectPort, capabilities))
       toast({
         title: 'Not saved — your session ended',
@@ -702,6 +739,11 @@ export async function executeSaveFile(
     // the reader. Queue the save so signing in completes it rather than leaving the
     // file dirty and the user unaware.
     if (isSaveBlockedByEndedSession()) {
+      if (!endedSessionCanBeRestored(capabilities)) {
+        toast({ ...ENDED_SESSION_NO_RETURN, variant: 'fail' })
+        return { success: false }
+      }
+
       resumeSaveAfterEdgeSignIn(() => executeSaveFile(fileName, projectPort, capabilities), {
         scope: 'file',
         fileName,


### PR DESCRIPTION
# Mirror of openplc-web#726 — the shared save path

`src/frontend/services/save-actions.ts` is shared surface and must stay byte-identical between the two repositories, so this PR carries the same change with no desktop-side variation. **Pairs with [openplc-web#726](https://github.com/Autonomy-Logic/openplc-web/pull/726); neither Shared Surface Sync check passes without the other open.**

## Why the change exists

It fixes a web-build defect. A partner sends its own end user into the web editor through Edge's launch link; that person is authenticated by an ephemeral session, has no Autonomy account, and is not meant to acquire one. The parent PR removes the account surface for that case, because the editor had been putting a sign-in dialog over a project that had loaded perfectly well.

Removing the dialog left the save path still believing a sign-in was coming. When the launch cookie ages out, the save gets a 401, the renewal fails (the launch sets only `accessToken`, never a refresh cookie), and the ended-session branch told the user to sign in again and parked the save on `onRestored`. With no sign-in on screen that event can never fire, so the save waited forever while the message named an action that did not exist. Silent, which is worse than the blocked save it replaced.

## What it means here

Nothing changes on the desktop. `EDITOR_CAPABILITIES.hasEdgeAccount` is `true`, so `endedSessionCanBeRestored` is always true and the new branch is unreachable: a real signed-out user still gets the resume queue and the existing message, exactly as before.

The test fixture now declares `hasEdgeAccount` explicitly. The shared save path reads it, and a fixture that leaves it off silently asserts "no account here" — which would send a future case down the branch that is meant to be unreachable in this build. Nothing here exercises it today; the editor's copy of that suite has no ended-session scenario.

## Verification

- `save-actions.ts` is byte-identical to the web branch (`cmp`, no output).
- `compare-surfaces.py` between the two branches: **match: true, 0 diffs.**
- `jest`: 359 suites pass, 7590 tests. The editor's `save-actions` suite passes with the mirrored file (20 tests).
- `eslint` 0 errors, `prettier --check` clean, architecture validator clean.

**Pre-existing failures, present identically on `development` and confirmed in a clean worktree — not from this change:** 8 suites (`compiler/*` ×6, `program-build-pipeline`, `element-card`) and 2 `tsc` errors in `program-build-pipeline.ts` (`retainBlobSize` missing from `DebugMapV2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6QpZdQSC511UjhgT1SWyY
