### PR TITLE
fix(firmware): mirror openplc_retain.h into src/ for every arduino-cli bundle [DOPE-602]

### DIFF
--- a/src/backend/shared/compile/__tests__/compose-firmware-bundle.test.ts
+++ b/src/backend/shared/compile/__tests__/compose-firmware-bundle.test.ts
@@ -129,6 +129,7 @@ describe('composeFirmwareBundle — full layout snapshot', () => {
       firmwareSkeleton: {
         'examples/Baremetal/Baremetal.ino': 'BAREMETAL_INO',
         'examples/Baremetal/c_blocks_code.cpp': 'STATIC_BASELINE',
+        'examples/Baremetal/openplc_retain.h': 'RETAIN_CONTRACT',
         'src/arduino.cpp': 'ARDUINO_HAL',
         'src/iec_std_lib.hpp': 'STRUCPP_RUNTIME_HEADER',
       },
@@ -146,6 +147,8 @@ describe('composeFirmwareBundle — full layout snapshot', () => {
       // The skeleton's static baseline survives alongside the generated unit:
       // it defines no symbols and pulls in no strucpp header.
       'examples/Baremetal/c_blocks_code.cpp': 'STATIC_BASELINE',
+      'examples/Baremetal/openplc_retain.h': 'RETAIN_CONTRACT',
+      'src/openplc_retain.h': 'RETAIN_CONTRACT',
       'src/c_blocks_code.cpp': 'CBLOCKS_CODE_WITH_USER',
       'src/arduino.cpp': 'ARDUINO_HAL',
       'src/iec_std_lib.hpp': 'STRUCPP_RUNTIME_HEADER',
@@ -183,6 +186,23 @@ describe('composeFirmwareBundle — full layout snapshot', () => {
       'src/defines.h': 'DEFINES_H',
       'src/OpenPLCUserLib.h': expect.stringContaining('#pragma once') as unknown as string,
     })
+  })
+})
+
+describe('composeFirmwareBundle — vendor-facing contract headers', () => {
+  // The web skeleton never passes through mergeStrucppRuntimeIntoSkeleton, so the mirror cannot depend on a HAL.
+  it('mirrors openplc_retain.h into src/ even when the skeleton carries no HAL', () => {
+    const out = composeFirmwareBundle({
+      ...baseInput,
+      firmwareSkeleton: { 'examples/Baremetal/openplc_retain.h': '/* contract */' },
+    })
+    expect(out['src/openplc_retain.h']).toBe('/* contract */')
+    expect(out['examples/Baremetal/openplc_retain.h']).toBe('/* contract */')
+  })
+
+  it('writes nothing under src/ when the skeleton lacks the header', () => {
+    const out = composeFirmwareBundle({ ...baseInput, firmwareSkeleton: {} })
+    expect('src/openplc_retain.h' in out).toBe(false)
   })
 })
 

--- a/src/backend/shared/compile/__tests__/merge-strucpp-runtime-into-skeleton.test.ts
+++ b/src/backend/shared/compile/__tests__/merge-strucpp-runtime-into-skeleton.test.ts
@@ -80,43 +80,4 @@ describe('mergeStrucppRuntimeIntoSkeleton', () => {
     })
     expect(input).toEqual(before)
   })
