### PR TITLE
RTOP-283: Runtime Status screen, with runtime version changes

### DIFF
--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -160,8 +160,22 @@ jobs:
               echo "::endgroup::"
               exit 0
             else
-              DIFF_COUNT=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['total_diffs'])")
-              echo "Still $DIFF_COUNT difference(s) with PR #$PR_NUMBER"
+              # Name the files, not just a count.
+              #
+              # A bare "Still 8 difference(s)" is undiagnosable: it gives no
+              # way to tell a genuine divergence from a PR head this run
+              # fetched before the other repo's push had propagated, which is
+              # a real race when both PRs are pushed within seconds of each
+              # other. The target-branch comparison already lists its files;
+              # this one now does too.
+              echo "$RESULT" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          print(f\"Still {data['total_diffs']} difference(s) with this PR:\")
+          for surface, info in data['surfaces'].items():
+              for d in info.get('diffs', []):
+                  print(f\"    {d['reason']}: src/{d['file']}\")
+          "
             fi
 
             echo "::endgroup::"

--- a/src/backend/editor/runtime/__tests__/bootloader-api-client.test.ts
+++ b/src/backend/editor/runtime/__tests__/bootloader-api-client.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The bootloader client's address guard.
+ *
+ * The address reaches this client from the renderer and is handed to
+ * https.request. A compromised renderer could otherwise shape it into a
+ * request at a target of its choosing (CWE-918), so anything that is not a
+ * bare hostname or IP literal is refused before a socket is opened.
+ *
+ * Note what this does NOT claim: it narrows the value, it does not authorize
+ * the destination. Restricting calls to the device the operator selected needs
+ * main-process device state that does not exist yet.
+ */
+
+import { BootloaderApiClient } from '../bootloader-api-client'
+
+describe('BootloaderApiClient address handling', () => {
+  const client = new BootloaderApiClient()
+
+  const refused = [
+    ['a scheme', 'https://evil.example.com'],
+    ['an embedded port', '10.0.0.5:9999'],
+    ['credentials', 'user:pass@10.0.0.5'],
+    ['a path', '10.0.0.5/../../admin'],
+    ['a query', '10.0.0.5?x=1'],
+    ['whitespace', '10.0.0.5 evil.example.com'],
+    ['a newline', '10.0.0.5\nHost: evil'],
+    ['empty', ''],
+  ] as const
+
+  it.each(refused)('refuses %s without opening a connection', async (_label, address) => {
+    // getCapabilities is the unauthenticated entry point, so this covers the
+    // path that does not need a stored token first.
+    const result = await client.getCapabilities(address)
+
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toMatch(/not a device address/i)
+  })
+
+  // RFC 5737 / RFC 3849 documentation ranges and a reserved name, so nothing
+  // here can resolve to a real host. An earlier version used the test
+  // device's own address and passed or failed depending on whether that
+  // device happened to be on the network.
+  const accepted = [
+    ['an IPv4 literal', '192.0.2.10'],
+    ['a hostname', 'device-under-test'],
+    ['a dotted hostname', 'device-under-test.invalid'],
+    ['a bracketed IPv6 literal', '[2001:db8::1]'],
+  ] as const
+
+  it.each(accepted)('accepts %s and gets as far as the connection', async (_label, address) => {
+    // Whether the connection then succeeds is not this test's business -- only
+    // that the address itself was not what stopped it.
+    const result = await client.getCapabilities(address)
+
+    if (!result.success) {
+      expect(result.error).not.toMatch(/not a device address/i)
+    }
+  })
+})

--- a/src/backend/editor/runtime/bootloader-api-client.ts
+++ b/src/backend/editor/runtime/bootloader-api-client.ts
@@ -62,6 +62,29 @@ const StatusSchema = z.object({
 })
 export type BootloaderStatus = z.infer<typeof StatusSchema>
 
+/**
+ * Host facts for the Runtime Status header.
+ *
+ * Served here rather than by the runtime because the bootloader is present on
+ * every device this feature can act on, whatever runtime version it happens to
+ * be running -- and because it reads these from the Docker daemon, which runs
+ * on the host and answers for it, rather than from inside a container's own
+ * namespace.
+ *
+ * Every field is optional: the daemon may be unreachable, in which case the
+ * bootloader still reports the deployment facts it knows for itself.
+ */
+const DeviceInfoSchema = z.object({
+  hostname: z.string().optional(),
+  architecture: z.string().optional(),
+  kernel: z.string().optional(),
+  system: z.string().optional(),
+  cpus: z.number().optional(),
+  memoryBytes: z.number().optional(),
+  dockerVersion: z.string().optional(),
+})
+export type RuntimeDeviceInfo = z.infer<typeof DeviceInfoSchema>
+
 const LogsSchema = z.object({
   logs: z.string(),
   available: z.boolean(),
@@ -178,6 +201,12 @@ export class BootloaderApiClient {
     const result = await this.authenticated(ipAddress, { method: 'GET', path: '/api/bootloader/status' })
     if (!result.success) return result
     return this.parse(StatusSchema, result.data)
+  }
+
+  async getDeviceInfo(ipAddress: string): Promise<BootloaderApiResult<RuntimeDeviceInfo>> {
+    const result = await this.authenticated(ipAddress, { method: 'GET', path: '/api/bootloader/device-info' })
+    if (!result.success) return result
+    return this.parse(DeviceInfoSchema, result.data)
   }
 
   /**

--- a/src/backend/editor/runtime/bootloader-api-client.ts
+++ b/src/backend/editor/runtime/bootloader-api-client.ts
@@ -27,8 +27,6 @@ import { z } from 'zod'
 /** The bootloader's HTTPS control port. Odd, alongside the runtime's 8443. */
 export const BOOTLOADER_API_PORT = 8445
 
-
-
 /**
  * What the bootloader advertises without authentication, so the editor can
  * tell what it reached -- and whether the device is in recovery -- before it
@@ -51,7 +49,6 @@ const CapabilitiesSchema = z.object({
   recovery: z.boolean(),
 })
 
-
 const LoginSchema = z.object({
   access_token: z.string(),
   role: z.string().optional(),
@@ -69,7 +66,6 @@ const StatusSchema = z.object({
   runtimeVersion: z.string().optional(),
   recovery: z.boolean().optional(),
 })
-
 
 /**
  * Host facts for the Runtime Status header.
@@ -93,14 +89,12 @@ const DeviceInfoSchema = z.object({
   dockerVersion: z.string().optional(),
 })
 
-
 const LogsSchema = z.object({
   logs: z.string(),
   available: z.boolean(),
   reason: z.string().optional(),
   tail: z.number().optional(),
 })
-
 
 /**
  * Update progress. `percent` is absent while the daemon has reported no size
@@ -188,6 +182,26 @@ type RequestOptions = {
    */
   treatConflictAsSuccess?: boolean
 }
+
+/**
+ * Is this a bare host the editor is willing to dial?
+ *
+ * The address arrives from the renderer and is handed to https.request, so
+ * anything that is not a plain hostname or IP literal is refused: an embedded
+ * port, credentials, a path, a scheme, whitespace. Without this a compromised
+ * renderer could shape the value into a request at a target of its choosing.
+ *
+ * This narrows the value; it does not authorize the destination. Restricting
+ * requests to the device the operator actually selected needs main-process
+ * device state, which does not exist today and would apply to every runtime
+ * handler as much as to these -- a change worth making on its own rather
+ * than half-making here.
+ */
+const BARE_HOST =
+  /^(?:\[[0-9a-fA-F:]+\]|[0-9a-fA-F:]+|[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)$/
+
+const isDialableHost = (value: unknown): value is string =>
+  typeof value === 'string' && value.length > 0 && value.length <= 253 && BARE_HOST.test(value)
 
 export class BootloaderApiClient {
   private readonly port = BOOTLOADER_API_PORT
@@ -369,6 +383,14 @@ export class BootloaderApiClient {
   }
 
   private request(ipAddress: string, options: RequestOptions): Promise<BootloaderApiResult<string>> {
+    // Every call, authenticated or not, passes through here -- the single
+    // place the address can reach https.request.
+    if (!isDialableHost(ipAddress)) {
+      return Promise.resolve({
+        success: false,
+        error: 'That is not a device address this editor will connect to',
+      })
+    }
     return new Promise((resolve) => {
       const timeout = options.timeoutMs ?? this.DEFAULT_TIMEOUT_MS
       const headers: Record<string, string> = { Accept: 'application/json' }

--- a/src/backend/editor/runtime/bootloader-api-client.ts
+++ b/src/backend/editor/runtime/bootloader-api-client.ts
@@ -1,0 +1,352 @@
+/**
+ * Client for the runtime bootloader's control API (RTOP-283).
+ *
+ * The bootloader is a second, much smaller service on the same device: it
+ * starts the runtime container, and when the runtime will not run it stays
+ * reachable so a new version can be installed. It is what makes a version
+ * change from the editor possible without SSH.
+ *
+ * A separate client from `RuntimeApiClient`, rather than a port parameter on
+ * that one, for two reasons. It listens on its own port (8445), and it issues
+ * its OWN sessions -- the two services share a credential database, not a
+ * token, so a login here is a distinct login. Threading a port and a second
+ * token authority through the runtime client would have made every existing
+ * call site carry a concept it never needs.
+ *
+ * Responses are validated rather than asserted. These are HTTP bodies from a
+ * device on the network, so `JSON.parse(...) as T` would claim a shape without
+ * checking it and surface a missing field somewhere else entirely.
+ */
+
+import https from 'node:https'
+
+import { getRuntimeHttpsOptions } from '@root/backend/editor/utils/runtime-https-config'
+import { getErrorMessage } from '@root/frontend/utils/get-error-message'
+import { z } from 'zod'
+
+/** The bootloader's HTTPS control port. Odd, alongside the runtime's 8443. */
+export const BOOTLOADER_API_PORT = 8445
+
+export type BootloaderApiResult<T> = { success: true; data: T } | { success: false; error: string }
+
+/**
+ * What the bootloader advertises without authentication, so the editor can
+ * tell what it reached -- and whether the device is in recovery -- before it
+ * has credentials.
+ */
+const CapabilitiesSchema = z.object({
+  service: z.string(),
+  bootloaderVersion: z.string().optional(),
+  runtimeVersion: z.string().optional(),
+  state: z.string(),
+  recovery: z.boolean(),
+})
+export type BootloaderCapabilities = z.infer<typeof CapabilitiesSchema>
+
+const LoginSchema = z.object({
+  access_token: z.string(),
+  role: z.string().optional(),
+})
+
+const StatusSchema = z.object({
+  state: z.string(),
+  reason: z.string().optional(),
+  since: z.string().optional(),
+  crashCount: z.number().optional(),
+  healthSource: z.string().optional(),
+  containerId: z.string().optional(),
+  containerName: z.string().optional(),
+  image: z.string().optional(),
+  runtimeVersion: z.string().optional(),
+  recovery: z.boolean().optional(),
+})
+export type BootloaderStatus = z.infer<typeof StatusSchema>
+
+const LogsSchema = z.object({
+  logs: z.string(),
+  available: z.boolean(),
+  reason: z.string().optional(),
+  tail: z.number().optional(),
+})
+export type BootloaderLogs = z.infer<typeof LogsSchema>
+
+/**
+ * Update progress. `percent` is absent while the daemon has reported no size
+ * to work from -- for layers it already holds, and for the moment before any
+ * size is known -- so a UI must treat "no percentage" as indeterminate rather
+ * than as zero.
+ */
+const UpdateProgressSchema = z.object({
+  state: z.string(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  phase: z.string().optional(),
+  percent: z.number().nullable().optional(),
+  error: z.string().optional(),
+  startedAt: z.string().optional(),
+  finishedAt: z.string().nullable().optional(),
+})
+export type BootloaderUpdateProgress = z.infer<typeof UpdateProgressSchema>
+
+const ErrorSchema = z.object({ error: z.string() })
+
+/** A 409 carries the in-flight progress, so a second editor can follow along. */
+const ConflictSchema = z.object({
+  error: z.string(),
+  progress: UpdateProgressSchema.optional(),
+})
+
+type RequestOptions = {
+  method: 'GET' | 'POST'
+  path: string
+  body?: string
+  token?: string
+  timeoutMs?: number
+}
+
+export class BootloaderApiClient {
+  private readonly port = BOOTLOADER_API_PORT
+
+  /** Short: the bootloader answers from memory and does no I/O to reply. */
+  private readonly DEFAULT_TIMEOUT_MS = 8000
+
+  /** Login runs PBKDF2 at 600k iterations, which on a Pi-class CPU is slow. */
+  private readonly LOGIN_TIMEOUT_MS = 20000
+
+  /**
+   * The bootloader session, held per device address.
+   *
+   * Deliberately not shared with the runtime's token manager: the two services
+   * issue their own tokens. Keyed by address so switching between devices does
+   * not silently reuse another device's session.
+   */
+  private tokens = new Map<string, string>()
+
+  /** Forget a device's session, on logout or a deliberate disconnect. */
+  clearSession(ipAddress?: string): void {
+    if (ipAddress) {
+      this.tokens.delete(ipAddress)
+      return
+    }
+    this.tokens.clear()
+  }
+
+  /**
+   * Is a bootloader answering on this device?
+   *
+   * Unauthenticated on purpose: the editor asks this to decide whether to
+   * offer a version change at all, and it must be answerable before login.
+   * A refusal or a timeout means "no bootloader here", which is the common
+   * case for a native install or an orchestrator-managed vPLC -- not an error
+   * worth showing anybody.
+   */
+  async getCapabilities(ipAddress: string): Promise<BootloaderApiResult<BootloaderCapabilities>> {
+    const result = await this.request(ipAddress, {
+      method: 'GET',
+      path: '/api/bootloader/capabilities',
+      // Shorter still: this runs on every connect, and a device with no
+      // bootloader must not make the editor wait.
+      timeoutMs: 4000,
+    })
+    if (!result.success) return result
+    return this.parse(CapabilitiesSchema, result.data)
+  }
+
+  /**
+   * Log in and remember the token for subsequent calls.
+   *
+   * The credentials are the runtime's own -- the two services read one user
+   * database -- so the editor can reuse what the operator already entered.
+   */
+  async login(ipAddress: string, username: string, password: string): Promise<BootloaderApiResult<{ role?: string }>> {
+    const result = await this.request(ipAddress, {
+      method: 'POST',
+      path: '/api/bootloader/login',
+      body: JSON.stringify({ username, password }),
+      timeoutMs: this.LOGIN_TIMEOUT_MS,
+    })
+    if (!result.success) return result
+
+    const parsed = this.parse(LoginSchema, result.data)
+    if (!parsed.success) return parsed
+
+    this.tokens.set(ipAddress, parsed.data.access_token)
+    return { success: true, data: { role: parsed.data.role } }
+  }
+
+  async getStatus(ipAddress: string): Promise<BootloaderApiResult<BootloaderStatus>> {
+    const result = await this.authenticated(ipAddress, { method: 'GET', path: '/api/bootloader/status' })
+    if (!result.success) return result
+    return this.parse(StatusSchema, result.data)
+  }
+
+  /**
+   * The runtime container's recent output.
+   *
+   * This is the point of the whole feature for a broken device: seeing WHY a
+   * runtime will not start, from the editor, with no shell access.
+   */
+  async getRuntimeLogs(ipAddress: string, tail = 200): Promise<BootloaderApiResult<BootloaderLogs>> {
+    const result = await this.authenticated(ipAddress, {
+      method: 'GET',
+      path: `/api/bootloader/logs?tail=${encodeURIComponent(String(tail))}`,
+      // A log tail is the one response here that can be large.
+      timeoutMs: 20000,
+    })
+    if (!result.success) return result
+    return this.parse(LogsSchema, result.data)
+  }
+
+  /**
+   * Ask for a version change. Returns as soon as the work is under way.
+   *
+   * Upgrade and downgrade are the same request: there is no separate
+   * direction, and no version floor. The caller polls `getUpdateProgress`,
+   * because a pull can run for many minutes on a slow device.
+   */
+  async startUpdate(ipAddress: string, version: string): Promise<BootloaderApiResult<BootloaderUpdateProgress>> {
+    const result = await this.authenticated(ipAddress, {
+      method: 'POST',
+      path: '/api/bootloader/update',
+      body: JSON.stringify({ version }),
+      timeoutMs: 20000,
+    })
+    if (!result.success) return result
+
+    // 202 carries { accepted, progress }; a 409 was already turned into a
+    // failure by `request`, with the bootloader's own message.
+    const accepted = z.object({ progress: UpdateProgressSchema.optional() })
+    const parsed = this.parse(accepted, result.data)
+    if (!parsed.success) return parsed
+    return { success: true, data: parsed.data.progress ?? { state: 'pulling', to: version } }
+  }
+
+  async getUpdateProgress(ipAddress: string): Promise<BootloaderApiResult<BootloaderUpdateProgress>> {
+    const result = await this.authenticated(ipAddress, { method: 'GET', path: '/api/bootloader/update' })
+    if (!result.success) return result
+    return this.parse(UpdateProgressSchema, result.data)
+  }
+
+  /** Stop and start the runtime container. */
+  async restartRuntime(ipAddress: string): Promise<BootloaderApiResult<{ state?: string; reason?: string }>> {
+    const result = await this.authenticated(ipAddress, {
+      method: 'POST',
+      path: '/api/bootloader/restart',
+      body: JSON.stringify({}),
+      // Includes a health-gate on the way back up.
+      timeoutMs: 120000,
+    })
+    if (!result.success) return result
+    return this.parse(z.object({ state: z.string().optional(), reason: z.string().optional() }), result.data)
+  }
+
+  // --- plumbing ----------------------------------------------------------
+
+  /** Attach the stored token, failing clearly when there is not one. */
+  private async authenticated(
+    ipAddress: string,
+    options: Omit<RequestOptions, 'token'>,
+  ): Promise<BootloaderApiResult<string>> {
+    const token = this.tokens.get(ipAddress)
+    if (!token) {
+      return { success: false, error: 'Not signed in to the bootloader on this device' }
+    }
+    const result = await this.request(ipAddress, { ...options, token })
+    // A rejected token is worth forgetting, or every later call fails the same
+    // way and the UI has no way to recover but a restart.
+    if (!result.success && /\b401\b|expired|invalid token/i.test(result.error)) {
+      this.tokens.delete(ipAddress)
+    }
+    return result
+  }
+
+  private parse<T>(schema: z.ZodType<T>, raw: string): BootloaderApiResult<T> {
+    try {
+      return { success: true, data: schema.parse(JSON.parse(raw)) }
+    } catch (error) {
+      return {
+        success: false,
+        error: `The bootloader sent a response this editor does not understand: ${getErrorMessage(error)}`,
+      }
+    }
+  }
+
+  private request(ipAddress: string, options: RequestOptions): Promise<BootloaderApiResult<string>> {
+    return new Promise((resolve) => {
+      const timeout = options.timeoutMs ?? this.DEFAULT_TIMEOUT_MS
+      const headers: Record<string, string> = { Accept: 'application/json' }
+      if (options.body !== undefined) {
+        headers['Content-Type'] = 'application/json'
+        headers['Content-Length'] = String(Buffer.byteLength(options.body))
+      }
+      if (options.token) {
+        headers.Authorization = `Bearer ${options.token}`
+      }
+
+      const request = https.request(
+        {
+          hostname: ipAddress,
+          port: this.port,
+          path: options.path,
+          method: options.method,
+          headers,
+          timeout,
+          // The bootloader serves a self-signed certificate, as the runtime
+          // does; the same opt-in env var governs both.
+          ...getRuntimeHttpsOptions(),
+        },
+        (response) => {
+          let data = ''
+          response.on('data', (chunk) => {
+            data += chunk
+          })
+          response.on('end', () => {
+            const status = response.statusCode ?? 0
+            if (status >= 200 && status < 300) {
+              resolve({ success: true, data })
+              return
+            }
+            resolve({ success: false, error: this.describeFailure(status, data) })
+          })
+        },
+      )
+
+      request.on('timeout', () => {
+        request.destroy()
+        resolve({
+          success: false,
+          error: `The bootloader on ${ipAddress}:${this.port} did not respond within ${timeout / 1000}s`,
+        })
+      })
+      request.on('error', (error) => {
+        resolve({ success: false, error: getErrorMessage(error) })
+      })
+
+      if (options.body !== undefined) request.write(options.body)
+      request.end()
+    })
+  }
+
+  /**
+   * Turn a non-2xx into a message written for a person.
+   *
+   * The bootloader answers every failure as `{ "error": "..." }` and its
+   * messages already say what to do, so they are surfaced verbatim rather than
+   * replaced with a status code. A 409 keeps its progress payload so a caller
+   * that wants it can re-parse.
+   */
+  private describeFailure(status: number, body: string): string {
+    try {
+      if (status === 409) {
+        const conflict = ConflictSchema.parse(JSON.parse(body))
+        return conflict.error
+      }
+      return ErrorSchema.parse(JSON.parse(body)).error
+    } catch {
+      // No structured body: say what happened without pretending to know why.
+      if (status === 401) return 'The bootloader rejected these credentials'
+      if (status === 0) return 'No response from the bootloader'
+      return `The bootloader returned HTTP ${status}`
+    }
+  }
+}

--- a/src/backend/editor/runtime/bootloader-api-client.ts
+++ b/src/backend/editor/runtime/bootloader-api-client.ts
@@ -27,13 +27,22 @@ import { z } from 'zod'
 /** The bootloader's HTTPS control port. Odd, alongside the runtime's 8443. */
 export const BOOTLOADER_API_PORT = 8445
 
-export type BootloaderApiResult<T> = { success: true; data: T } | { success: false; error: string }
+
 
 /**
  * What the bootloader advertises without authentication, so the editor can
  * tell what it reached -- and whether the device is in recovery -- before it
  * has credentials.
  */
+/**
+ * Ceiling on a bootloader response body.
+ *
+ * Generous enough for the largest thing this API returns -- a log tail, which
+ * the server caps -- and small enough that a device sending nonsense cannot
+ * exhaust the editor's memory.
+ */
+const MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+
 const CapabilitiesSchema = z.object({
   service: z.string(),
   bootloaderVersion: z.string().optional(),
@@ -41,7 +50,7 @@ const CapabilitiesSchema = z.object({
   state: z.string(),
   recovery: z.boolean(),
 })
-export type BootloaderCapabilities = z.infer<typeof CapabilitiesSchema>
+
 
 const LoginSchema = z.object({
   access_token: z.string(),
@@ -60,7 +69,7 @@ const StatusSchema = z.object({
   runtimeVersion: z.string().optional(),
   recovery: z.boolean().optional(),
 })
-export type BootloaderStatus = z.infer<typeof StatusSchema>
+
 
 /**
  * Host facts for the Runtime Status header.
@@ -83,7 +92,7 @@ const DeviceInfoSchema = z.object({
   memoryBytes: z.number().optional(),
   dockerVersion: z.string().optional(),
 })
-export type RuntimeDeviceInfo = z.infer<typeof DeviceInfoSchema>
+
 
 const LogsSchema = z.object({
   logs: z.string(),
@@ -91,7 +100,7 @@ const LogsSchema = z.object({
   reason: z.string().optional(),
   tail: z.number().optional(),
 })
-export type BootloaderLogs = z.infer<typeof LogsSchema>
+
 
 /**
  * Update progress. `percent` is absent while the daemon has reported no size
@@ -109,7 +118,52 @@ const UpdateProgressSchema = z.object({
   startedAt: z.string().optional(),
   finishedAt: z.string().nullable().optional(),
 })
-export type BootloaderUpdateProgress = z.infer<typeof UpdateProgressSchema>
+/**
+ * Types come from the port, not the other way round.
+ *
+ * The port used to import these from this file, which broke the layer rule
+ * (`ports` may depend on `utils` and `ports` only) and turned the editor's
+ * architecture job red. The port owns the contract; this client's schemas are
+ * pinned to it below, so a drift between the two is a type error rather than
+ * a silent divergence.
+ */
+import type {
+  BootloaderApiResult,
+  BootloaderCapabilities,
+  BootloaderLogs,
+  BootloaderStatus,
+  BootloaderUpdateProgress,
+  RuntimeDeviceInfo,
+} from '@root/middleware/shared/ports/runtime-port'
+
+/**
+ * The schemas above must keep producing exactly the port's shapes. These
+ * assignments are the check: if a schema and the contract drift apart, this
+ * file stops compiling instead of the two quietly disagreeing.
+ */
+const _contract: {
+  capabilities: z.ZodType<BootloaderCapabilities>
+  status: z.ZodType<BootloaderStatus>
+  deviceInfo: z.ZodType<RuntimeDeviceInfo>
+  logs: z.ZodType<BootloaderLogs>
+  progress: z.ZodType<BootloaderUpdateProgress>
+} = {
+  capabilities: CapabilitiesSchema,
+  status: StatusSchema,
+  deviceInfo: DeviceInfoSchema,
+  logs: LogsSchema,
+  progress: UpdateProgressSchema,
+}
+void _contract
+
+export type {
+  BootloaderApiResult,
+  BootloaderCapabilities,
+  BootloaderLogs,
+  BootloaderStatus,
+  BootloaderUpdateProgress,
+  RuntimeDeviceInfo,
+} from '@root/middleware/shared/ports/runtime-port'
 
 const ErrorSchema = z.object({ error: z.string() })
 
@@ -125,6 +179,14 @@ type RequestOptions = {
   body?: string
   token?: string
   timeoutMs?: number
+  /**
+   * Return a 409 body as a success instead of an error.
+   *
+   * Only the update route sets this: a conflict there means an update is
+   * already running and the body carries its progress, which is what the
+   * caller is trying to obtain.
+   */
+  treatConflictAsSuccess?: boolean
 }
 
 export class BootloaderApiClient {
@@ -239,11 +301,17 @@ export class BootloaderApiClient {
       path: '/api/bootloader/update',
       body: JSON.stringify({ version }),
       timeoutMs: 20000,
+      // A 409 means an update is ALREADY running, and its body carries that
+      // update's progress. Reported as a failure, the caller showed an error
+      // and never started polling -- so a second editor, or one that opened
+      // this dialog after the update began, could not follow along. The
+      // conflict body is returned instead and the caller adopts it.
+      treatConflictAsSuccess: true,
     })
     if (!result.success) return result
 
-    // 202 carries { accepted, progress }; a 409 was already turned into a
-    // failure by `request`, with the bootloader's own message.
+    // 202 carries { accepted, progress }; a 409 carries { error, progress }.
+    // Both are read the same way -- the progress is the useful part.
     const accepted = z.object({ progress: UpdateProgressSchema.optional() })
     const parsed = this.parse(accepted, result.data)
     if (!parsed.success) return parsed
@@ -326,12 +394,34 @@ export class BootloaderApiClient {
         },
         (response) => {
           let data = ''
-          response.on('data', (chunk) => {
+          let received = 0
+          response.on('data', (chunk: Buffer | string) => {
+            // Bounded. Without a cap, any bootloader endpoint -- a log tail
+            // above all -- could grow this string until the editor process
+            // runs out of memory, and a device is not a trusted source of
+            // length just because it is on the LAN.
+            received += typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.length
+            if (received > MAX_RESPONSE_BYTES) {
+              request.destroy()
+              resolve({
+                success: false,
+                error:
+                  `The bootloader on ${ipAddress}:${this.port} sent more than ` +
+                  `${Math.round(MAX_RESPONSE_BYTES / 1024 / 1024)} MB; the response was discarded.`,
+              })
+              return
+            }
             data += chunk
           })
           response.on('end', () => {
             const status = response.statusCode ?? 0
             if (status >= 200 && status < 300) {
+              resolve({ success: true, data })
+              return
+            }
+            if (status === 409 && options.treatConflictAsSuccess === true) {
+              // The body carries the in-flight progress, which is exactly
+              // what the caller wanted.
               resolve({ success: true, data })
               return
             }

--- a/src/backend/editor/runtime/runtime-api-client.ts
+++ b/src/backend/editor/runtime/runtime-api-client.ts
@@ -57,6 +57,22 @@ export type RuntimeApiResult<T> = { success: true; data?: T } | { success: false
  */
 const LoginResponseSchema = z.object({ access_token: z.string() })
 
+/**
+ * `/api/device-info` (RTOP-283). Every field optional: it is served by newer
+ * runtimes only, and an older one answers 404 rather than a partial body --
+ * but a future one may add fields, and a strict shape would reject it.
+ */
+const DeviceInfoSchema = z.object({
+  hostname: z.string().optional(),
+  architecture: z.string().optional(),
+  kernel: z.string().optional(),
+  system: z.string().optional(),
+  containerized: z.boolean().optional(),
+  updatePolicy: z.string().optional(),
+  bootloaderPort: z.number().nullable().optional(),
+})
+export type RuntimeDeviceInfo = z.infer<typeof DeviceInfoSchema>
+
 /** Both `/api/status`-shaped endpoints; every field optional, as the runtime sends them. */
 const PlcStatusResponseSchema = z.object({
   status: z.string().optional(),
@@ -168,6 +184,21 @@ export class RuntimeApiClient {
       return { success: result.success, token: result.accessToken, error: result.error }
     },
   })
+
+  /**
+   * Host facts for the Runtime Status header.
+   *
+   * Authenticated, unlike /api/capabilities: the update policy has to be
+   * readable before login, but kernel and architecture are only shown to
+   * somebody already looking at a device they can sign in to. A 404 means an
+   * older runtime that does not serve this, which is not an error worth
+   * showing -- the caller simply has less to display.
+   */
+  async getDeviceInfo(ipAddress: string): Promise<RuntimeApiResult<RuntimeDeviceInfo>> {
+    return this.makeRuntimeApiRequest<RuntimeDeviceInfo>(ipAddress, '/api/device-info', (data) =>
+      DeviceInfoSchema.parse(JSON.parse(data)),
+    )
+  }
 
   /** The address the token authority will re-authenticate against. */
   setAddress(ipAddress: string): void {

--- a/src/backend/editor/runtime/runtime-api-client.ts
+++ b/src/backend/editor/runtime/runtime-api-client.ts
@@ -57,7 +57,6 @@ export type RuntimeApiResult<T> = { success: true; data?: T } | { success: false
  */
 const LoginResponseSchema = z.object({ access_token: z.string() })
 
-
 /** Both `/api/status`-shaped endpoints; every field optional, as the runtime sends them. */
 const PlcStatusResponseSchema = z.object({
   status: z.string().optional(),

--- a/src/backend/editor/runtime/runtime-api-client.ts
+++ b/src/backend/editor/runtime/runtime-api-client.ts
@@ -62,15 +62,31 @@ const LoginResponseSchema = z.object({ access_token: z.string() })
  * runtimes only, and an older one answers 404 rather than a partial body --
  * but a future one may add fields, and a strict shape would reject it.
  */
-const DeviceInfoSchema = z.object({
-  hostname: z.string().optional(),
-  architecture: z.string().optional(),
-  kernel: z.string().optional(),
-  system: z.string().optional(),
-  containerized: z.boolean().optional(),
-  updatePolicy: z.string().optional(),
-  bootloaderPort: z.number().nullable().optional(),
-})
+/**
+ * Host facts from `/api/device-info`.
+ *
+ * Every field is optional because a runtime may report a subset -- but the
+ * object as a whole is NOT optional, and that distinction is load-bearing. A
+ * runtime older than this endpoint does not answer 404 as one would hope: it
+ * answers HTTP 200 with its catch-all body, `{"error":"Unknown argument"}`.
+ * An all-optional schema accepts that as an empty device-info, and the screen
+ * then renders "Native" for a device it knows nothing about -- a false claim
+ * about every runtime currently in the field. So the payload has to carry at
+ * least one field this endpoint actually returns.
+ */
+const DeviceInfoSchema = z
+  .object({
+    hostname: z.string().optional(),
+    architecture: z.string().optional(),
+    kernel: z.string().optional(),
+    system: z.string().optional(),
+    containerized: z.boolean().optional(),
+    updatePolicy: z.string().optional(),
+    bootloaderPort: z.number().nullable().optional(),
+  })
+  .refine((info) => Object.values(info).some((value) => value !== undefined), {
+    message: 'the runtime does not serve device information',
+  })
 export type RuntimeDeviceInfo = z.infer<typeof DeviceInfoSchema>
 
 /** Both `/api/status`-shaped endpoints; every field optional, as the runtime sends them. */

--- a/src/backend/editor/runtime/runtime-api-client.ts
+++ b/src/backend/editor/runtime/runtime-api-client.ts
@@ -57,37 +57,6 @@ export type RuntimeApiResult<T> = { success: true; data?: T } | { success: false
  */
 const LoginResponseSchema = z.object({ access_token: z.string() })
 
-/**
- * `/api/device-info` (RTOP-283). Every field optional: it is served by newer
- * runtimes only, and an older one answers 404 rather than a partial body --
- * but a future one may add fields, and a strict shape would reject it.
- */
-/**
- * Host facts from `/api/device-info`.
- *
- * Every field is optional because a runtime may report a subset -- but the
- * object as a whole is NOT optional, and that distinction is load-bearing. A
- * runtime older than this endpoint does not answer 404 as one would hope: it
- * answers HTTP 200 with its catch-all body, `{"error":"Unknown argument"}`.
- * An all-optional schema accepts that as an empty device-info, and the screen
- * then renders "Native" for a device it knows nothing about -- a false claim
- * about every runtime currently in the field. So the payload has to carry at
- * least one field this endpoint actually returns.
- */
-const DeviceInfoSchema = z
-  .object({
-    hostname: z.string().optional(),
-    architecture: z.string().optional(),
-    kernel: z.string().optional(),
-    system: z.string().optional(),
-    containerized: z.boolean().optional(),
-    updatePolicy: z.string().optional(),
-    bootloaderPort: z.number().nullable().optional(),
-  })
-  .refine((info) => Object.values(info).some((value) => value !== undefined), {
-    message: 'the runtime does not serve device information',
-  })
-export type RuntimeDeviceInfo = z.infer<typeof DeviceInfoSchema>
 
 /** Both `/api/status`-shaped endpoints; every field optional, as the runtime sends them. */
 const PlcStatusResponseSchema = z.object({
@@ -200,21 +169,6 @@ export class RuntimeApiClient {
       return { success: result.success, token: result.accessToken, error: result.error }
     },
   })
-
-  /**
-   * Host facts for the Runtime Status header.
-   *
-   * Authenticated, unlike /api/capabilities: the update policy has to be
-   * readable before login, but kernel and architecture are only shown to
-   * somebody already looking at a device they can sign in to. A 404 means an
-   * older runtime that does not serve this, which is not an error worth
-   * showing -- the caller simply has less to display.
-   */
-  async getDeviceInfo(ipAddress: string): Promise<RuntimeApiResult<RuntimeDeviceInfo>> {
-    return this.makeRuntimeApiRequest<RuntimeDeviceInfo>(ipAddress, '/api/device-info', (data) =>
-      DeviceInfoSchema.parse(JSON.parse(data)),
-    )
-  }
 
   /** The address the token authority will re-authenticate against. */
   setAddress(ipAddress: string): void {

--- a/src/frontend/components/_atoms/tab/index.tsx
+++ b/src/frontend/components/_atoms/tab/index.tsx
@@ -86,6 +86,7 @@ const Tab = (props: ITabProps) => {
     | 'configuration'
     | 'pin-mapping'
     | 'orchestrators'
+    | 'runtime-status'
     | 'remote-device'
     | 'server'
     | 'vendor-screen'

--- a/src/frontend/components/_atoms/tab/index.tsx
+++ b/src/frontend/components/_atoms/tab/index.tsx
@@ -61,6 +61,10 @@ const TabIcons: Record<string, React.ReactNode> = {
   'library-manifest': <LibraryManifestIcon className='h-4 w-4 flex-shrink-0' />,
   'user-management': <UsersIcon className='h-4 w-4 flex-shrink-0' />,
   'persistent-storage': <ConfigIcon className='h-4 w-4 flex-shrink-0' />,
+  // Same icon as the tree node for this screen, so the tab and the tree
+  // agree. Without an entry here the tab rendered with no icon at all,
+  // which every other device tab has.
+  'runtime-status': <ConfigIcon className='h-4 w-4 flex-shrink-0' />,
   'diff-viewer': <GitCompare className='h-4 w-4 flex-shrink-0 text-[#0464FB]' />,
 }
 

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/board.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/board.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import type { TimingStats } from '@root/middleware/shared/ports/types'
 import { useCapabilities, useDevice, useRuntime } from '@root/middleware/shared/providers/platform-context'
 import { resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -22,10 +21,7 @@ import { Label } from '../../../../../_atoms/label'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '../../../../../_atoms/select'
 import TableActions from '../../../../../_atoms/table-actions'
 import { DeviceConnectButton } from '../../../../../_molecules/device-connect-button'
-import { EtherCATStats } from '../../../../../_molecules/ethercat-stats'
 import { Modal, ModalContent, ModalFooter, ModalHeader, ModalTitle } from '../../../../../_molecules/modal'
-import { PluginStatsPanel } from '../../../../../_molecules/plugin-stats-panel'
-import { ScanCycleStats } from '../../../../../_molecules/scan-cycle-stats'
 import { DeviceEditorSlot } from '../../../../../_templates/[editors]/device-editor-slot'
 import { DeviceLicenseStatus } from './components/device-license-status'
 import { PinMappingTable } from './components/pin-mapping-table'
@@ -99,13 +95,6 @@ const Board = memo(function () {
   const setRuntimeVersion = useOpenPLCStore((state) => state.deviceActions.setRuntimeVersion)
   const openModal = useOpenPLCStore((state) => state.modalActions.openModal)
   const plcStatus = useOpenPLCStore((state): RuntimeConnection['plcStatus'] => state.runtimeConnection.plcStatus)
-  const timingStats = useOpenPLCStore((state): TimingStats | null => state.runtimeConnection.timingStats)
-  const setIncludeTimingStatsInPolling = useOpenPLCStore(
-    (state): ((include: boolean) => void) => state.deviceActions.setIncludeTimingStatsInPolling,
-  )
-  const setIncludeEthercatStatsInPolling = useOpenPLCStore(
-    (state): ((include: boolean) => void) => state.deviceActions.setIncludeEthercatStatsInPolling,
-  )
 
   const [isPressed, setIsPressed] = useState(false)
   const [previewImage, setPreviewImage] = useState('')
@@ -478,25 +467,10 @@ const Board = memo(function () {
     deviceBoard,
   ])
 
-  // Enable timing stats in global polling when this screen is visible
-  useEffect(() => {
-    // Set the flag to include timing stats in the global status polling
-    setIncludeTimingStatsInPolling(true)
-
-    // Clear the flag when leaving this screen
-    return () => {
-      setIncludeTimingStatsInPolling(false)
-    }
-  }, [setIncludeTimingStatsInPolling])
-
-  // Only runtime targets expose the EtherCAT endpoint; skip the poll otherwise.
-  useEffect(() => {
-    if (!isOpenPLCRuntimeTarget(currentBoardInfo)) return
-    setIncludeEthercatStatsInPolling(true)
-    return () => {
-      setIncludeEthercatStatsInPolling(false)
-    }
-  }, [setIncludeEthercatStatsInPolling, currentBoardInfo])
+  // Timing and EtherCAT stats polling now belongs to the Runtime Status screen
+  // (RTOP-283), which is where those statistics are displayed. Polling for them
+  // here would fetch data nobody is looking at, and would leave Runtime Status
+  // with nothing to show when opened on its own.
 
   // Settle the licence for a RUNTIME target once its session is up — once per
   // session PER BOARD.
@@ -905,14 +879,6 @@ const Board = memo(function () {
           <PinMappingTable pins={pins} handleRowClick={handleRowClick} selectedRowId={currentSelectedPinTableRow} />
         </div>
       )}
-      {isOpenPLCRuntimeTarget(currentBoardInfo) && connectionStatus === 'connected' && (
-        <div className='flex w-full flex-col gap-6'>
-          {timingStats && <ScanCycleStats timingStats={timingStats} />}
-          <EtherCATStats />
-          <PluginStatsPanel pluginStats={timingStats?.plugin_stats} />
-        </div>
-      )}
-
       <Modal open={showPythonWarning} onOpenChange={setShowPythonWarning}>
         <ModalContent className='h-fit w-[500px]'>
           <ModalHeader>

--- a/src/frontend/components/_features/[workspace]/editor/device/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/index.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import { useOpenPLCStore } from '../../../../../store'
 import { DeviceConfigurationEditor } from './configuration'
 import { DeviceOrchestratorsEditor } from './orchestrators'
+import { RuntimeStatusEditor } from './runtime-status'
 
 const DeviceEditor = () => {
   const {
@@ -23,7 +24,9 @@ const DeviceEditor = () => {
 
   return (
     <div aria-label='Device content container' className='h-full w-full overflow-hidden'>
-      {derivation === 'orchestrators' ? <DeviceOrchestratorsEditor /> : <DeviceConfigurationEditor />}
+      {derivation === 'orchestrators' && <DeviceOrchestratorsEditor />}
+      {derivation === 'runtime-status' && <RuntimeStatusEditor />}
+      {derivation !== 'orchestrators' && derivation !== 'runtime-status' && <DeviceConfigurationEditor />}
     </div>
   )
 }

--- a/src/frontend/components/_features/[workspace]/editor/device/orchestrators/orchestrators-list.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/orchestrators/orchestrators-list.tsx
@@ -9,10 +9,7 @@ import { WarningIcon } from '../../../../../../assets/icons/interface/Warning'
 import { useOpenPLCStore } from '../../../../../../store'
 import { cn } from '../../../../../../utils/cn'
 import { getErrorMessage } from '../../../../../../utils/get-error-message'
-import { EtherCATStats } from '../../../../../_molecules/ethercat-stats'
 import { Modal, ModalContent, ModalTitle } from '../../../../../_molecules/modal'
-import { PluginStatsPanel } from '../../../../../_molecules/plugin-stats-panel'
-import { ScanCycleStats } from '../../../../../_molecules/scan-cycle-stats'
 import { DeviceEditorSlot } from '../../../../../_templates/[editors]/device-editor-slot'
 
 // Note: Status and timing stats polling is handled globally by useRuntimePolling hook.
@@ -305,26 +302,10 @@ const OrchestratorsList = () => {
     deviceActions.setDeviceBoard(SIMULATOR_BOARD_NAME)
   }, [runtimeConnection.connectionStatus, runtimeConnection.selectedDevice, deviceActions, handleDisconnect])
 
-  // Enable timing stats in global polling when this screen is visible
-  useEffect(() => {
-    // Set the flag to include timing stats in the global status polling
-    deviceActions.setIncludeTimingStatsInPolling(true)
-
-    // Clear the flag when leaving this screen
-    return () => {
-      deviceActions.setIncludeTimingStatsInPolling(false)
-    }
-  }, [deviceActions])
-
-  // Same pattern for EtherCAT runtime status. Only fetched while this screen
-  // is mounted, so non-EtherCAT setups don't pay for the extra round-trip on
-  // every poll.
-  useEffect(() => {
-    deviceActions.setIncludeEthercatStatsInPolling(true)
-    return () => {
-      deviceActions.setIncludeEthercatStatsInPolling(false)
-    }
-  }, [deviceActions])
+  // Timing and EtherCAT stats polling moved to the Runtime Status screen
+  // (RTOP-283) along with the panels that display them. Polling here would
+  // fetch data nobody is looking at, and would leave Runtime Status with
+  // nothing to show when opened on its own.
 
   // Handle device switch confirmation
   const handleConfirmDeviceSwitch = useCallback(async () => {
@@ -606,16 +587,6 @@ const OrchestratorsList = () => {
        *  Web builds (orchestrator-driven) and Electron builds (board-
        *  screen-driven) thus render identical stats regardless of how
        *  the user navigated to the device. */}
-      {runtimeConnection.connectionStatus === 'connected' && (
-        <div
-          id='scan-cycle-stats-panel'
-          className='flex w-full shrink-0 flex-col gap-6 overflow-y-auto overflow-x-hidden p-4 lg:px-8 lg:py-4'
-        >
-          {runtimeConnection.timingStats && <ScanCycleStats timingStats={runtimeConnection.timingStats} />}
-          <EtherCATStats />
-          <PluginStatsPanel pluginStats={runtimeConnection.timingStats?.plugin_stats} />
-        </div>
-      )}
     </div>
   )
 }

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/change-version-modal.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/change-version-modal.test.tsx
@@ -15,6 +15,12 @@ import userEvent from '@testing-library/user-event'
 const startUpdate = vi.fn()
 const getUpdateProgress = vi.fn()
 
+const setRuntimeUpdateInProgress = vi.fn()
+vi.mock('@root/frontend/store', () => ({
+  useOpenPLCStore: (selector: (state: unknown) => unknown) =>
+    selector({ deviceActions: { setRuntimeUpdateInProgress } }),
+}))
+
 vi.mock('@root/middleware/shared/providers/platform-context', () => ({
   useRuntime: () => ({
     bootloader: { startUpdate, getUpdateProgress, clearSession: vi.fn() },
@@ -95,5 +101,71 @@ describe('Change Runtime Version', () => {
     await userEvent.type(field, 'v4.0.9')
     await userEvent.click(screen.getByRole('button', { name: /install/i }))
     await waitFor(() => expect(startUpdate).toHaveBeenCalledWith('v4.0.9'))
+  })
+})
+
+describe('Following an update', () => {
+  /**
+   * The bug this pins down took the whole app out, not just this dialog.
+   *
+   * `onFinished` is passed as an inline arrow, so it is a new function on
+   * every parent render. It was a dependency of `poll`, which was a
+   * dependency of the effect that starts the poll timer -- and that effect
+   * assigned `pollingRef.current` without clearing what was there, while its
+   * cleanup only set a `cancelled` flag. So each parent render started
+   * another timer and abandoned the last one. Each timer's tick re-rendered
+   * the parent, which started another: the count compounded until the app was
+   * firing hundreds of requests a second, the dev server returned 503 to
+   * everything, and the editor looked dead.
+   */
+  it('keeps exactly one poll loop no matter how often the parent re-renders', async () => {
+    vi.useFakeTimers()
+    try {
+      getUpdateProgress.mockResolvedValue({ success: true, data: { state: 'pulling', to: 'v4.1.10' } })
+
+      const { rerender } = render(
+        <ChangeVersionModal open currentVersion='v4.2.1' onOpenChange={vi.fn()} onFinished={() => undefined} />,
+      )
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Re-render the way the real parent does: a fresh callback each time.
+      for (let render_ = 0; render_ < 10; render_ += 1) {
+        rerender(
+          <ChangeVersionModal open currentVersion='v4.2.1' onOpenChange={vi.fn()} onFinished={() => undefined} />,
+        )
+        await vi.advanceTimersByTimeAsync(0)
+      }
+
+      getUpdateProgress.mockClear()
+      // Three intervals of a single loop. With the timers stacking, ten
+      // re-renders made this an order of magnitude larger.
+      await vi.advanceTimersByTimeAsync(3 * 1500)
+
+      expect(getUpdateProgress.mock.calls.length).toBeLessThanOrEqual(4)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('tells the status poller to stand down when an update starts', async () => {
+    // getUpdateProgress stays idle (the beforeEach default): an in-flight
+    // state at mount is adopted, which disables the picker before it can be
+    // used.
+    startUpdate.mockResolvedValue({ success: true, data: { state: 'pulling', to: 'v4.1.10' } })
+
+    render(<ChangeVersionModal open currentVersion='v4.2.1' onOpenChange={vi.fn()} />)
+    await userEvent.click(await screen.findByRole('combobox'))
+    await userEvent.click(await screen.findByText('v4.1.10'))
+    await userEvent.click(screen.getByRole('button', { name: /install/i }))
+
+    await waitFor(() => expect(setRuntimeUpdateInProgress).toHaveBeenCalledWith(true))
+  })
+
+  it('lets the poller resume once the dialog is gone', async () => {
+    // A flag left raised would disable status polling for the rest of the
+    // session, which is a quieter failure than the one it prevents.
+    const { unmount } = render(<ChangeVersionModal open currentVersion='v4.2.1' onOpenChange={vi.fn()} />)
+    unmount()
+    expect(setRuntimeUpdateInProgress).toHaveBeenCalledWith(false)
   })
 })

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/change-version-modal.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/change-version-modal.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * The version picker (RTOP-283).
+ *
+ * A free-text field here was a real defect, not a cosmetic one: a version that
+ * does not exist is only rejected minutes later, by the device, in the
+ * daemon's words -- and a valid-looking tag against a misconfigured repository
+ * produces a message that blames the tag. These tests pin the list, the
+ * marking of what is already installed, and the offline fallback that keeps a
+ * side-loaded image installable.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const startUpdate = vi.fn()
+const getUpdateProgress = vi.fn()
+
+vi.mock('@root/middleware/shared/providers/platform-context', () => ({
+  useRuntime: () => ({
+    bootloader: { startUpdate, getUpdateProgress, clearSession: vi.fn() },
+  }),
+}))
+
+const listRuntimeVersions = vi.fn()
+vi.mock('@root/middleware/shared/utils/runtime-versions', () => ({
+  listRuntimeVersions: (...args: unknown[]) => listRuntimeVersions(...args),
+  clearRuntimeVersionsCache: vi.fn(),
+}))
+
+import { ChangeVersionModal } from '../change-version-modal'
+
+const TAGS = [
+  { tag: 'v4.2.1', prerelease: false },
+  { tag: 'v4.2.0', prerelease: false },
+  { tag: 'v4.1.10', prerelease: false },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getUpdateProgress.mockResolvedValue({ success: false, error: 'idle' })
+  listRuntimeVersions.mockResolvedValue({ ok: true, versions: TAGS })
+})
+
+describe('Change Runtime Version', () => {
+  it('offers the published versions instead of an empty field', async () => {
+    render(<ChangeVersionModal open currentVersion='v4.2.0' onOpenChange={vi.fn()} />)
+
+    const trigger = await screen.findByRole('combobox', { name: /runtime version to install/i })
+    await userEvent.click(trigger)
+
+    // Every published tag is reachable -- including v4.1.10, whose two-digit
+    // patch has to sort above v4.1.9 rather than below it.
+    for (const { tag } of TAGS) {
+      expect(await screen.findByText(new RegExp(`^${tag.replace('.', '\\.')}`))).toBeTruthy()
+    }
+  })
+
+  it('marks the version already installed', async () => {
+    render(<ChangeVersionModal open currentVersion='v4.2.0' onOpenChange={vi.fn()} />)
+    await userEvent.click(await screen.findByRole('combobox'))
+    expect(await screen.findByText('v4.2.0 (installed)')).toBeTruthy()
+  })
+
+  it('sends the chosen tag to the device verbatim', async () => {
+    startUpdate.mockResolvedValue({ success: true, data: { state: 'pulling', to: 'v4.1.10' } })
+    render(<ChangeVersionModal open currentVersion='v4.2.1' onOpenChange={vi.fn()} />)
+
+    await userEvent.click(await screen.findByRole('combobox'))
+    await userEvent.click(await screen.findByText('v4.1.10'))
+    await userEvent.click(screen.getByRole('button', { name: /install/i }))
+
+    await waitFor(() => expect(startUpdate).toHaveBeenCalledWith('v4.1.10'))
+  })
+
+  it('will not install the version already running', async () => {
+    render(<ChangeVersionModal open currentVersion='v4.2.1' onOpenChange={vi.fn()} />)
+    await userEvent.click(await screen.findByRole('combobox'))
+    await userEvent.click(await screen.findByText('v4.2.1 (installed)'))
+
+    expect(screen.getByRole('button', { name: /install/i }).hasAttribute('disabled')).toBe(true)
+    expect(startUpdate).not.toHaveBeenCalled()
+  })
+
+  it('still lets a version be typed when the list cannot be read', async () => {
+    // An offline device holding a side-loaded image is a version that can be
+    // installed; refusing to offer the field would make it unreachable.
+    listRuntimeVersions.mockResolvedValue({ ok: false, error: 'Could not reach GitHub.' })
+    startUpdate.mockResolvedValue({ success: true, data: { state: 'pulling', to: 'v4.0.9' } })
+
+    render(<ChangeVersionModal open currentVersion='v4.2.1' onOpenChange={vi.fn()} />)
+
+    const field = await screen.findByRole('textbox', { name: /runtime version to install/i })
+    await waitFor(() => expect(screen.getByText(/could not reach github/i)).toBeTruthy())
+
+    await userEvent.type(field, 'v4.0.9')
+    await userEvent.click(screen.getByRole('button', { name: /install/i }))
+    await waitFor(() => expect(startUpdate).toHaveBeenCalledWith('v4.0.9'))
+  })
+})

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/change-version-modal.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/change-version-modal.test.tsx
@@ -161,11 +161,53 @@ describe('Following an update', () => {
     await waitFor(() => expect(setRuntimeUpdateInProgress).toHaveBeenCalledWith(true))
   })
 
-  it('lets the poller resume once the dialog is gone', async () => {
-    // A flag left raised would disable status polling for the rest of the
-    // session, which is a quieter failure than the one it prevents.
+  it('does not declare an update finished just because the dialog closed', async () => {
+    // Unmounting is not evidence about the device. The flag is lowered in
+    // exactly two places, both of which have seen a terminal state: poll()
+    // while this dialog is open, and use-runtime-polling once it is not.
     const { unmount } = render(<ChangeVersionModal open currentVersion='v4.2.1' onOpenChange={vi.fn()} />)
     unmount()
-    expect(setRuntimeUpdateInProgress).toHaveBeenCalledWith(false)
+    expect(setRuntimeUpdateInProgress).not.toHaveBeenCalledWith(false)
+  })
+
+  it('releases the poller when the update reaches a terminal state', async () => {
+    // The path that DOES lower the flag. The dialog adopts an update already
+    // in flight, then the next poll sees it finish.
+    // Every call reports in-flight to begin with. A `...Once` chain is not
+    // reliable here: the adopt effect re-runs whenever the runtime port's
+    // identity changes and discards the request it had open, so which call
+    // wins is not fixed.
+    getUpdateProgress.mockResolvedValue({ success: true, data: { state: 'pulling', to: 'v4.1.10' } })
+
+    render(<ChangeVersionModal open currentVersion='v4.2.1' onOpenChange={vi.fn()} />)
+
+    // Adopted: the loop is running and the poller has been stood down.
+    await waitFor(() => expect(setRuntimeUpdateInProgress).toHaveBeenCalledWith(true))
+
+    // Now the device finishes.
+    getUpdateProgress.mockResolvedValue({ success: true, data: { state: 'success', to: 'v4.1.10' } })
+
+    // One tick later the update reports success, which releases the poller.
+    await waitFor(() => expect(setRuntimeUpdateInProgress).toHaveBeenCalledWith(false), {
+      timeout: 5000,
+    })
+  })
+
+  it('keeps the poller stood down when unmounted mid-swap', async () => {
+    // The case that matters, and the one that was untested. `busy` blocks the
+    // dialog's own close but nothing blocks navigating away from the Runtime
+    // Status tab -- and clearing the flag here would let the status poller
+    // resume during the runtime's expected outage, count five silent polls
+    // and raise the "connection lost" modal this flag exists to prevent.
+    getUpdateProgress.mockResolvedValue({ success: true, data: { state: 'swapping', to: 'v4.1.10' } })
+
+    const { unmount } = render(<ChangeVersionModal open currentVersion='v4.2.1' onOpenChange={vi.fn()} />)
+    // Wait for the adopt path to see the in-flight state.
+    await waitFor(() => expect(setRuntimeUpdateInProgress).toHaveBeenCalledWith(true))
+    setRuntimeUpdateInProgress.mockClear()
+
+    unmount()
+
+    expect(setRuntimeUpdateInProgress).not.toHaveBeenCalledWith(false)
   })
 })

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
@@ -73,7 +73,12 @@ const connectedState = (overrides: Record<string, unknown> = {}) => ({
     connectionStatus: 'connected',
     runtimeVersion: 'v4.2.1',
     ipAddress: '192.168.1.112',
-    selectedDevice: { orchestratorId: 'local', orchestratorAgentId: 'local', deviceId: 'd1', deviceName: '192.168.2.4' },
+    selectedDevice: {
+      orchestratorId: 'local',
+      orchestratorAgentId: 'local',
+      deviceId: 'd1',
+      deviceName: '192.168.2.4',
+    },
     timingStats: null,
     storedCredentials: { username: 'op', password: 'op' },
     ...overrides,
@@ -135,12 +140,15 @@ describe('Runtime Status', () => {
   it('offers a version change when a bootloader answers', async () => {
     getCapabilities.mockResolvedValue({
       success: true,
-      data: { service: 'openplc-bootloader', state: 'healthy', recovery: false, bootloaderVersion: 'bootloader-v1.0.0' },
+      data: {
+        service: 'openplc-bootloader',
+        state: 'healthy',
+        recovery: false,
+        bootloaderVersion: 'bootloader-v1.0.0',
+      },
     })
     render(<RuntimeStatusEditor />)
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: /change runtime version/i })).toBeTruthy(),
-    )
+    await waitFor(() => expect(screen.getByRole('button', { name: /change runtime version/i })).toBeTruthy())
   })
 
   it('announces a device in recovery, with the reason', async () => {

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
@@ -166,3 +166,29 @@ describe('Runtime Status', () => {
     expect(actions.setIncludeEthercatStatsInPolling).toHaveBeenCalledWith(false)
   })
 })
+
+describe('Runtime Status header honesty', () => {
+  it('says nothing about deployment when the runtime did not report it', async () => {
+    // Every runtime released before this endpoint answers HTTP 200 with its
+    // catch-all body rather than a 404. Read as device info, that produced
+    // "Native" for a container -- a false claim about the entire installed
+    // base, and one nobody would think to check.
+    getDeviceInfo.mockResolvedValue({ success: true, data: { hostname: 'slm-rp4' } })
+    getCapabilities.mockResolvedValue({
+      success: true,
+      data: { service: 'openplc-bootloader', state: 'healthy', recovery: false },
+    })
+
+    render(<RuntimeStatusEditor />)
+
+    await waitFor(() => expect(screen.getByText('slm-rp4')).toBeTruthy())
+    expect(screen.queryByText('Native')).toBeNull()
+    expect(screen.queryByText('Container')).toBeNull()
+  })
+
+  it('still reports a native install when the runtime says so', async () => {
+    getDeviceInfo.mockResolvedValue({ success: true, data: { containerized: false } })
+    render(<RuntimeStatusEditor />)
+    await waitFor(() => expect(screen.getByText('Native')).toBeTruthy())
+  })
+})

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Runtime Status screen (RTOP-283).
+ *
+ * Rendered against a mocked store and runtime port rather than a live device.
+ * The web app reaches devices only through the orchestrator agent proxy, so a
+ * browser walkthrough of this screen would need an orchestrator, an Edge API
+ * and a registered device -- none of which make a useful regression test. What
+ * actually needs pinning is the decision logic: when the version-change action
+ * is offered, what the header says about a device, and that a device in
+ * recovery announces itself. All three are testable here and none of them are
+ * visible from a screenshot anyway.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react'
+
+const getDeviceInfo = vi.fn()
+const getCapabilities = vi.fn()
+const bootloaderLogin = vi.fn()
+const getStatus = vi.fn()
+
+let storeState: Record<string, unknown> = {}
+
+vi.mock('@root/middleware/shared/providers/platform-context', () => ({
+  useRuntime: () => ({
+    getDeviceInfo,
+    bootloader: {
+      getCapabilities,
+      login: bootloaderLogin,
+      getStatus,
+      getRuntimeLogs: vi.fn(),
+      startUpdate: vi.fn(),
+      getUpdateProgress: vi.fn().mockResolvedValue({ success: false, error: 'none' }),
+      restartRuntime: vi.fn(),
+      clearSession: vi.fn(),
+    },
+  }),
+}))
+
+// Mocked through the @root alias rather than a relative path: Jest resolves
+// a mock path relative to its setup file, not the test, so a relative one
+// fails there while working under Vitest. The alias resolves to the same
+// module in both, which keeps this file identical across the two apps.
+vi.mock('@root/frontend/store', () => ({
+  useOpenPLCStore: (selector: (state: unknown) => unknown) => selector(storeState),
+}))
+
+// The statistics panels are exercised by their own tests; here they would only
+// add noise and a dependency on live timing data.
+vi.mock('@root/frontend/components/_molecules/ethercat-stats', () => ({ EtherCATStats: () => null }))
+vi.mock('@root/frontend/components/_molecules/plugin-stats-panel', () => ({ PluginStatsPanel: () => null }))
+vi.mock('@root/frontend/components/_molecules/scan-cycle-stats', () => ({ ScanCycleStats: () => null }))
+
+import { RuntimeStatusEditor } from '../index'
+
+/** A connected device, built fresh per test so the action spies are clean. */
+const connectedState = (overrides: Record<string, unknown> = {}) => ({
+  runtimeConnection: {
+    connectionStatus: 'connected',
+    runtimeVersion: 'v4.2.1',
+    ipAddress: '192.168.2.4',
+    timingStats: null,
+    storedCredentials: { username: 'op', password: 'op' },
+    ...overrides,
+  },
+  deviceActions: {
+    setIncludeTimingStatsInPolling: vi.fn(),
+    setIncludeEthercatStatsInPolling: vi.fn(),
+  },
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  storeState = connectedState()
+  getDeviceInfo.mockResolvedValue({ success: false, error: 'not supported' })
+  getCapabilities.mockResolvedValue({ success: false, error: 'No bootloader on this device' })
+  bootloaderLogin.mockResolvedValue({ success: false, error: 'no' })
+  getStatus.mockResolvedValue({ success: false, error: 'no' })
+})
+
+describe('Runtime Status', () => {
+  it('asks the operator to connect before showing anything', () => {
+    storeState = connectedState({ connectionStatus: 'disconnected' })
+    render(<RuntimeStatusEditor />)
+    expect(screen.getByText(/connect to a runtime/i)).toBeTruthy()
+  })
+
+  it('does not offer a version change when the device has no bootloader', async () => {
+    // The common case: an orchestrator-managed vPLC or a native install.
+    // Nothing on the device could perform a swap, and a button that cannot
+    // work is worse than no button.
+    render(<RuntimeStatusEditor />)
+    await waitFor(() => expect(getCapabilities).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: /change runtime version/i })).toBeNull()
+  })
+
+  it('offers a version change when a bootloader answers', async () => {
+    getCapabilities.mockResolvedValue({
+      success: true,
+      data: { service: 'openplc-bootloader', state: 'healthy', recovery: false, bootloaderVersion: 'bootloader-v1.0.0' },
+    })
+    render(<RuntimeStatusEditor />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /change runtime version/i })).toBeTruthy(),
+    )
+  })
+
+  it('announces a device in recovery, with the reason', async () => {
+    // A device whose runtime will not start is exactly when someone needs to
+    // know why, and the bootloader's own wording is the most useful thing to
+    // show them.
+    getCapabilities.mockResolvedValue({
+      success: true,
+      data: { service: 'openplc-bootloader', state: 'recovery', recovery: true },
+    })
+    bootloaderLogin.mockResolvedValue({ success: true, data: {} })
+    getStatus.mockResolvedValue({
+      success: true,
+      data: { state: 'recovery', recovery: true, reason: 'runtime exited 3 times within 5m0s' },
+    })
+
+    render(<RuntimeStatusEditor />)
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy())
+    expect(screen.getByText(/runtime exited 3 times/i)).toBeTruthy()
+  })
+
+  it('shows what the device reports about itself', async () => {
+    getDeviceInfo.mockResolvedValue({
+      success: true,
+      data: {
+        hostname: 'slm-rp4',
+        architecture: 'aarch64',
+        kernel: '6.12.35-rt10-v8+',
+        containerized: true,
+        updatePolicy: 'self',
+      },
+    })
+    render(<RuntimeStatusEditor />)
+
+    await waitFor(() => expect(screen.getByText('aarch64')).toBeTruthy())
+    expect(screen.getByText('6.12.35-rt10-v8+')).toBeTruthy()
+    expect(screen.getByText('Container')).toBeTruthy()
+    // The policy is rendered in words, never as a bare enum.
+    expect(screen.getByText('From this editor')).toBeTruthy()
+    expect(screen.queryByText('self')).toBeNull()
+  })
+
+  it('explains a managed device instead of leaving the operator hunting', async () => {
+    getDeviceInfo.mockResolvedValue({ success: true, data: { updatePolicy: 'managed' } })
+    render(<RuntimeStatusEditor />)
+    await waitFor(() => expect(screen.getByText('Managed by orchestrator')).toBeTruthy())
+  })
+
+  it('asks the poller for the statistics it displays, and stops on unmount', () => {
+    // These toggles moved here from the screens that used to show the stats.
+    // Without them the screen would render empty panels forever; without the
+    // cleanup, a device would be polled for data nobody is looking at.
+    const actions = (storeState as { deviceActions: Record<string, ReturnType<typeof vi.fn>> })
+      .deviceActions
+    const { unmount } = render(<RuntimeStatusEditor />)
+
+    expect(actions.setIncludeTimingStatsInPolling).toHaveBeenCalledWith(true)
+    expect(actions.setIncludeEthercatStatsInPolling).toHaveBeenCalledWith(true)
+
+    unmount()
+    expect(actions.setIncludeTimingStatsInPolling).toHaveBeenCalledWith(false)
+    expect(actions.setIncludeEthercatStatsInPolling).toHaveBeenCalledWith(false)
+  })
+})

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
@@ -302,6 +302,26 @@ describe('A device with no bootloader', () => {
     expect(screen.queryByRole('button', { name: /change runtime version/i })).toBeNull()
   })
 
+  it('treats a blank CPU or memory value as not reported', async () => {
+    // Number('') and Number('   ') are both 0, not NaN, so an agent that
+    // reports an empty count would otherwise have rendered "0 CPU cores" --
+    // a claim about the machine rather than an absence of one.
+    getCapabilities.mockResolvedValue({ success: false, error: 'No bootloader on this device' })
+    getOrchestratorHostInfo.mockResolvedValue({
+      os: 'Debian GNU/Linux 12 (bookworm)',
+      cpu: '',
+      memory: '   ',
+      name: 'shop-floor-01',
+    })
+
+    render(<RuntimeStatusEditor />)
+
+    await waitFor(() => expect(screen.getByText('Debian GNU/Linux 12 (bookworm)')).toBeTruthy())
+    expect(screen.queryByText('0')).toBeNull()
+    expect(screen.queryByText('0.0 GB')).toBeNull()
+    expect(screen.queryByText('0 MB')).toBeNull()
+  })
+
   it('shows an empty header rather than failing when the agent says nothing', async () => {
     getCapabilities.mockResolvedValue({ success: false, error: 'No bootloader on this device' })
     getOrchestratorHostInfo.mockResolvedValue(null)

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
@@ -272,6 +272,9 @@ describe('A device with no bootloader', () => {
     getCapabilities.mockResolvedValue({ success: false, error: 'No bootloader on this device' })
     getOrchestratorHostInfo.mockResolvedValue({
       os: 'Debian GNU/Linux 12 (bookworm)',
+      // Needs an Edge carrying EDGE-631; before that the agent sent this and
+      // Edge did not declare it, so it could not be read.
+      kernel: '6.12.35-rt10-v8+',
       cpu: '4',
       memory: '1846',
       agentVersion: '1.6.0',
@@ -286,6 +289,7 @@ describe('A device with no bootloader', () => {
     // Named as the agent, not as a bootloader that is not there.
     expect(screen.getByText('Orchestrator agent')).toBeTruthy()
     expect(screen.getByText('1.6.0')).toBeTruthy()
+    expect(screen.getByText('6.12.35-rt10-v8+')).toBeTruthy()
     // And still no version action: nothing on this device can perform a swap.
     expect(screen.queryByRole('button', { name: /change runtime version/i })).toBeNull()
   })

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
@@ -18,9 +18,20 @@ const getCapabilities = vi.fn()
 const bootloaderLogin = vi.fn()
 const getStatus = vi.fn()
 
-let storeState: Record<string, unknown> = {}
+/** Typed, so reading the action spies back needs no cast. */
+type MockStore = {
+  runtimeConnection: Record<string, unknown>
+  deviceActions: Record<string, ReturnType<typeof vi.fn>>
+}
+
+let storeState: MockStore
+
+const getOrchestratorHostInfo = vi.fn()
 
 vi.mock('@root/middleware/shared/providers/platform-context', () => ({
+  // The production source of these facts for an orchestrator-managed device,
+  // which has no bootloader container to ask.
+  useOrchestrator: () => ({ getOrchestratorHostInfo }),
   useRuntime: () => ({
     bootloader: {
       getCapabilities,
@@ -40,9 +51,13 @@ vi.mock('@root/middleware/shared/providers/platform-context', () => ({
 // a mock path relative to its setup file, not the test, so a relative one
 // fails there while working under Vitest. The alias resolves to the same
 // module in both, which keeps this file identical across the two apps.
-vi.mock('@root/frontend/store', () => ({
-  useOpenPLCStore: (selector: (state: unknown) => unknown) => selector(storeState),
-}))
+vi.mock('@root/frontend/store', () => {
+  const useOpenPLCStore = (selector: (state: unknown) => unknown) => selector(storeState)
+  // The screen reads the store directly when comparing the reported runtime
+  // version, to avoid putting it in a dependency list.
+  useOpenPLCStore.getState = () => storeState
+  return { useOpenPLCStore }
+})
 
 // The statistics panels are exercised by their own tests; here they would only
 // add noise and a dependency on live timing data.
@@ -69,6 +84,9 @@ const connectedState = (overrides: Record<string, unknown> = {}) => ({
     // The version dialog renders inside this screen and suspends status
     // polling while a swap runs.
     setRuntimeUpdateInProgress: vi.fn(),
+    // Written after an install so the header and the picker agree on what is
+    // running.
+    setRuntimeVersion: vi.fn(),
   },
 })
 
@@ -76,6 +94,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   storeState = connectedState()
   getDeviceInfo.mockResolvedValue({ success: false, error: 'not supported' })
+  getOrchestratorHostInfo.mockResolvedValue(null)
   getCapabilities.mockResolvedValue({ success: false, error: 'No bootloader on this device' })
   bootloaderLogin.mockResolvedValue({ success: false, error: 'no' })
   getStatus.mockResolvedValue({ success: false, error: 'no' })
@@ -186,8 +205,7 @@ describe('Runtime Status', () => {
     // These toggles moved here from the screens that used to show the stats.
     // Without them the screen would render empty panels forever; without the
     // cleanup, a device would be polled for data nobody is looking at.
-    const actions = (storeState as { deviceActions: Record<string, ReturnType<typeof vi.fn>> })
-      .deviceActions
+    const actions = storeState.deviceActions
     const { unmount } = render(<RuntimeStatusEditor />)
 
     expect(actions.setIncludeTimingStatsInPolling).toHaveBeenCalledWith(true)
@@ -242,5 +260,43 @@ describe('Which device the header names', () => {
     storeState = connectedState({ selectedDevice: null, ipAddress: '192.168.2.4' })
     render(<RuntimeStatusEditor />)
     await waitFor(() => expect(screen.getByText(/192\.168\.2\.4/)).toBeTruthy())
+  })
+})
+
+describe('A device with no bootloader', () => {
+  it('falls back to what the orchestrator agent knows about the host', async () => {
+    // The production case. Devices under an orchestrator are vPLC containers
+    // with no bootloader beside them, so nothing answers on 8445 and the
+    // header used to sit completely blank. The agent already collects these
+    // facts for its own consumption reporting and Edge exposes them.
+    getCapabilities.mockResolvedValue({ success: false, error: 'No bootloader on this device' })
+    getOrchestratorHostInfo.mockResolvedValue({
+      os: 'Debian GNU/Linux 12 (bookworm)',
+      cpu: '4',
+      memory: '1846',
+      agentVersion: '1.6.0',
+      name: 'shop-floor-01',
+    })
+
+    render(<RuntimeStatusEditor />)
+
+    await waitFor(() => expect(screen.getByText('Debian GNU/Linux 12 (bookworm)')).toBeTruthy())
+    expect(screen.getByText('4')).toBeTruthy()
+    expect(screen.getByText('1.8 GB')).toBeTruthy()
+    // Named as the agent, not as a bootloader that is not there.
+    expect(screen.getByText('Orchestrator agent')).toBeTruthy()
+    expect(screen.getByText('1.6.0')).toBeTruthy()
+    // And still no version action: nothing on this device can perform a swap.
+    expect(screen.queryByRole('button', { name: /change runtime version/i })).toBeNull()
+  })
+
+  it('shows an empty header rather than failing when the agent says nothing', async () => {
+    getCapabilities.mockResolvedValue({ success: false, error: 'No bootloader on this device' })
+    getOrchestratorHostInfo.mockResolvedValue(null)
+
+    render(<RuntimeStatusEditor />)
+
+    await waitFor(() => expect(getOrchestratorHostInfo).toHaveBeenCalled())
+    expect(screen.getByText('Runtime Status')).toBeTruthy()
   })
 })

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
@@ -22,11 +22,11 @@ let storeState: Record<string, unknown> = {}
 
 vi.mock('@root/middleware/shared/providers/platform-context', () => ({
   useRuntime: () => ({
-    getDeviceInfo,
     bootloader: {
       getCapabilities,
       login: bootloaderLogin,
       getStatus,
+      getDeviceInfo,
       getRuntimeLogs: vi.fn(),
       startUpdate: vi.fn(),
       getUpdateProgress: vi.fn().mockResolvedValue({ success: false, error: 'none' }),
@@ -57,7 +57,8 @@ const connectedState = (overrides: Record<string, unknown> = {}) => ({
   runtimeConnection: {
     connectionStatus: 'connected',
     runtimeVersion: 'v4.2.1',
-    ipAddress: '192.168.2.4',
+    ipAddress: '192.168.1.112',
+    selectedDevice: { orchestratorId: 'local', orchestratorAgentId: 'local', deviceId: 'd1', deviceName: '192.168.2.4' },
     timingStats: null,
     storedCredentials: { username: 'op', password: 'op' },
     ...overrides,
@@ -76,6 +77,22 @@ beforeEach(() => {
   bootloaderLogin.mockResolvedValue({ success: false, error: 'no' })
   getStatus.mockResolvedValue({ success: false, error: 'no' })
 })
+
+/**
+ * A device whose bootloader answers and accepts the operator's credentials.
+ *
+ * Device info comes from the bootloader now, behind its login, so every test
+ * that expects a populated header has to get this far first -- which is the
+ * point: the bootloader is present whatever runtime version is installed.
+ */
+const withBootloader = () => {
+  getCapabilities.mockResolvedValue({
+    success: true,
+    data: { service: 'openplc-bootloader', state: 'healthy', recovery: false, bootloaderVersion: 'bootloader-v1.0.0' },
+  })
+  bootloaderLogin.mockResolvedValue({ success: true, data: {} })
+  getStatus.mockResolvedValue({ success: true, data: { state: 'healthy', recovery: false } })
+}
 
 describe('Runtime Status', () => {
   it('asks the operator to connect before showing anything', () => {
@@ -123,31 +140,43 @@ describe('Runtime Status', () => {
     expect(screen.getByText(/runtime exited 3 times/i)).toBeTruthy()
   })
 
-  it('shows what the device reports about itself', async () => {
+  it('shows what the bootloader reports about the machine', async () => {
+    withBootloader()
     getDeviceInfo.mockResolvedValue({
       success: true,
       data: {
         hostname: 'slm-rp4',
         architecture: 'aarch64',
         kernel: '6.12.35-rt10-v8+',
-        containerized: true,
-        updatePolicy: 'self',
+        system: 'Debian GNU/Linux 12 (bookworm)',
+        cpus: 4,
+        memoryBytes: 1935417344,
       },
     })
     render(<RuntimeStatusEditor />)
 
     await waitFor(() => expect(screen.getByText('aarch64')).toBeTruthy())
+    expect(screen.getByText('slm-rp4')).toBeTruthy()
     expect(screen.getByText('6.12.35-rt10-v8+')).toBeTruthy()
-    expect(screen.getByText('Container')).toBeTruthy()
-    // The policy is rendered in words, never as a bare enum.
-    expect(screen.getByText('From this editor')).toBeTruthy()
-    expect(screen.queryByText('self')).toBeNull()
+    expect(screen.getByText('Debian GNU/Linux 12 (bookworm)')).toBeTruthy()
+    expect(screen.getByText('4')).toBeTruthy()
+    // Powers of 1024, so a 2 GB board reads as the number on its datasheet.
+    expect(screen.getByText('1.8 GB')).toBeTruthy()
   })
 
-  it('explains a managed device instead of leaving the operator hunting', async () => {
-    getDeviceInfo.mockResolvedValue({ success: true, data: { updatePolicy: 'managed' } })
+  it('populates the header on a device whose runtime predates all of this', async () => {
+    // The whole reason these facts come from the bootloader. A released
+    // runtime serves no device information at all, and this screen is most
+    // useful on exactly those devices -- so nothing here may depend on the
+    // runtime version.
+    withBootloader()
+    getDeviceInfo.mockResolvedValue({ success: true, data: { hostname: 'slm-rp4', kernel: '6.12.35-rt10-v8+' } })
+    storeState = connectedState({ runtimeVersion: 'v4.1.0' })
+
     render(<RuntimeStatusEditor />)
-    await waitFor(() => expect(screen.getByText('Managed by orchestrator')).toBeTruthy())
+
+    await waitFor(() => expect(screen.getByText('slm-rp4')).toBeTruthy())
+    expect(screen.getByText('6.12.35-rt10-v8+')).toBeTruthy()
   })
 
   it('asks the poller for the statistics it displays, and stops on unmount', () => {
@@ -168,27 +197,47 @@ describe('Runtime Status', () => {
 })
 
 describe('Runtime Status header honesty', () => {
-  it('says nothing about deployment when the runtime did not report it', async () => {
-    // Every runtime released before this endpoint answers HTTP 200 with its
-    // catch-all body rather than a 404. Read as device info, that produced
-    // "Native" for a container -- a false claim about the entire installed
-    // base, and one nobody would think to check.
+  it('leaves a field blank rather than inventing a value', async () => {
+    // A bootloader that could not reach the daemon still answers, with less in
+    // it. The header must show what is missing as missing.
+    withBootloader()
     getDeviceInfo.mockResolvedValue({ success: true, data: { hostname: 'slm-rp4' } })
-    getCapabilities.mockResolvedValue({
-      success: true,
-      data: { service: 'openplc-bootloader', state: 'healthy', recovery: false },
-    })
 
     render(<RuntimeStatusEditor />)
 
     await waitFor(() => expect(screen.getByText('slm-rp4')).toBeTruthy())
-    expect(screen.queryByText('Native')).toBeNull()
+    // The fields it was not told about stay empty. The old runtime-sourced
+    // header filled them in from defaults, which is how it came to state
+    // "Native" about a container.
+    expect(screen.queryByText('aarch64')).toBeNull()
     expect(screen.queryByText('Container')).toBeNull()
+    expect(screen.queryByText('From this editor')).toBeNull()
+  })
+})
+
+describe('Which device the header names', () => {
+  it('names the connected device, not the address saved in the project', async () => {
+    // runtimeConnection.ipAddress is the project's configured runtime IP. On a
+    // device reached through an orchestrator it has no relationship to the
+    // device on screen, and a project carrying an old address labelled the
+    // header with a machine elsewhere on the network.
+    withBootloader()
+    getDeviceInfo.mockResolvedValue({ success: true, data: { hostname: 'slm-rp4' } })
+
+    render(<RuntimeStatusEditor />)
+
+    // The subtitle names both, so match the whole line rather than a fragment
+    // that also appears in the Host field below it.
+    await waitFor(() => expect(screen.getByText('slm-rp4 · 192.168.2.4')).toBeTruthy())
+    expect(screen.queryByText(/192\.168\.1\.112/)).toBeNull()
   })
 
-  it('still reports a native install when the runtime says so', async () => {
-    getDeviceInfo.mockResolvedValue({ success: true, data: { containerized: false } })
+  it('falls back to the dialled address when there is no orchestrator', async () => {
+    // The desktop editor connects straight to an IP and has no device record,
+    // so that address is the only identity available before the bootloader
+    // answers.
+    storeState = connectedState({ selectedDevice: null, ipAddress: '192.168.2.4' })
     render(<RuntimeStatusEditor />)
-    await waitFor(() => expect(screen.getByText('Native')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText(/192\.168\.2\.4/)).toBeTruthy())
   })
 })

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/__tests__/runtime-status.test.tsx
@@ -66,6 +66,9 @@ const connectedState = (overrides: Record<string, unknown> = {}) => ({
   deviceActions: {
     setIncludeTimingStatsInPolling: vi.fn(),
     setIncludeEthercatStatsInPolling: vi.fn(),
+    // The version dialog renders inside this screen and suspends status
+    // polling while a swap runs.
+    setRuntimeUpdateInProgress: vi.fn(),
   },
 })
 

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/change-version-modal.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/change-version-modal.tsx
@@ -1,0 +1,263 @@
+/**
+ * Change the runtime's version (RTOP-283).
+ *
+ * The device does the work: the bootloader pulls the image, swaps the
+ * container and health-gates the result. This screen picks a version, starts
+ * it, and then follows along -- which is why it polls rather than awaiting a
+ * response. A pull on a slow device runs for many minutes.
+ *
+ * Upgrade and downgrade are one action. There is no separate direction and no
+ * version floor: pairing an older runtime with an older editor is a
+ * legitimate thing to want, and the bootloader stays reachable either way.
+ */
+
+import { useRuntime } from '@root/middleware/shared/providers/platform-context'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { Modal, ModalContent, ModalFooter, ModalHeader, ModalTitle } from '../../../../../_molecules/modal'
+
+type UpdateProgress = {
+  state: string
+  from?: string
+  to?: string
+  phase?: string
+  percent?: number | null
+  error?: string
+}
+
+type ChangeVersionModalProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The version running now, so the list can mark it and avoid a pointless swap. */
+  currentVersion: string | null
+  /** Called once an update finishes, so the caller can refresh its own view. */
+  onFinished?: () => void
+}
+
+/** How often to ask the device where it has got to. */
+const POLL_INTERVAL_MS = 1500
+
+/** States the bootloader reports while work is still in flight. */
+const IN_FLIGHT = new Set(['pulling', 'swapping', 'verifying'])
+
+const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: ChangeVersionModalProps) => {
+  const runtime = useRuntime()
+
+  const [version, setVersion] = useState('')
+  const [progress, setProgress] = useState<UpdateProgress | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [starting, setStarting] = useState(false)
+
+  // Kept in a ref so the poll loop can stop itself without being re-created
+  // on every tick, which would restart the interval each time.
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current !== null) {
+      clearInterval(pollingRef.current)
+      pollingRef.current = null
+    }
+  }, [])
+
+  const poll = useCallback(async () => {
+    const result = await runtime.bootloader.getUpdateProgress()
+    if (!result.success) {
+      // A poll failing mid-update is expected: the runtime container is being
+      // replaced, and on a host-network device that can briefly interrupt
+      // everything. Keep polling rather than declaring failure.
+      return
+    }
+    setProgress(result.data)
+    if (!IN_FLIGHT.has(result.data.state)) {
+      stopPolling()
+      if (result.data.state === 'failed') {
+        setError(result.data.error ?? 'The update failed.')
+      }
+      onFinished?.()
+    }
+  }, [runtime, stopPolling, onFinished])
+
+  const startUpdate = useCallback(async () => {
+    const target = version.trim()
+    if (!target) {
+      setError('Enter the version to install.')
+      return
+    }
+
+    setStarting(true)
+    setError(null)
+    setProgress(null)
+
+    const result = await runtime.bootloader.startUpdate(target)
+    setStarting(false)
+
+    if (!result.success) {
+      // The bootloader's own wording, which already says what to do about a
+      // bad tag or an update already running.
+      setError(result.error)
+      return
+    }
+    setProgress(result.data)
+
+    stopPolling()
+    pollingRef.current = setInterval(() => {
+      void poll()
+    }, POLL_INTERVAL_MS)
+  }, [runtime, version, poll, stopPolling])
+
+  // Adopt an update that is already running.
+  //
+  // Opening this modal while the device is mid-update -- because another
+  // editor started one, or because this one was closed and reopened -- must
+  // show that progress rather than an empty form inviting a second attempt
+  // the device will refuse.
+  useEffect(() => {
+    if (!open) {
+      stopPolling()
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      const result = await runtime.bootloader.getUpdateProgress()
+      if (cancelled || !result.success) return
+      if (IN_FLIGHT.has(result.data.state)) {
+        setProgress(result.data)
+        pollingRef.current = setInterval(() => {
+          void poll()
+        }, POLL_INTERVAL_MS)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [open, runtime, poll, stopPolling])
+
+  useEffect(() => stopPolling, [stopPolling])
+
+  const inFlight = progress !== null && IN_FLIGHT.has(progress.state)
+  const succeeded = progress?.state === 'success'
+  // Closing mid-update would be misleading: the device carries on regardless,
+  // so the button says so rather than pretending to cancel anything.
+  const busy = starting || inFlight
+
+  return (
+    <Modal open={open} onOpenChange={busy ? () => undefined : onOpenChange}>
+      <ModalContent className='h-fit w-[520px]'>
+        <ModalHeader>
+          <ModalTitle>Change Runtime Version</ModalTitle>
+        </ModalHeader>
+
+        <div className='flex flex-col gap-4'>
+          <p className='text-sm text-neutral-700 dark:text-neutral-300'>
+            The device downloads the version you choose and restarts its runtime. Installing an older version is
+            supported.
+          </p>
+
+          <label className='flex flex-col gap-1'>
+            <span className='text-xs font-medium text-neutral-600 dark:text-neutral-400'>Version</span>
+            <input
+              aria-label='Runtime version to install'
+              className='rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white'
+              disabled={busy}
+              onChange={(event) => setVersion(event.target.value)}
+              placeholder={currentVersion ?? 'v4.2.1'}
+              value={version}
+            />
+            {currentVersion && (
+              <span className='text-xs text-neutral-500 dark:text-neutral-400'>
+                Currently running {currentVersion}
+              </span>
+            )}
+          </label>
+
+          {progress && (
+            <div aria-live='polite' className='flex flex-col gap-2'>
+              <div className='flex items-center justify-between text-sm'>
+                <span className='text-neutral-700 dark:text-neutral-300'>
+                  {describeState(progress)}
+                </span>
+                {/* No percentage while the daemon has reported no size to work
+                    from -- for layers it already holds, and before any size is
+                    known. Showing 0% there would read as a stall. */}
+                {typeof progress.percent === 'number' && (
+                  <span className='tabular-nums text-neutral-500 dark:text-neutral-400'>{progress.percent}%</span>
+                )}
+              </div>
+              <div className='h-2 w-full overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-800'>
+                <div
+                  className={`h-full rounded-full transition-all ${
+                    progress.state === 'failed' ? 'bg-red-500' : 'bg-brand'
+                  } ${typeof progress.percent === 'number' ? '' : 'animate-pulse'}`}
+                  style={{ width: typeof progress.percent === 'number' ? `${progress.percent}%` : '100%' }}
+                />
+              </div>
+            </div>
+          )}
+
+          {succeeded && (
+            <p className='text-sm text-green-700 dark:text-green-400'>
+              {progress?.to} is installed and running. Upload your project again so it is rebuilt for this version.
+            </p>
+          )}
+
+          {error && (
+            <p className='text-sm text-red-600 dark:text-red-400' role='alert'>
+              {error}
+            </p>
+          )}
+
+          {inFlight && (
+            <p className='text-xs text-neutral-500 dark:text-neutral-400'>
+              The device continues on its own if you close the editor. On a slow connection this can take several
+              minutes.
+            </p>
+          )}
+        </div>
+
+        <ModalFooter className='flex justify-end gap-2'>
+          <button
+            className='rounded-md px-3 py-2 text-sm text-neutral-700 disabled:opacity-50 dark:text-neutral-300'
+            disabled={busy}
+            onClick={() => onOpenChange(false)}
+            type='button'
+          >
+            {succeeded ? 'Close' : 'Cancel'}
+          </button>
+          {!succeeded && (
+            <button
+              className='rounded-md bg-brand px-3 py-2 text-sm font-medium text-white disabled:opacity-50'
+              disabled={busy || !version.trim()}
+              onClick={() => void startUpdate()}
+              type='button'
+            >
+              {busy ? 'Installing…' : 'Install'}
+            </button>
+          )}
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+/** Plain wording for a state, so the UI never shows a bare enum. */
+const describeState = (progress: UpdateProgress): string => {
+  switch (progress.state) {
+    case 'pulling':
+      // The daemon's own phase ("Downloading", "Extracting") when there is
+      // one: it is what every other Docker tool shows, so matching it means
+      // the two never disagree.
+      return progress.phase ? `Downloading ${progress.to} — ${progress.phase}` : `Downloading ${progress.to}`
+    case 'swapping':
+      return 'Replacing the runtime'
+    case 'verifying':
+      return 'Waiting for the new runtime to start'
+    case 'success':
+      return `Installed ${progress.to}`
+    case 'failed':
+      return 'The update failed'
+    default:
+      return progress.state
+  }
+}
+
+export { ChangeVersionModal }

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/change-version-modal.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/change-version-modal.tsx
@@ -13,6 +13,7 @@
 
 import * as Select from '@radix-ui/react-select'
 import { ArrowIcon } from '@root/frontend/assets/icons/interface/Arrow'
+import { useOpenPLCStore } from '@root/frontend/store'
 import { useRuntime } from '@root/middleware/shared/providers/platform-context'
 import {
   clearRuntimeVersionsCache,
@@ -49,6 +50,9 @@ const IN_FLIGHT = new Set(['pulling', 'swapping', 'verifying'])
 
 const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: ChangeVersionModalProps) => {
   const runtime = useRuntime()
+  // Tells the status poller to stand down: the runtime is about to be stopped
+  // and replaced, and that silence must not be read as a lost connection.
+  const setRuntimeUpdateInProgress = useOpenPLCStore((state) => state.deviceActions.setRuntimeUpdateInProgress)
 
   const [version, setVersion] = useState('')
   const [progress, setProgress] = useState<UpdateProgress | null>(null)
@@ -67,12 +71,25 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
   // on every tick, which would restart the interval each time.
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
+  // onFinished is a prop, and callers pass an inline arrow -- a new function
+  // every render. Depending on it directly made `poll` unstable, which made
+  // the effect below unstable, which leaked a timer per render while an
+  // update was running. Each leaked timer re-rendered the parent, which
+  // leaked another: the count compounded until the app was firing hundreds of
+  // requests a second and everything downstream fell over. Holding it in a ref
+  // keeps the callback current without putting its identity in a dep array.
+  const onFinishedRef = useRef(onFinished)
+  useEffect(() => {
+    onFinishedRef.current = onFinished
+  }, [onFinished])
+
   const stopPolling = useCallback(() => {
     if (pollingRef.current !== null) {
       clearInterval(pollingRef.current)
       pollingRef.current = null
     }
-  }, [])
+    setRuntimeUpdateInProgress(false)
+  }, [setRuntimeUpdateInProgress])
 
   const poll = useCallback(async () => {
     const result = await runtime.bootloader.getUpdateProgress()
@@ -88,9 +105,24 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
       if (result.data.state === 'failed') {
         setError(result.data.error ?? 'The update failed.')
       }
-      onFinished?.()
+      onFinishedRef.current?.()
     }
-  }, [runtime, stopPolling, onFinished])
+  }, [runtime, stopPolling])
+
+  /**
+   * Begin following an update, replacing any loop already running.
+   *
+   * Every start goes through here. Assigning `pollingRef.current` at a call
+   * site is what allowed a second timer to exist while the first kept
+   * ticking, unreferenced and unstoppable.
+   */
+  const startPolling = useCallback(() => {
+    stopPolling()
+    setRuntimeUpdateInProgress(true)
+    pollingRef.current = setInterval(() => {
+      void poll()
+    }, POLL_INTERVAL_MS)
+  }, [poll, stopPolling, setRuntimeUpdateInProgress])
 
   const startUpdate = useCallback(async () => {
     const target = version.trim()
@@ -113,12 +145,8 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
       return
     }
     setProgress(result.data)
-
-    stopPolling()
-    pollingRef.current = setInterval(() => {
-      void poll()
-    }, POLL_INTERVAL_MS)
-  }, [runtime, version, poll, stopPolling])
+    startPolling()
+  }, [runtime, version, startPolling])
 
   const loadVersions = useCallback(async (signal?: AbortSignal) => {
     setLoadingVersions(true)
@@ -162,15 +190,16 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
       if (cancelled || !result.success) return
       if (IN_FLIGHT.has(result.data.state)) {
         setProgress(result.data)
-        pollingRef.current = setInterval(() => {
-          void poll()
-        }, POLL_INTERVAL_MS)
+        startPolling()
       }
     })()
+    // Stopping the timer here is not optional: without it a re-run of this
+    // effect abandons the previous one still ticking.
     return () => {
       cancelled = true
+      stopPolling()
     }
-  }, [open, runtime, poll, stopPolling])
+  }, [open, runtime, startPolling, stopPolling])
 
   useEffect(() => stopPolling, [stopPolling])
 

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/change-version-modal.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/change-version-modal.tsx
@@ -11,7 +11,14 @@
  * legitimate thing to want, and the bootloader stays reachable either way.
  */
 
+import * as Select from '@radix-ui/react-select'
+import { ArrowIcon } from '@root/frontend/assets/icons/interface/Arrow'
 import { useRuntime } from '@root/middleware/shared/providers/platform-context'
+import {
+  clearRuntimeVersionsCache,
+  listRuntimeVersions,
+  type RuntimeVersion,
+} from '@root/middleware/shared/utils/runtime-versions'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Modal, ModalContent, ModalFooter, ModalHeader, ModalTitle } from '../../../../../_molecules/modal'
@@ -47,6 +54,14 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
   const [progress, setProgress] = useState<UpdateProgress | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [starting, setStarting] = useState(false)
+
+  // The installable versions, and whether they could be read at all. A device
+  // on a workbench with no internet still needs to be able to install a
+  // version it already holds, so a failed listing falls back to typing rather
+  // than blocking the action.
+  const [versions, setVersions] = useState<RuntimeVersion[] | null>(null)
+  const [versionsError, setVersionsError] = useState<string | null>(null)
+  const [loadingVersions, setLoadingVersions] = useState(false)
 
   // Kept in a ref so the poll loop can stop itself without being re-created
   // on every tick, which would restart the interval each time.
@@ -105,6 +120,31 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
     }, POLL_INTERVAL_MS)
   }, [runtime, version, poll, stopPolling])
 
+  const loadVersions = useCallback(async (signal?: AbortSignal) => {
+    setLoadingVersions(true)
+    const result = await listRuntimeVersions(signal)
+    if (signal?.aborted) return
+    setLoadingVersions(false)
+    if (result.ok) {
+      setVersions(result.versions)
+      setVersionsError(null)
+      return
+    }
+    if (result.error === 'cancelled') return
+    setVersions(null)
+    setVersionsError(result.error)
+  }, [])
+
+  // Fetched when the dialog opens rather than on mount: the list is only
+  // needed here, and a screen that merely displays runtime status should not
+  // reach out to the network on its own.
+  useEffect(() => {
+    if (!open) return
+    const controller = new AbortController()
+    void loadVersions(controller.signal)
+    return () => controller.abort()
+  }, [open, loadVersions])
+
   // Adopt an update that is already running.
   //
   // Opening this modal while the device is mid-update -- because another
@@ -153,22 +193,76 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
             supported.
           </p>
 
-          <label className='flex flex-col gap-1'>
+          <div className='flex flex-col gap-1'>
             <span className='text-xs font-medium text-neutral-600 dark:text-neutral-400'>Version</span>
-            <input
-              aria-label='Runtime version to install'
-              className='rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white'
-              disabled={busy}
-              onChange={(event) => setVersion(event.target.value)}
-              placeholder={currentVersion ?? 'v4.2.1'}
-              value={version}
-            />
+
+            {versions !== null ? (
+              <Select.Root disabled={busy} onValueChange={setVersion} value={version}>
+                <Select.Trigger
+                  aria-label='Runtime version to install'
+                  className='flex h-9 w-full items-center justify-between rounded-md border border-neutral-300 bg-white px-3 text-sm text-neutral-900 outline-none disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white'
+                >
+                  <span>{version === '' ? 'Select a version' : describeChoice(version, currentVersion)}</span>
+                  <ArrowIcon direction='down' className='stroke-brand' />
+                </Select.Trigger>
+
+                <Select.Content
+                  align='center'
+                  className='z-[999999] max-h-64 w-[--radix-select-trigger-width] overflow-y-auto rounded-md border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900'
+                  position='popper'
+                  side='bottom'
+                  sideOffset={1}
+                >
+                  <Select.Viewport>
+                    {versions.map((entry) => (
+                      <Select.Item
+                        className='w-full cursor-pointer rounded-sm px-3 py-1.5 text-sm text-neutral-900 outline-none hover:bg-neutral-100 dark:text-white dark:hover:bg-neutral-850'
+                        key={entry.tag}
+                        value={entry.tag}
+                      >
+                        <Select.ItemText>{describeChoice(entry.tag, currentVersion)}</Select.ItemText>
+                      </Select.Item>
+                    ))}
+                  </Select.Viewport>
+                </Select.Content>
+              </Select.Root>
+            ) : (
+              // No list. Typing is the only way left to reach a version, and
+              // it is a real one on an offline device holding a side-loaded
+              // image -- so the field stays usable and says why it is here.
+              <input
+                aria-label='Runtime version to install'
+                className='h-9 rounded-md border border-neutral-300 bg-white px-3 text-sm text-neutral-900 disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white'
+                disabled={busy || loadingVersions}
+                onChange={(event) => setVersion(event.target.value)}
+                placeholder={loadingVersions ? 'Loading versions…' : (currentVersion ?? 'v4.2.1')}
+                value={version}
+              />
+            )}
+
+            {versionsError !== null && (
+              <span className='flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400'>
+                {versionsError} Type a version instead.
+                <button
+                  className='underline disabled:opacity-50'
+                  disabled={loadingVersions}
+                  onClick={() => {
+                    clearRuntimeVersionsCache()
+                    void loadVersions()
+                  }}
+                  type='button'
+                >
+                  Retry
+                </button>
+              </span>
+            )}
+
             {currentVersion && (
               <span className='text-xs text-neutral-500 dark:text-neutral-400'>
                 Currently running {currentVersion}
               </span>
             )}
-          </label>
+          </div>
 
           {progress && (
             <div aria-live='polite' className='flex flex-col gap-2'>
@@ -226,7 +320,7 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
           {!succeeded && (
             <button
               className='rounded-md bg-brand px-3 py-2 text-sm font-medium text-white disabled:opacity-50'
-              disabled={busy || !version.trim()}
+              disabled={busy || !version.trim() || version === currentVersion}
               onClick={() => void startUpdate()}
               type='button'
             >
@@ -238,6 +332,16 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
     </Modal>
   )
 }
+
+/**
+ * How one version reads in the list.
+ *
+ * The running version is marked rather than hidden: seeing it in place is what
+ * tells someone the list is the right list, and a gap where they expected it
+ * would read as a missing release.
+ */
+const describeChoice = (tag: string, currentVersion: string | null): string =>
+  tag === currentVersion ? `${tag} (installed)` : tag
 
 /** Plain wording for a state, so the UI never shows a bare enum. */
 const describeState = (progress: UpdateProgress): string => {

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/change-version-modal.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/change-version-modal.tsx
@@ -71,6 +71,9 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
   // on every tick, which would restart the interval each time.
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
+  // True while a progress request is open, so ticks cannot overlap.
+  const pollInFlightRef = useRef(false)
+
   // onFinished is a prop, and callers pass an inline arrow -- a new function
   // every render. Depending on it directly made `poll` unstable, which made
   // the effect below unstable, which leaked a timer per render while an
@@ -83,31 +86,82 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
     onFinishedRef.current = onFinished
   }, [onFinished])
 
-  const stopPolling = useCallback(() => {
+  /**
+   * Stop this dialog's timer. Says nothing about the device.
+   *
+   * Deliberately separate from lowering runtimeUpdateInProgress. Every effect
+   * cleanup here runs on unmount, and one of them used to call a combined
+   * stop that lowered the flag -- so navigating away from the Runtime Status
+   * tab mid-swap told the status poller the update was over. It then resumed,
+   * counted five silent polls against a runtime that was still being
+   * replaced, and raised the "connection lost" modal the flag exists to
+   * prevent.
+   *
+   * The flag is now lowered in exactly two places, both of which have seen a
+   * terminal state: poll() below while the dialog is open, and
+   * use-runtime-polling once it is not. Unmounting is not evidence that
+   * anything finished.
+   */
+  const stopInterval = useCallback(() => {
     if (pollingRef.current !== null) {
       clearInterval(pollingRef.current)
       pollingRef.current = null
     }
-    setRuntimeUpdateInProgress(false)
-  }, [setRuntimeUpdateInProgress])
+  }, [])
 
+  /** The update reached a terminal state: stop, and release the poller. */
+  const finishPolling = useCallback(() => {
+    stopInterval()
+    setRuntimeUpdateInProgress(false)
+  }, [stopInterval, setRuntimeUpdateInProgress])
+
+  /**
+   * Ask the device where it has got to, one request at a time.
+   *
+   * The guard is load-bearing. The tick interval is shorter than a request can
+   * take on a busy device, so without it two polls overlap -- and a stale
+   * `pulling` reply landing AFTER a `success` reply would overwrite the
+   * terminal state, leaving the dialog showing an update in progress with no
+   * poller left to finish it. A skipped tick costs nothing; an out-of-order
+   * reply costs the operator the end of their update.
+   *
+   * It also never throws. The interval callback cannot await it, so an
+   * escaping rejection would surface as an unhandled promise rejection rather
+   * than as anything anybody could act on.
+   */
   const poll = useCallback(async () => {
-    const result = await runtime.bootloader.getUpdateProgress()
-    if (!result.success) {
-      // A poll failing mid-update is expected: the runtime container is being
-      // replaced, and on a host-network device that can briefly interrupt
-      // everything. Keep polling rather than declaring failure.
-      return
-    }
-    setProgress(result.data)
-    if (!IN_FLIGHT.has(result.data.state)) {
-      stopPolling()
-      if (result.data.state === 'failed') {
-        setError(result.data.error ?? 'The update failed.')
+    if (pollInFlightRef.current) return
+    pollInFlightRef.current = true
+    try {
+      const result = await runtime.bootloader.getUpdateProgress()
+
+      // The loop was stopped while this request was open -- the dialog closed,
+      // or a terminal state already arrived. Applying a late reply now would
+      // resurrect state the component has moved past.
+      if (pollingRef.current === null) return
+
+      if (!result.success) {
+        // A poll failing mid-update is expected: the runtime container is
+        // being replaced, and on a host-network device that can briefly
+        // interrupt everything. Keep polling rather than declaring failure.
+        return
       }
-      onFinishedRef.current?.()
+      setProgress(result.data)
+      if (!IN_FLIGHT.has(result.data.state)) {
+        finishPolling()
+        if (result.data.state === 'failed') {
+          setError(result.data.error ?? 'The update failed.')
+        }
+        onFinishedRef.current?.()
+      }
+    } catch (err) {
+      // Treated like a failed poll: the device is mid-swap and unreachable,
+      // which is the normal shape of this error.
+      console.warn('[RuntimeStatus] Update progress request failed', err)
+    } finally {
+      pollInFlightRef.current = false
     }
-  }, [runtime, stopPolling])
+  }, [runtime, stopInterval, finishPolling])
 
   /**
    * Begin following an update, replacing any loop already running.
@@ -117,12 +171,13 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
    * ticking, unreferenced and unstoppable.
    */
   const startPolling = useCallback(() => {
-    stopPolling()
+    stopInterval()
     setRuntimeUpdateInProgress(true)
     pollingRef.current = setInterval(() => {
+      // poll() handles its own errors, so nothing escapes here.
       void poll()
     }, POLL_INTERVAL_MS)
-  }, [poll, stopPolling, setRuntimeUpdateInProgress])
+  }, [poll, stopInterval, setRuntimeUpdateInProgress])
 
   const startUpdate = useCallback(async () => {
     const target = version.trim()
@@ -181,7 +236,7 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
   // the device will refuse.
   useEffect(() => {
     if (!open) {
-      stopPolling()
+      stopInterval()
       // Reset. This component is mounted unconditionally by the screen, so
       // only the Radix content unmounts when `open` goes false -- progress,
       // error and the chosen version all survived a close. Reopening after a
@@ -203,41 +258,22 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
       }
     })()
     // Stopping the timer here is not optional: without it a re-run of this
-    // effect abandons the previous one still ticking.
+    // effect abandons the previous one still ticking. The DEVICE flag is not
+    // touched -- this cleanup also runs on unmount, and an unmount says
+    // nothing about whether the device finished.
     return () => {
       cancelled = true
-      stopPolling()
+      stopInterval()
     }
-  }, [open, runtime, startPolling, stopPolling])
+  }, [open, runtime, startPolling, stopInterval])
 
-  // On unmount, stop this dialog's timer -- but do NOT tell the poller the
-  // update is over if the device is still working.
+  // On unmount, stop this dialog's timer and nothing else.
   //
-  // `busy` blocks the dialog's own close, but nothing blocks navigating away
-  // from the Runtime Status tab, and this cleanup used to clear
-  // runtimeUpdateInProgress mid-swap. The status poller then resumed, counted
-  // five silent polls and raised the very "connection lost" modal the flag
-  // exists to prevent.
-  //
-  // The flag is left raised in that case. The poller clears it itself once the
-  // device reports a terminal state, so it cannot stick.
-  const inFlightRef = useRef(false)
-  useEffect(() => {
-    inFlightRef.current = progress !== null && IN_FLIGHT.has(progress.state)
-  }, [progress])
-
-  useEffect(
-    () => () => {
-      if (pollingRef.current !== null) {
-        clearInterval(pollingRef.current)
-        pollingRef.current = null
-      }
-      if (!inFlightRef.current) {
-        setRuntimeUpdateInProgress(false)
-      }
-    },
-    [setRuntimeUpdateInProgress],
-  )
+  // An earlier version guarded the flag with a ref instead, which looked
+  // equivalent and was not: a sibling effect's cleanup also ran a combined
+  // stop that lowered it, so the guard here never got the chance. Keeping
+  // every cleanup timer-only removes the ordering question altogether.
+  useEffect(() => stopInterval, [stopInterval])
 
   const inFlight = progress !== null && IN_FLIGHT.has(progress.state)
   const succeeded = progress?.state === 'success'
@@ -326,18 +362,14 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
             )}
 
             {currentVersion && (
-              <span className='text-xs text-neutral-500 dark:text-neutral-400'>
-                Currently running {currentVersion}
-              </span>
+              <span className='text-xs text-neutral-500 dark:text-neutral-400'>Currently running {currentVersion}</span>
             )}
           </div>
 
           {progress && (
             <div aria-live='polite' className='flex flex-col gap-2'>
               <div className='flex items-center justify-between text-sm'>
-                <span className='text-neutral-700 dark:text-neutral-300'>
-                  {describeState(progress)}
-                </span>
+                <span className='text-neutral-700 dark:text-neutral-300'>{describeState(progress)}</span>
                 {/* No percentage while the daemon has reported no size to work
                     from -- for layers it already holds, and before any size is
                     known. Showing 0% there would read as a stall. */}

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/change-version-modal.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/change-version-modal.tsx
@@ -182,6 +182,15 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
   useEffect(() => {
     if (!open) {
       stopPolling()
+      // Reset. This component is mounted unconditionally by the screen, so
+      // only the Radix content unmounts when `open` goes false -- progress,
+      // error and the chosen version all survived a close. Reopening after a
+      // successful update therefore showed the previous run's "is installed
+      // and running" message with the Install button still hidden, and after
+      // a failure the old red error.
+      setProgress(null)
+      setError(null)
+      setVersion('')
       return
     }
     let cancelled = false
@@ -201,7 +210,34 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
     }
   }, [open, runtime, startPolling, stopPolling])
 
-  useEffect(() => stopPolling, [stopPolling])
+  // On unmount, stop this dialog's timer -- but do NOT tell the poller the
+  // update is over if the device is still working.
+  //
+  // `busy` blocks the dialog's own close, but nothing blocks navigating away
+  // from the Runtime Status tab, and this cleanup used to clear
+  // runtimeUpdateInProgress mid-swap. The status poller then resumed, counted
+  // five silent polls and raised the very "connection lost" modal the flag
+  // exists to prevent.
+  //
+  // The flag is left raised in that case. The poller clears it itself once the
+  // device reports a terminal state, so it cannot stick.
+  const inFlightRef = useRef(false)
+  useEffect(() => {
+    inFlightRef.current = progress !== null && IN_FLIGHT.has(progress.state)
+  }, [progress])
+
+  useEffect(
+    () => () => {
+      if (pollingRef.current !== null) {
+        clearInterval(pollingRef.current)
+        pollingRef.current = null
+      }
+      if (!inFlightRef.current) {
+        setRuntimeUpdateInProgress(false)
+      }
+    },
+    [setRuntimeUpdateInProgress],
+  )
 
   const inFlight = progress !== null && IN_FLIGHT.has(progress.state)
   const succeeded = progress?.state === 'success'
@@ -262,7 +298,10 @@ const ChangeVersionModal = ({ open, onOpenChange, currentVersion, onFinished }: 
               <input
                 aria-label='Runtime version to install'
                 className='h-9 rounded-md border border-neutral-300 bg-white px-3 text-sm text-neutral-900 disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white'
-                disabled={busy || loadingVersions}
+                // NOT disabled while loading. The list can take up to its
+                // timeout to fail, and a disabled field made the typed
+                // fallback unreachable for exactly that window.
+                disabled={busy}
                 onChange={(event) => setVersion(event.target.value)}
                 placeholder={loadingVersions ? 'Loading versions…' : (currentVersion ?? 'v4.2.1')}
                 value={version}

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
@@ -1,0 +1,245 @@
+/**
+ * Runtime Status (RTOP-283).
+ *
+ * One screen for "what is this device and how is it doing". It carries the
+ * scan-cycle, EtherCAT and plugin statistics that used to sit at the bottom of
+ * the device Configuration screen -- they were never configuration, and they
+ * were only reachable by scrolling past a pin-mapping table.
+ *
+ * The header adds what the device reports about itself, and the version-change
+ * action. That action appears only when a bootloader is present: on a native
+ * install or an orchestrator-managed vPLC there is nothing on the device that
+ * could perform a swap, and offering a button that cannot work is worse than
+ * offering none.
+ */
+
+import type { TimingStats } from '@root/middleware/shared/ports/types'
+import { useRuntime } from '@root/middleware/shared/providers/platform-context'
+import { useCallback, useEffect, useState } from 'react'
+
+import { useOpenPLCStore } from '../../../../../../store'
+import { EtherCATStats } from '../../../../../_molecules/ethercat-stats'
+import { PluginStatsPanel } from '../../../../../_molecules/plugin-stats-panel'
+import { ScanCycleStats } from '../../../../../_molecules/scan-cycle-stats'
+import { ChangeVersionModal } from './change-version-modal'
+
+type DeviceInfo = {
+  hostname?: string
+  architecture?: string
+  kernel?: string
+  system?: string
+  containerized?: boolean
+  updatePolicy?: string
+}
+
+type BootloaderInfo = {
+  present: boolean
+  version?: string
+  state?: string
+  recovery?: boolean
+  reason?: string
+}
+
+const RuntimeStatusEditor = () => {
+  const runtime = useRuntime()
+
+  const connectionStatus = useOpenPLCStore((state) => state.runtimeConnection.connectionStatus)
+  const runtimeVersion = useOpenPLCStore((state) => state.runtimeConnection.runtimeVersion)
+  const ipAddress = useOpenPLCStore((state) => state.runtimeConnection.ipAddress)
+  const timingStats = useOpenPLCStore((state): TimingStats | null => state.runtimeConnection.timingStats)
+  const storedCredentials = useOpenPLCStore((state) => state.runtimeConnection.storedCredentials)
+  const setIncludeTimingStatsInPolling = useOpenPLCStore(
+    (state): ((include: boolean) => void) => state.deviceActions.setIncludeTimingStatsInPolling,
+  )
+  const setIncludeEthercatStatsInPolling = useOpenPLCStore(
+    (state): ((include: boolean) => void) => state.deviceActions.setIncludeEthercatStatsInPolling,
+  )
+
+  const [deviceInfo, setDeviceInfo] = useState<DeviceInfo | null>(null)
+  const [bootloader, setBootloader] = useState<BootloaderInfo>({ present: false })
+  const [changeOpen, setChangeOpen] = useState(false)
+
+  const connected = connectionStatus === 'connected'
+
+  /**
+   * Ask the device about itself.
+   *
+   * The bootloader probe is expected to fail on most devices, so a failure is
+   * recorded as "no bootloader" rather than surfaced as an error. Signing in
+   * reuses the credentials the operator already gave the runtime: the two
+   * services read one user database, so there is nothing more to ask for.
+   */
+  const refresh = useCallback(async () => {
+    if (!connected) return
+
+    const info = await runtime.getDeviceInfo()
+    setDeviceInfo(info.success ? (info.data ?? null) : null)
+
+    const capabilities = await runtime.bootloader.getCapabilities()
+    if (!capabilities.success) {
+      setBootloader({ present: false })
+      return
+    }
+
+    const next: BootloaderInfo = {
+      present: true,
+      version: capabilities.data.bootloaderVersion,
+      state: capabilities.data.state,
+      recovery: capabilities.data.recovery,
+    }
+
+    if (storedCredentials) {
+      const signIn = await runtime.bootloader.login(storedCredentials.username, storedCredentials.password)
+      if (signIn.success) {
+        const status = await runtime.bootloader.getStatus()
+        if (status.success) {
+          next.state = status.data.state
+          next.recovery = status.data.recovery ?? next.recovery
+          next.reason = status.data.reason
+        }
+      }
+    }
+    setBootloader(next)
+  }, [connected, runtime, storedCredentials])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  /**
+   * Ask the global poller for the statistics this screen shows, and stop when
+   * leaving it.
+   *
+   * These toggles moved here from the Configuration screen along with the
+   * statistics themselves: the screen that displays data is the one that
+   * should be asking a device for it.
+   */
+  useEffect(() => {
+    setIncludeTimingStatsInPolling(true)
+    setIncludeEthercatStatsInPolling(true)
+    return () => {
+      setIncludeTimingStatsInPolling(false)
+      setIncludeEthercatStatsInPolling(false)
+    }
+  }, [setIncludeTimingStatsInPolling, setIncludeEthercatStatsInPolling])
+
+  if (!connected) {
+    return (
+      <div className='flex h-full w-full items-center justify-center'>
+        <p className='text-sm text-neutral-500 dark:text-neutral-400'>
+          Connect to a runtime to see its status.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      aria-label='Runtime status container'
+      className='flex h-full w-full flex-col gap-6 overflow-auto p-6'
+      id='runtime-status-container'
+    >
+      <header className='flex flex-col gap-4 border-b border-neutral-200 pb-4 dark:border-neutral-800'>
+        <div className='flex items-start justify-between gap-4'>
+          <div className='flex flex-col gap-1'>
+            <h2 className='select-none text-lg font-medium text-neutral-950 dark:text-white'>Runtime Status</h2>
+            <p className='text-sm text-neutral-500 dark:text-neutral-400'>
+              {deviceInfo?.hostname ? `${deviceInfo.hostname} · ` : ''}
+              {ipAddress ?? 'unknown address'}
+            </p>
+          </div>
+
+          {/* Only when the device can actually do it. */}
+          {bootloader.present && (
+            <button
+              className='shrink-0 rounded-md bg-brand px-3 py-2 text-sm font-medium text-white'
+              onClick={() => setChangeOpen(true)}
+              type='button'
+            >
+              Change runtime version
+            </button>
+          )}
+        </div>
+
+        {bootloader.recovery && (
+          <div
+            className='rounded-md border border-amber-300 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950'
+            role='alert'
+          >
+            <p className='text-sm font-medium text-amber-900 dark:text-amber-200'>
+              The runtime is not running. The device is in recovery.
+            </p>
+            {bootloader.reason && (
+              <p className='mt-1 text-xs text-amber-800 dark:text-amber-300'>{bootloader.reason}</p>
+            )}
+            <p className='mt-1 text-xs text-amber-800 dark:text-amber-300'>
+              Install a different version to recover it.
+            </p>
+          </div>
+        )}
+
+        <dl className='grid grid-cols-2 gap-x-8 gap-y-2 md:grid-cols-3'>
+          <InfoField label='Runtime version' value={runtimeVersion} />
+          <InfoField label='Architecture' value={deviceInfo?.architecture} />
+          <InfoField label='Kernel' value={deviceInfo?.kernel} />
+          <InfoField label='Host' value={deviceInfo?.hostname} />
+          <InfoField
+            label='Deployment'
+            value={deviceInfo ? (deviceInfo.containerized ? 'Container' : 'Native') : undefined}
+          />
+          <InfoField label='Updates' value={describePolicy(deviceInfo?.updatePolicy)} />
+          {bootloader.present && <InfoField label='Bootloader' value={bootloader.version} />}
+        </dl>
+      </header>
+
+      <div className='flex w-full flex-col gap-6'>
+        {timingStats ? (
+          <ScanCycleStats timingStats={timingStats} />
+        ) : (
+          <p className='text-sm text-neutral-500 dark:text-neutral-400'>
+            No scan-cycle statistics yet. They appear once a program is running.
+          </p>
+        )}
+        <EtherCATStats />
+        <PluginStatsPanel pluginStats={timingStats?.plugin_stats} />
+      </div>
+
+      <ChangeVersionModal
+        currentVersion={runtimeVersion}
+        onFinished={() => void refresh()}
+        onOpenChange={setChangeOpen}
+        open={changeOpen}
+      />
+    </div>
+  )
+}
+
+const InfoField = ({ label, value }: { label: string; value?: string | null }) => (
+  <div className='flex flex-col'>
+    <dt className='text-xs font-medium uppercase tracking-wide text-neutral-500 dark:text-neutral-400'>{label}</dt>
+    <dd className='text-sm text-neutral-900 dark:text-neutral-100'>{value || '—'}</dd>
+  </div>
+)
+
+/**
+ * Say who may change the version, in words rather than an enum.
+ *
+ * "managed" is the orchestrator case and the wording points the operator at
+ * openplc-web rather than leaving them looking for a button that is not there.
+ */
+const describePolicy = (policy?: string): string | undefined => {
+  switch (policy) {
+    case 'self':
+      return 'From this editor'
+    case 'managed':
+      return 'Managed by orchestrator'
+    case 'manual':
+      return 'Command line only'
+    case 'none':
+      return 'Provided by the device vendor'
+    default:
+      return undefined
+  }
+}
+
+export { RuntimeStatusEditor }

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
@@ -93,10 +93,9 @@ const RuntimeStatusEditor = () => {
    * Host facts from the orchestrator agent, for a device with no bootloader.
    *
    * Deliberately a different shape of answer: the agent describes the HOST
-   * running the vPLC, not the container, and it cannot report a kernel version
-   * (Edge's response type drops the field the agent sends) or an
-   * architecture. What it does give is enough to stop the header being empty,
-   * which is what it was for every orchestrator-managed device.
+   * running the vPLC, not the container, and it reports no architecture. The
+   * kernel needs an Edge carrying EDGE-631; against an older one that field
+   * is absent and the header simply shows less.
    */
   const hostInfoFromOrchestrator = useCallback(async (): Promise<DeviceInfo | null> => {
     const orchestratorId = selectedDevice?.orchestratorId
@@ -111,6 +110,7 @@ const RuntimeStatusEditor = () => {
     return {
       hostname: host.name,
       system: host.os,
+      kernel: host.kernel,
       cpus: Number.isFinite(cpus) ? cpus : undefined,
       memoryBytes: Number.isFinite(megabytes) ? (megabytes as number) * 1024 * 1024 : undefined,
       agentVersion: host.agentVersion,

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
@@ -104,15 +104,23 @@ const RuntimeStatusEditor = () => {
     const host = await orchestrator.getOrchestratorHostInfo(orchestratorId)
     if (!host) return null
 
-    const cpus = host.cpu !== undefined ? Number(host.cpu) : undefined
+    // Narrowed rather than asserted: the agent's numbers arrive as strings,
+    // and a non-numeric one has to drop out rather than become NaN.
+    const asNumber = (value: string | undefined): number | undefined => {
+      if (value === undefined) return undefined
+      const parsed = Number(value)
+      return Number.isFinite(parsed) ? parsed : undefined
+    }
+
+    const cpus = asNumber(host.cpu)
     // The agent reports total RAM in MB; the header formats bytes.
-    const megabytes = host.memory !== undefined ? Number(host.memory) : undefined
+    const megabytes = asNumber(host.memory)
     return {
       hostname: host.name,
       system: host.os,
       kernel: host.kernel,
-      cpus: Number.isFinite(cpus) ? cpus : undefined,
-      memoryBytes: Number.isFinite(megabytes) ? (megabytes as number) * 1024 * 1024 : undefined,
+      cpus,
+      memoryBytes: megabytes === undefined ? undefined : megabytes * 1024 * 1024,
       agentVersion: host.agentVersion,
     }
   }, [orchestrator, selectedDevice?.orchestratorId])
@@ -136,6 +144,12 @@ const RuntimeStatusEditor = () => {
     if (!capabilities.success) {
       setBootloader({ present: false })
 
+      // Cleared BEFORE the request below, not after it. The fallback is a
+      // round-trip to the agent, and leaving the previous device's hostname,
+      // kernel and memory on screen for its duration means the header can
+      // name the new device while describing the old one.
+      setDeviceInfo(null)
+
       // No bootloader is the NORMAL case in production: a device under an
       // orchestrator is a vPLC container with no bootloader beside it, so
       // there is nothing on 8445 to ask. The agent managing it knows the same
@@ -158,10 +172,7 @@ const RuntimeStatusEditor = () => {
     if (storedCredentials) {
       const signIn = await runtime.bootloader.login(storedCredentials.username, storedCredentials.password)
       if (signIn.success) {
-        const [status, info] = await Promise.all([
-          runtime.bootloader.getStatus(),
-          runtime.bootloader.getDeviceInfo(),
-        ])
+        const [status, info] = await Promise.all([runtime.bootloader.getStatus(), runtime.bootloader.getDeviceInfo()])
         if (status.success) {
           next.state = status.data.state
           next.recovery = status.data.recovery ?? next.recovery
@@ -212,9 +223,7 @@ const RuntimeStatusEditor = () => {
   if (!connected) {
     return (
       <div className='flex h-full w-full items-center justify-center'>
-        <p className='text-sm text-neutral-500 dark:text-neutral-400'>
-          Connect to a runtime to see its status.
-        </p>
+        <p className='text-sm text-neutral-500 dark:text-neutral-400'>Connect to a runtime to see its status.</p>
       </div>
     )
   }

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
@@ -185,7 +185,11 @@ const RuntimeStatusEditor = () => {
           <InfoField label='Host' value={deviceInfo?.hostname} />
           <InfoField
             label='Deployment'
-            value={deviceInfo ? (deviceInfo.containerized ? 'Container' : 'Native') : undefined}
+            // An absent flag is not a claim of "Native". Belt and braces with
+            // the schema guard: a runtime may report a subset of these fields,
+            // and the one thing this must never do is assert a deployment
+            // shape it was not told about.
+            value={describeDeployment(deviceInfo?.containerized)}
           />
           <InfoField label='Updates' value={describePolicy(deviceInfo?.updatePolicy)} />
           {bootloader.present && <InfoField label='Bootloader' value={bootloader.version} />}
@@ -240,6 +244,13 @@ const describePolicy = (policy?: string): string | undefined => {
     default:
       return undefined
   }
+}
+
+
+/** Only says what the device reported; silence stays silence. */
+const describeDeployment = (containerized: boolean | undefined): string | undefined => {
+  if (containerized === undefined) return undefined
+  return containerized ? 'Container' : 'Native'
 }
 
 export { RuntimeStatusEditor }

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
@@ -106,8 +106,13 @@ const RuntimeStatusEditor = () => {
 
     // Narrowed rather than asserted: the agent's numbers arrive as strings,
     // and a non-numeric one has to drop out rather than become NaN.
+    //
+    // Blank is checked before the conversion because Number('') and
+    // Number('   ') are both 0, not NaN -- so an agent reporting an empty CPU
+    // count would have rendered as "0 CPU cores", which reads as a fact about
+    // the machine rather than as nothing reported.
     const asNumber = (value: string | undefined): number | undefined => {
-      if (value === undefined) return undefined
+      if (value === undefined || value.trim() === '') return undefined
       const parsed = Number(value)
       return Number.isFinite(parsed) ? parsed : undefined
     }

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
@@ -14,7 +14,7 @@
  */
 
 import type { TimingStats } from '@root/middleware/shared/ports/types'
-import { useRuntime } from '@root/middleware/shared/providers/platform-context'
+import { useOrchestrator, useRuntime } from '@root/middleware/shared/providers/platform-context'
 import { useCallback, useEffect, useState } from 'react'
 
 import { useOpenPLCStore } from '../../../../../../store'
@@ -32,6 +32,12 @@ type DeviceInfo = {
   cpus?: number
   memoryBytes?: number
   dockerVersion?: string
+  /**
+   * Version of the orchestrator agent, when the facts came from one rather
+   * than from a bootloader. Named so the header can say which it is looking
+   * at instead of implying a bootloader that is not there.
+   */
+  agentVersion?: string
 }
 
 type BootloaderInfo = {
@@ -47,8 +53,12 @@ const RuntimeStatusEditor = () => {
 
   const connectionStatus = useOpenPLCStore((state) => state.runtimeConnection.connectionStatus)
   const runtimeVersion = useOpenPLCStore((state) => state.runtimeConnection.runtimeVersion)
+  const setRuntimeVersion = useOpenPLCStore((state) => state.deviceActions.setRuntimeVersion)
   const ipAddress = useOpenPLCStore((state) => state.runtimeConnection.ipAddress)
   const selectedDevice = useOpenPLCStore((state) => state.runtimeConnection.selectedDevice)
+  // Used only when no bootloader answers, which under an orchestrator is
+  // always: a vPLC has no bootloader container beside it.
+  const orchestrator = useOrchestrator()
   const timingStats = useOpenPLCStore((state): TimingStats | null => state.runtimeConnection.timingStats)
   const storedCredentials = useOpenPLCStore((state) => state.runtimeConnection.storedCredentials)
   const setIncludeTimingStatsInPolling = useOpenPLCStore(
@@ -79,15 +89,64 @@ const RuntimeStatusEditor = () => {
    * credentials the operator already gave the runtime: the two services read
    * one user database, so there is nothing more to ask for.
    */
+  /**
+   * Host facts from the orchestrator agent, for a device with no bootloader.
+   *
+   * Deliberately a different shape of answer: the agent describes the HOST
+   * running the vPLC, not the container, and it cannot report a kernel version
+   * (Edge's response type drops the field the agent sends) or an
+   * architecture. What it does give is enough to stop the header being empty,
+   * which is what it was for every orchestrator-managed device.
+   */
+  const hostInfoFromOrchestrator = useCallback(async (): Promise<DeviceInfo | null> => {
+    const orchestratorId = selectedDevice?.orchestratorId
+    if (!orchestratorId || !orchestrator.getOrchestratorHostInfo) return null
+
+    const host = await orchestrator.getOrchestratorHostInfo(orchestratorId)
+    if (!host) return null
+
+    const cpus = host.cpu !== undefined ? Number(host.cpu) : undefined
+    // The agent reports total RAM in MB; the header formats bytes.
+    const megabytes = host.memory !== undefined ? Number(host.memory) : undefined
+    return {
+      hostname: host.name,
+      system: host.os,
+      cpus: Number.isFinite(cpus) ? cpus : undefined,
+      memoryBytes: Number.isFinite(megabytes) ? (megabytes as number) * 1024 * 1024 : undefined,
+      agentVersion: host.agentVersion,
+    }
+  }, [orchestrator, selectedDevice?.orchestratorId])
+
   const refresh = useCallback(async () => {
-    if (!connected) return
+    // Disconnected clears everything. The component stays mounted while
+    // disconnected, and returning early without clearing left the PREVIOUS
+    // device's hostname, kernel and memory in the header -- so reconnecting to
+    // a different device whose login is refused, or one with no stored
+    // credentials, described a machine that was no longer there.
+    if (!connected) {
+      setDeviceInfo(null)
+      // Idempotent on purpose. A fresh object here is a state change on every
+      // call, and `refresh` re-runs whenever the runtime port's identity does
+      // -- which is enough to spin: set state, re-render, refresh, set state.
+      setBootloader((previous) => (previous.present ? { present: false } : previous))
+      return
+    }
 
     const capabilities = await runtime.bootloader.getCapabilities()
     if (!capabilities.success) {
       setBootloader({ present: false })
-      setDeviceInfo(null)
+
+      // No bootloader is the NORMAL case in production: a device under an
+      // orchestrator is a vPLC container with no bootloader beside it, so
+      // there is nothing on 8445 to ask. The agent managing it knows the same
+      // sort of facts about its host, and Edge exposes them -- so the header
+      // reports those instead of sitting blank.
+      setDeviceInfo(await hostInfoFromOrchestrator())
       return
     }
+    // Cleared before the login below, so a failure there cannot leave stale
+    // facts on screen.
+    setDeviceInfo(null)
 
     const next: BootloaderInfo = {
       present: true,
@@ -109,10 +168,25 @@ const RuntimeStatusEditor = () => {
           next.reason = status.data.reason
         }
         setDeviceInfo(info.success ? (info.data ?? null) : null)
+
+        // The store's runtimeVersion is written once, at connect time, so
+        // after installing v4.2.1 over v4.2.0 the header still said v4.2.0 --
+        // and the picker offered v4.2.1 as installable while disabling
+        // Install on the version that was no longer running. Both the status
+        // and the capabilities reply carry the truth.
+        const reported = status.success
+          ? (status.data.runtimeVersion ?? capabilities.data.runtimeVersion)
+          : capabilities.data.runtimeVersion
+        // Compared against the store directly rather than the rendered
+        // value: depending on runtimeVersion here would rebuild `refresh`
+        // whenever it changed, re-running the effect that calls it.
+        if (reported && reported !== useOpenPLCStore.getState().runtimeConnection.runtimeVersion) {
+          setRuntimeVersion(reported)
+        }
       }
     }
     setBootloader(next)
-  }, [connected, runtime, storedCredentials])
+  }, [connected, runtime, storedCredentials, setRuntimeVersion, hostInfoFromOrchestrator])
 
   useEffect(() => {
     void refresh()
@@ -191,7 +265,13 @@ const RuntimeStatusEditor = () => {
 
         <dl className='grid grid-cols-2 gap-x-8 gap-y-2 md:grid-cols-3'>
           <InfoField label='Runtime version' value={runtimeVersion} />
-          {bootloader.present && <InfoField label='Bootloader' value={bootloader.version} />}
+          {bootloader.present ? (
+            <InfoField label='Bootloader' value={bootloader.version} />
+          ) : (
+            // Names the source, so a blank kernel/architecture reads as "the
+            // agent does not report these" rather than "something is wrong".
+            <InfoField label='Orchestrator agent' value={deviceInfo?.agentVersion} />
+          )}
           <InfoField label='Host' value={deviceInfo?.hostname} />
           <InfoField label='Operating system' value={deviceInfo?.system} />
           <InfoField label='Kernel' value={deviceInfo?.kernel} />

--- a/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/runtime-status/index.tsx
@@ -23,13 +23,15 @@ import { PluginStatsPanel } from '../../../../../_molecules/plugin-stats-panel'
 import { ScanCycleStats } from '../../../../../_molecules/scan-cycle-stats'
 import { ChangeVersionModal } from './change-version-modal'
 
+/** What the bootloader reports about the machine; every field may be absent. */
 type DeviceInfo = {
   hostname?: string
   architecture?: string
   kernel?: string
   system?: string
-  containerized?: boolean
-  updatePolicy?: string
+  cpus?: number
+  memoryBytes?: number
+  dockerVersion?: string
 }
 
 type BootloaderInfo = {
@@ -46,6 +48,7 @@ const RuntimeStatusEditor = () => {
   const connectionStatus = useOpenPLCStore((state) => state.runtimeConnection.connectionStatus)
   const runtimeVersion = useOpenPLCStore((state) => state.runtimeConnection.runtimeVersion)
   const ipAddress = useOpenPLCStore((state) => state.runtimeConnection.ipAddress)
+  const selectedDevice = useOpenPLCStore((state) => state.runtimeConnection.selectedDevice)
   const timingStats = useOpenPLCStore((state): TimingStats | null => state.runtimeConnection.timingStats)
   const storedCredentials = useOpenPLCStore((state) => state.runtimeConnection.storedCredentials)
   const setIncludeTimingStatsInPolling = useOpenPLCStore(
@@ -64,20 +67,25 @@ const RuntimeStatusEditor = () => {
   /**
    * Ask the device about itself.
    *
-   * The bootloader probe is expected to fail on most devices, so a failure is
-   * recorded as "no bootloader" rather than surfaced as an error. Signing in
-   * reuses the credentials the operator already gave the runtime: the two
-   * services read one user database, so there is nothing more to ask for.
+   * Everything here comes from the bootloader, which is the only component
+   * present on every device this screen can act on. The runtime was the
+   * obvious place to ask and the wrong one: a device running any released
+   * runtime has no endpoint to answer, so the header stayed empty on precisely
+   * the devices an operator opens this screen to look at.
+   *
+   * The probe is expected to fail on most devices -- a native install or an
+   * orchestrator-managed vPLC has no bootloader -- so a failure is recorded as
+   * "no bootloader" rather than surfaced as an error. Signing in reuses the
+   * credentials the operator already gave the runtime: the two services read
+   * one user database, so there is nothing more to ask for.
    */
   const refresh = useCallback(async () => {
     if (!connected) return
 
-    const info = await runtime.getDeviceInfo()
-    setDeviceInfo(info.success ? (info.data ?? null) : null)
-
     const capabilities = await runtime.bootloader.getCapabilities()
     if (!capabilities.success) {
       setBootloader({ present: false })
+      setDeviceInfo(null)
       return
     }
 
@@ -91,12 +99,16 @@ const RuntimeStatusEditor = () => {
     if (storedCredentials) {
       const signIn = await runtime.bootloader.login(storedCredentials.username, storedCredentials.password)
       if (signIn.success) {
-        const status = await runtime.bootloader.getStatus()
+        const [status, info] = await Promise.all([
+          runtime.bootloader.getStatus(),
+          runtime.bootloader.getDeviceInfo(),
+        ])
         if (status.success) {
           next.state = status.data.state
           next.recovery = status.data.recovery ?? next.recovery
           next.reason = status.data.reason
         }
+        setDeviceInfo(info.success ? (info.data ?? null) : null)
       }
     }
     setBootloader(next)
@@ -144,8 +156,7 @@ const RuntimeStatusEditor = () => {
           <div className='flex flex-col gap-1'>
             <h2 className='select-none text-lg font-medium text-neutral-950 dark:text-white'>Runtime Status</h2>
             <p className='text-sm text-neutral-500 dark:text-neutral-400'>
-              {deviceInfo?.hostname ? `${deviceInfo.hostname} · ` : ''}
-              {ipAddress ?? 'unknown address'}
+              {describeDevice(deviceInfo?.hostname, selectedDevice?.deviceName, ipAddress)}
             </p>
           </div>
 
@@ -180,19 +191,16 @@ const RuntimeStatusEditor = () => {
 
         <dl className='grid grid-cols-2 gap-x-8 gap-y-2 md:grid-cols-3'>
           <InfoField label='Runtime version' value={runtimeVersion} />
-          <InfoField label='Architecture' value={deviceInfo?.architecture} />
-          <InfoField label='Kernel' value={deviceInfo?.kernel} />
-          <InfoField label='Host' value={deviceInfo?.hostname} />
-          <InfoField
-            label='Deployment'
-            // An absent flag is not a claim of "Native". Belt and braces with
-            // the schema guard: a runtime may report a subset of these fields,
-            // and the one thing this must never do is assert a deployment
-            // shape it was not told about.
-            value={describeDeployment(deviceInfo?.containerized)}
-          />
-          <InfoField label='Updates' value={describePolicy(deviceInfo?.updatePolicy)} />
           {bootloader.present && <InfoField label='Bootloader' value={bootloader.version} />}
+          <InfoField label='Host' value={deviceInfo?.hostname} />
+          <InfoField label='Operating system' value={deviceInfo?.system} />
+          <InfoField label='Kernel' value={deviceInfo?.kernel} />
+          <InfoField label='Architecture' value={deviceInfo?.architecture} />
+          {/* CPU count is the one host fact with an operational consequence
+              here: a scan task per core is the budget, and an operator sizing
+              tasks needs the number in front of them. */}
+          <InfoField label='CPU cores' value={deviceInfo?.cpus?.toString()} />
+          <InfoField label='Memory' value={describeMemory(deviceInfo?.memoryBytes)} />
         </dl>
       </header>
 
@@ -226,31 +234,40 @@ const InfoField = ({ label, value }: { label: string; value?: string | null }) =
 )
 
 /**
- * Say who may change the version, in words rather than an enum.
+ * Name the device this screen is actually showing.
  *
- * "managed" is the orchestrator case and the wording points the operator at
- * openplc-web rather than leaving them looking for a button that is not there.
+ * `runtimeConnection.ipAddress` is NOT that address whenever a device is
+ * reached through an orchestrator: it is the IP saved in the project's Device
+ * configuration, which has no relationship to the device being displayed. On a
+ * project carrying an old address, the header confidently labelled a device
+ * with a machine somewhere else on the network.
+ *
+ * So the connected device's own name wins, and the direct-connection address
+ * is used only when there is no orchestrator in the picture. The hostname the
+ * machine reports for itself is added when it says something the identifier
+ * does not.
  */
-const describePolicy = (policy?: string): string | undefined => {
-  switch (policy) {
-    case 'self':
-      return 'From this editor'
-    case 'managed':
-      return 'Managed by orchestrator'
-    case 'manual':
-      return 'Command line only'
-    case 'none':
-      return 'Provided by the device vendor'
-    default:
-      return undefined
-  }
+const describeDevice = (
+  hostname: string | undefined,
+  deviceName: string | undefined,
+  ipAddress: string | null,
+): string => {
+  const identity = deviceName ?? ipAddress ?? undefined
+  if (hostname && identity && hostname !== identity) return `${hostname} · ${identity}`
+  return hostname ?? identity ?? 'unknown device'
 }
 
-
-/** Only says what the device reported; silence stays silence. */
-const describeDeployment = (containerized: boolean | undefined): string | undefined => {
-  if (containerized === undefined) return undefined
-  return containerized ? 'Container' : 'Native'
+/**
+ * Total RAM, in the units a datasheet uses.
+ *
+ * Powers of 1024 rather than 1000: the daemon reports what the kernel sees, so
+ * 1935417344 is the 2 GB a board is sold as, and rounding it to "1.9 GB" would
+ * leave someone comparing it against the wrong number.
+ */
+const describeMemory = (bytes: number | undefined): string | undefined => {
+  if (bytes === undefined || bytes <= 0) return undefined
+  const gib = bytes / 1024 ** 3
+  return gib >= 1 ? `${gib.toFixed(1)} GB` : `${Math.round(bytes / 1024 ** 2)} MB`
 }
 
 export { RuntimeStatusEditor }

--- a/src/frontend/components/_organisms/explorer/project.tsx
+++ b/src/frontend/components/_organisms/explorer/project.tsx
@@ -64,6 +64,10 @@ const Project = () => {
   const runtimeConnected = useOpenPLCStore((s) => s.runtimeConnection.connectionStatus === 'connected')
   const runtimeVersion = useOpenPLCStore((s) => s.runtimeConnection.runtimeVersion)
   const showUserManagement = runtimeConnected && isUserManagementCapableRuntime(runtimeVersion)
+  // Everything on the Runtime Status screen is read from a live device -- scan
+  // statistics, host facts, the bootloader's state -- so the leaf appears only
+  // while connected rather than opening onto an empty screen.
+  const showRuntimeStatus = runtimeConnected
 
   // Per-project-type capability matrix — drives which branches
   // render.  Library projects only show Functions / Function Blocks /
@@ -432,6 +436,21 @@ const Project = () => {
                       name: 'Orchestrators',
                       path: `/device/orchestrators`,
                       elementType: { type: 'device', derivation: 'orchestrators' },
+                    })
+                  }
+                />
+              )}
+              {showRuntimeStatus && (
+                <ProjectTreeLeaf
+                  key='Runtime Status'
+                  leafLang='devConfig'
+                  leafType='device'
+                  label='Runtime Status'
+                  onClick={() =>
+                    handleCreateTab({
+                      name: 'Runtime Status',
+                      path: `/device/runtime-status`,
+                      elementType: { type: 'device', derivation: 'runtime-status' },
                     })
                   }
                 />

--- a/src/frontend/hooks/__tests__/use-runtime-polling.test.ts
+++ b/src/frontend/hooks/__tests__/use-runtime-polling.test.ts
@@ -146,3 +146,56 @@ describe('useRuntimePolling — EtherCAT branches', () => {
     expect(mockOpenModal).not.toHaveBeenCalled()
   })
 })
+
+describe('useRuntimePolling — while the runtime is being replaced', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRuntime.getStatus.mockResolvedValue({ success: true, status: 'RUNNING' })
+    mockRuntime.getLogs.mockResolvedValue({ success: true, logs: [] })
+    mockRuntime.getEthercatRuntimeStatus = undefined
+    Object.assign(mockState.runtimeConnection as object, {
+      connectionStatus: 'connected',
+      jwtToken: 'tok',
+      includeTimingStatsInPolling: false,
+      includeEthercatStatsInPolling: false,
+      runtimeUpdateInProgress: false,
+      selectedDevice: { deviceName: '192.168.2.4' },
+      ipAddress: '192.168.1.112',
+    })
+  })
+
+  it('stands down while a version change is in flight', async () => {
+    // The runtime is stopped and its container replaced during an update, so
+    // its silence is the expected state, not a fault. Polling through it
+    // counted the gap as failures and announced a lost connection in the
+    // middle of an update that was working.
+    Object.assign(mockState.runtimeConnection as object, { runtimeUpdateInProgress: true })
+
+    renderHook(() => useRuntimePolling())
+    await flushAll()
+
+    expect(mockRuntime.getStatus).not.toHaveBeenCalled()
+    expect(mockOpenModal).not.toHaveBeenCalled()
+  })
+
+  it('names the device when the connection really is lost', async () => {
+    // This path passed null, which the modal rendered as the literal
+    // "Unknown" -- so every message from it read "The connection to Unknown
+    // has been lost".
+    mockRuntime.getStatus.mockResolvedValue({ success: false })
+    mockRuntime.getLogs.mockResolvedValue({ success: false })
+
+    renderHook(() => useRuntimePolling())
+    for (let attempt = 0; attempt < 5; attempt += 1) await flushAll()
+
+    if (mockOpenModal.mock.calls.length > 0) {
+      const [id, data] = mockOpenModal.mock.calls[mockOpenModal.mock.calls.length - 1] as [
+        string,
+        { label?: string } | null,
+      ]
+      expect(id).toBe('runtime-connection-lost')
+      expect(data).not.toBeNull()
+      expect(data?.label).toBe('192.168.2.4')
+    }
+  })
+})

--- a/src/frontend/hooks/__tests__/use-runtime-polling.test.ts
+++ b/src/frontend/hooks/__tests__/use-runtime-polling.test.ts
@@ -20,8 +20,36 @@ const mockSetPlcLogs = jest.fn()
 const mockAppendPlcLogs = jest.fn()
 const mockSetPlcLogsLastId = jest.fn()
 const mockClearPlcLogs = jest.fn()
+// The poller lowers this once the device reports a terminal update state.
+const mockSetRuntimeUpdateInProgress = jest.fn()
 
-const mockState: Record<string, unknown> = {
+/**
+ * The slice of the store this hook reads.
+ *
+ * Typed so the per-test setup can assign fields directly. It used to be
+ * `Record<string, unknown>` and every setup cast it with `as object`, which
+ * meant a typo in a field name -- or a field the hook stopped reading --
+ * produced no error at all.
+ */
+type MockRuntimeConnection = {
+  connectionStatus: string
+  jwtToken: string | null
+  includeTimingStatsInPolling: boolean
+  includeEthercatStatsInPolling: boolean
+  plcStatus: unknown
+  ethercatStatus: unknown
+  runtimeUpdateInProgress?: boolean
+  selectedDevice?: { deviceName?: string } | null
+  ipAddress?: string | null
+}
+
+const mockState: {
+  runtimeConnection: MockRuntimeConnection
+  workspace: Record<string, unknown>
+  deviceActions: Record<string, jest.Mock>
+  modalActions: Record<string, jest.Mock>
+  workspaceActions: Record<string, jest.Mock>
+} = {
   runtimeConnection: {
     connectionStatus: 'connected',
     jwtToken: 'tok',
@@ -38,6 +66,7 @@ const mockState: Record<string, unknown> = {
     setEthercatStatus: mockSetEthercatStatus,
     setRuntimeJwtToken: mockSetRuntimeJwtToken,
     setRuntimeConnectionStatus: mockSetRuntimeConnectionStatus,
+    setRuntimeUpdateInProgress: mockSetRuntimeUpdateInProgress,
   },
   modalActions: { openModal: mockOpenModal },
   workspaceActions: {
@@ -93,7 +122,7 @@ describe('useRuntimePolling — EtherCAT branches', () => {
     mockRuntime.getStatus.mockResolvedValue({ success: true, status: 'RUNNING' })
     mockRuntime.getLogs.mockResolvedValue({ success: true, logs: [] })
     mockRuntime.getEthercatRuntimeStatus = undefined
-    Object.assign(mockState.runtimeConnection as object, {
+    Object.assign(mockState.runtimeConnection, {
       connectionStatus: 'connected',
       jwtToken: 'tok',
       includeTimingStatsInPolling: false,
@@ -102,7 +131,7 @@ describe('useRuntimePolling — EtherCAT branches', () => {
   })
 
   it('clears stored ethercat status when the polling flag is off', async () => {
-    Object.assign(mockState.runtimeConnection as object, { includeEthercatStatsInPolling: false })
+    Object.assign(mockState.runtimeConnection, { includeEthercatStatsInPolling: false })
     mockRuntime.getEthercatRuntimeStatus = jest.fn().mockResolvedValue({ success: true, data: { masters: [] } })
 
     renderHook(() => useRuntimePolling())
@@ -115,7 +144,7 @@ describe('useRuntimePolling — EtherCAT branches', () => {
   })
 
   it('skips cleanly when the optional getEthercatRuntimeStatus method is not on the runtime', async () => {
-    Object.assign(mockState.runtimeConnection as object, { includeEthercatStatsInPolling: true })
+    Object.assign(mockState.runtimeConnection, { includeEthercatStatsInPolling: true })
     mockRuntime.getEthercatRuntimeStatus = undefined
 
     renderHook(() => useRuntimePolling())
@@ -128,7 +157,7 @@ describe('useRuntimePolling — EtherCAT branches', () => {
   })
 
   it('writes the runtime payload into the store on a successful ethercat poll', async () => {
-    Object.assign(mockState.runtimeConnection as object, { includeEthercatStatsInPolling: true })
+    Object.assign(mockState.runtimeConnection, { includeEthercatStatsInPolling: true })
     const payload = { masters: [{ name: 'BusA', plugin_state: 'OPERATIONAL' }] }
     mockRuntime.getEthercatRuntimeStatus = jest.fn().mockResolvedValue({ success: true, data: payload })
 
@@ -140,7 +169,7 @@ describe('useRuntimePolling — EtherCAT branches', () => {
   })
 
   it('does not tear down the connection on a transient ethercat rejection', async () => {
-    Object.assign(mockState.runtimeConnection as object, { includeEthercatStatsInPolling: true })
+    Object.assign(mockState.runtimeConnection, { includeEthercatStatsInPolling: true })
     mockRuntime.getEthercatRuntimeStatus = jest.fn().mockRejectedValue(new Error('boom'))
 
     renderHook(() => useRuntimePolling())
@@ -162,7 +191,7 @@ describe('useRuntimePolling — while the runtime is being replaced', () => {
     mockRuntime.getLogs.mockResolvedValue({ success: true, logs: [] })
     mockRuntime.getEthercatRuntimeStatus = undefined
     mockRuntime.bootloader.getUpdateProgress.mockResolvedValue({ success: false, error: 'idle' })
-    Object.assign(mockState.runtimeConnection as object, {
+    Object.assign(mockState.runtimeConnection, {
       connectionStatus: 'connected',
       jwtToken: 'tok',
       includeTimingStatsInPolling: false,
@@ -178,7 +207,7 @@ describe('useRuntimePolling — while the runtime is being replaced', () => {
     // its silence is the expected state, not a fault. Polling through it
     // counted the gap as failures and announced a lost connection in the
     // middle of an update that was working.
-    Object.assign(mockState.runtimeConnection as object, { runtimeUpdateInProgress: true })
+    Object.assign(mockState.runtimeConnection, { runtimeUpdateInProgress: true })
 
     renderHook(() => useRuntimePolling())
     await flushAll()
@@ -198,7 +227,7 @@ describe('useRuntimePolling — while the runtime is being replaced', () => {
     // microtasks in a loop -- what this used to do -- runs the FIRST poll five
     // times over and never reaches the failure threshold, which is why the
     // assertions below were reachable only behind an `if`.
-    jest.useFakeTimers();
+    jest.useFakeTimers()
     try {
       renderHook(() => useRuntimePolling())
       for (let attempt = 0; attempt < MAX_CONSECUTIVE_FAILURES + 1; attempt += 1) {

--- a/src/frontend/hooks/__tests__/use-runtime-polling.test.ts
+++ b/src/frontend/hooks/__tests__/use-runtime-polling.test.ts
@@ -1,4 +1,8 @@
-import { renderHook } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
+
+// Mirrors the hook's own constant; the test has to cross it to reach the
+// connection-lost path at all.
+const MAX_CONSECUTIVE_FAILURES = 5
 
 // The `mock*` prefix lets ts-jest hoist these references into the
 // `jest.mock` factories below — Jest reuses the same babel-plugin-jest
@@ -54,9 +58,13 @@ const mockRuntime: {
   getStatus: jest.Mock
   getLogs: jest.Mock
   getEthercatRuntimeStatus: undefined | jest.Mock
+  // The hook asks the bootloader whether a version change has finished, so it
+  // can lower the flag that suspends connection-lost detection.
+  bootloader: { getUpdateProgress: jest.Mock }
 } = {
   getStatus: jest.fn(),
   getLogs: jest.fn(),
+  bootloader: { getUpdateProgress: jest.fn() },
   getEthercatRuntimeStatus: undefined,
 }
 
@@ -153,6 +161,7 @@ describe('useRuntimePolling — while the runtime is being replaced', () => {
     mockRuntime.getStatus.mockResolvedValue({ success: true, status: 'RUNNING' })
     mockRuntime.getLogs.mockResolvedValue({ success: true, logs: [] })
     mockRuntime.getEthercatRuntimeStatus = undefined
+    mockRuntime.bootloader.getUpdateProgress.mockResolvedValue({ success: false, error: 'idle' })
     Object.assign(mockState.runtimeConnection as object, {
       connectionStatus: 'connected',
       jwtToken: 'tok',
@@ -185,17 +194,31 @@ describe('useRuntimePolling — while the runtime is being replaced', () => {
     mockRuntime.getStatus.mockResolvedValue({ success: false })
     mockRuntime.getLogs.mockResolvedValue({ success: false })
 
-    renderHook(() => useRuntimePolling())
-    for (let attempt = 0; attempt < 5; attempt += 1) await flushAll()
-
-    if (mockOpenModal.mock.calls.length > 0) {
-      const [id, data] = mockOpenModal.mock.calls[mockOpenModal.mock.calls.length - 1] as [
-        string,
-        { label?: string } | null,
-      ]
-      expect(id).toBe('runtime-connection-lost')
-      expect(data).not.toBeNull()
-      expect(data?.label).toBe('192.168.2.4')
+    // The polls happen on a 2s interval, so the clock has to move. Awaiting
+    // microtasks in a loop -- what this used to do -- runs the FIRST poll five
+    // times over and never reaches the failure threshold, which is why the
+    // assertions below were reachable only behind an `if`.
+    jest.useFakeTimers();
+    try {
+      renderHook(() => useRuntimePolling())
+      for (let attempt = 0; attempt < MAX_CONSECUTIVE_FAILURES + 1; attempt += 1) {
+        await act(async () => {
+          jest.advanceTimersByTime(2000)
+          await flushAll()
+        })
+      }
+    } finally {
+      jest.useRealTimers()
     }
+
+    // Asserted unconditionally. This sat behind `if (calls.length > 0)`, so
+    // when the five failing polls never reached handleConnectionLost the test
+    // asserted nothing and passed -- it could not regress, and did not prove
+    // the label fix it was named for.
+    expect(mockOpenModal).toHaveBeenCalled()
+    const [id, data] = mockOpenModal.mock.calls[mockOpenModal.mock.calls.length - 1]
+    expect(id).toBe('runtime-connection-lost')
+    expect(data).not.toBeNull()
+    expect(data.label).toBe('192.168.2.4')
   })
 })

--- a/src/frontend/hooks/use-runtime-polling.ts
+++ b/src/frontend/hooks/use-runtime-polling.ts
@@ -10,6 +10,10 @@ const POLL_INTERVAL_MS = 2000
 // Number of consecutive poll failures before showing connection lost modal
 const MAX_CONSECUTIVE_FAILURES = 5
 
+// Bootloader update states that mean the device is still working. Kept in step
+// with the dialog's own list; anything else is terminal.
+const UPDATE_IN_FLIGHT = new Set(['pulling', 'swapping', 'verifying'])
+
 /**
  * Custom hook that handles runtime status and logs polling.
  * Uses the RuntimePort abstraction so the same hook works on both
@@ -86,6 +90,18 @@ export const useRuntimePolling = () => {
     // first poll after the swap starts from zero.
     if (currentState.runtimeConnection.runtimeUpdateInProgress) {
       consecutiveFailuresRef.current = 0
+      // Ask the device whether it is still working, and lower the flag when it
+      // is not.
+      //
+      // The dialog raises the flag and used to lower it on unmount -- which
+      // happened mid-swap if the operator navigated away, re-arming the
+      // "connection lost" modal the flag prevents. It now leaves the flag up,
+      // so the clearing has to happen here: this hook runs for as long as the
+      // device is connected, whatever screen is open.
+      const update = await runtime.bootloader?.getUpdateProgress?.()
+      if (update?.success === true && !UPDATE_IN_FLIGHT.has(update.data.state)) {
+        useOpenPLCStore.getState().deviceActions.setRuntimeUpdateInProgress(false)
+      }
       return
     }
 

--- a/src/frontend/hooks/use-runtime-polling.ts
+++ b/src/frontend/hooks/use-runtime-polling.ts
@@ -51,7 +51,15 @@ export const useRuntimePolling = () => {
     const { workspaceActions } = useOpenPLCStore.getState()
     workspaceActions.setPlcLogsVisible(false)
     workspaceActions.clearPlcLogs()
-    openModal('runtime-connection-lost', null)
+    // Name the device. Passing null here fell through to the literal
+    // "Unknown", so every message from this path read "The connection to
+    // Unknown has been lost".
+    const { runtimeConnection } = useOpenPLCStore.getState()
+    const endpoint = runtimeConnection.selectedDevice?.deviceName ?? runtimeConnection.ipAddress ?? 'the runtime'
+    openModal('runtime-connection-lost', {
+      label: endpoint,
+      body: `The connection to ${endpoint} was lost after several failed attempts. Check that the runtime is running and reachable, then connect again.`,
+    })
   }, [clearConnectionState, openModal])
 
   const poll = useCallback(async () => {
@@ -70,6 +78,16 @@ export const useRuntimePolling = () => {
     } = currentState
 
     if (curStatus !== 'connected' || !curToken) return
+
+    // A version change stops the runtime on purpose and replaces its
+    // container. Polling through that window would count the gap as failures
+    // and tear down a connection that is about to come back on its own -- so
+    // stand down entirely, and forget the failures already counted so the
+    // first poll after the swap starts from zero.
+    if (currentState.runtimeConnection.runtimeUpdateInProgress) {
+      consecutiveFailuresRef.current = 0
+      return
+    }
 
     isPollingRef.current = true
 

--- a/src/frontend/store/__tests__/device-types.test.ts
+++ b/src/frontend/store/__tests__/device-types.test.ts
@@ -106,6 +106,7 @@ describe('Device slice types', () => {
         includeTimingStatsInPolling: false,
         ethercatStatus: null,
         includeEthercatStatsInPolling: false,
+      runtimeUpdateInProgress: false,
       }
       expect(conn.jwtToken).toBeNull()
       expect(conn.connectionStatus).toBe('disconnected')
@@ -154,6 +155,7 @@ describe('Device slice types', () => {
         includeTimingStatsInPolling: true,
         ethercatStatus: null,
         includeEthercatStatsInPolling: false,
+      runtimeUpdateInProgress: false,
       }
       expect(conn.jwtToken).toBe('token')
       expect(conn.connectionStatus).toBe('connected')
@@ -191,6 +193,7 @@ describe('Device slice types', () => {
           includeTimingStatsInPolling: false,
           ethercatStatus: null,
           includeEthercatStatsInPolling: false,
+      runtimeUpdateInProgress: false,
         },
         deviceConnection: { status: 'disconnected', port: null, transport: null, debugTransport: null },
         deviceLicense: { phase: 'idle', report: null, awaitingPurchaseUntil: null },

--- a/src/frontend/store/__tests__/device-types.test.ts
+++ b/src/frontend/store/__tests__/device-types.test.ts
@@ -106,7 +106,7 @@ describe('Device slice types', () => {
         includeTimingStatsInPolling: false,
         ethercatStatus: null,
         includeEthercatStatsInPolling: false,
-      runtimeUpdateInProgress: false,
+        runtimeUpdateInProgress: false,
       }
       expect(conn.jwtToken).toBeNull()
       expect(conn.connectionStatus).toBe('disconnected')
@@ -155,7 +155,7 @@ describe('Device slice types', () => {
         includeTimingStatsInPolling: true,
         ethercatStatus: null,
         includeEthercatStatsInPolling: false,
-      runtimeUpdateInProgress: false,
+        runtimeUpdateInProgress: false,
       }
       expect(conn.jwtToken).toBe('token')
       expect(conn.connectionStatus).toBe('connected')
@@ -193,7 +193,7 @@ describe('Device slice types', () => {
           includeTimingStatsInPolling: false,
           ethercatStatus: null,
           includeEthercatStatsInPolling: false,
-      runtimeUpdateInProgress: false,
+          runtimeUpdateInProgress: false,
         },
         deviceConnection: { status: 'disconnected', port: null, transport: null, debugTransport: null },
         deviceLicense: { phase: 'idle', report: null, awaitingPurchaseUntil: null },

--- a/src/frontend/store/slices/device/slice.ts
+++ b/src/frontend/store/slices/device/slice.ts
@@ -106,6 +106,7 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
     plcStatus: null,
     switchPosition: null,
     ipAddress: null,
+    runtimeUpdateInProgress: false,
     runtimeVersion: null,
     selectedDevice: null,
     storedCredentials: null,
@@ -596,6 +597,13 @@ const createDeviceSlice: StateCreator<DeviceSliceRoot, [], [], DeviceSlice> = (s
       setState(
         produce(({ runtimeConnection }: DeviceSlice) => {
           runtimeConnection.includeTimingStatsInPolling = include
+        }),
+      )
+    },
+    setRuntimeUpdateInProgress: (inProgress): void => {
+      setState(
+        produce(({ runtimeConnection }: DeviceSlice) => {
+          runtimeConnection.runtimeUpdateInProgress = inProgress
         }),
       )
     },

--- a/src/frontend/store/slices/device/types.ts
+++ b/src/frontend/store/slices/device/types.ts
@@ -85,6 +85,16 @@ export type RuntimeConnection = {
   includeTimingStatsInPolling: boolean
   ethercatStatus: EtherCATRuntimeStatusResponse | null
   includeEthercatStatsInPolling: boolean
+  /**
+   * A runtime version change is in flight on the device.
+   *
+   * The runtime is deliberately stopped and replaced during one, so its
+   * silence is expected rather than a fault. Without this the status poller
+   * counted the swap as five failed polls and announced a lost connection --
+   * in the middle of an update that was working, while the dialog beside it
+   * said the device carries on by itself.
+   */
+  runtimeUpdateInProgress: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -252,6 +262,8 @@ export type DeviceActions = {
   setStoredCredentials: (credentials: StoredCredentials | null) => void
   setTimingStats: (stats: TimingStats | null) => void
   setIncludeTimingStatsInPolling: (include: boolean) => void
+  /** Suspend "connection lost" detection while the runtime is being replaced. */
+  setRuntimeUpdateInProgress: (inProgress: boolean) => void
   setEthercatStatus: (status: EtherCATRuntimeStatusResponse | null) => void
   setIncludeEthercatStatsInPolling: (include: boolean) => void
   setTemporaryDhcpIp: (ipAddress?: string) => void

--- a/src/frontend/store/slices/editor/types.ts
+++ b/src/frontend/store/slices/editor/types.ts
@@ -164,7 +164,7 @@ export type EditorModel = EditorModelBase &
         type: 'plc-device'
         meta: {
           name: string
-          derivation: 'configuration' | 'pin-mapping' | 'orchestrators'
+          derivation: 'configuration' | 'pin-mapping' | 'orchestrators' | 'runtime-status'
         }
       }
     | {

--- a/src/frontend/store/slices/tabs/types.ts
+++ b/src/frontend/store/slices/tabs/types.ts
@@ -12,7 +12,7 @@ export type TabsProps = {
     | { type: 'data-type'; derivation: 'enumerated' | 'structure' | 'array' }
     | { type: 'global-variable-list' }
     | { type: 'resource' }
-    | { type: 'device'; derivation: 'configuration' | 'pin-mapping' | 'orchestrators' }
+    | { type: 'device'; derivation: 'configuration' | 'pin-mapping' | 'orchestrators' | 'runtime-status' }
     | { type: 'server'; protocol: 'modbus-tcp' | 's7comm' | 'ethernet-ip' | 'opcua' }
     | { type: 'remote-device'; protocol: 'modbus-tcp' | 'ethernet-ip' | 'ethercat' | 'profinet' }
     | { type: 'vendor-screen'; screenName: string }

--- a/src/frontend/store/slices/tabs/utils.ts
+++ b/src/frontend/store/slices/tabs/utils.ts
@@ -82,7 +82,7 @@ const CreateResourceEditor = (name = 'Resource'): EditorModel => ({
 
 const CreateDeviceEditor = (
   name = 'device',
-  derivation: 'configuration' | 'pin-mapping' | 'orchestrators',
+  derivation: 'configuration' | 'pin-mapping' | 'orchestrators' | 'runtime-status',
 ): EditorModel => {
   if (!derivation) throw new Error('Invalid derivation value')
   return {

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -322,6 +322,9 @@ class MainProcessBridge implements MainIpcModule {
 
   handleRuntimeGetUsersInfo = (_event: IpcMainInvokeEvent, ipAddress: string) => this.runtimeApi.getUsersInfo(ipAddress)
 
+  handleRuntimeGetDeviceInfo = (_event: IpcMainInvokeEvent, ipAddress: string) =>
+    this.runtimeApi.getDeviceInfo(ipAddress)
+
   handleRuntimeCreateUser = (
     _event: IpcMainInvokeEvent,
     ipAddress: string,
@@ -876,6 +879,7 @@ class MainProcessBridge implements MainIpcModule {
     this.registerHandle('runtime:update-user', this.handleRuntimeUpdateUser)
     this.registerHandle('runtime:delete-user', this.handleRuntimeDeleteUser)
     this.registerHandle('runtime:login', this.handleRuntimeLogin)
+    this.registerHandle('runtime:get-device-info', this.handleRuntimeGetDeviceInfo)
     this.registerHandle('runtime:get-status', this.handleRuntimeGetStatus)
     this.registerHandle('runtime:start-plc', this.handleRuntimeStartPlc)
     this.registerHandle('runtime:stop-plc', this.handleRuntimeStopPlc)

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -77,6 +77,7 @@ import {
   resolveDeviceLicense,
 } from '../../../backend/editor/license/license-flow'
 import { PackageManagerModule } from '../../../backend/editor/package-manager'
+import { BootloaderApiClient } from '../../../backend/editor/runtime/bootloader-api-client'
 import { RuntimeApiClient } from '../../../backend/editor/runtime/runtime-api-client'
 import { logger } from '../../../backend/editor/services'
 import {
@@ -225,6 +226,13 @@ class MainProcessBridge implements MainIpcModule {
    * channel), so this one goes.
    */
   private runtimeApi = new RuntimeApiClient()
+
+  /**
+   * The runtime bootloader (RTOP-283), on its own port with its own session.
+   * Separate from runtimeApi because the two services share a credential
+   * database, not a token.
+   */
+  private bootloaderApi = new BootloaderApiClient()
   // Address of the runtime this session is authenticated against. Captured at
   // login so the token authority can re-authenticate against the same device.
   // Current project root path used to validate file-watcher IPC calls
@@ -274,6 +282,36 @@ class MainProcessBridge implements MainIpcModule {
       // R1/E2). Channels opened per call already read the manager at create().
       this.deviceSession.getDebugClient()?.reauth?.(newToken)
     })
+  }
+
+  // ===================== BOOTLOADER HANDLERS =====================
+  // Thin pass-throughs: the client owns validation and message wording, and
+  // its errors are written to be shown to a person as they are.
+
+  handleBootloaderGetCapabilities = (_event: IpcMainInvokeEvent, ipAddress: string) =>
+    this.bootloaderApi.getCapabilities(ipAddress)
+
+  handleBootloaderLogin = (_event: IpcMainInvokeEvent, ipAddress: string, username: string, password: string) =>
+    this.bootloaderApi.login(ipAddress, username, password)
+
+  handleBootloaderGetStatus = (_event: IpcMainInvokeEvent, ipAddress: string) =>
+    this.bootloaderApi.getStatus(ipAddress)
+
+  handleBootloaderGetRuntimeLogs = (_event: IpcMainInvokeEvent, ipAddress: string, tail?: number) =>
+    this.bootloaderApi.getRuntimeLogs(ipAddress, tail)
+
+  handleBootloaderStartUpdate = (_event: IpcMainInvokeEvent, ipAddress: string, version: string) =>
+    this.bootloaderApi.startUpdate(ipAddress, version)
+
+  handleBootloaderGetUpdateProgress = (_event: IpcMainInvokeEvent, ipAddress: string) =>
+    this.bootloaderApi.getUpdateProgress(ipAddress)
+
+  handleBootloaderRestartRuntime = (_event: IpcMainInvokeEvent, ipAddress: string) =>
+    this.bootloaderApi.restartRuntime(ipAddress)
+
+  handleBootloaderClearSession = (_event: IpcMainInvokeEvent, ipAddress?: string) => {
+    this.bootloaderApi.clearSession(ipAddress)
+    return { success: true as const }
   }
 
   // ===================== RUNTIME API HANDLERS =====================
@@ -848,6 +886,16 @@ class MainProcessBridge implements MainIpcModule {
     this.registerHandle('runtime:discover-devices', this.handleRuntimeDiscoverDevices)
     this.registerHandle('runtime:retrieve-project', this.handleRuntimeRetrieveProject)
     this.registerHandle('runtime:install-retrieved-libraries', this.handleInstallRetrievedLibraries)
+
+    // ===================== BOOTLOADER =====================
+    this.registerHandle('bootloader:get-capabilities', this.handleBootloaderGetCapabilities)
+    this.registerHandle('bootloader:login', this.handleBootloaderLogin)
+    this.registerHandle('bootloader:get-status', this.handleBootloaderGetStatus)
+    this.registerHandle('bootloader:get-runtime-logs', this.handleBootloaderGetRuntimeLogs)
+    this.registerHandle('bootloader:start-update', this.handleBootloaderStartUpdate)
+    this.registerHandle('bootloader:get-update-progress', this.handleBootloaderGetUpdateProgress)
+    this.registerHandle('bootloader:restart-runtime', this.handleBootloaderRestartRuntime)
+    this.registerHandle('bootloader:clear-session', this.handleBootloaderClearSession)
 
     // ===================== ETHERCAT DISCOVERY =====================
     this.registerHandle('ethercat:get-interfaces', this.handleEtherCATGetInterfaces)

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -297,6 +297,9 @@ class MainProcessBridge implements MainIpcModule {
   handleBootloaderGetStatus = (_event: IpcMainInvokeEvent, ipAddress: string) =>
     this.bootloaderApi.getStatus(ipAddress)
 
+  handleBootloaderGetDeviceInfo = (_event: IpcMainInvokeEvent, ipAddress: string) =>
+    this.bootloaderApi.getDeviceInfo(ipAddress)
+
   handleBootloaderGetRuntimeLogs = (_event: IpcMainInvokeEvent, ipAddress: string, tail?: number) =>
     this.bootloaderApi.getRuntimeLogs(ipAddress, tail)
 
@@ -321,9 +324,6 @@ class MainProcessBridge implements MainIpcModule {
   // because one of them was the `8443` this work claimed to have unified.
 
   handleRuntimeGetUsersInfo = (_event: IpcMainInvokeEvent, ipAddress: string) => this.runtimeApi.getUsersInfo(ipAddress)
-
-  handleRuntimeGetDeviceInfo = (_event: IpcMainInvokeEvent, ipAddress: string) =>
-    this.runtimeApi.getDeviceInfo(ipAddress)
 
   handleRuntimeCreateUser = (
     _event: IpcMainInvokeEvent,
@@ -879,7 +879,6 @@ class MainProcessBridge implements MainIpcModule {
     this.registerHandle('runtime:update-user', this.handleRuntimeUpdateUser)
     this.registerHandle('runtime:delete-user', this.handleRuntimeDeleteUser)
     this.registerHandle('runtime:login', this.handleRuntimeLogin)
-    this.registerHandle('runtime:get-device-info', this.handleRuntimeGetDeviceInfo)
     this.registerHandle('runtime:get-status', this.handleRuntimeGetStatus)
     this.registerHandle('runtime:start-plc', this.handleRuntimeStartPlc)
     this.registerHandle('runtime:stop-plc', this.handleRuntimeStopPlc)
@@ -895,6 +894,7 @@ class MainProcessBridge implements MainIpcModule {
     this.registerHandle('bootloader:get-capabilities', this.handleBootloaderGetCapabilities)
     this.registerHandle('bootloader:login', this.handleBootloaderLogin)
     this.registerHandle('bootloader:get-status', this.handleBootloaderGetStatus)
+    this.registerHandle('bootloader:get-device-info', this.handleBootloaderGetDeviceInfo)
     this.registerHandle('bootloader:get-runtime-logs', this.handleBootloaderGetRuntimeLogs)
     this.registerHandle('bootloader:start-update', this.handleBootloaderStartUpdate)
     this.registerHandle('bootloader:get-update-progress', this.handleBootloaderGetUpdateProgress)

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -294,8 +294,7 @@ class MainProcessBridge implements MainIpcModule {
   handleBootloaderLogin = (_event: IpcMainInvokeEvent, ipAddress: string, username: string, password: string) =>
     this.bootloaderApi.login(ipAddress, username, password)
 
-  handleBootloaderGetStatus = (_event: IpcMainInvokeEvent, ipAddress: string) =>
-    this.bootloaderApi.getStatus(ipAddress)
+  handleBootloaderGetStatus = (_event: IpcMainInvokeEvent, ipAddress: string) => this.bootloaderApi.getStatus(ipAddress)
 
   handleBootloaderGetDeviceInfo = (_event: IpcMainInvokeEvent, ipAddress: string) =>
     this.bootloaderApi.getDeviceInfo(ipAddress)

--- a/src/main/modules/ipc/main.ts
+++ b/src/main/modules/ipc/main.ts
@@ -518,6 +518,10 @@ class MainProcessBridge implements MainIpcModule {
   handleRuntimeClearCredentials = (_event: IpcMainInvokeEvent) => {
     this.tokens.clear()
     this.runtimeApi.clearSession()
+    // The bootloader keeps its own session, so clearing only the runtime's
+    // left the previous user's bootloader token usable -- and that token can
+    // change the runtime version. Signing out has to mean both.
+    this.bootloaderApi.clearSession()
     return { success: true }
   }
 

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -1,4 +1,11 @@
 import type { CompileProgramIpcArgs } from '@root/middleware/adapters/editor/compile-program-flow'
+import type {
+  BootloaderApiResult,
+  BootloaderCapabilities,
+  BootloaderLogs,
+  BootloaderStatus,
+  BootloaderUpdateProgress,
+} from '../../../backend/editor/runtime/bootloader-api-client'
 import type { CompileLibraryIpcArgs } from '@root/middleware/adapters/editor/compiler-adapter'
 import type {
   DiscoveredRuntimeDevice,
@@ -582,6 +589,36 @@ const rendererProcessBridge = {
     ipcRenderer.invoke('runtime:start-plc', ipAddress),
   runtimeStopPlc: (ipAddress: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('runtime:stop-plc', ipAddress),
+
+  // ===================== BOOTLOADER (RTOP-283) =====================
+  // The bootloader is a separate service on port 8445 with its own session.
+  // Results are the client's discriminated union, so a caller checks `success`
+  // and shows `error` verbatim -- its messages are written for a person.
+  bootloaderGetCapabilities: (ipAddress: string): Promise<BootloaderApiResult<BootloaderCapabilities>> =>
+    ipcRenderer.invoke('bootloader:get-capabilities', ipAddress),
+  bootloaderLogin: (
+    ipAddress: string,
+    username: string,
+    password: string,
+  ): Promise<BootloaderApiResult<{ role?: string }>> =>
+    ipcRenderer.invoke('bootloader:login', ipAddress, username, password),
+  bootloaderGetStatus: (ipAddress: string): Promise<BootloaderApiResult<BootloaderStatus>> =>
+    ipcRenderer.invoke('bootloader:get-status', ipAddress),
+  bootloaderGetRuntimeLogs: (ipAddress: string, tail?: number): Promise<BootloaderApiResult<BootloaderLogs>> =>
+    ipcRenderer.invoke('bootloader:get-runtime-logs', ipAddress, tail),
+  bootloaderStartUpdate: (
+    ipAddress: string,
+    version: string,
+  ): Promise<BootloaderApiResult<BootloaderUpdateProgress>> =>
+    ipcRenderer.invoke('bootloader:start-update', ipAddress, version),
+  bootloaderGetUpdateProgress: (ipAddress: string): Promise<BootloaderApiResult<BootloaderUpdateProgress>> =>
+    ipcRenderer.invoke('bootloader:get-update-progress', ipAddress),
+  bootloaderRestartRuntime: (
+    ipAddress: string,
+  ): Promise<BootloaderApiResult<{ state?: string; reason?: string }>> =>
+    ipcRenderer.invoke('bootloader:restart-runtime', ipAddress),
+  bootloaderClearSession: (ipAddress?: string): Promise<{ success: true }> =>
+    ipcRenderer.invoke('bootloader:clear-session', ipAddress),
   runtimeGetCompilationStatus: (
     ipAddress: string,
   ): Promise<{

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -45,8 +45,8 @@ import type {
   BootloaderLogs,
   BootloaderStatus,
   BootloaderUpdateProgress,
+  RuntimeDeviceInfo,
 } from '../../../backend/editor/runtime/bootloader-api-client'
-import type { RuntimeApiResult, RuntimeDeviceInfo } from '../../../backend/editor/runtime/runtime-api-client'
 
 type IpcRendererCallbacks = (_event: IpcRendererEvent, ...args: unknown[]) => void
 
@@ -592,9 +592,6 @@ const rendererProcessBridge = {
   runtimeStopPlc: (ipAddress: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('runtime:stop-plc', ipAddress),
 
-  runtimeGetDeviceInfo: (ipAddress: string): Promise<RuntimeApiResult<RuntimeDeviceInfo>> =>
-    ipcRenderer.invoke('runtime:get-device-info', ipAddress),
-
   // ===================== BOOTLOADER (RTOP-283) =====================
   // The bootloader is a separate service on port 8445 with its own session.
   // Results are the client's discriminated union, so a caller checks `success`
@@ -609,6 +606,8 @@ const rendererProcessBridge = {
     ipcRenderer.invoke('bootloader:login', ipAddress, username, password),
   bootloaderGetStatus: (ipAddress: string): Promise<BootloaderApiResult<BootloaderStatus>> =>
     ipcRenderer.invoke('bootloader:get-status', ipAddress),
+  bootloaderGetDeviceInfo: (ipAddress: string): Promise<BootloaderApiResult<RuntimeDeviceInfo>> =>
+    ipcRenderer.invoke('bootloader:get-device-info', ipAddress),
   bootloaderGetRuntimeLogs: (ipAddress: string, tail?: number): Promise<BootloaderApiResult<BootloaderLogs>> =>
     ipcRenderer.invoke('bootloader:get-runtime-logs', ipAddress, tail),
   bootloaderStartUpdate: (

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -1,11 +1,4 @@
 import type { CompileProgramIpcArgs } from '@root/middleware/adapters/editor/compile-program-flow'
-import type {
-  BootloaderApiResult,
-  BootloaderCapabilities,
-  BootloaderLogs,
-  BootloaderStatus,
-  BootloaderUpdateProgress,
-} from '../../../backend/editor/runtime/bootloader-api-client'
 import type { CompileLibraryIpcArgs } from '@root/middleware/adapters/editor/compiler-adapter'
 import type {
   DiscoveredRuntimeDevice,
@@ -45,6 +38,15 @@ import type { PLCProjectData } from '@root/middleware/shared/ports/types'
 import { CreatePouFileProps, PouServiceResponse } from '@root/types/IPC/pou-service'
 import { CreateProjectFileProps, IProjectServiceResponse } from '@root/types/IPC/project-service'
 import { ipcRenderer, IpcRendererEvent } from 'electron'
+
+import type {
+  BootloaderApiResult,
+  BootloaderCapabilities,
+  BootloaderLogs,
+  BootloaderStatus,
+  BootloaderUpdateProgress,
+} from '../../../backend/editor/runtime/bootloader-api-client'
+import type { RuntimeApiResult, RuntimeDeviceInfo } from '../../../backend/editor/runtime/runtime-api-client'
 
 type IpcRendererCallbacks = (_event: IpcRendererEvent, ...args: unknown[]) => void
 
@@ -589,6 +591,9 @@ const rendererProcessBridge = {
     ipcRenderer.invoke('runtime:start-plc', ipAddress),
   runtimeStopPlc: (ipAddress: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('runtime:stop-plc', ipAddress),
+
+  runtimeGetDeviceInfo: (ipAddress: string): Promise<RuntimeApiResult<RuntimeDeviceInfo>> =>
+    ipcRenderer.invoke('runtime:get-device-info', ipAddress),
 
   // ===================== BOOTLOADER (RTOP-283) =====================
   // The bootloader is a separate service on port 8445 with its own session.

--- a/src/main/modules/ipc/renderer.ts
+++ b/src/main/modules/ipc/renderer.ts
@@ -610,16 +610,11 @@ const rendererProcessBridge = {
     ipcRenderer.invoke('bootloader:get-device-info', ipAddress),
   bootloaderGetRuntimeLogs: (ipAddress: string, tail?: number): Promise<BootloaderApiResult<BootloaderLogs>> =>
     ipcRenderer.invoke('bootloader:get-runtime-logs', ipAddress, tail),
-  bootloaderStartUpdate: (
-    ipAddress: string,
-    version: string,
-  ): Promise<BootloaderApiResult<BootloaderUpdateProgress>> =>
+  bootloaderStartUpdate: (ipAddress: string, version: string): Promise<BootloaderApiResult<BootloaderUpdateProgress>> =>
     ipcRenderer.invoke('bootloader:start-update', ipAddress, version),
   bootloaderGetUpdateProgress: (ipAddress: string): Promise<BootloaderApiResult<BootloaderUpdateProgress>> =>
     ipcRenderer.invoke('bootloader:get-update-progress', ipAddress),
-  bootloaderRestartRuntime: (
-    ipAddress: string,
-  ): Promise<BootloaderApiResult<{ state?: string; reason?: string }>> =>
+  bootloaderRestartRuntime: (ipAddress: string): Promise<BootloaderApiResult<{ state?: string; reason?: string }>> =>
     ipcRenderer.invoke('bootloader:restart-runtime', ipAddress),
   bootloaderClearSession: (ipAddress?: string): Promise<{ success: true }> =>
     ipcRenderer.invoke('bootloader:clear-session', ipAddress),

--- a/src/middleware/adapters/editor/__tests__/runtime-adapter.test.ts
+++ b/src/middleware/adapters/editor/__tests__/runtime-adapter.test.ts
@@ -28,6 +28,20 @@ beforeEach(() => {
       data: { status: 'SUCCESS', logs: [], exit_code: 0 },
     }),
     runtimeClearCredentials: jest.fn().mockResolvedValue({ success: true }),
+    // The bootloader surface (RTOP-283). A separate service on the device
+    // with its own session, reached over the same IPC bridge.
+    bootloaderGetCapabilities: jest.fn().mockResolvedValue({
+      success: true,
+      data: { service: 'openplc-bootloader', state: 'healthy', recovery: false },
+    }),
+    bootloaderLogin: jest.fn().mockResolvedValue({ success: true, data: { role: 'admin' } }),
+    bootloaderGetStatus: jest.fn().mockResolvedValue({ success: true, data: { state: 'healthy' } }),
+    bootloaderGetDeviceInfo: jest.fn().mockResolvedValue({ success: true, data: { hostname: 'slm-rp4' } }),
+    bootloaderGetRuntimeLogs: jest.fn().mockResolvedValue({ success: true, data: { logs: '', available: true } }),
+    bootloaderStartUpdate: jest.fn().mockResolvedValue({ success: true, data: { state: 'pulling' } }),
+    bootloaderGetUpdateProgress: jest.fn().mockResolvedValue({ success: true, data: { state: 'success' } }),
+    bootloaderRestartRuntime: jest.fn().mockResolvedValue({ success: true, data: { state: 'starting' } }),
+    bootloaderClearSession: jest.fn().mockResolvedValue(undefined),
     onRuntimeTokenRefreshed: jest.fn().mockImplementation(() => jest.fn()),
     runtimeDiscoverDevices: jest.fn().mockResolvedValue({ success: true, devices: [] }),
     onRuntimeDeviceDiscovered: jest.fn().mockImplementation(() => jest.fn()),
@@ -833,5 +847,61 @@ describe('selectRetrievableDevice', () => {
     adapter.selectRetrievableDevice!({ key: '192.168.1.77', name: '192.168.1.77', answeredScan: true })
 
     expect(openPLCStoreBase.getState().deviceDefinitions.configuration.runtimeIpAddress).toBe('192.168.1.77')
+  })
+})
+
+describe('the bootloader surface', () => {
+  // Every method is a thin pass-through to the IPC bridge, so what is worth
+  // pinning is that each one reaches the right channel with the device address
+  // the adapter was given -- and that a thrown bridge error becomes the
+  // port's failure union rather than escaping to the caller.
+
+  it('reaches the bridge for each call, with the selected device address', async () => {
+    await adapter.bootloader.getCapabilities()
+    expect(window.bridge.bootloaderGetCapabilities).toHaveBeenCalledWith(mockIpAddress)
+
+    await adapter.bootloader.login('op', 'op')
+    expect(window.bridge.bootloaderLogin).toHaveBeenCalledWith(mockIpAddress, 'op', 'op')
+
+    await adapter.bootloader.getStatus()
+    expect(window.bridge.bootloaderGetStatus).toHaveBeenCalledWith(mockIpAddress)
+
+    await adapter.bootloader.getDeviceInfo()
+    expect(window.bridge.bootloaderGetDeviceInfo).toHaveBeenCalledWith(mockIpAddress)
+
+    await adapter.bootloader.getRuntimeLogs(50)
+    expect(window.bridge.bootloaderGetRuntimeLogs).toHaveBeenCalledWith(mockIpAddress, 50)
+
+    await adapter.bootloader.startUpdate('v4.1.10')
+    expect(window.bridge.bootloaderStartUpdate).toHaveBeenCalledWith(mockIpAddress, 'v4.1.10')
+
+    await adapter.bootloader.getUpdateProgress()
+    expect(window.bridge.bootloaderGetUpdateProgress).toHaveBeenCalledWith(mockIpAddress)
+
+    await adapter.bootloader.restartRuntime()
+    expect(window.bridge.bootloaderRestartRuntime).toHaveBeenCalledWith(mockIpAddress)
+
+    await adapter.bootloader.clearSession()
+    expect(window.bridge.bootloaderClearSession).toHaveBeenCalledWith(mockIpAddress)
+  })
+
+  it('returns what the bridge returns', async () => {
+    const result = await adapter.bootloader.getDeviceInfo()
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.hostname).toBe('slm-rp4')
+  })
+
+  it('turns a bridge failure into the port failure union', async () => {
+    // A dead IPC channel must not throw past the adapter: every caller in the
+    // Runtime Status screen branches on `success`, and an exception there
+    // would take the screen down instead of showing "no bootloader".
+    ;(window.bridge.bootloaderGetCapabilities as jest.Mock).mockRejectedValue(new Error('ipc gone'))
+
+    const result = await adapter.bootloader.getCapabilities()
+
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toMatch(/ipc gone/)
   })
 })

--- a/src/middleware/adapters/editor/runtime-adapter.ts
+++ b/src/middleware/adapters/editor/runtime-adapter.ts
@@ -142,6 +142,14 @@ export function createEditorRuntimeAdapter(getIpAddress: () => string): RuntimeP
       }
     },
 
+    async getDeviceInfo() {
+      try {
+        return await window.bridge.runtimeGetDeviceInfo(requireIp())
+      } catch (err) {
+        return { success: false as const, error: getErrorMessage(err) }
+      }
+    },
+
     async getUsersInfo(): Promise<UsersInfoResult> {
       try {
         const ip = requireIp()

--- a/src/middleware/adapters/editor/runtime-adapter.ts
+++ b/src/middleware/adapters/editor/runtime-adapter.ts
@@ -82,6 +82,13 @@ export function createEditorRuntimeAdapter(getIpAddress: () => string): RuntimeP
           return { success: false as const, error: getErrorMessage(err) }
         }
       },
+      async getDeviceInfo() {
+        try {
+          return await window.bridge.bootloaderGetDeviceInfo(requireIp())
+        } catch (err) {
+          return { success: false as const, error: getErrorMessage(err) }
+        }
+      },
       async getRuntimeLogs(tail?: number) {
         try {
           return await window.bridge.bootloaderGetRuntimeLogs(requireIp(), tail)
@@ -139,14 +146,6 @@ export function createEditorRuntimeAdapter(getIpAddress: () => string): RuntimeP
         return await window.bridge.runtimeCreateUser(ip, params.username, params.password, params.role)
       } catch (err) {
         return { success: false, error: getErrorMessage(err) }
-      }
-    },
-
-    async getDeviceInfo() {
-      try {
-        return await window.bridge.runtimeGetDeviceInfo(requireIp())
-      } catch (err) {
-        return { success: false as const, error: getErrorMessage(err) }
       }
     },
 

--- a/src/middleware/adapters/editor/runtime-adapter.ts
+++ b/src/middleware/adapters/editor/runtime-adapter.ts
@@ -52,6 +52,74 @@ export function createEditorRuntimeAdapter(getIpAddress: () => string): RuntimeP
       return getIpAddress() !== '' && loggedIn
     },
 
+    /**
+     * The bootloader on the currently targeted device.
+     *
+     * A nested object rather than eight more top-level methods: it is a
+     * different service on a different port with its own session, and keeping
+     * that boundary visible at the call site stops it being mistaken for the
+     * runtime's API.
+     */
+    bootloader: {
+      async getCapabilities() {
+        try {
+          return await window.bridge.bootloaderGetCapabilities(requireIp())
+        } catch (err) {
+          return { success: false as const, error: getErrorMessage(err) }
+        }
+      },
+      async login(username: string, password: string) {
+        try {
+          return await window.bridge.bootloaderLogin(requireIp(), username, password)
+        } catch (err) {
+          return { success: false as const, error: getErrorMessage(err) }
+        }
+      },
+      async getStatus() {
+        try {
+          return await window.bridge.bootloaderGetStatus(requireIp())
+        } catch (err) {
+          return { success: false as const, error: getErrorMessage(err) }
+        }
+      },
+      async getRuntimeLogs(tail?: number) {
+        try {
+          return await window.bridge.bootloaderGetRuntimeLogs(requireIp(), tail)
+        } catch (err) {
+          return { success: false as const, error: getErrorMessage(err) }
+        }
+      },
+      async startUpdate(version: string) {
+        try {
+          return await window.bridge.bootloaderStartUpdate(requireIp(), version)
+        } catch (err) {
+          return { success: false as const, error: getErrorMessage(err) }
+        }
+      },
+      async getUpdateProgress() {
+        try {
+          return await window.bridge.bootloaderGetUpdateProgress(requireIp())
+        } catch (err) {
+          return { success: false as const, error: getErrorMessage(err) }
+        }
+      },
+      async restartRuntime() {
+        try {
+          return await window.bridge.bootloaderRestartRuntime(requireIp())
+        } catch (err) {
+          return { success: false as const, error: getErrorMessage(err) }
+        }
+      },
+      async clearSession() {
+        try {
+          await window.bridge.bootloaderClearSession(requireIp())
+        } catch {
+          // Best effort: a session the main process may already have dropped
+          // is not worth surfacing to anybody.
+        }
+      },
+    },
+
     async login(params: LoginParams): Promise<LoginResult> {
       try {
         const ip = requireIp()

--- a/src/middleware/shared/ports/orchestrator-port.ts
+++ b/src/middleware/shared/ports/orchestrator-port.ts
@@ -79,6 +79,13 @@ export interface DiscoveredOrchestratorRuntime {
 export type OrchestratorHostInfo = {
   /** Operating system description, e.g. "Debian GNU/Linux 12 (bookworm)". */
   os?: string
+  /**
+   * Host kernel version, e.g. "6.12.35-rt10-v8+".
+   *
+   * The agent has always sent this; Edge did not declare it until EDGE-631,
+   * so it could not be read. An older Edge simply yields nothing here.
+   */
+  kernel?: string
   /** CPU count, as the agent reports it. */
   cpu?: string
   /** Total RAM in MB, as the agent reports it. */
@@ -102,9 +109,8 @@ export interface OrchestratorPort {
    * forwards, and an Edge new enough to expose the details route. A failure
    * yields nothing and the header simply shows less.
    *
-   * Note that `kernel` is NOT available here even though the agent sends it --
-   * Edge's own response type drops it. Adding it needs a change in
-   * autonomy-edge.
+   * `kernel` needs an Edge carrying EDGE-631; against an older one the field
+   * is simply absent and the header shows less.
    */
   getOrchestratorHostInfo?(orchestratorId: string): Promise<OrchestratorHostInfo | null>
 

--- a/src/middleware/shared/ports/orchestrator-port.ts
+++ b/src/middleware/shared/ports/orchestrator-port.ts
@@ -63,9 +63,50 @@ export interface DiscoveredOrchestratorRuntime {
 /**
  * Port interface for orchestrator operations.
  */
+/**
+ * What the orchestrator agent knows about the machine it runs on.
+ *
+ * The Runtime Status header's real source in production. Devices under an
+ * orchestrator are vPLC containers with no bootloader beside them, so the
+ * bootloader's device-info endpoint answers nothing there and the header sat
+ * blank. The agent already collects exactly these facts for its own
+ * consumption reporting (`tools/system_info.py::get_static_system_info`), and
+ * Edge bridges them to REST at `GET /orchestrators/:id/details`.
+ *
+ * Every field is optional: an agent too old to report, or one that is offline
+ * when asked, yields nothing rather than an error.
+ */
+export type OrchestratorHostInfo = {
+  /** Operating system description, e.g. "Debian GNU/Linux 12 (bookworm)". */
+  os?: string
+  /** CPU count, as the agent reports it. */
+  cpu?: string
+  /** Total RAM in MB, as the agent reports it. */
+  memory?: string
+  /** Total disk in GB, as the agent reports it. */
+  disk?: string
+  /** Version of the agent itself. */
+  agentVersion?: string
+  /** The orchestrator's name, which is the closest thing to a hostname here. */
+  name?: string
+}
+
 export interface OrchestratorPort {
   /** Fetch all orchestrators with their devices. */
   listOrchestrators(): Promise<OrchestratorInfo[]>
+
+  /**
+   * Host facts for one orchestrator, from its agent.
+   *
+   * Optional: it needs an agent that answers the consumption request Edge
+   * forwards, and an Edge new enough to expose the details route. A failure
+   * yields nothing and the header simply shows less.
+   *
+   * Note that `kernel` is NOT available here even though the agent sends it --
+   * Edge's own response type drops it. Adding it needs a change in
+   * autonomy-edge.
+   */
+  getOrchestratorHostInfo?(orchestratorId: string): Promise<OrchestratorHostInfo | null>
 
   /**
    * Ask one orchestrator's agent what its runtimes are advertising.

--- a/src/middleware/shared/ports/runtime-port.ts
+++ b/src/middleware/shared/ports/runtime-port.ts
@@ -38,15 +38,6 @@
  */
 
 import type {
-  BootloaderApiResult,
-  BootloaderCapabilities,
-  BootloaderLogs,
-  BootloaderStatus,
-  BootloaderUpdateProgress,
-  RuntimeDeviceInfo,
-} from '@root/backend/editor/runtime/bootloader-api-client'
-
-import type {
   EtherCATRuntimeStatusResponse,
   EtherCATScanRequest,
   EtherCATScanResponse,
@@ -237,62 +228,99 @@ export interface FetchedProject {
 }
 
 /**
+ * Result shape shared by every bootloader call. `error` strings come from the
+ * bootloader itself and are written to be shown to a person.
+ */
+export type BootloaderApiResult<T> = { success: true; data: T } | { success: false; error: string }
+
+/**
  * The runtime bootloader (RTOP-283): a second service on the device that
  * starts the runtime container and stays reachable when the runtime will not
- * run, so a version can be changed or repaired without SSH.
+ * run, so a version can be changed or repaired without shell access.
  *
- * Every method returns the client's discriminated union. `error` strings are
- * written for a person and are meant to be shown as they are.
+ * Reached through the same agent proxy as the runtime, on its own port. A
+ * device with no bootloader -- an orchestrator-managed vPLC, or a native
+ * install -- simply fails getCapabilities, which is the ordinary answer and
+ * not an error to surface.
  */
+export type BootloaderCapabilities = {
+  service: string
+  bootloaderVersion?: string
+  runtimeVersion?: string
+  state: string
+  recovery: boolean
+}
+
+export type BootloaderStatus = {
+  state: string
+  reason?: string
+  since?: string
+  crashCount?: number
+  healthSource?: string
+  containerId?: string
+  containerName?: string
+  image?: string
+  runtimeVersion?: string
+  recovery?: boolean
+}
+
+export type BootloaderLogs = {
+  logs: string
+  available: boolean
+  reason?: string
+  tail?: number
+}
+
+/**
+ * Update progress. `percent` is absent while the daemon has reported no size
+ * to work from -- for layers it already holds, and before any size is known --
+ * so a UI must treat "no percentage" as indeterminate, never as zero.
+ */
+export type BootloaderUpdateProgress = {
+  state: string
+  from?: string
+  to?: string
+  phase?: string
+  percent?: number | null
+  error?: string
+  startedAt?: string
+  finishedAt?: string | null
+}
+
+/**
+ * Host facts for the Runtime Status header, served by the bootloader.
+ *
+ * The bootloader rather than the runtime, because the bootloader is present on
+ * every device that can be updated at all -- including one running a runtime
+ * far older than this feature. A runtime-served equivalent only answered on
+ * runtimes new enough to have it, which is none of the devices in the field,
+ * so the screen sat empty exactly where it was most needed.
+ *
+ * It is also the better-placed of the two: the bootloader reads these from the
+ * Docker daemon, which runs on the host and answers for it, while a runtime
+ * inside a container can only describe its own namespace.
+ */
+export type RuntimeDeviceInfo = {
+  hostname?: string
+  architecture?: string
+  kernel?: string
+  system?: string
+  cpus?: number
+  memoryBytes?: number
+  dockerVersion?: string
+}
+
 export interface BootloaderPort {
-  /**
-   * Is a bootloader answering on this device?
-   *
-   * Answerable before login, because the editor uses it to decide whether to
-   * offer a version change at all. A failure here is the ordinary case for a
-   * native install or an orchestrator-managed vPLC, not an error to surface.
-   */
   getCapabilities(): Promise<BootloaderApiResult<BootloaderCapabilities>>
-
-  /**
-   * Sign in to the bootloader.
-   *
-   * Its credentials are the runtime's own -- the two services read one user
-   * database -- so the editor can reuse what the operator already entered.
-   * They do NOT share a session, so this is a separate login.
-   */
   login(username: string, password: string): Promise<BootloaderApiResult<{ role?: string }>>
-
-  /**
-   * Host facts for the Runtime Status header.
-   *
-   * Served by the bootloader rather than the runtime, because the bootloader
-   * is present on every device this feature can act on whatever runtime
-   * version is installed -- and because it reads them from the Docker daemon,
-   * which runs on the host and answers for it.
-   */
-  getDeviceInfo(): Promise<BootloaderApiResult<RuntimeDeviceInfo>>
-
-  /** Supervisor state: healthy, starting, updating or recovery, and why. */
   getStatus(): Promise<BootloaderApiResult<BootloaderStatus>>
-
-  /** The runtime container's recent output, for diagnosing a failed start. */
+  /** Host facts for the Runtime Status header. Authenticated, like status. */
+  getDeviceInfo(): Promise<BootloaderApiResult<RuntimeDeviceInfo>>
   getRuntimeLogs(tail?: number): Promise<BootloaderApiResult<BootloaderLogs>>
-
-  /**
-   * Change the runtime version. Returns once the work is under way; poll
-   * `getUpdateProgress`, because a pull can run for many minutes.
-   *
-   * Upgrade and downgrade are the same call: no direction, no version floor.
-   */
+  /** Upgrade and downgrade are the same call: no direction, no version floor. */
   startUpdate(version: string): Promise<BootloaderApiResult<BootloaderUpdateProgress>>
-
   getUpdateProgress(): Promise<BootloaderApiResult<BootloaderUpdateProgress>>
-
-  /** Stop and start the runtime container, health-gated on the way back. */
   restartRuntime(): Promise<BootloaderApiResult<{ state?: string; reason?: string }>>
-
-  /** Forget the bootloader session for this device. */
   clearSession(): Promise<void>
 }
 

--- a/src/middleware/shared/ports/runtime-port.ts
+++ b/src/middleware/shared/ports/runtime-port.ts
@@ -43,8 +43,8 @@ import type {
   BootloaderLogs,
   BootloaderStatus,
   BootloaderUpdateProgress,
+  RuntimeDeviceInfo,
 } from '@root/backend/editor/runtime/bootloader-api-client'
-import type { RuntimeApiResult, RuntimeDeviceInfo } from '@root/backend/editor/runtime/runtime-api-client'
 
 import type {
   EtherCATRuntimeStatusResponse,
@@ -263,6 +263,16 @@ export interface BootloaderPort {
    */
   login(username: string, password: string): Promise<BootloaderApiResult<{ role?: string }>>
 
+  /**
+   * Host facts for the Runtime Status header.
+   *
+   * Served by the bootloader rather than the runtime, because the bootloader
+   * is present on every device this feature can act on whatever runtime
+   * version is installed -- and because it reads them from the Docker daemon,
+   * which runs on the host and answers for it.
+   */
+  getDeviceInfo(): Promise<BootloaderApiResult<RuntimeDeviceInfo>>
+
   /** Supervisor state: healthy, starting, updating or recovery, and why. */
   getStatus(): Promise<BootloaderApiResult<BootloaderStatus>>
 
@@ -298,12 +308,6 @@ export interface RuntimePort {
 
   /** Create a new user on the runtime (first-time setup). */
   createUser(params: CreateUserParams): Promise<{ success: boolean; error?: string }>
-
-  /**
-   * Host facts for the Runtime Status header (RTOP-283). Older runtimes do not
-   * serve this and answer 404, so a failure means "less to show", not a fault.
-   */
-  getDeviceInfo(): Promise<RuntimeApiResult<RuntimeDeviceInfo>>
 
   /** Check if the runtime has users and get its version. */
   getUsersInfo(): Promise<UsersInfoResult>

--- a/src/middleware/shared/ports/runtime-port.ts
+++ b/src/middleware/shared/ports/runtime-port.ts
@@ -49,6 +49,13 @@ import type {
   NetworkInterface,
 } from './ethercat-types'
 import type { PlcStatus, RuntimeLogEntry, SerialPort, TimingStats, Unsubscribe } from './types'
+import type {
+  BootloaderApiResult,
+  BootloaderCapabilities,
+  BootloaderLogs,
+  BootloaderStatus,
+  BootloaderUpdateProgress,
+} from '@root/backend/editor/runtime/bootloader-api-client'
 
 export interface LoginParams {
   username: string
@@ -227,7 +234,60 @@ export interface FetchedProject {
   libraries?: Array<{ name: string; version: string; status: 'installed' | 'differs' | 'missing' }>
 }
 
+/**
+ * The runtime bootloader (RTOP-283): a second service on the device that
+ * starts the runtime container and stays reachable when the runtime will not
+ * run, so a version can be changed or repaired without SSH.
+ *
+ * Every method returns the client's discriminated union. `error` strings are
+ * written for a person and are meant to be shown as they are.
+ */
+export interface BootloaderPort {
+  /**
+   * Is a bootloader answering on this device?
+   *
+   * Answerable before login, because the editor uses it to decide whether to
+   * offer a version change at all. A failure here is the ordinary case for a
+   * native install or an orchestrator-managed vPLC, not an error to surface.
+   */
+  getCapabilities(): Promise<BootloaderApiResult<BootloaderCapabilities>>
+
+  /**
+   * Sign in to the bootloader.
+   *
+   * Its credentials are the runtime's own -- the two services read one user
+   * database -- so the editor can reuse what the operator already entered.
+   * They do NOT share a session, so this is a separate login.
+   */
+  login(username: string, password: string): Promise<BootloaderApiResult<{ role?: string }>>
+
+  /** Supervisor state: healthy, starting, updating or recovery, and why. */
+  getStatus(): Promise<BootloaderApiResult<BootloaderStatus>>
+
+  /** The runtime container's recent output, for diagnosing a failed start. */
+  getRuntimeLogs(tail?: number): Promise<BootloaderApiResult<BootloaderLogs>>
+
+  /**
+   * Change the runtime version. Returns once the work is under way; poll
+   * `getUpdateProgress`, because a pull can run for many minutes.
+   *
+   * Upgrade and downgrade are the same call: no direction, no version floor.
+   */
+  startUpdate(version: string): Promise<BootloaderApiResult<BootloaderUpdateProgress>>
+
+  getUpdateProgress(): Promise<BootloaderApiResult<BootloaderUpdateProgress>>
+
+  /** Stop and start the runtime container, health-gated on the way back. */
+  restartRuntime(): Promise<BootloaderApiResult<{ state?: string; reason?: string }>>
+
+  /** Forget the bootloader session for this device. */
+  clearSession(): Promise<void>
+}
+
 export interface RuntimePort {
+  /** The bootloader on this device, when one is present. */
+  bootloader: BootloaderPort
+
   /** Set the target device for subsequent API calls. */
   setDeviceContext?(context: { agentId: string; deviceId: string } | null): void
 

--- a/src/middleware/shared/ports/runtime-port.ts
+++ b/src/middleware/shared/ports/runtime-port.ts
@@ -38,6 +38,15 @@
  */
 
 import type {
+  BootloaderApiResult,
+  BootloaderCapabilities,
+  BootloaderLogs,
+  BootloaderStatus,
+  BootloaderUpdateProgress,
+} from '@root/backend/editor/runtime/bootloader-api-client'
+import type { RuntimeApiResult, RuntimeDeviceInfo } from '@root/backend/editor/runtime/runtime-api-client'
+
+import type {
   EtherCATRuntimeStatusResponse,
   EtherCATScanRequest,
   EtherCATScanResponse,
@@ -49,13 +58,6 @@ import type {
   NetworkInterface,
 } from './ethercat-types'
 import type { PlcStatus, RuntimeLogEntry, SerialPort, TimingStats, Unsubscribe } from './types'
-import type {
-  BootloaderApiResult,
-  BootloaderCapabilities,
-  BootloaderLogs,
-  BootloaderStatus,
-  BootloaderUpdateProgress,
-} from '@root/backend/editor/runtime/bootloader-api-client'
 
 export interface LoginParams {
   username: string
@@ -296,6 +298,12 @@ export interface RuntimePort {
 
   /** Create a new user on the runtime (first-time setup). */
   createUser(params: CreateUserParams): Promise<{ success: boolean; error?: string }>
+
+  /**
+   * Host facts for the Runtime Status header (RTOP-283). Older runtimes do not
+   * serve this and answer 404, so a failure means "less to show", not a fault.
+   */
+  getDeviceInfo(): Promise<RuntimeApiResult<RuntimeDeviceInfo>>
 
   /** Check if the runtime has users and get its version. */
   getUsersInfo(): Promise<UsersInfoResult>

--- a/src/middleware/shared/utils/__tests__/runtime-versions.test.ts
+++ b/src/middleware/shared/utils/__tests__/runtime-versions.test.ts
@@ -1,0 +1,179 @@
+/**
+ * The version list (RTOP-283).
+ *
+ * This module had no test at all: the dialog's test mocks it with pre-sorted
+ * tags, so the sort, the release filter, the pre-release ordering, the 403
+ * handling and the cache all ran under nothing. The one property anybody
+ * actually quoted -- that v4.1.10 sorts above v4.1.9 -- was never exercised.
+ */
+
+import { clearRuntimeVersionsCache, listRuntimeVersions } from '../runtime-versions'
+
+const tags = (...names: unknown[]) => names.map((name) => ({ name }))
+
+/**
+ * `vi.stubGlobal` has no Jest equivalent, so fetch is replaced directly and
+ * restored between tests. Same coverage as the web copy, different runner --
+ * the two apps share this module but not a test framework.
+ */
+const stubFetch = (impl: unknown): void => {
+  ;(globalThis as { fetch: unknown }).fetch = impl
+}
+
+const respondWith = (body: unknown, status = 200) =>
+  jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  })
+
+const realFetch = globalThis.fetch
+
+beforeEach(() => {
+  clearRuntimeVersionsCache()
+  jest.restoreAllMocks()
+})
+
+afterEach(() => {
+  ;(globalThis as { fetch: unknown }).fetch = realFetch
+})
+
+describe('listRuntimeVersions', () => {
+  it('sorts numerically, so v4.1.10 comes above v4.1.9', async () => {
+    // The whole reason this is not a string sort: lexicographically v4.1.10
+    // falls below v4.1.9 and the newest patch release ends up buried.
+    stubFetch(respondWith(tags('v4.1.9', 'v4.1.10', 'v4.2.0')))
+
+    const result = await listRuntimeVersions()
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.versions.map((v) => v.tag)).toEqual(['v4.2.0', 'v4.1.10', 'v4.1.9'])
+  })
+
+  it('puts a release above its own pre-releases', async () => {
+    stubFetch(respondWith(tags('v4.2.0-rc.1', 'v4.2.0', 'v4.2.0-rc.2')))
+
+    const result = await listRuntimeVersions()
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.versions.map((v) => v.tag)).toEqual(['v4.2.0', 'v4.2.0-rc.2', 'v4.2.0-rc.1'])
+    expect(result.versions[0].prerelease).toBe(false)
+    expect(result.versions[1].prerelease).toBe(true)
+  })
+
+  it('keeps only release tags', async () => {
+    // A tag that is not a release has no published image behind it, so
+    // offering it would produce a failed pull and a confusing message.
+    stubFetch(respondWith(tags('v4.2.0', 'nightly', 'RTOP-283', 'v4', 'v4.2')))
+
+    const result = await listRuntimeVersions()
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.versions.map((v) => v.tag)).toEqual(['v4.2.0'])
+  })
+
+  it('survives a null entry instead of losing every tag', async () => {
+    // The bug: the old code cast each entry and read `.name`, so one null
+    // element threw, landed in the catch and was reported as "could not reach
+    // GitHub" -- discarding all the valid tags with it.
+    stubFetch(respondWith([null, { name: 'v4.2.0' }, 'v9', { nope: 1 }]))
+
+    const result = await listRuntimeVersions()
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.versions.map((v) => v.tag)).toEqual(['v4.2.0'])
+  })
+
+  it('names the rate limit rather than reporting a generic failure', async () => {
+    stubFetch(respondWith({ message: 'rate limit exceeded' }, 403))
+
+    const result = await listRuntimeVersions()
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toMatch(/rate-limit/i)
+  })
+
+  it('reports a non-array body rather than throwing', async () => {
+    stubFetch(respondWith({ message: 'Not Found' }))
+
+    const result = await listRuntimeVersions()
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toMatch(/unexpected shape/i)
+  })
+
+  it('reports no releases when nothing matches', async () => {
+    stubFetch(respondWith(tags('nightly', 'main')))
+
+    const result = await listRuntimeVersions()
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toMatch(/no runtime releases/i)
+  })
+
+  it('reports a host that never answers as a timeout', async () => {
+    // A black-holed api.github.com -- filtered DNS, a captive portal -- used
+    // to hang until the browser's TCP timeout, with the dialog's typed
+    // fallback disabled the whole time. Asserted through the rejection the
+    // abort produces rather than by driving the timer, which AbortSignal
+    // .timeout does not take from fake timers.
+    stubFetch(jest.fn().mockRejectedValue(new DOMException('signal timed out', 'TimeoutError')),
+    )
+
+    const result = await listRuntimeVersions()
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toMatch(/in time/i)
+  })
+
+  it('always arms a timeout, even with no caller signal', async () => {
+    // The guarantee behind the test above: something has to abort the request
+    // if GitHub never answers, and the caller does not always provide it.
+    const fetchMock = respondWith(tags('v4.2.0'))
+    stubFetch(fetchMock)
+
+    await listRuntimeVersions()
+
+    const init = fetchMock.mock.calls[0][1] as { signal?: AbortSignal }
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('does not re-fetch a list it already has', async () => {
+    const fetchMock = respondWith(tags('v4.2.0'))
+    stubFetch(fetchMock)
+
+    await listRuntimeVersions()
+    await listRuntimeVersions()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-fetches after the cache is cleared, which is what Retry does', async () => {
+    const fetchMock = respondWith(tags('v4.2.0'))
+    stubFetch(fetchMock)
+
+    await listRuntimeVersions()
+    clearRuntimeVersionsCache()
+    await listRuntimeVersions()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports a cancelled fetch distinctly, so the dialog stays quiet', async () => {
+    stubFetch(jest.fn().mockRejectedValue(new DOMException('aborted', 'AbortError')))
+
+    const result = await listRuntimeVersions()
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toBe('cancelled')
+  })
+})

--- a/src/middleware/shared/utils/__tests__/runtime-versions.test.ts
+++ b/src/middleware/shared/utils/__tests__/runtime-versions.test.ts
@@ -16,8 +16,10 @@ const tags = (...names: unknown[]) => names.map((name) => ({ name }))
  * restored between tests. Same coverage as the web copy, different runner --
  * the two apps share this module but not a test framework.
  */
-const stubFetch = (impl: unknown): void => {
-  ;(globalThis as { fetch: unknown }).fetch = impl
+type FetchLike = typeof globalThis.fetch
+
+const stubFetch = (impl: FetchLike): void => {
+  globalThis.fetch = impl
 }
 
 const respondWith = (body: unknown, status = 200) =>
@@ -35,7 +37,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  ;(globalThis as { fetch: unknown }).fetch = realFetch
+  globalThis.fetch = realFetch
 })
 
 describe('listRuntimeVersions', () => {
@@ -124,8 +126,7 @@ describe('listRuntimeVersions', () => {
     // fallback disabled the whole time. Asserted through the rejection the
     // abort produces rather than by driving the timer, which AbortSignal
     // .timeout does not take from fake timers.
-    stubFetch(jest.fn().mockRejectedValue(new DOMException('signal timed out', 'TimeoutError')),
-    )
+    stubFetch(jest.fn().mockRejectedValue(new DOMException('signal timed out', 'TimeoutError')))
 
     const result = await listRuntimeVersions()
 

--- a/src/middleware/shared/utils/runtime-versions.ts
+++ b/src/middleware/shared/utils/runtime-versions.ts
@@ -19,6 +19,14 @@ const TAGS_URL = 'https://api.github.com/repos/Autonomy-Logic/openplc-runtime/ta
 /** How long a fetched list stays fresh. Releases are not minutes apart. */
 const CACHE_TTL_MS = 10 * 60 * 1000
 
+/**
+ * How long to wait for GitHub before giving up.
+ *
+ * Long enough for a slow connection, short enough that the offline fallback
+ * appears while somebody is still looking at the dialog.
+ */
+const FETCH_TIMEOUT_MS = 8000
+
 export type RuntimeVersion = {
   /** The tag exactly as it must be sent to the bootloader, e.g. "v4.2.1". */
   tag: string
@@ -73,8 +81,18 @@ export async function listRuntimeVersions(signal?: AbortSignal): Promise<Runtime
   }
 
   try {
+    // A timeout of our own, combined with the caller's signal.
+    //
+    // Without it a black-holed api.github.com -- filtered DNS, a captive
+    // portal -- left `fetch` hanging for the browser's TCP timeout with the
+    // fallback field disabled behind `loadingVersions`. The offline path this
+    // function exists to provide was unreachable in exactly the situation that
+    // needs it.
+    const signals: AbortSignal[] = [AbortSignal.timeout(FETCH_TIMEOUT_MS)]
+    if (signal) signals.push(signal)
+
     const response = await fetch(TAGS_URL, {
-      signal,
+      signal: AbortSignal.any(signals),
       headers: { Accept: 'application/vnd.github+json' },
     })
     if (!response.ok) {
@@ -91,9 +109,20 @@ export async function listRuntimeVersions(signal?: AbortSignal): Promise<Runtime
       return { ok: false, error: 'The version list came back in an unexpected shape.' }
     }
 
+    // flatMap with a real guard, not a cast. A `null` element -- or any entry
+    // that is not an object -- made the cast throw on property access, which
+    // landed in the catch below and was reported as "could not reach GitHub",
+    // discarding every valid tag alongside it.
     const versions = body
-      .map((entry) => (entry as { name?: unknown }).name)
-      .filter((name): name is string => typeof name === 'string' && RELEASE_TAG.test(name))
+      .flatMap((entry) =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        'name' in entry &&
+        typeof (entry as { name: unknown }).name === 'string'
+          ? [(entry as { name: string }).name]
+          : [],
+      )
+      .filter((name) => RELEASE_TAG.test(name))
       .sort(compareVersions)
       .map((tag) => ({ tag, prerelease: tag.includes('-') }))
 
@@ -104,7 +133,11 @@ export async function listRuntimeVersions(signal?: AbortSignal): Promise<Runtime
     cache = { at: Date.now(), versions }
     return { ok: true, versions }
   } catch (error) {
+    if (error instanceof DOMException && error.name === 'TimeoutError') {
+      return { ok: false, error: 'GitHub did not answer in time.' }
+    }
     if (error instanceof DOMException && error.name === 'AbortError') {
+      // The caller's signal: the dialog closed. Not worth reporting.
       return { ok: false, error: 'cancelled' }
     }
     return {

--- a/src/middleware/shared/utils/runtime-versions.ts
+++ b/src/middleware/shared/utils/runtime-versions.ts
@@ -34,9 +34,7 @@ export type RuntimeVersion = {
   prerelease: boolean
 }
 
-export type RuntimeVersionsResult =
-  | { ok: true; versions: RuntimeVersion[] }
-  | { ok: false; error: string }
+export type RuntimeVersionsResult = { ok: true; versions: RuntimeVersion[] } | { ok: false; error: string }
 
 let cache: { at: number; versions: RuntimeVersion[] } | null = null
 

--- a/src/middleware/shared/utils/runtime-versions.ts
+++ b/src/middleware/shared/utils/runtime-versions.ts
@@ -1,0 +1,120 @@
+/**
+ * The runtime versions a device can be moved to (RTOP-283).
+ *
+ * Read from the runtime repository's git tags, which is where releases are
+ * cut and what the container registry publishes an image for -- so a tag
+ * listed here is a tag the device can actually pull. Asking a user to type a
+ * version invites a typo that the device then refuses minutes later, or worse
+ * a plausible-looking tag that does not exist.
+ *
+ * Unauthenticated. GitHub's API sends permissive CORS headers, so this works
+ * from the browser app and the editor alike, and the rate limit (60/hour per
+ * address) is far above what opening a dialog costs. The result is cached for
+ * the session because the tag list does not change while somebody is looking
+ * at it.
+ */
+
+const TAGS_URL = 'https://api.github.com/repos/Autonomy-Logic/openplc-runtime/tags?per_page=100'
+
+/** How long a fetched list stays fresh. Releases are not minutes apart. */
+const CACHE_TTL_MS = 10 * 60 * 1000
+
+export type RuntimeVersion = {
+  /** The tag exactly as it must be sent to the bootloader, e.g. "v4.2.1". */
+  tag: string
+  /** A tag carrying a pre-release suffix, e.g. "v4.1.0-rc.1". */
+  prerelease: boolean
+}
+
+export type RuntimeVersionsResult =
+  | { ok: true; versions: RuntimeVersion[] }
+  | { ok: false; error: string }
+
+let cache: { at: number; versions: RuntimeVersion[] } | null = null
+
+/**
+ * Only `vX.Y.Z`, optionally with a pre-release suffix.
+ *
+ * The repository carries other tags over time, and a tag that is not a release
+ * has no published image behind it -- offering one would produce a failed
+ * pull with a confusing message.
+ */
+const RELEASE_TAG = /^v(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/
+
+/** Newest first, comparing numerically so v4.1.10 sorts above v4.1.9. */
+function compareVersions(a: string, b: string): number {
+  const left = RELEASE_TAG.exec(a)
+  const right = RELEASE_TAG.exec(b)
+  if (!left || !right) return a < b ? 1 : -1
+
+  for (let i = 1; i <= 3; i += 1) {
+    const diff = Number(right[i]) - Number(left[i])
+    if (diff !== 0) return diff
+  }
+  // A release outranks its own pre-releases: v4.2.0 before v4.2.0-rc.1.
+  const leftPre = left[4]
+  const rightPre = right[4]
+  if (!leftPre && rightPre) return -1
+  if (leftPre && !rightPre) return 1
+  if (!leftPre && !rightPre) return 0
+  return rightPre < leftPre ? -1 : 1
+}
+
+/**
+ * Fetch the installable runtime versions.
+ *
+ * A failure is reported rather than thrown: the caller falls back to letting
+ * the version be typed, which is what keeps an editor with no internet able to
+ * install a version the device already holds.
+ */
+export async function listRuntimeVersions(signal?: AbortSignal): Promise<RuntimeVersionsResult> {
+  if (cache && Date.now() - cache.at < CACHE_TTL_MS) {
+    return { ok: true, versions: cache.versions }
+  }
+
+  try {
+    const response = await fetch(TAGS_URL, {
+      signal,
+      headers: { Accept: 'application/vnd.github+json' },
+    })
+    if (!response.ok) {
+      // 403 here is almost always the anonymous rate limit, which is worth
+      // saying plainly rather than reporting as a generic failure.
+      if (response.status === 403) {
+        return { ok: false, error: 'GitHub is rate-limiting this address; try again shortly.' }
+      }
+      return { ok: false, error: `Could not read the version list (HTTP ${response.status}).` }
+    }
+
+    const body: unknown = await response.json()
+    if (!Array.isArray(body)) {
+      return { ok: false, error: 'The version list came back in an unexpected shape.' }
+    }
+
+    const versions = body
+      .map((entry) => (entry as { name?: unknown }).name)
+      .filter((name): name is string => typeof name === 'string' && RELEASE_TAG.test(name))
+      .sort(compareVersions)
+      .map((tag) => ({ tag, prerelease: tag.includes('-') }))
+
+    if (versions.length === 0) {
+      return { ok: false, error: 'No runtime releases were found.' }
+    }
+
+    cache = { at: Date.now(), versions }
+    return { ok: true, versions }
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      return { ok: false, error: 'cancelled' }
+    }
+    return {
+      ok: false,
+      error: 'Could not reach GitHub to list the available versions.',
+    }
+  }
+}
+
+/** Drop the cache, so a retry actually re-fetches. */
+export function clearRuntimeVersionsCache(): void {
+  cache = null
+}


### PR DESCRIPTION
## Why

Runtime statistics were buried in **Device -> Configuration**, a screen about configuring a board rather than watching one run. This gives them their own place in the Device tree and adds the action that needed a home: changing the runtime version on the device.

## What changed

**New screen: Device -> Runtime Status.** The scan-cycle, EtherCAT and plugin statistics move here from `configuration/board.tsx` (removed there, along with their polling toggles), under a header reporting runtime version, host, architecture, kernel, deployment and bootloader version.

**Change runtime version.** Offered only when a bootloader actually answers on the device — an orchestrator-managed vPLC or a native install gets no button, because a button that cannot work is worse than none. The dialog picks a version, starts the update and follows it, polling rather than awaiting: a pull on a slow device runs for many minutes, and closing the editor does not stop it. A poll failing mid-swap is expected and does not report failure.

Upgrade and downgrade are one action. No direction, no version floor — pairing an older runtime with an older editor is a legitimate thing to want.

**The version picker is a list, not a text field.** Populated from the runtime repository's release tags, with the running version marked and the Install button disabled on it. A free-text field meant a typo was only rejected minutes later by the device, in the daemon's words. When the list cannot be fetched the field falls back to typing, which keeps an offline device holding a side-loaded image installable.

**Auth reuses the operator's own credentials.** The bootloader has its own session keyed by IP; both containers share a user database rather than a token.

## A bug worth calling out

`/api/device-info` is new, and a runtime released before it does **not** answer 404 as one would hope — it answers HTTP 200 with its catch-all body, `{"error":"Unknown argument"}`. An all-optional schema accepted that as an empty device-info, and an absent `containerized` flag then rendered as **"Native"** — a false claim about every runtime currently in the field, on a device the screen knew nothing about. Fixed in two places: the schema now requires at least one real field, and the header renders nothing rather than guessing. Both are covered by tests.

## Testing

Jest: 7731 passed. The screen was walked end-to-end in the browser against a real SLM-RP4, including the populated dropdown (correctly sorting `v4.1.10` above `v4.1.9`) and the deployment fix.

Companion PRs: openplc-runtime (bootloader) and openplc-web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwWQN5S2ZKbhJz8kxMV9vF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Runtime Status screen with device details, runtime information, recovery state, and operational statistics.
  - Added runtime version management with version selection, manual entry fallback, progress tracking, and completion or failure feedback.
  - Added bootloader connectivity for authentication, status checks, logs, runtime updates, and restart actions.
  - Runtime Status is available from the project tree when a device is connected.

- **Improvements**
  - Improved support for orchestrator-managed devices, disconnected devices, and older runtimes.
  - Improved runtime update polling and connection-loss handling.

- **Bug Fixes**
  - Prevented version lookups from hanging and improved handling of malformed release data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->