### PR TITLE
fix(editor): make execution order legible, drop it from ladder, stop it rewiring blocks [DOPE-606 + DOPE-611]

### DIFF
--- a/src/frontend/components/_atoms/graphical-editor/fbd/block.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/fbd/block.tsx
@@ -816,11 +816,11 @@ const Block = <T extends object>(block: BlockProps<T>) => {
     }
   }
 
-  // `executionOrder` is optional on older nodes and 0 means "not ordered", so
-  // anything not a positive integer renders no badge at all.
-  const rawExecutionOrder = Number((data as { executionOrder?: unknown }).executionOrder ?? 0)
+  // 0 means "not ordered", so only a positive, finite order renders a badge.
+  // `Number.isFinite` still earns its place: a project file can carry anything,
+  // and a non-finite value must not reach the badge as "Infinity".
   const executionOrderBadge =
-    Number.isFinite(rawExecutionOrder) && rawExecutionOrder > 0 ? Math.trunc(rawExecutionOrder) : null
+    Number.isFinite(data.executionOrder) && data.executionOrder > 0 ? Math.trunc(data.executionOrder) : null
 
   return (
     <div

--- a/src/frontend/components/_atoms/graphical-editor/fbd/block.tsx
+++ b/src/frontend/components/_atoms/graphical-editor/fbd/block.tsx
@@ -357,6 +357,21 @@ export const BlockNodeElement = <T extends object>({
   )
 }
 
+/**
+ * Where the execution-order badge's centre sits, measured in from the block's
+ * bottom-right corner.
+ *
+ * The badge is meant to be quartered by the two borders -- a quarter inside the
+ * block, three quarters out. Centring it on the mathematical corner does that
+ * on paper, but `rounded-md` (6px) means the drawn border has already curved
+ * away by the time it reaches that point, so the circle reads as hanging low
+ * and outside. The straight run of each border ends one radius short of the
+ * corner, so the midpoint between the two -- half the radius -- is where the
+ * borders visually cut the circle in half.
+ */
+const BLOCK_CORNER_RADIUS = 6
+const EXECUTION_ORDER_BADGE_INSET = BLOCK_CORNER_RADIUS / 2
+
 const Block = <T extends object>(block: BlockProps<T>) => {
   const { data, dragging, height, width, selected, id } = block
   const pouName = useBoundPou()
@@ -801,6 +816,12 @@ const Block = <T extends object>(block: BlockProps<T>) => {
     }
   }
 
+  // `executionOrder` is optional on older nodes and 0 means "not ordered", so
+  // anything not a positive integer renders no badge at all.
+  const rawExecutionOrder = Number((data as { executionOrder?: unknown }).executionOrder ?? 0)
+  const executionOrderBadge =
+    Number.isFinite(rawExecutionOrder) && rawExecutionOrder > 0 ? Math.trunc(rawExecutionOrder) : null
+
   return (
     <div
       className={cn('relative', {
@@ -809,6 +830,31 @@ const Block = <T extends object>(block: BlockProps<T>) => {
       onMouseEnter={() => setHoveringBlock(true)}
       onMouseLeave={() => setHoveringBlock(false)}
     >
+      {/* Execution-order badge. Only when the block carries an order (> 0 --
+          0 means "unordered", see the Block Properties dialog), so an ordinary
+          diagram stays uncluttered and a numbered one shows its sequence
+          without opening a dialog per block (DOPE-606).
+
+          Anchored to the block's own width/height rather than the wrapper's
+          edges: the wrapper is a few pixels taller than the drawn block, so
+          `bottom-0` sat below the border. Centring on the corner leaves the
+          badge a quarter inside the block and three quarters outside, and it
+          holds for a two-digit number because the translate is relative to the
+          badge's own size. */}
+      {executionOrderBadge !== null && (
+        <div
+          className='pointer-events-none absolute z-10 flex h-5 min-w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-brand px-1 font-caption text-[10px] font-medium leading-none text-white shadow-sm ring-2 ring-white dark:ring-neutral-950'
+          style={{
+            left: (width ?? DEFAULT_BLOCK_WIDTH) - EXECUTION_ORDER_BADGE_INSET,
+            top: (height ?? DEFAULT_BLOCK_HEIGHT) - EXECUTION_ORDER_BADGE_INSET,
+          }}
+          aria-label={`Execution order ${executionOrderBadge}`}
+          title={`Execution order: ${executionOrderBadge}`}
+        >
+          {executionOrderBadge}
+        </div>
+      )}
+
       {data.hasDivergence && hoveringBlock && (
         <div
           className='pointer absolute right-[-12px] top-[-12px] z-10 flex h-6 w-6 items-center justify-center rounded-full bg-slate-600 shadow-sm'

--- a/src/frontend/components/_features/[workspace]/editor/graphical/elements/fbd/block/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/elements/fbd/block/index.tsx
@@ -492,29 +492,49 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
     // shares names. A wire whose pin is genuinely gone cannot be re-pointed
     // anywhere honest, so it is dropped and reported rather than silently
     // piled onto the first pin.
-    const newNodeData = newNode.data as {
-      inputHandles?: { id?: string }[]
-      outputHandles?: { id?: string }[]
-    }
-    const survivingPins = (handles: { id?: string }[] | undefined): Set<string> =>
+    // Handle type taken from the node itself, so this cannot drift from the
+    // builder and needs neither an import nor an assertion.
+    const pinIds = (handles: typeof newNode.data.inputHandles): Set<string> =>
       new Set((handles ?? []).map((handle) => handle.id).filter((id): id is string => !!id))
-    const newInputPins = survivingPins(newNodeData.inputHandles)
-    const newOutputPins = survivingPins(newNodeData.outputHandles)
+    const newInputPins = pinIds(newNode.data.inputHandles)
+    const newOutputPins = pinIds(newNode.data.outputHandles)
 
-    let droppedWires = 0
-    const rewire = (edge: (typeof newEdges)[number], side: 'source' | 'target', pins: Set<string>): void => {
-      const handle = side === 'source' ? edge.sourceHandle : edge.targetHandle
-      if (handle && pins.has(handle)) {
-        const moved = { ...edge, id: edge.id.replace(node.id, newNode.id), [side]: newNode.id }
-        newEdges = newEdges.map((e) => (e.id === edge.id ? moved : e))
-        return
+    // One pass over the affected edges, keyed by id, so an edge that is BOTH a
+    // source and a target of this block -- a self-loop, which the canvas allows
+    // -- has both endpoints resolved together. Two passes rewrote the id on the
+    // first and then failed to find the edge on the second, leaving the other
+    // endpoint pointing at a node that no longer exists.
+    const affected = new Map<string, (typeof newEdges)[number]>()
+    for (const edge of [...(edges.source ?? []), ...(edges.target ?? [])]) affected.set(edge.id, edge)
+
+    const replacements = new Map<string, (typeof newEdges)[number] | null>()
+    for (const edge of affected.values()) {
+      let next = { ...edge, id: edge.id.replace(node.id, newNode.id) }
+      let drop = false
+
+      if (edge.source === selectedNode.id) {
+        if (edge.sourceHandle && newOutputPins.has(edge.sourceHandle)) next = { ...next, source: newNode.id }
+        else drop = true
       }
-      droppedWires += 1
-      newEdges = newEdges.filter((e) => e.id !== edge.id)
+      if (!drop && edge.target === selectedNode.id) {
+        if (edge.targetHandle && newInputPins.has(edge.targetHandle)) next = { ...next, target: newNode.id }
+        else drop = true
+      }
+      replacements.set(edge.id, drop ? null : next)
     }
 
-    edges.source?.forEach((edge) => rewire(edge, 'source', newOutputPins))
-    edges.target?.forEach((edge) => rewire(edge, 'target', newInputPins))
+    // Replace IN PLACE, never append: an id from `edges` that is no longer in
+    // `newEdges` must stay gone rather than being resurrected alongside it.
+    let droppedWires = 0
+    newEdges = newEdges.flatMap((edge) => {
+      if (!replacements.has(edge.id)) return [edge]
+      const replacement = replacements.get(edge.id) ?? null
+      if (replacement === null) {
+        droppedWires += 1
+        return []
+      }
+      return [replacement]
+    })
 
     if (droppedWires > 0) {
       toast({

--- a/src/frontend/components/_features/[workspace]/editor/graphical/elements/fbd/block/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/elements/fbd/block/index.tsx
@@ -81,6 +81,7 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
   const [node, setNode] = useState<BlockNode<object>>(selectedNode)
   const blockVariant = node.data.variant as BlockVariant
 
+  const [isExecutionOrderFocused, setIsExecutionOrderFocused] = useState(false)
   const [selectedFileKey, setSelectedFileKey] = useState<string | null>(null)
   const [selectedFile, setSelectedFile] = useState<BlockVariant | null>(null)
   const [documentation, setDocumentation] = useState<string | null>(getBlockDocumentation(blockVariant))
@@ -318,14 +319,45 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
     }))
   }
 
+  // Execution order is stored as a plain number, where 0 means "not ordered":
+  // the transpiler buckets anything > 0 ahead of everything else and sorts the
+  // rest by layout position, so 0 is the absence of an order rather than the
+  // lowest one. Showing a bare "0" read as "runs first" and meant the opposite,
+  // so the field renders it as None (DOPE-606).
+  const NO_EXECUTION_ORDER = '0'
+  const isNoExecutionOrder = (value: string) => value === '' || Number(value) === 0
+  const executionOrderDisplay = isExecutionOrderFocused
+    ? formState.executionOrder === NO_EXECUTION_ORDER
+      ? ''
+      : formState.executionOrder
+    : isNoExecutionOrder(formState.executionOrder)
+      ? 'None'
+      : formState.executionOrder
+
+  /** Digits only — a leading `-` is dropped rather than rejected on submit. */
+  const handleExecutionOrderChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const digits = event.target.value.replace(/[^0-9]/g, '')
+    setFormState((prevState) => ({
+      ...prevState,
+      executionOrder: digits === '' ? NO_EXECUTION_ORDER : String(Number(digits)),
+    }))
+  }
+
+  // Blank the field while it has focus so the user types over "None" rather
+  // than around it; restore the label on the way out.
+  const handleExecutionOrderFocus = () => setIsExecutionOrderFocused(true)
+  const handleExecutionOrderBlur = () => setIsExecutionOrderFocused(false)
+
   const handleExecutionOrderIncrement = () => {
     setFormState((prevState) => ({
       ...prevState,
-      executionOrder: String(Math.min(Number(prevState.executionOrder) + 1, maxInputs)),
+      executionOrder: String(Number(prevState.executionOrder) + 1),
     }))
   }
 
   const handleExecutionOrderDecrement = () => {
+    // Floors at 0, which is None. There is no upper clamp: execution order is
+    // an ordering key, not a count, and the old ceiling reused `maxInputs`.
     setFormState((prevState) => ({
       ...prevState,
       executionOrder: String(Math.max(Number(prevState.executionOrder) - 1, 0)),
@@ -557,9 +589,12 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
                 id='executionOrder'
                 className={inputStyle}
                 placeholder=''
-                type='number'
-                value={formState.executionOrder}
-                onChange={handleInputChange}
+                type='text'
+                inputMode='numeric'
+                value={executionOrderDisplay}
+                onChange={handleExecutionOrderChange}
+                onFocus={handleExecutionOrderFocus}
+                onBlur={handleExecutionOrderBlur}
               />
               <ArrowButtonGroup
                 onIncrement={() => handleExecutionOrderIncrement()}

--- a/src/frontend/components/_features/[workspace]/editor/graphical/elements/fbd/block/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/elements/fbd/block/index.tsx
@@ -502,11 +502,7 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
     const newOutputPins = survivingPins(newNodeData.outputHandles)
 
     let droppedWires = 0
-    const rewire = (
-      edge: (typeof newEdges)[number],
-      side: 'source' | 'target',
-      pins: Set<string>,
-    ): void => {
+    const rewire = (edge: (typeof newEdges)[number], side: 'source' | 'target', pins: Set<string>): void => {
       const handle = side === 'source' ? edge.sourceHandle : edge.targetHandle
       if (handle && pins.has(handle)) {
         const moved = { ...edge, id: edge.id.replace(node.id, newNode.id), [side]: newNode.id }

--- a/src/frontend/components/_features/[workspace]/editor/graphical/elements/ladder/block/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/elements/ladder/block/index.tsx
@@ -97,30 +97,20 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
       LadderBlockVariant?.variables
         .filter((variable) => (variable.class === 'input' || variable.class === 'inOut') && variable.name !== 'EN')
         .length.toString() || '0',
-    executionOrder: selectedNode.data.executionOrder.toString(),
+    // Ladder has no execution order: rung position IS the order. Any value a
+    // project already carries is dropped on the next edit rather than kept
+    // alive by this dialog (DOPE-606).
+    executionOrder: '0',
     executionControl: selectedNode.data.executionControl,
   })
 
   const isFormValid = Object.values(formState).every((value) => value !== '')
   const isBlockDifferent = selectedNode !== node
 
-  // The execution order this dialog opened with. `useRef` keeps the first
-  // render's value for the life of the dialog, and the modal is mounted
-  // conditionally, so reopening it recaptures a fresh baseline.
-  const initialExecutionOrder = useRef(formState.executionOrder)
-
-  // Execution order is the ONE field `isBlockDifferent` cannot see. Every
-  // other control in this dialog also calls `setNode` -- input count, the
-  // execution-control switch, and a name that resolves to a library block --
-  // which replaces `node` and so already enabled OK. The arrows and the
-  // execution-order field call `setFormState` alone, so the value could be
-  // typed but never applied (DOPE-606).
-  //
-  // Deliberately NOT keyed on `formState.name`: `handleBlockSubmit` builds the
-  // new node from `blockVariant`, never from the typed name, so enabling OK
-  // for a name that resolves to nothing would rebuild the node and discard
-  // what was typed without saying so.
-  const isExecutionOrderDirty = formState.executionOrder !== initialExecutionOrder.current
+  // No execution-order dirty check here, unlike the FBD dialog: a ladder block
+  // has no execution order to edit (see below), so every control that remains
+  // -- input count, the execution-control switch, a resolvable name -- calls
+  // `setNode` and is already covered by `isBlockDifferent`.
 
   useEffect(() => {
     if (!selectedFileKey) return
@@ -190,7 +180,7 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
         ...newNode,
         data: {
           ...newNode.data,
-          executionOrder: Number(formState.executionOrder),
+          executionOrder: 0,
           variable: selectedNode.data.variable,
         },
       })
@@ -326,20 +316,6 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
     }))
   }
 
-  const handleExecutionOrderIncrement = () => {
-    setFormState((prevState) => ({
-      ...prevState,
-      executionOrder: String(Math.min(Number(prevState.executionOrder) + 1, maxInputs)),
-    }))
-  }
-
-  const handleExecutionOrderDecrement = () => {
-    setFormState((prevState) => ({
-      ...prevState,
-      executionOrder: String(Math.max(Number(prevState.executionOrder) - 1, 0)),
-    }))
-  }
-
   const handleExecutionControlChange = (checked: boolean) => {
     if (lockExecutionControl) return
 
@@ -408,7 +384,10 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
     })
     newNode.data = {
       ...newNode.data,
-      executionOrder: Number(formState.executionOrder),
+      // Always 0 in ladder: the walker buckets anything > 0 ahead of everything
+      // else GLOBALLY across rungs, so a stale number here would hoist this
+      // block above earlier rungs and silently break rung-order semantics.
+      executionOrder: 0,
     }
 
     const { ladderFlows } = useOpenPLCStore.getState()
@@ -597,24 +576,6 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
                 </div>
               </>
             )}
-            <label htmlFor='executionOrder' className={labelStyle}>
-              Execution Order:
-            </label>
-            <div className='flex items-center gap-1'>
-              <InputWithRef
-                id='executionOrder'
-                className={inputStyle}
-                placeholder=''
-                type='number'
-                value={formState.executionOrder}
-                onChange={handleInputChange}
-              />
-              <ArrowButtonGroup
-                onIncrement={() => handleExecutionOrderIncrement()}
-                onDecrement={() => handleExecutionOrderDecrement()}
-              />
-            </div>
-
             <div className='flex items-center gap-2'>
               <label htmlFor='executionControlSwitch' className={labelStyle}>
                 Execution Control:
@@ -663,7 +624,7 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
             className={
               'h-full w-[236px] items-center rounded-lg bg-brand text-center font-medium text-white disabled:cursor-not-allowed disabled:opacity-50'
             }
-            disabled={!isFormValid || (!isExecutionOrderDirty && !isBlockDifferent)}
+            disabled={!isFormValid || !isBlockDifferent}
             onClick={handleBlockSubmit}
           >
             Ok

--- a/src/frontend/components/_features/[workspace]/editor/graphical/elements/ladder/block/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/graphical/elements/ladder/block/index.tsx
@@ -373,6 +373,14 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
       return
     }
 
+    // The rung is boolean power flow, so it can only land on BOOL pins. A block
+    // whose top input or top output is not BOOL therefore has to carry EN/ENO.
+    // That rule is NOT re-implemented here: ladder's own
+    // `getBlockVariantAndExecutionControl` already forces execution control on
+    // in exactly that case (and sets `lockExecutionControl`), and
+    // `buildBlockNode` runs it for every block placed on a rung. Passing the
+    // form's value through means the rebuilt block obeys the same rule as a
+    // freshly placed one, with one implementation to drift from.
     const newNode = buildBlockNode({
       id: `BLOCK_${uuidv4()}`,
       posX: selectedNode.position.x,
@@ -465,50 +473,81 @@ const BlockElement = <T extends object>({ isOpen, onClose, selectedNode }: Block
     // covers the whole same-variant case and the matching pins of a swap; the
     // rung chain follows the connectors as before; anything else is dropped
     // and reported rather than piled onto the first pin.
-    const newNodeData = newNode.data as {
-      inputHandles?: { id?: string }[]
-      outputHandles?: { id?: string }[]
-      inputConnector?: { id?: string }
-      outputConnector?: { id?: string }
-    }
-    const oldNodeData = node.data as { inputConnector?: { id?: string }; outputConnector?: { id?: string } }
-    const survivingPins = (handles: { id?: string }[] | undefined): Set<string> =>
+    // Handle type taken from the node itself, so this cannot drift from the
+    // builder and needs neither an import nor an assertion.
+    const pinIds = (handles: typeof newNode.data.inputHandles): Set<string> =>
       new Set((handles ?? []).map((handle) => handle.id).filter((id): id is string => !!id))
-    const newInputPins = survivingPins(newNodeData.inputHandles)
-    const newOutputPins = survivingPins(newNodeData.outputHandles)
+    const newInputPins = pinIds(newNode.data.inputHandles)
+    const newOutputPins = pinIds(newNode.data.outputHandles)
 
-    let droppedWires = 0
-    const rewire = (
-      edge: (typeof newEdges)[number],
-      side: 'source' | 'target',
+    // The connectors the EXISTING edges ride, read from `selectedNode` and not
+    // from `node`: picking a replacement variant rebuilds `node` with the
+    // REPLACEMENT's connector ids, while the edges being remapped here belong
+    // to `selectedNode.id`. Comparing against the rebuilt copy made the rung
+    // chain unrecognisable on a swap, and it was dropped instead of moved.
+    const oldInputConnector = selectedNode.data.inputConnector?.id
+    const oldOutputConnector = selectedNode.data.outputConnector?.id
+    const newInputConnector = newNode.data.inputConnector?.id
+    const newOutputConnector = newNode.data.outputConnector?.id
+
+    /** The handle this endpoint should ride on the rebuilt node, or false to drop it. */
+    const resolveHandle = (
+      handle: string | null | undefined,
       pins: Set<string>,
       oldConnector: string | undefined,
       newConnector: string | undefined,
-    ): void => {
-      const handleKey = side === 'source' ? 'sourceHandle' : 'targetHandle'
-      const handle = side === 'source' ? edge.sourceHandle : edge.targetHandle
-      const base = { ...edge, id: edge.id.replace(node.id, newNode.id), [side]: newNode.id }
-
-      if (handle && pins.has(handle)) {
-        newEdges = newEdges.map((e) => (e.id === edge.id ? base : e))
-        return
-      }
-      // The rung chain: it rode the old connector, so it rides the new one.
-      if (handle && oldConnector && handle === oldConnector && newConnector) {
-        const moved = { ...base, [handleKey]: newConnector }
-        newEdges = newEdges.map((e) => (e.id === edge.id ? moved : e))
-        return
-      }
-      droppedWires += 1
-      newEdges = newEdges.filter((e) => e.id !== edge.id)
+    ): string | null | undefined | false => {
+      // The RUNG CHAIN first, before any pin-name match. An edge riding the old
+      // connector is power flow, and it has to follow the new connector even
+      // when the old connector's NAME survives on the replacement as an
+      // ordinary data pin -- `AND`'s `IN1` connector becoming `ADD`'s `IN1`
+      // data pin, say, where keeping the rung on `IN1` leaves it sharing a pin
+      // with the branch `reconcileBranches` just rebuilt there.
+      if (handle && oldConnector && handle === oldConnector && newConnector) return newConnector
+      if (handle && pins.has(handle)) return handle
+      return false
     }
 
-    edges.source?.forEach((edge) =>
-      rewire(edge, 'source', newOutputPins, oldNodeData.outputConnector?.id, newNodeData.outputConnector?.id),
-    )
-    edges.target?.forEach((edge) =>
-      rewire(edge, 'target', newInputPins, oldNodeData.inputConnector?.id, newNodeData.inputConnector?.id),
-    )
+    // One pass over the affected edges, keyed by id, so an edge that is BOTH a
+    // source and a target of this block -- a self-loop, which the canvas allows
+    // -- has both endpoints resolved together. Two passes rewrote the id on the
+    // first and then failed to find the edge on the second, leaving the other
+    // endpoint pointing at a node that no longer exists.
+    const affected = new Map<string, (typeof newEdges)[number]>()
+    for (const edge of [...(edges.source ?? []), ...(edges.target ?? [])]) affected.set(edge.id, edge)
+
+    const replacements = new Map<string, (typeof newEdges)[number] | null>()
+    for (const edge of affected.values()) {
+      let next = { ...edge, id: edge.id.replace(node.id, newNode.id) }
+      let drop = false
+
+      if (edge.source === selectedNode.id) {
+        const resolved = resolveHandle(edge.sourceHandle, newOutputPins, oldOutputConnector, newOutputConnector)
+        if (resolved === false) drop = true
+        else next = { ...next, source: newNode.id, sourceHandle: resolved }
+      }
+      if (!drop && edge.target === selectedNode.id) {
+        const resolved = resolveHandle(edge.targetHandle, newInputPins, oldInputConnector, newInputConnector)
+        if (resolved === false) drop = true
+        else next = { ...next, target: newNode.id, targetHandle: resolved }
+      }
+      replacements.set(edge.id, drop ? null : next)
+    }
+
+    // Replace IN PLACE, never append. `reconcileBranches` above has already
+    // rewritten the branch edges and changed their ids, so an id from `edges`
+    // may no longer be in `newEdges` -- appending it back would resurrect a
+    // stale edge alongside the reconciled one and leave two wires on one pin.
+    let droppedWires = 0
+    newEdges = newEdges.flatMap((edge) => {
+      if (!replacements.has(edge.id)) return [edge]
+      const replacement = replacements.get(edge.id) ?? null
+      if (replacement === null) {
+        droppedWires += 1
+        return []
+      }
+      return [replacement]
+    })
 
     if (droppedWires > 0) {
       toast({


### PR DESCRIPTION
[DOPE-606](https://autonomylogic.atlassian.net/browse/DOPE-606) follow-up. Mirror PR: Autonomy-Logic/openplc-web#734

Now that execution order can actually be saved (#1084), **four** things about it needed fixing. [DOPE-611](https://autonomylogic.atlassian.net/browse/DOPE-611) is folded in here rather than shipped separately: every execution-order edit runs through the code that rewires the block, so the two apart would deliver a feature that corrupts diagrams the moment it is used.

## 0. Editing a block no longer rewires it (DOPE-611)

Every edge was forced onto `inputConnector` / `outputConnector` — just the **first** pin on each side. A block with two or more inputs had all its input wires collapsed onto `IN1`, and the wires to `IN2`, `IN3` … were lost. Two wires on one pin transpile as a parallel combination, so `SUB(acc, 3)` came out as `SUB(IN1 := 3 OR acc)` and failed to compile. With same-typed pins it would have changed the logic and still built.

A pin that still exists on the rebuilt node now keeps its wire. That covers the whole same-variant case — an execution-order edit rebuilds with an identical pin set, so nothing moves — and preserves the matching pins of a variant swap. A wire whose pin is genuinely gone is dropped and reported, rather than piled onto the first pin. In ladder the rung chain still follows the connectors, because there an edge into a block is power flow rather than a data read.

Before / after on the same edit (set execution order 1 on `SUB`):

```
before:  -> SUB  targetHandle=IN1   (acc)
         -> SUB  targetHandle=IN1   (3)     <-- was IN2, collapsed
after:   -> SUB  targetHandle=IN1   (acc)
         -> SUB  targetHandle=IN2   (3)     <-- preserved
```

## 1. Ladder no longer has an execution order

Rung position is the order in ladder — but the LD Block Properties dialog exposed the same field FBD does, and `emitLdBody` collects sinks **globally across all rungs** before bucketing. So numbering a block in rung 2 hoisted it above rung 1.

Confirmed on a P1AM-100 with a two-rung program (`rung 1: ADD(seed,1) -> acc`, `rung 2: MUL(acc,10) -> acc`):

| Setup | Generated | Hardware |
|---|---|---|
| both blocks unnumbered | `ADD, MUL` (rung order) | acc = **10** ✅ |
| rung 2's block numbered 1 | `MUL, ADD` | acc = **1** ❌ rung order violated |

The field is gone from the LD dialog. The dialog also now writes `executionOrder: 0` rather than preserving whatever the project carried, so editing a block *clears* a stale value instead of keeping it alive. The walker is untouched — this is a UI-level fix, so a project that already has numbers baked in still misorders until its blocks are edited. Worth knowing if we'd rather scope the bucketing per-rung for LD instead; that was the alternative and it's a bigger change.

## 2. `0` now reads as "None"

The transpiler treats anything `> 0` as ordered and sorts the rest by layout position, so **0 is the absence of an order, not the lowest one**. A bare "0" read as "runs first" and meant the opposite.

- Displays `None` when unset; blanks on focus so you type over it rather than around it.
- Digits only — a leading `-` is dropped rather than rejected on submit.
- A typed `0`, or an emptied field, falls back to None.
- Arrows step by one and floor at None.
- No upper clamp. The old ceiling reused `maxInputs`, an input-count constant; execution order is an ordering key, not a count. (This also closes the range-validation point CodeRabbit raised on #1084, which I'd deferred for exactly this reason.)

## 3. A numbered block shows a badge

Small round badge on the bottom-right corner, only when the block carries an order — an ordinary diagram stays uncluttered, and a numbered one shows its sequence without opening a dialog per block.

Anchored to the block's own `width`/`height` rather than the wrapper's edges (the wrapper is a few px taller, so `bottom-0` sat below the border), and inset by half the 6px corner radius: centring on the mathematical corner puts the badge past the curve, where the drawn border has already turned away, and it reads as hanging low. The translate is relative to the badge's own size, so it holds for two-digit numbers.

## Testing

Verified end to end on a P1AM-100: setting execution order 1 on the `SUB` block **through the dialog**, saving, and compiling now yields `SUB ADD MUL` with both of SUB's input wires intact, and the board computes `acc = 10` as predicted. Before this change the same edit produced `SUB(IN1 := 3 OR acc)` and would not build.

Verified visually in a browser at each step (`npm run dev:local`), including the badge geometry measured against the block's border box.

Browser coverage lives in the web mirror, `e2e/dope-606-execution-order-ux.spec.ts` — None on an unset order, digits-only with a typed 0 falling back to None, arrows stepping and flooring, the badge appearing and clearing, and a ladder block having no field at all. It also updates the existing execution-order test, which did arithmetic on the field's value and now reads "None" there.

`tsc` clean, 0 lint errors, editor jest green (7724 passing).

## Note for review

Removing the field from ladder is a **behaviour change for existing LD projects**: a block edited through the dialog loses any execution order it had. That's the intent — ladder should never have had one — but it is worth a second opinion before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHm2wRkKn33qqsN8QcUWSa

[DOPE-606]: https://autonomylogic.atlassian.net/browse/DOPE-606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - FBD blocks now display their execution order when a positive, valid value is set.

- **Improvements**
  - FBD execution-order editing supports digits only, clears the existing value on focus, and displays “None” for empty or zero values.
  - Execution-order increments can exceed the previous input limit.
  - FBD block replacements preserve connections by surviving pin IDs, including self-loops, and report dropped connections.
  - Ladder block replacements preserve connections by matching pin names and report unavailable connections.

- **Updates**
  - Ladder block properties no longer include an execution-order field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[DOPE-611]: https://autonomylogic.atlassian.net/browse/DOPE-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