-
-  // --- vendor-facing contract headers ------------------------------------
-  //
-  // The HAL lands at `src/arduino.cpp` while the firmware's own headers stay
-  // under `examples/Baremetal/`, so without this mirroring a HAL cannot
-  // `#include "openplc_retain.h"` at all — the two directories never see each
-  // other, and a vendor implementing retain has to restate the ABI by hand.
-
-  it('mirrors openplc_retain.h into src/ so the HAL can include it', () => {
-    const merged = mergeStrucppRuntimeIntoSkeleton({
-      firmwareSkeleton: { 'examples/Baremetal/openplc_retain.h': '/* contract */' },
-      strucppRuntimeHeaders: {},
-      boardHalContent: '#include "openplc_retain.h"',
-    })
-    expect(merged['src/openplc_retain.h']).toBe('/* contract */')
-    // Copied, not moved: the Baremetal build still compiles its own copy.
-    expect(merged['examples/Baremetal/openplc_retain.h']).toBe('/* contract */')
-  })
-
-  it('mirrors nothing when there is no HAL to include it', () => {
-    // No HAL means no `src/` at all; putting a lone header there would give
-    // arduino-cli a library directory with nothing in it.
-    const merged = mergeStrucppRuntimeIntoSkeleton({
-      firmwareSkeleton: { 'examples/Baremetal/openplc_retain.h': '/* contract */' },
-      strucppRuntimeHeaders: {},
-    })
-    expect(merged['src/openplc_retain.h']).toBeUndefined()
-  })
-
-  it('skips a contract header the skeleton does not carry', () => {
-    // A skeleton assembled before the header existed must still merge, rather
-    // than writing `undefined` into src/ and failing the build later.
-    const merged = mergeStrucppRuntimeIntoSkeleton({
-      firmwareSkeleton: { 'examples/Baremetal/Baremetal.ino': '/* sketch */' },
-      strucppRuntimeHeaders: {},
-      boardHalContent: 'hal',
-    })
-    expect('src/openplc_retain.h' in merged).toBe(false)
-  })
 })

--- a/src/backend/shared/compile/steps/compose-firmware-bundle.ts
+++ b/src/backend/shared/compile/steps/compose-firmware-bundle.ts
@@ -114,6 +114,9 @@ export function buildCBlocksFromPous(
   }
 }
 
+// Included from src/ units (runtime glue, HALs); arduino-cli hides the sketch dir from library builds.
+const VENDOR_FACING_CONTRACT_HEADERS = ['openplc_retain.h'] as const
+
 /**
  * Assemble the firmware file tree.
  *
@@ -122,6 +125,7 @@ export function buildCBlocksFromPous(
  *  - `src/c_blocks_code.cpp`                         — written when `cBlocks.code !== null`
  *  - `examples/Baremetal/modules/...`                — from skeleton (Arduino library helpers)
  *  - `src/arduino.cpp`                               — from skeleton (HAL adapter, simulator-specific)
+ *  - `src/openplc_retain.h`                          — mirrored from `examples/Baremetal/` (vendor-facing contract)
  *  - `src/c_blocks.h`                                — written verbatim from `cBlocks.header`
  *  - `src/defines.h`                                 — written verbatim from `definesH`
  *  - `src/<strucpp-emitted-file>`                    — every key from `strucppFiles`
@@ -142,6 +146,12 @@ export function composeFirmwareBundle(input: ComposeFirmwareBundleInput): Record
   // runtime header, etc.).  Subsequent overwrites replace specific
   // entries.
   const files: Record<string, string> = { ...firmwareSkeleton }
+
+  // Copied, not moved: the sketch still compiles its own copy next to openplc_retain_weak.cpp.
+  for (const header of VENDOR_FACING_CONTRACT_HEADERS) {
+    const content = files[`examples/Baremetal/${header}`]
+    if (typeof content === 'string') files[`src/${header}`] = content
+  }
 
   // Strucpp output lands under `src/` alongside the runtime glue
   // — arduino-cli's `--library src` pass picks every TU there into

--- a/src/backend/shared/compile/steps/merge-strucpp-runtime-into-skeleton.ts
+++ b/src/backend/shared/compile/steps/merge-strucpp-runtime-into-skeleton.ts
@@ -57,16 +57,6 @@ export interface MergeStrucppRuntimeArgs {
  * (web's simulator HAL is dropped in favour of the editor's
  * per-board variant when both are present).
  */
