### PR TITLE
fix(lsp): keep the variables code view's tokens and markers in step with its document (DOPE-552)

### DIFF
--- a/src/frontend/services/lsp-shared/__tests__/line-window.test.ts
+++ b/src/frontend/services/lsp-shared/__tests__/line-window.test.ts
@@ -7,6 +7,7 @@ import {
   clipEditsToWindow,
   clipSymbolsToWindow,
   lspLineInWindow,
+  modelMatchesDocumentLines,
   modelMatchesDocumentWindow,
 } from '../internal/line-window'
 
@@ -197,5 +198,37 @@ describe('modelMatchesDocumentWindow', () => {
 
   it('rejects when the window start precedes the model frame', () => {
     expect(modelMatchesDocumentWindow(PRISTINE_VARS, POU_DOC, 5, { startLine: 1, endLineExclusive: 5 })).toBe(false)
+  })
+})
+
+describe('modelMatchesDocumentLines', () => {
+  // pou:// document: declaration line 0, VAR block lines 1..4, body after.
+  const POU_DOC = ['FUNCTION_BLOCK FB0', 'VAR', '  State : INT;', '  Enable : BOOL;', 'END_VAR', 'ST body line;'].join(
+    '\n',
+  )
+  const PRISTINE_VARS = ['VAR', '  State : INT;', '  Enable : BOOL;', 'END_VAR'].join('\n')
+  const VAR_LINES = [1, 2, 3, 4]
+
+  it('accepts every VAR line of a pristine pouvars buffer', () => {
+    expect(VAR_LINES.map(modelMatchesDocumentLines(PRISTINE_VARS, POU_DOC, 1))).toEqual([true, true, true, true])
+  })
+
+  it('rejects only the line an in-place edit changed', () => {
+    const edited = PRISTINE_VARS.replace('State', 'Status')
+    expect(VAR_LINES.map(modelMatchesDocumentLines(edited, POU_DOC, 1))).toEqual([true, false, true, true])
+  })
+
+  it('rejects the inserted line and everything it pushed down', () => {
+    const inserted = PRISTINE_VARS.replace('  State : INT;', '  State : INT;\n  Count : INT;')
+    expect(VAR_LINES.map(modelMatchesDocumentLines(inserted, POU_DOC, 1))).toEqual([true, true, false, false])
+  })
+
+  it('rejects lines above the model frame', () => {
+    expect(modelMatchesDocumentLines(PRISTINE_VARS, POU_DOC, 1)(0)).toBe(false)
+  })
+
+  it('normalises CRLF in the model buffer', () => {
+    const crlf = PRISTINE_VARS.replace(/\n/g, '\r\n')
+    expect(VAR_LINES.map(modelMatchesDocumentLines(crlf, POU_DOC, 1))).toEqual([true, true, true, true])
   })
 })

--- a/src/frontend/services/lsp-shared/__tests__/semantic-tokens-shift.test.ts
+++ b/src/frontend/services/lsp-shared/__tests__/semantic-tokens-shift.test.ts
@@ -37,4 +37,12 @@ describe('shiftSemanticTokensToBody', () => {
   it('returns an empty stream when the window selects nothing', () => {
     expect(Array.from(shiftSemanticTokensToBody(AGGREGATE, 9, 12))).toEqual([])
   })
+
+  it('drops the lines keepLine rejects and re-encodes the survivors as one delta stream', () => {
+    // Lines 1..4 kept by the window; `speed` (line 3) rejected, so `END_STRUCT`
+    // follows `Motor` with a delta of two lines.
+    expect(Array.from(shiftSemanticTokensToBody(AGGREGATE, 1, 5, 0, (line) => line !== 3))).toEqual([
+      0, 2, 6, 0, 0, 1, 2, 5, 0, 0, 2, 2, 10, 0, 0,
+    ])
+  })
 })

--- a/src/frontend/services/lsp-shared/internal/line-window.ts
+++ b/src/frontend/services/lsp-shared/internal/line-window.ts
@@ -91,3 +91,21 @@ export function modelMatchesDocumentWindow(
   }
   return true
 }
+
+/**
+ * Per-line form of {@link modelMatchesDocumentWindow}: true for the LSP
+ * lines whose text the model still shows unchanged. Semantic tokens carry
+ * their own line, so an edit only has to cost the lines it moved.
+ */
+export function modelMatchesDocumentLines(
+  modelText: string,
+  documentText: string,
+  lineOffset: number,
+): (lspLine: number) => boolean {
+  const modelLines = modelText.split(/\r?\n/)
+  const documentLines = documentText.split(/\r?\n/)
+  return (lspLine) => {
+    const modelLine = lspLine - lineOffset
+    return modelLine >= 0 && modelLines[modelLine] === documentLines[lspLine]
+  }
+}

--- a/src/frontend/services/lsp-shared/internal/semantic-tokens-shift.ts
+++ b/src/frontend/services/lsp-shared/internal/semantic-tokens-shift.ts
@@ -29,12 +29,17 @@
  * When `startLine === 0` and `endLineExclusive === ∞` (e.g. early
  * boot before the registry is populated) the function is a copy;
  * cheap enough that the dead branch isn't worth special-casing.