-/**
- * Firmware headers a board HAL is expected to be able to include.
- *
- * Deliberately a short, explicit list rather than "every header in
- * examples/Baremetal": these are the ones that describe a contract a VENDOR
- * implements, and copying the whole firmware into `src/` would put two copies
- * of every translation unit in front of arduino-cli.
- */
-const VENDOR_FACING_CONTRACT_HEADERS = ['openplc_retain.h'] as const
-
 export function mergeStrucppRuntimeIntoSkeleton(args: MergeStrucppRuntimeArgs): Record<string, string> {
   const merged: Record<string, string> = { ...args.firmwareSkeleton }
   for (const [v4Key, content] of Object.entries(args.strucppRuntimeHeaders)) {
@@ -76,23 +66,6 @@ export function mergeStrucppRuntimeIntoSkeleton(args: MergeStrucppRuntimeArgs): 
   }
   if (typeof args.boardHalContent === 'string' && args.boardHalContent.length > 0) {
     merged['src/arduino.cpp'] = args.boardHalContent
-
-    // Vendor-facing runtime contracts, mirrored into `src/` beside the HAL.
-    //
-    // The HAL lands at `src/arduino.cpp` while the firmware's own headers stay
-    // under `examples/Baremetal/`, so a HAL that implements one of these
-    // contracts could not `#include` it — the two directories never see each
-    // other. A vendor writing a retain backend hits this immediately: the
-    // include fails, and the only workaround is to restate the contract by
-    // hand in the HAL, which is how two copies of an ABI start drifting.
-    //
-    // Copied rather than moved: the Baremetal build still compiles its own
-    // copy, and arduino-cli's `--library src` pass is what makes this one
-    // visible to the HAL.
-    for (const contract of VENDOR_FACING_CONTRACT_HEADERS) {
-      const header = merged[`examples/Baremetal/${contract}`]
-      if (typeof header === 'string') merged[`src/${contract}`] = header
-    }
   }
   return merged
 }


### PR DESCRIPTION
## Summary

Mirror of the openplc-web fix. Every openplc-web simulator build on `development` fails at the compile service with `fatal error: openplc_retain.h: No such file or directory`. `src/arduino_runtime_glue.cpp` includes the header unconditionally since the NODE-94 retain work, but the header ships only next to the sketch at `examples/Baremetal/`, and arduino-cli never puts the sketch directory on a library unit's include path.

The editor was unaffected by accident: `mergeStrucppRuntimeIntoSkeleton` mirrored the header into `src/` only when a board HAL was supplied, which the editor always does and the web never calls.

## Change

- `composeFirmwareBundle` now mirrors `examples/Baremetal/openplc_retain.h` to `src/openplc_retain.h` for every arduino-cli bundle, on both platforms, HAL or not.
- The HAL-gated copy in `mergeStrucppRuntimeIntoSkeleton` is removed, so the contract header list lives in one place.
- Tests updated accordingly; `src/backend/shared/` coverage stays at 100%.

No change to compiler-service: it writes any relative path it receives.

## Mirror

openplc-web PR on the same branch: https://github.com/Autonomy-Logic/openplc-web/pull/727. Shared files are byte-identical (`scripts/compare-surfaces.py` reports a match on all surfaces).

## Verification

- jest on `src/backend/shared/compile`, eslint and `tsc --noEmit`: green.
- Root cause reproduced with arduino-cli and the `arduino:avr` 1.8.7 core: a `src/` unit including a sketch-only header fails to compile; mirroring the header into `src/` makes it compile.

Jira: [DOPE-602](https://autonomylogic.atlassian.net/browse/DOPE-602)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzuqKbcGGoYD4Ditojw3bE


[DOPE-602]: https://autonomylogic.atlassian.net/browse/DOPE-602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Firmware bundles now consistently include required contract headers in the generated source, preserving compatibility with sketches and runtime components.
  * Header files remain available in their original example location while also being copied into the generated firmware source.
  * Bundles without the relevant header no longer create an unnecessary source file.

* **Tests**
  * Added coverage for header mirroring across complete, minimal, and absent-header bundle layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->