+ *
+ * `keepLine` drops the tokens of any line it rejects. A partial view
+ * whose buffer drifted from the document on some lines keeps colours
+ * only where the text still matches.
  */
 export function shiftSemanticTokensToBody(
   data: number[],
   startLine: number,
   endLineExclusive: number = Number.POSITIVE_INFINITY,
   outputStartLine: number = 0,
+  keepLine?: (lspLine: number) => boolean,
 ): Uint32Array {
   // Decode to absolute positions.
   const abs: Array<{ line: number; col: number; len: number; type: number; mods: number }> = []
@@ -57,6 +62,7 @@ export function shiftSemanticTokensToBody(
   for (const t of abs) {
     if (t.line < startLine) continue
     if (t.line >= endLineExclusive) continue
+    if (keepLine && !keepLine(t.line)) continue
     const shiftedLine = t.line - startLine + outputStartLine
     const dLine = shiftedLine - prevLine
     const dStart = dLine === 0 ? t.col - prevCol : t.col

--- a/src/frontend/services/lsp-shared/semantic-tokens.ts
+++ b/src/frontend/services/lsp-shared/semantic-tokens.ts
@@ -41,12 +41,19 @@ export interface SemanticTokensRegistration extends monaco.IDisposable {
  * to clip the end at the body line so only VAR-block tokens render.
  * `outputStartLine` rebases the kept window for views that render
  * their own framing above it (the data type `.dt` code view).
+ * `keepLine` further drops the lines whose text the view no longer
+ * shares with the document (the variables view mid-edit).
  */
 export type ResolveSemanticTokensViewport = (
   lspUri: string,
   modelUri: string,
   lineOffset: number,
-) => { startLine: number; endLineExclusive: number; outputStartLine?: number }
+) => {
+  startLine: number
+  endLineExclusive: number
+  outputStartLine?: number
+  keepLine?: (lspLine: number) => boolean
+}
 
 const defaultViewport: ResolveSemanticTokensViewport = (_lspUri, _modelUri, lineOffset) => ({
   startLine: lineOffset,
@@ -89,10 +96,10 @@ export function registerLspSemanticTokens(opts: RegisterLspSemanticTokensOptions
         textDocument: { uri: lspUri },
       })
       if (!result) return null
-      const { startLine, endLineExclusive, outputStartLine } = resolveViewport(lspUri, modelUri, lineOffset)
+      const { startLine, endLineExclusive, outputStartLine, keepLine } = resolveViewport(lspUri, modelUri, lineOffset)
       return {
         ...(result.resultId ? { resultId: result.resultId } : {}),
-        data: shiftSemanticTokensToBody(result.data, startLine, endLineExclusive, outputStartLine),
+        data: shiftSemanticTokensToBody(result.data, startLine, endLineExclusive, outputStartLine, keepLine),
       }
     },
     releaseDocumentSemanticTokens() {

--- a/src/frontend/services/st-lsp/__tests__/index.test.ts
+++ b/src/frontend/services/st-lsp/__tests__/index.test.ts
@@ -1,12 +1,22 @@
 /**
  * @jest-environment jsdom
  */
+import type * as monaco from 'monaco-editor'
+import type { Diagnostic } from 'vscode-languageserver-protocol'
+
+import type { PLCPou } from '../../../../middleware/shared/ports/types'
+import { openPLCStoreBase } from '../../../store'
+import { __clearBodyLineOffsetsForTests, getBodyLineOffset, setBodyLineOffset } from '../../lsp-shared/body-offsets'
+import type { StartLanguageServiceOptions } from '../../lsp-shared/start-language-service'
 import type { StlibSourcePort } from '../../../../middleware/shared/ports/stlib-source-port'
 
-// Mock the LSP transport layer so `startStLsp` runs for real (we're testing
-// `requestBodySemanticTokens`'s own error handling, not `startLanguageService`).
+// Mock the LSP transport layer so `startStLsp` runs for real: the tests drive
+// the hooks it hands to `startLanguageService`, not the service itself.
 const mockRequestSemanticTokens = jest.fn()
 const mockGetSemanticTokensLegend = jest.fn()
+const mockRefreshSemanticTokens = jest.fn()
+const mockGetSyncedDocumentText = jest.fn<string | undefined, [string]>()
+let mockCapturedOptions: StartLanguageServiceOptions | undefined
 
 // `vscode-languageserver-protocol`'s Node entry point is ESM-only and Jest's
 // CJS transform can't parse it; index.ts only needs `CompletionRequest.type`
@@ -17,31 +27,100 @@ jest.mock('vscode-languageserver-protocol', () => ({
 }))
 
 jest.mock('../../lsp-shared', () => ({
-  startLanguageService: () => ({
-    // Never settles — nothing in this test awaits `ready`, and a pending
-    // promise (unlike a rejected one) can never trigger an unhandled-rejection
-    // warning if `warmUpScopeWorker`'s background await never gets there.
-    ready: new Promise<void>(() => undefined),
-    openDocument: jest.fn(),
-    changeDocument: jest.fn(),
-    closeDocument: jest.fn(),
-    refreshSemanticTokens: jest.fn(),
-    getSemanticTokensLegend: () => mockGetSemanticTokensLegend(),
-    requestSemanticTokens: (uri: string) => mockRequestSemanticTokens(uri),
-    dispose: jest.fn(),
+  startLanguageService: (options: StartLanguageServiceOptions) => {
+    mockCapturedOptions = options
+    return {
+      // Never settles — nothing in this test awaits `ready`, and a pending
+      // promise (unlike a rejected one) can never trigger an unhandled-rejection
+      // warning if `warmUpScopeWorker`'s background await never gets there.
+      ready: new Promise<void>(() => undefined),
+      openDocument: jest.fn(),
+      changeDocument: jest.fn(),
+      closeDocument: jest.fn(),
+      refreshSemanticTokens: () => mockRefreshSemanticTokens(),
+      getSemanticTokensLegend: () => mockGetSemanticTokensLegend(),
+      requestSemanticTokens: (uri: string) => mockRequestSemanticTokens(uri),
+      dispose: jest.fn(),
+    }
+  },
+  // The real registry, so `resolve-context.ts` (which imports it directly)
+  // and index.ts agree on the body line.
+  getBodyLineOffset: (uri: string) => getBodyLineOffset(uri),
+  lspDiagnosticToMonaco: (d: Diagnostic, _api: unknown, lineOffset: number) => ({
+    startLineNumber: d.range.start.line - lineOffset + 1,
+    message: d.message,
   }),
-  getBodyLineOffset: () => 0,
-  lspDiagnosticToMonaco: jest.fn(),
   shiftSemanticTokensToBody: (data: unknown) => data,
   suppressNoDefinitionFound: jest.fn(),
 }))
 
+jest.mock('../project-sync', () => ({
+  getSyncedDocumentText: (uri: string) => mockGetSyncedDocumentText(uri),
+}))
+
 import { startStLsp } from '../index'
 import { getPrintSemanticTokensApi } from '../print-tokens-api'
+import { pouUri, pouVarsUri } from '../types'
 
 function makeStlibSource(): StlibSourcePort {
   return { listStlibs: jest.fn().mockResolvedValue([]), readStlib: jest.fn() }
 }
+
+function makeStPou(name: string): PLCPou {
+  return {
+    name,
+    pouType: 'program',
+    interface: { variables: [] },
+    body: { language: 'st', value: 'x := 1;' },
+    documentation: '',
+  } as PLCPou
+}
+
+const diagnosticAt = (line: number): Diagnostic => ({
+  range: { start: { line, character: 0 }, end: { line, character: 4 } },
+  message: `line ${line}`,
+})
+
+/** Enough of `monaco.editor` for the mirror, the viewport and the model-mount replay. */
+function makeMonacoStub() {
+  const models: Array<{ uri: { toString(): string }; getValue(): string }> = []
+  const createdListeners: Array<(model: unknown) => void> = []
+  const setModelMarkers = jest.fn()
+  const api = {
+    editor: {
+      getModels: () => models,
+      setModelMarkers,
+      onDidCreateModel: (listener: (model: unknown) => void) => {
+        createdListeners.push(listener)
+        return { dispose: jest.fn() }
+      },
+    },
+  } as unknown as typeof monaco
+  const mount = (uri: string, text: string) => {
+    const model = { uri: { toString: () => uri }, getValue: () => text }
+    models.push(model)
+    for (const listener of createdListeners) listener(model)
+    return model
+  }
+  return { api, setModelMarkers, mount }
+}
+
+let services: Array<{ dispose(): void }> = []
+
+function start(api?: typeof monaco) {
+  const service = startStLsp({
+    stlibSource: makeStlibSource(),
+    workerUrlOverride: 'blob:test',
+    ...(api ? { monaco: api } : {}),
+  })
+  services.push(service)
+  return service
+}
+
+afterEach(() => {
+  for (const service of services) service.dispose()
+  services = []
+})
 
 describe('requestBodySemanticTokens', () => {
   beforeEach(() => {
@@ -52,7 +131,7 @@ describe('requestBodySemanticTokens', () => {
 
   it('returns null instead of throwing when the underlying semantic-tokens request rejects', async () => {
     mockRequestSemanticTokens.mockRejectedValue(new Error('worker crashed'))
-    startStLsp({ stlibSource: makeStlibSource(), workerUrlOverride: 'blob:test' })
+    start()
 
     const api = getPrintSemanticTokensApi()
     expect(api).not.toBeNull()
@@ -62,11 +141,126 @@ describe('requestBodySemanticTokens', () => {
   it('returns the shifted tokens when the request resolves normally', async () => {
     const data = new Uint32Array([1, 2, 3])
     mockRequestSemanticTokens.mockResolvedValue({ data })
-    startStLsp({ stlibSource: makeStlibSource(), workerUrlOverride: 'blob:test' })
+    start()
 
     const api = getPrintSemanticTokensApi()
     const result = await api?.requestBodySemanticTokens('Main')
 
     expect(result).toEqual({ legend: { tokenTypes: [], tokenModifiers: [] }, data })
+  })
+})
+
+describe('pouvars view sync', () => {
+  // pou://main, LSP lines: 0 PROGRAM main · 1 VAR · 2 Level · 3 Enable · 4 END_VAR · 5 body
+  const MAIN_DOC = ['PROGRAM main', 'VAR', '  Level : INT;', '  Enable : BOOL;', 'END_VAR', 'Level := 1;'].join('\n')
+  const PRISTINE_VARS = ['VAR', '  Level : INT;', '  Enable : BOOL;', 'END_VAR'].join('\n')
+  const MARKER_CTX = { markerOwner: 'strucpp-lsp', bodyOffset: 5, defaultSource: 'strucpp' }
+
+  beforeEach(() => {
+    __clearBodyLineOffsetsForTests()
+    mockRefreshSemanticTokens.mockReset()
+    mockGetSyncedDocumentText.mockReset()
+    mockCapturedOptions = undefined
+    openPLCStoreBase.setState((s) => ({
+      project: { ...s.project, data: { ...s.project.data, pous: [makeStPou('main')] } },
+    }))
+    setBodyLineOffset(pouUri('main'), 5)
+  })
+
+  it('mirrors the VAR-block slice of a publish onto a mounted variables view', () => {
+    const { api, setModelMarkers, mount } = makeMonacoStub()
+    start(api)
+    const model = mount(pouVarsUri('main'), PRISTINE_VARS)
+
+    mockCapturedOptions?.diagnosticsMirror?.(
+      { uri: pouUri('main'), diagnostics: [diagnosticAt(0), diagnosticAt(2), diagnosticAt(6)] },
+      { ...MARKER_CTX, monacoApi: api },
+    )
+
+    expect(setModelMarkers).toHaveBeenCalledWith(model, 'strucpp-lsp', [{ startLineNumber: 2, message: 'line 2' }])
+  })
+
+  it('replays the last publish onto a variables view that mounts afterwards', () => {
+    const { api, setModelMarkers, mount } = makeMonacoStub()
+    start(api)
+
+    mockCapturedOptions?.diagnosticsMirror?.(
+      { uri: pouUri('main'), diagnostics: [diagnosticAt(3)] },
+      { ...MARKER_CTX, monacoApi: api },
+    )
+    expect(setModelMarkers).not.toHaveBeenCalled()
+
+    const model = mount(pouVarsUri('main'), PRISTINE_VARS)
+
+    expect(setModelMarkers).toHaveBeenCalledWith(model, 'strucpp-lsp', [{ startLineNumber: 3, message: 'line 3' }])
+  })
+
+  it('leaves a body model mount alone', () => {
+    const { api, setModelMarkers, mount } = makeMonacoStub()
+    start(api)
+    mockCapturedOptions?.diagnosticsMirror?.(
+      { uri: pouUri('main'), diagnostics: [diagnosticAt(3)] },
+      { ...MARKER_CTX, monacoApi: api },
+    )
+
+    mount(pouUri('main'), 'Level := 1;')
+
+    expect(setModelMarkers).not.toHaveBeenCalled()
+  })
+
+  it('clips variables-view tokens to the VAR blocks, minus the lines the buffer no longer shares with the synced document', () => {
+    const { api, mount } = makeMonacoStub()
+    start(api)
+    mockGetSyncedDocumentText.mockReturnValue(MAIN_DOC)
+    mount(pouVarsUri('main'), PRISTINE_VARS.replace('  Level : INT;', '  Level : INT;\n  Count : INT;'))
+
+    const viewport = mockCapturedOptions?.resolveSemanticTokensViewport?.(pouUri('main'), pouVarsUri('main'), 1)
+
+    expect(viewport).toMatchObject({ startLine: 1, endLineExclusive: 5 })
+    expect([1, 2, 3, 4].map((line) => viewport?.keepLine?.(line))).toEqual([true, true, false, false])
+  })
+
+  it('gives a variables view no tokens until project-sync has sent its document', () => {
+    const { api, mount } = makeMonacoStub()
+    start(api)
+    mockGetSyncedDocumentText.mockReturnValue(undefined)
+    mount(pouVarsUri('main'), PRISTINE_VARS)
+
+    expect(mockCapturedOptions?.resolveSemanticTokensViewport?.(pouUri('main'), pouVarsUri('main'), 1)).toEqual({
+      startLine: 0,
+      endLineExclusive: 0,
+    })
+  })
+
+  it('keeps body editors on the open-ended window', () => {
+    const { api } = makeMonacoStub()
+    start(api)
+
+    expect(mockCapturedOptions?.resolveSemanticTokensViewport?.(pouUri('main'), pouUri('main'), 5)).toEqual({
+      startLine: 5,
+      endLineExclusive: Number.POSITIVE_INFINITY,
+    })
+  })
+
+  it('re-tokenises when a mounted variables view POU changes its VAR blocks, and not on a body edit', () => {
+    const { api, mount } = makeMonacoStub()
+    start(api)
+    const updateMain = (change: (pou: PLCPou) => PLCPou) =>
+      openPLCStoreBase.setState((s) => ({
+        project: {
+          ...s.project,
+          data: { ...s.project.data, pous: s.project.data.pous.map((p) => (p.name === 'main' ? change(p) : p)) },
+        },
+      }))
+
+    updateMain((p) => ({ ...p, interface: { ...p.interface, variables: [] } }))
+    expect(mockRefreshSemanticTokens).not.toHaveBeenCalled()
+
+    mount(pouVarsUri('main'), PRISTINE_VARS)
+    updateMain((p) => ({ ...p, body: { language: 'st', value: 'x := 2;' } }))
+    expect(mockRefreshSemanticTokens).not.toHaveBeenCalled()
+
+    updateMain((p) => ({ ...p, interface: { ...p.interface, variables: [] } }))
+    expect(mockRefreshSemanticTokens).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/frontend/services/st-lsp/__tests__/index.test.ts
+++ b/src/frontend/services/st-lsp/__tests__/index.test.ts
@@ -60,7 +60,7 @@ jest.mock('../project-sync', () => ({
 
 import { startStLsp } from '../index'
 import { getPrintSemanticTokensApi } from '../print-tokens-api'
-import { pouUri, pouVarsUri } from '../types'
+import { pouUri, pouVarsUri, stubUri } from '../types'
 
 function makeStlibSource(): StlibSourcePort {
   return { listStlibs: jest.fn().mockResolvedValue([]), readStlib: jest.fn() }
@@ -193,6 +193,26 @@ describe('pouvars view sync', () => {
     const model = mount(pouVarsUri('main'), PRISTINE_VARS)
 
     expect(setModelMarkers).toHaveBeenCalledWith(model, 'strucpp-lsp', [{ startLineNumber: 3, message: 'line 3' }])
+  })
+
+  it('mirrors a stub:// publish onto the variables view of a graphical POU', () => {
+    openPLCStoreBase.setState((s) => ({
+      project: {
+        ...s.project,
+        data: { ...s.project.data, pous: [{ ...makeStPou('main'), body: { language: 'ld', value: '' } } as PLCPou] },
+      },
+    }))
+    setBodyLineOffset(stubUri('main'), 5)
+    const { api, setModelMarkers, mount } = makeMonacoStub()
+    start(api)
+    const model = mount(pouVarsUri('main'), PRISTINE_VARS)
+
+    mockCapturedOptions?.diagnosticsMirror?.(
+      { uri: stubUri('main'), diagnostics: [diagnosticAt(2), diagnosticAt(7)] },
+      { ...MARKER_CTX, monacoApi: api },
+    )
+
+    expect(setModelMarkers).toHaveBeenCalledWith(model, 'strucpp-lsp', [{ startLineNumber: 2, message: 'line 2' }])
   })
 
   it('leaves a body model mount alone', () => {

--- a/src/frontend/services/st-lsp/__tests__/pouvars-context.test.ts
+++ b/src/frontend/services/st-lsp/__tests__/pouvars-context.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { Diagnostic } from 'vscode-languageserver-protocol'
+
+import { diagnosticsInVarBlocks, pouVarsTokenViewport, pouVarsWindow } from '../pouvars-context'
+
+// Synthesized POU document, LSP (0-indexed) lines:
+//   0  PROGRAM main
+//   1  VAR
+//   2    Level : INT;
+//   3    Enable : BOOL;
+//   4  END_VAR
+//   5  Level := 1;          ← body starts here, so bodyLineOffset = 5
+const POU_DOC = ['PROGRAM main', 'VAR', '  Level : INT;', '  Enable : BOOL;', 'END_VAR', 'Level := 1;'].join('\n')
+const PRISTINE_VARS = ['VAR', '  Level : INT;', '  Enable : BOOL;', 'END_VAR'].join('\n')
+const BODY_LINE = 5
+const VAR_LINES = [1, 2, 3, 4]
+const EMPTY = { startLine: 0, endLineExclusive: 0 }
+
+const diagnosticAt = (line: number): Diagnostic => ({
+  range: { start: { line, character: 0 }, end: { line, character: 4 } },
+  message: `line ${line}`,
+})
+
+describe('pouVarsWindow', () => {
+  it('covers the VAR blocks between the declaration line and the body', () => {
+    expect(pouVarsWindow(BODY_LINE)).toEqual({ startLine: 1, endLineExclusive: 5 })
+  })
+
+  it('is null while the body line is unregistered — an unpopulated registry reads 0', () => {
+    expect(pouVarsWindow(0)).toBeNull()
+  })
+
+  it('is null for a document with no VAR block at all', () => {
+    expect(pouVarsWindow(1)).toBeNull()
+  })
+})
+
+describe('diagnosticsInVarBlocks', () => {
+  it('keeps what falls inside the VAR blocks', () => {
+    const inside = [diagnosticAt(1), diagnosticAt(4)]
+    expect(diagnosticsInVarBlocks([diagnosticAt(0), ...inside, diagnosticAt(5)], BODY_LINE)).toEqual(inside)
+  })
+
+  it('drops the declaration line and the body', () => {
+    expect(diagnosticsInVarBlocks([diagnosticAt(0), diagnosticAt(5), diagnosticAt(9)], BODY_LINE)).toEqual([])
+  })
+
+  it('returns nothing while the body line is unregistered', () => {
+    expect(diagnosticsInVarBlocks([diagnosticAt(2)], 0)).toEqual([])
+  })
+})
+
+describe('pouVarsTokenViewport', () => {
+  it('keeps every VAR line of a pristine buffer', () => {
+    const viewport = pouVarsTokenViewport(PRISTINE_VARS, POU_DOC, BODY_LINE)
+    expect(viewport).toMatchObject({ startLine: 1, endLineExclusive: 5 })
+    expect(VAR_LINES.map((line) => viewport.keepLine?.(line))).toEqual([true, true, true, true])
+  })
+
+  it('blanks only the lines an uncommitted edit moved', () => {
+    const edited = PRISTINE_VARS.replace('  Level : INT;', '  Level : INT;\n  Count : INT;')
+    const viewport = pouVarsTokenViewport(edited, POU_DOC, BODY_LINE)
+    expect(VAR_LINES.map((line) => viewport.keepLine?.(line))).toEqual([true, true, false, false])
+  })
+
+  it('is empty while the body line is unregistered', () => {
+    expect(pouVarsTokenViewport(PRISTINE_VARS, POU_DOC, 0)).toEqual(EMPTY)
+  })
+
+  it('is empty when the model or the synced document is missing', () => {
+    expect(pouVarsTokenViewport(undefined, POU_DOC, BODY_LINE)).toEqual(EMPTY)
+    expect(pouVarsTokenViewport(PRISTINE_VARS, undefined, BODY_LINE)).toEqual(EMPTY)
+  })
+})

--- a/src/frontend/services/st-lsp/index.ts
+++ b/src/frontend/services/st-lsp/index.ts
@@ -16,7 +16,8 @@
  *     definition redirects to the Zustand store / graphical
  *     editor.
  *   - Diagnostics mirror onto the `pouvars://` model so var-block
- *     errors surface in the variables editor too.
+ *     errors surface in the variables editor too, replayed when that
+ *     model mounts after the last publish.
  *   - Semantic-tokens viewport clip for the variables-text view.
  *   - The `strucpp/loadStlibBuffer` custom RPC + post-initialize
  *     stlib push, plus the public `refreshStlibs()` method.
@@ -50,6 +51,7 @@ import { parseScopedCompletionType } from './completion-type'
 import { diagnosticsInSpan, dtViewLineOffset, dtViewSpan, dtViewWindow } from './dtview-context'
 import { redirectDefinitionToStore } from './goto-definition-redirect'
 import { redirectToGraphicalPou } from './graphical-redirect'
+import { diagnosticsInVarBlocks, pouVarsTokenViewport } from './pouvars-context'
 import { type PrintSemanticTokens, registerPrintSemanticTokensApi } from './print-tokens-api'
 import { getSyncedDocumentText } from './project-sync'
 import { registerScopedQueryApi, type ScopedCompletionItem } from './scoped-query'
@@ -117,6 +119,31 @@ function applyDataTypeDiagnostics(monacoApi: typeof monaco, markerOwner: string,
   }
 }
 
+/** Last diagnostics strucpp published per POU document, keyed by LSP URI. */
+const lastPouDiagnostics = new Map<string, Diagnostic[]>()
+
+/**
+ * Mirror the VAR-block slice of a POU's diagnostics onto its `pouvars://`
+ * model, if mounted. strucpp publishes against the `pou://` / `stub://`
+ * document, so the slice is re-emitted shifted to the view's frame.
+ */
+function applyPouVarsDiagnostics(
+  monacoApi: typeof monaco,
+  pouName: string,
+  markerOwner: string,
+  defaultSource: string,
+): void {
+  const model = monacoApi.editor.getModels().find((m) => m.uri.toString() === pouVarsUri(pouName))
+  if (!model) return
+  const { lspUri } = resolveStLspContext(pouVarsUri(pouName))
+  const diagnostics = diagnosticsInVarBlocks(lastPouDiagnostics.get(lspUri) ?? [], getBodyLineOffset(lspUri))
+  monacoApi.editor.setModelMarkers(
+    model,
+    markerOwner,
+    diagnostics.map((d) => lspDiagnosticToMonaco(d, monacoApi, POU_DECLARATION_LINE_COUNT, defaultSource)),
+  )
+}
+
 export function startStLsp(opts: StLspStartOptions): StLspService {
   const { stlibSource, monaco: monacoApi, workerUrlOverride, onCrash } = opts
 
@@ -168,8 +195,8 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
     // registered — see comment in `lsp-shared/providers.ts`.
 
     // Semantic-tokens viewport: variables-text view clips to the
-    // VAR-block region; body editors keep everything from the
-    // body line onwards.
+    // VAR-block region, minus the lines its buffer has drifted on;
+    // body editors keep everything from the body line onwards.
     resolveSemanticTokensViewport: (lspUri, modelUri, lineOffset) => {
       const dtName = parseDtViewUri(modelUri)
       if (dtName !== null) {
@@ -181,11 +208,11 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
         }
         return { ...dtViewWindow(span), outputStartLine: DT_VIEW_FRAME_LINE_COUNT }
       }
-      const isVarsView = parsePouVarsUri(modelUri) !== null
-      return {
-        startLine: lineOffset,
-        endLineExclusive: isVarsView ? getBodyLineOffset(lspUri) : Number.POSITIVE_INFINITY,
+      if (parsePouVarsUri(modelUri) !== null) {
+        const model = monacoApi?.editor.getModels().find((m) => m.uri.toString() === modelUri)
+        return pouVarsTokenViewport(model?.getValue(), getSyncedDocumentText(lspUri), getBodyLineOffset(lspUri))
       }
+      return { startLine: lineOffset, endLineExclusive: Number.POSITIVE_INFINITY }
     },
 
     // Diagnostics configuration
@@ -202,26 +229,13 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
         applyDataTypeDiagnostics(ctx.monacoApi, ctx.markerOwner, ctx.defaultSource)
         return
       }
-      // Mirror VAR-block diagnostics onto the variables-text editor
-      // for the same POU (if mounted).  The variables editor uses a
-      // separate Monaco model under `pouvars://<name>.st`; strucpp
-      // doesn't publish against that URI directly, so we filter the
-      // body-doc diagnostics down to the VAR region and re-emit
-      // them shifted to the declaration-line frame.
+      // Mirror VAR-block diagnostics onto the variables-text editor for
+      // the same POU. Cached so a `pouvars://` model created after this
+      // publish still gets its markers.
       const parsed = parsePouUri(params.uri)
       if (!parsed) return
-      const varsModel = ctx.monacoApi.editor.getModels().find((m) => m.uri.toString() === pouVarsUri(parsed.name))
-      if (!varsModel) return
-      const varDiagnostics: Diagnostic[] = params.diagnostics.filter(
-        (d) => d.range.start.line >= POU_DECLARATION_LINE_COUNT && d.range.start.line < ctx.bodyOffset,
-      )
-      ctx.monacoApi.editor.setModelMarkers(
-        varsModel,
-        ctx.markerOwner,
-        varDiagnostics.map((d) =>
-          lspDiagnosticToMonaco(d, ctx.monacoApi, POU_DECLARATION_LINE_COUNT, ctx.defaultSource),
-        ),
-      )
+      lastPouDiagnostics.set(params.uri, params.diagnostics)
+      applyPouVarsDiagnostics(ctx.monacoApi, parsed.name, ctx.markerOwner, ctx.defaultSource)
     },
 
     // Lifecycle hooks
@@ -234,14 +248,19 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
     ...(onCrash ? { onCrash } : {}),
   })
 
-  // A `.dt` view's colours and markers come from the aggregate document,
-  // so a change there leaves the model's own text untouched and Monaco
+  // A partial view's colours and markers come from a document it does not
+  // own, so a change there leaves the model's own text untouched and Monaco
   // never re-queries on its own. Re-drive both from the store instead.
-  const dtViewSyncDisposables: Array<() => void> = []
+  const viewSyncDisposables: Array<() => void> = []
   if (monacoApi) {
     const api = monacoApi
     const hasDtViewModel = () => api.editor.getModels().some((m) => parseDtViewUri(m.uri.toString()) !== null)
-    dtViewSyncDisposables.push(
+    const mountedPouVarsNames = () =>
+      api.editor
+        .getModels()
+        .map((m) => parsePouVarsUri(m.uri.toString()))
+        .filter((name): name is string => name !== null)
+    viewSyncDisposables.push(
       openPLCStoreBase.subscribe(
         (state) => state.project.data.dataTypes,
         () => {
@@ -252,12 +271,29 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
           applyDataTypeDiagnostics(api, MARKER_OWNER, DIAGNOSTIC_SOURCE)
         },
       ),
+      openPLCStoreBase.subscribe(
+        (state) => state.project.data.pous,
+        (pous, previous) => {
+          // Every body keystroke lands here too; only a VAR-block change on
+          // a POU whose variables view is mounted is worth the re-tokenise.
+          const varsChanged = mountedPouVarsNames().some((name) => {
+            const pou = pous.find((p) => p.name === name)
+            const prev = previous.find((p) => p.name === name)
+            return (
+              pou?.interface?.variables !== prev?.interface?.variables || pou?.body.language !== prev?.body.language
+            )
+          })
+          if (varsChanged) sharedService.refreshSemanticTokens()
+        },
+      ),
     )
     const onModelAdded = api.editor.onDidCreateModel((model) => {
-      if (parseDtViewUri(model.uri.toString()) === null) return
-      applyDataTypeDiagnostics(api, MARKER_OWNER, DIAGNOSTIC_SOURCE)
+      const uri = model.uri.toString()
+      if (parseDtViewUri(uri) !== null) applyDataTypeDiagnostics(api, MARKER_OWNER, DIAGNOSTIC_SOURCE)
+      const varsPou = parsePouVarsUri(uri)
+      if (varsPou !== null) applyPouVarsDiagnostics(api, varsPou, MARKER_OWNER, DIAGNOSTIC_SOURCE)
     })
-    dtViewSyncDisposables.push(() => onModelAdded.dispose())
+    viewSyncDisposables.push(() => onModelAdded.dispose())
   }
 
   // ---------------------------------------------------------------------------
@@ -522,9 +558,10 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
     dispose() {
       registerScopedQueryApi(null)
       registerPrintSemanticTokensApi(null)
-      for (const off of dtViewSyncDisposables) off()
-      dtViewSyncDisposables.length = 0
+      for (const off of viewSyncDisposables) off()
+      viewSyncDisposables.length = 0
       lastDataTypeDiagnostics = []
+      lastPouDiagnostics.clear()
       sharedService.dispose()
     },
   }

--- a/src/frontend/services/st-lsp/pouvars-context.ts
+++ b/src/frontend/services/st-lsp/pouvars-context.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Autonomy / OpenPLC Project
+/**
+ * Coordinate helpers for the `pouvars://` code view.
+ *
+ * The view renders a POU's VAR blocks only, while strucpp sees the whole
+ * synthesized document: declaration line, VAR blocks, body. The VAR
+ * blocks sit on document lines `[POU_DECLARATION_LINE_COUNT, bodyLineOffset)`,
+ * and everything crossing that seam is shifted by the declaration line.
+ *
+ * Takes texts and offsets rather than reading the store or Monaco, so the
+ * arithmetic is testable on its own — same reason as `dtview-context.ts`.
+ */
+
+import type { Diagnostic } from 'vscode-languageserver-protocol'
+
+import { lspLineInWindow, type LspLineWindow, modelMatchesDocumentLines } from '../lsp-shared/internal/line-window'
+import { POU_DECLARATION_LINE_COUNT } from './types'
+
+export interface PouVarsTokenViewport {
+  startLine: number
+  endLineExclusive: number
+  keepLine?: (lspLine: number) => boolean
+}
+
+const EMPTY_VIEWPORT: PouVarsTokenViewport = { startLine: 0, endLineExclusive: 0 }
+
+/**
+ * Document lines the view renders, or null while project-sync has not
+ * registered the body line yet — an unpopulated registry reads 0.
+ */
+export function pouVarsWindow(bodyLineOffset: number): LspLineWindow | null {
+  if (bodyLineOffset <= POU_DECLARATION_LINE_COUNT) return null
+  return { startLine: POU_DECLARATION_LINE_COUNT, endLineExclusive: bodyLineOffset }
+}
+
+/** The published diagnostics that fall inside the VAR blocks. */
+export function diagnosticsInVarBlocks(diagnostics: Diagnostic[], bodyLineOffset: number): Diagnostic[] {
+  const varsWindow = pouVarsWindow(bodyLineOffset)
+  if (!varsWindow) return []
+  return diagnostics.filter((d) => lspLineInWindow(d.range.start.line, varsWindow))
+}
+
+/**
+ * Semantic-token window for the view. Tokens describe the synced document,
+ * so a line keeps its colours only while the buffer still shows that
+ * document's text for it: an uncommitted edit blanks the lines it moved and
+ * nothing else. No colours beats colours describing the previous text.
+ */
+export function pouVarsTokenViewport(
+  modelText: string | undefined,
+  documentText: string | undefined,
+  bodyLineOffset: number,
+): PouVarsTokenViewport {
+  const varsWindow = pouVarsWindow(bodyLineOffset)
+  if (!varsWindow || modelText === undefined || documentText === undefined) return EMPTY_VIEWPORT
+  return { ...varsWindow, keepLine: modelMatchesDocumentLines(modelText, documentText, POU_DECLARATION_LINE_COUNT) }
+}


### PR DESCRIPTION
Fixes [DOPE-552](https://autonomylogic.atlassian.net/browse/DOPE-552).

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/741

Bug fix: no Requirements Gathering page, and no Cybersecurity Risk Assessment trigger area is touched — frontend token and marker rendering only.

## Problem

The `pouvars://` code view renders a POU's VAR blocks, but its colours and markers come from the synthesized document strucpp analyses, and both were driven by upstream events only:

- **Stale semantic tokens.** Monaco re-queries tokens while the user types, when the store and the synced document still hold the previous text. Tokens resolved against that document were painted onto the moved lines: wrong colours, and `Invalid Semantic Tokens Data From Extension: end character > model.getLineLength` when the old line was longer. Committing updates the store but not the model, so nothing re-queried and the wrong colours stayed until a remount.
- **Diagnostics lost on remount.** The mirror only set markers when a `publishDiagnostics` arrived, so a `pouvars://` model created after the last publish (table → code toggle, or opening a POU whose VAR block already has an error) showed no squiggles until strucpp happened to republish.

DOPE-537 fixed the same pair on the `.dt` view; this carries it to the variables view.

## Fix

- **Per-line drift guard** — `pouVarsTokenViewport` (new `st-lsp/pouvars-context.ts`) windows tokens to the VAR blocks and keeps a line's tokens only while the model still shows the synced document's text for that line (`modelMatchesDocumentLines`, the per-line sibling of DOPE-554's `modelMatchesDocumentWindow`). Per line rather than whole buffer on purpose: the synced document resolves `AT <alias>` to a literal address, so a pristine buffer with an alias-bound variable never matches as a whole. Whole-buffer would blank every such POU permanently; per line blanks only the alias lines (already mis-coloured today) and the lines an edit moved. `ResolveSemanticTokensViewport` and `shiftSemanticTokensToBody` gain an optional `keepLine` for this; Python LSP and the print path are untouched.
- **Known limitation.** In code mode the buffer is never re-canonicalised after a commit (`variables-editor/index.tsx:208-212` regenerates only when `display !== 'code'`), so a line typed in a non-canonical form (`Count:INT;`, a different indent) stays uncoloured after commit until the view is toggled table → code. Not a regression: today that line is mis-coloured rather than blank, and the `.dt` view has the same gap with a whole-view blank. Whether to rewrite the user's text on blur is a product call, tracked for both views in [DOPE-622](https://autonomylogic.atlassian.net/browse/DOPE-622).
- **Refresh trigger** — a `project.data.pous` subscription calls `refreshSemanticTokens()` when a POU with a **mounted** variables view changed its `interface.variables` (or body language). Every body keystroke changes the same slice, so anything wider would re-tokenise the whole language on each key.
- **Marker replay** — the mirror now caches the last publish per POU document (`lastPouDiagnostics`) and `applyPouVarsDiagnostics` re-applies the VAR-block slice both on publish and on `onDidCreateModel` for a `pouvars://` URI, the same replay the `.dt` view already had.

Not touched: `resolve-context.ts`, `variables-code-editor`, `providers.ts`.

## Tests

- `st-lsp/__tests__/index.test.ts` now captures the options handed to `startLanguageService` and drives the real hooks with a Monaco stub: mirror onto a mounted view, replay onto a view that mounts after the publish, body-model mount left alone, viewport clip + per-line blanking, empty viewport before project-sync has sent the document, body editors unwindowed, refresh on VAR change but not on body edit or with no view mounted.
- New `pouvars-context.test.ts` (window, VAR-block diagnostics filter, viewport).
- `semantic-tokens-shift.test.ts` +1 (`keepLine` re-encoding), `line-window.test.ts` +5 (`modelMatchesDocumentLines`).

Local gate in both repos: prettier, eslint, tsc, architecture validation, `st-lsp` + `lsp-shared` suites 213/213. `scripts/compare-surfaces.py` between the two branches: `total_diffs: 0`.

Shared surface: `src/frontend/**` only, byte-identical with the sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOPE-552]: https://autonomylogic.atlassian.net/browse/DOPE-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOPE-622]: https://autonomylogic.atlassian.net/browse/DOPE-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Diagnostics now appear consistently in the variables view, including when the view is reopened.
  - Semantic highlighting in the variables view remains accurate during edits and is limited to lines whose content still matches the document.
  - Highlighting refreshes when variable blocks or body language settings change.
  - Improved handling of unsynchronized or unavailable document content prevents stale diagnostics and token colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->