### PR TITLE
fix(lsp): navigate on activation only, never while resolving a definition (DOPE-551)

### DIFF
--- a/src/frontend/services/lsp-shared/__tests__/line-window.test.ts
+++ b/src/frontend/services/lsp-shared/__tests__/line-window.test.ts
@@ -9,6 +9,7 @@ import {
   lspLineInWindow,
   modelMatchesDocumentLines,
   modelMatchesDocumentWindow,
+  symbolsBeforeWindow,
 } from '../internal/line-window'
 
 // `Motor` occupies lines 2..4 of the aggregate datatypes document, so
@@ -230,5 +231,44 @@ describe('modelMatchesDocumentLines', () => {
   it('normalises CRLF in the model buffer', () => {
     const crlf = PRISTINE_VARS.replace(/\n/g, '\r\n')
     expect(VAR_LINES.map(modelMatchesDocumentLines(crlf, POU_DOC, 1))).toEqual([true, true, true, true])
+  })
+})
+
+describe('symbolsBeforeWindow', () => {
+  // pou://main: 0 declaration, 1 VAR, 2 Level, 3 Enable, 4 END_VAR, body from 5.
+  const BODY = { startLine: 5, endLineExclusive: Number.MAX_SAFE_INTEGER }
+  const leaf = (name: string, line: number): LspDocumentSymbol => ({
+    name,
+    kind: 13,
+    range: { start: { line, character: 2 }, end: { line, character: 12 } },
+    selectionRange: { start: { line, character: 2 }, end: { line, character: 7 } },
+  })
+  const pou: LspDocumentSymbol = {
+    name: 'main',
+    kind: 12,
+    range: { start: { line: 0, character: 0 }, end: { line: 9, character: 0 } },
+    selectionRange: { start: { line: 0, character: 8 }, end: { line: 0, character: 12 } },
+    children: [leaf('Level', 2), leaf('Enable', 3), leaf('State', 7)],
+  }
+
+  it('lists the declarations before the body and not the POU that wraps them', () => {
+    expect(symbolsBeforeWindow([pou], BODY).map((s) => s.name)).toEqual(['Level', 'Enable'])
+  })
+
+  it('leaves what starts inside the window to the window', () => {
+    expect(symbolsBeforeWindow([leaf('State', 7)], BODY)).toEqual([])
+  })
+
+  it('lists the leaves of an earlier container, never the container', () => {
+    const block: LspDocumentSymbol = {
+      ...leaf('VAR_INPUT', 1),
+      range: { start: { line: 1, character: 0 }, end: { line: 4, character: 7 } },
+      children: [leaf('Level', 2), leaf('Enable', 3)],
+    }
+    expect(symbolsBeforeWindow([{ ...pou, children: [block] }], BODY).map((s) => s.name)).toEqual(['Level', 'Enable'])
+  })
+
+  it('is empty for a document with no preamble', () => {
+    expect(symbolsBeforeWindow([leaf('x', 0)], { startLine: 0, endLineExclusive: Number.MAX_SAFE_INTEGER })).toEqual([])
   })
 })

--- a/src/frontend/services/lsp-shared/__tests__/line-window.test.ts
+++ b/src/frontend/services/lsp-shared/__tests__/line-window.test.ts
@@ -271,4 +271,9 @@ describe('symbolsBeforeWindow', () => {
   it('is empty for a document with no preamble', () => {
     expect(symbolsBeforeWindow([leaf('x', 0)], { startLine: 0, endLineExclusive: Number.MAX_SAFE_INTEGER })).toEqual([])
   })
+
+  it('never lists a childless POU that reaches into the body, which has nothing to declare', () => {
+    expect(symbolsBeforeWindow([{ ...pou, children: [] }], BODY)).toEqual([])
+    expect(symbolsBeforeWindow([{ ...pou, children: undefined }], BODY)).toEqual([])
+  })
 })

--- a/src/frontend/services/lsp-shared/__tests__/lsp-mirror.test.ts
+++ b/src/frontend/services/lsp-shared/__tests__/lsp-mirror.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ */
+import type * as monaco from 'monaco-editor'
+
+import { createLspDocumentMirror, lspMirrorUri, parseLspMirrorUri } from '../lsp-mirror'
+
+describe('lspMirrorUri / parseLspMirrorUri', () => {
+  it.each([
+    'inmemory://pou/main.st',
+    'inmemory://stub/Ladder.st',
+    'inmemory://datatypes/__project__.st',
+    'inmemory://globals/__resource__.st',
+    'file:///projects/p1/MyPou.py',
+  ])('round-trips %s', (lspUri) => {
+    const mirrored = lspMirrorUri(lspUri)
+    expect(mirrored.startsWith('inmemory://lsp-mirror/')).toBe(true)
+    expect(parseLspMirrorUri(mirrored)).toBe(lspUri)
+  })
+
+  it('keeps the document extension so the preview colours by it', () => {
+    expect(lspMirrorUri('inmemory://pou/main.st').endsWith('.st')).toBe(true)
+    expect(lspMirrorUri('file:///MyPou.py').endsWith('.py')).toBe(true)
+  })
+
+  it('returns null for anything that is not a mirror URI', () => {
+    expect(parseLspMirrorUri('inmemory://pou/main.st')).toBeNull()
+    expect(parseLspMirrorUri('inmemory://lsp-mirror/')).toBeNull()
+    expect(parseLspMirrorUri('inmemory://lsp-mirror/nopath')).toBeNull()
+  })
+})
+
+describe('createLspDocumentMirror', () => {
+  function makeMonacoStub() {
+    const models = new Map<string, { uri: string; language: string; value: string; disposed: boolean }>()
+    const api = {
+      Uri: { parse: (s: string) => ({ toString: () => s }) },
+      editor: {
+        getModel: (uri: { toString(): string }) => {
+          const m = models.get(uri.toString())
+          return m && !m.disposed ? asModel(m) : null
+        },
+        createModel: (value: string, language: string, uri: { toString(): string }) => {
+          const m = { uri: uri.toString(), language, value, disposed: false }
+          models.set(m.uri, m)
+          return asModel(m)
+        },
+      },
+    } as unknown as typeof monaco
+    function asModel(m: { uri: string; language: string; value: string; disposed: boolean }) {
+      return {
+        uri: { toString: () => m.uri },
+        getValue: () => m.value,
+        setValue: (v: string) => {
+          m.value = v
+        },
+        dispose: () => {
+          m.disposed = true
+        },
+      } as unknown as monaco.editor.ITextModel
+    }
+    return { api, models }
+  }
+
+  it('creates a plaintext model at the mirror URI on first set and updates it on change', () => {
+    const { api, models } = makeMonacoStub()
+    const mirror = createLspDocumentMirror(api)
+
+    mirror.set('inmemory://pou/main.st', 'PROGRAM main')
+    mirror.set('inmemory://pou/main.st', 'PROGRAM main\nx := 1;')
+
+    const model = models.get(lspMirrorUri('inmemory://pou/main.st'))
+    expect(model).toMatchObject({ language: 'plaintext', value: 'PROGRAM main\nx := 1;' })
+    expect(models.size).toBe(1)
+  })
+
+  it('adopts a model that already exists at the mirror URI', () => {
+    const { api, models } = makeMonacoStub()
+    api.editor.createModel('stale', 'plaintext', api.Uri.parse(lspMirrorUri('inmemory://pou/main.st')))
+    const mirror = createLspDocumentMirror(api)
+
+    mirror.set('inmemory://pou/main.st', 'fresh')
+
+    expect(models.size).toBe(1)
+    expect(models.get(lspMirrorUri('inmemory://pou/main.st'))?.value).toBe('fresh')
+  })
+
+  it('disposes a document on delete and everything on dispose', () => {
+    const { api, models } = makeMonacoStub()
+    const mirror = createLspDocumentMirror(api)
+    mirror.set('inmemory://pou/a.st', 'A')
+    mirror.set('inmemory://pou/b.st', 'B')
+
+    mirror.delete('inmemory://pou/a.st')
+    expect(models.get(lspMirrorUri('inmemory://pou/a.st'))?.disposed).toBe(true)
+    expect(models.get(lspMirrorUri('inmemory://pou/b.st'))?.disposed).toBe(false)
+
+    mirror.dispose()
+    expect(models.get(lspMirrorUri('inmemory://pou/b.st'))?.disposed).toBe(true)
+  })
+})

--- a/src/frontend/services/lsp-shared/__tests__/navigation.test.ts
+++ b/src/frontend/services/lsp-shared/__tests__/navigation.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @jest-environment jsdom
+ */
+import type * as monaco from 'monaco-editor'
+
+import { __clearBodyLineOffsetsForTests, setBodyLineOffset } from '../body-offsets'
+import { lspMirrorUri } from '../lsp-mirror'
+import {
+  attachOutlineActivation,
+  bindOutlineTarget,
+  navTargetForResource,
+  OUTLINE_TARGET_COLUMN_BASE,
+  outlineBindingFor,
+  registerDefinitionOpener,
+  resetOutlineTargets,
+} from '../navigation'
+
+const POU = 'inmemory://pou/main.st'
+const JUMP = 'code.jump'
+
+beforeEach(() => {
+  __clearBodyLineOffsetsForTests()
+  resetOutlineTargets(POU)
+})
+
+describe('navTargetForResource', () => {
+  it('reads LSP coordinates straight off a mirror URI', () => {
+    expect(navTargetForResource(lspMirrorUri(POU), { lineNumber: 3, column: 5 })).toEqual({
+      uri: POU,
+      lineLsp: 2,
+      characterLsp: 4,
+    })
+  })
+
+  it('shifts a body model line back by its document preamble', () => {
+    setBodyLineOffset(POU, 5)
+    expect(navTargetForResource(POU, { lineNumber: 2, column: 1 })).toEqual({ uri: POU, lineLsp: 6, characterLsp: 0 })
+  })
+})
+
+describe('registerDefinitionOpener', () => {
+  function makeMonacoStub() {
+    let opener: monaco.editor.ICodeEditorOpener | undefined
+    const api = {
+      editor: {
+        registerEditorOpener: (o: monaco.editor.ICodeEditorOpener) => {
+          opener = o
+          return { dispose: jest.fn() }
+        },
+      },
+    } as unknown as typeof monaco
+    const source = (modelUri: string) =>
+      ({ getModel: () => ({ uri: { toString: () => modelUri } }) }) as unknown as monaco.editor.ICodeEditor
+    const resource = (uri: string) => ({ toString: () => uri }) as unknown as monaco.Uri
+    return { api, open: () => opener!, source, resource }
+  }
+
+  it('leaves a target inside the source model to Monaco', async () => {
+    const navigate = jest.fn(() => true)
+    const { api, open, source, resource } = makeMonacoStub()
+    registerDefinitionOpener(api, navigate)
+
+    expect(await open().openCodeEditor(source(POU), resource(POU), { lineNumber: 4, column: 1 })).toBe(false)
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('navigates a mirror target with the range start as its position', async () => {
+    const navigate = jest.fn(() => true)
+    const { api, open, source, resource } = makeMonacoStub()
+    registerDefinitionOpener(api, navigate)
+
+    const range = { startLineNumber: 3, startColumn: 3, endLineNumber: 3, endColumn: 8 }
+    expect(await open().openCodeEditor(source(POU), resource(lspMirrorUri(POU)), range)).toBe(true)
+    expect(navigate).toHaveBeenCalledWith({ uri: POU, lineLsp: 2, characterLsp: 2 })
+  })
+
+  it('hands the request on when the navigator does not own the URI', async () => {
+    const navigate = jest.fn(() => false)
+    const { api, open, source, resource } = makeMonacoStub()
+    registerDefinitionOpener(api, navigate)
+
+    expect(await open().openCodeEditor(source(POU), resource('file:///other.py'))).toBe(false)
+    expect(navigate).toHaveBeenCalledWith({ uri: 'file:///other.py', lineLsp: 0, characterLsp: 0 })
+  })
+})
+
+describe('outline target binding', () => {
+  const navigate = () => true
+
+  it('hands out one column past the base per entry and finds it again', () => {
+    const first = bindOutlineTarget(POU, 7, { uri: POU, lineLsp: 1, characterLsp: 2 }, navigate)
+    const second = bindOutlineTarget(POU, 7, { uri: POU, lineLsp: 2, characterLsp: 2 }, navigate)
+
+    expect(first).toEqual({
+      startLineNumber: 7,
+      startColumn: OUTLINE_TARGET_COLUMN_BASE,
+      endLineNumber: 7,
+      endColumn: OUTLINE_TARGET_COLUMN_BASE,
+    })
+    expect(second.startColumn).toBe(OUTLINE_TARGET_COLUMN_BASE + 1)
+    expect(outlineBindingFor(POU, second)?.target).toEqual({ uri: POU, lineLsp: 2, characterLsp: 2 })
+  })
+
+  it('knows nothing about an ordinary range, and forgets bindings on reset', () => {
+    const bound = bindOutlineTarget(POU, 1, { uri: POU, lineLsp: 1, characterLsp: 0 }, navigate)
+    expect(outlineBindingFor(POU, { startLineNumber: 1, startColumn: 4, endLineNumber: 1, endColumn: 4 })).toBeNull()
+
+    resetOutlineTargets(POU)
+    expect(outlineBindingFor(POU, bound)).toBeNull()
+  })
+})
+
+describe('attachOutlineActivation', () => {
+  function makeEditor(modelUri: string) {
+    const original = jest.fn()
+    const editor = {
+      getModel: () => ({ uri: { toString: () => modelUri } }),
+      setSelection: original,
+    } as unknown as monaco.editor.ICodeEditor
+    return { editor, original }
+  }
+
+  function makeMonacoStub(existing: monaco.editor.ICodeEditor[]) {
+    const created: Array<(e: monaco.editor.ICodeEditor) => void> = []
+    const api = {
+      editor: {
+        getEditors: () => existing,
+        onDidCreateEditor: (listener: (e: monaco.editor.ICodeEditor) => void) => {
+          created.push(listener)
+          return { dispose: jest.fn() }
+        },
+      },
+    } as unknown as typeof monaco
+    return { api, create: (e: monaco.editor.ICodeEditor) => created.forEach((l) => l(e)) }
+  }
+
+  it('navigates instead of selecting when Go to Symbol accepts a bound entry', () => {
+    const navigate = jest.fn(() => true)
+    const { editor, original } = makeEditor(POU)
+    attachOutlineActivation(makeMonacoStub([editor]).api)
+    const bound = bindOutlineTarget(POU, 3, { uri: POU, lineLsp: 2, characterLsp: 4 }, navigate)
+
+    editor.setSelection(bound, JUMP)
+
+    expect(navigate).toHaveBeenCalledWith({ uri: POU, lineLsp: 2, characterLsp: 4 })
+    expect(original).not.toHaveBeenCalled()
+  })
+
+  it('selects as usual for an ordinary jump, a non-jump source, or a navigator that declines', () => {
+    const { editor, original } = makeEditor(POU)
+    attachOutlineActivation(makeMonacoStub([editor]).api)
+    const plain = { startLineNumber: 3, startColumn: 1, endLineNumber: 3, endColumn: 1 }
+    const declined = bindOutlineTarget(POU, 3, { uri: POU, lineLsp: 2, characterLsp: 0 }, () => false)
+
+    editor.setSelection(plain, JUMP)
+    editor.setSelection(declined, 'mouse')
+    editor.setSelection(declined, JUMP)
+
+    expect(original.mock.calls).toEqual([
+      [plain, JUMP],
+      [declined, 'mouse'],
+      [declined, JUMP],
+    ])
+  })
+
+  it('patches editors created later, once per Monaco namespace', () => {
+    const navigate = jest.fn(() => true)
+    const stub = makeMonacoStub([])
+    attachOutlineActivation(stub.api)
+    attachOutlineActivation(stub.api)
+    const { editor, original } = makeEditor(POU)
+    stub.create(editor)
+    const bound = bindOutlineTarget(POU, 1, { uri: POU, lineLsp: 1, characterLsp: 0 }, navigate)
+
+    editor.setSelection(bound, JUMP)
+
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(original).not.toHaveBeenCalled()
+  })
+})

--- a/src/frontend/services/lsp-shared/__tests__/providers.test.ts
+++ b/src/frontend/services/lsp-shared/__tests__/providers.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment jsdom
+ */
+import type * as monaco from 'monaco-editor'
+import type { DocumentSymbol, Location as LspLocation, MessageConnection } from 'vscode-languageserver-protocol'
+
+// The package's Node entry is ESM-only; the providers only read the request
+// type constants, so a stub keeps Jest away from it.
+jest.mock('vscode-languageserver-protocol', () => ({
+  CompletionRequest: { type: 'textDocument/completion' },
+  HoverRequest: { type: 'textDocument/hover' },
+  SignatureHelpRequest: { type: 'textDocument/signatureHelp' },
+  DefinitionRequest: { type: 'textDocument/definition' },
+  ReferencesRequest: { type: 'textDocument/references' },
+  DocumentSymbolRequest: { type: 'textDocument/documentSymbol' },
+  DocumentFormattingRequest: { type: 'textDocument/formatting' },
+}))
+
+import { __clearBodyLineOffsetsForTests, setBodyLineOffset } from '../body-offsets'
+import { OUTLINE_TARGET_COLUMN_BASE, outlineBindingFor } from '../navigation'
+import { type ProviderHooks, registerLspProviders } from '../providers'
+
+const POU = 'inmemory://pou/main.st'
+const OTHER = 'inmemory://pou/other.st'
+
+class FakeRange {
+  constructor(
+    public startLineNumber: number,
+    public startColumn: number,
+    public endLineNumber: number,
+    public endColumn: number,
+  ) {}
+}
+
+function makeHarness(hooks: ProviderHooks, editorLine = 1) {
+  const providers: Record<string, unknown> = {}
+  const register = (key: string) => (_language: string, provider: unknown) => {
+    providers[key] = provider
+    return { dispose: jest.fn() }
+  }
+  const model = {
+    uri: { toString: () => POU },
+    getWordUntilPosition: () => ({ startColumn: 1, endColumn: 1, word: '' }),
+  } as unknown as monaco.editor.ITextModel
+  const editor = {
+    getModel: () => model,
+    getPosition: () => ({ lineNumber: editorLine, column: 1 }),
+    setSelection: jest.fn(),
+  }
+  const api = {
+    Uri: { parse: (s: string) => ({ toString: () => s }) },
+    Range: FakeRange,
+    languages: {
+      registerCompletionItemProvider: register('completion'),
+      registerHoverProvider: register('hover'),
+      registerSignatureHelpProvider: register('signature'),
+      registerDefinitionProvider: register('definition'),
+      registerReferenceProvider: register('references'),
+      registerDocumentSymbolProvider: register('symbols'),
+      registerDocumentFormattingEditProvider: register('formatting'),
+    },
+    editor: { getEditors: () => [editor], onDidCreateEditor: () => ({ dispose: jest.fn() }) },
+  } as unknown as typeof monaco
+  const sendRequest = jest.fn()
+  registerLspProviders({
+    connection: { sendRequest } as unknown as MessageConnection,
+    monacoApi: api,
+    languageId: 'st',
+    hooks: { resolveLspContext: () => ({ lspUri: POU, lineOffset: 5 }), ...hooks },
+  })
+  return {
+    model,
+    sendRequest,
+    definition: providers.definition as monaco.languages.DefinitionProvider,
+    symbols: providers.symbols as monaco.languages.DocumentSymbolProvider,
+  }
+}
+
+const at = (uri: string, line: number, character = 2): LspLocation => ({
+  uri,
+  range: { start: { line, character }, end: { line, character: character + 4 } },
+})
+
+const token = {} as monaco.CancellationToken
+const position = { lineNumber: 2, column: 6 } as monaco.Position
+
+beforeEach(() => __clearBodyLineOffsetsForTests())
+
+describe('provideDefinition', () => {
+  it('shows each target where the mapper puts it, as a parsed Monaco URI', async () => {
+    const { model, sendRequest, definition } = makeHarness({
+      mapDefinitionLocation: (loc) => ({ uri: `mirror:${loc.uri}`, range: new FakeRange(1, 1, 1, 1) }),
+    })
+    sendRequest.mockResolvedValue([at(OTHER, 3)])
+
+    const result = (await definition.provideDefinition(model, position, token)) as monaco.languages.Location[]
+
+    expect(result.map((l) => l.uri.toString())).toEqual([`mirror:${OTHER}`])
+    expect(result[0].range).toEqual(new FakeRange(1, 1, 1, 1))
+  })
+
+  it('claims the definition with a self location when every target is unreachable', async () => {
+    const { model, sendRequest, definition } = makeHarness({ mapDefinitionLocation: () => null })
+    sendRequest.mockResolvedValue([at('file:///typeshed/builtins.pyi', 3)])
+
+    const result = (await definition.provideDefinition(model, position, token)) as monaco.languages.Location[]
+
+    expect(result).toHaveLength(1)
+    expect(result[0].uri).toBe(model.uri)
+    expect(result[0].range).toEqual(new FakeRange(2, 5, 2, 5))
+  })
+
+  it("shifts a target into its own document's body view by default", async () => {
+    const { model, sendRequest, definition } = makeHarness({})
+    setBodyLineOffset(OTHER, 4)
+    sendRequest.mockResolvedValue(at(OTHER, 7))
+
+    const result = (await definition.provideDefinition(model, position, token)) as monaco.languages.Location[]
+
+    expect(result[0].uri.toString()).toBe(OTHER)
+    expect(result[0].range).toMatchObject({ startLineNumber: 4, startColumn: 3 })
+  })
+})
+
+describe('provideDocumentSymbols', () => {
+  // pou://main: 0 declaration, 1 VAR, 2 Level, 3 Enable, 4 END_VAR, body from 5.
+  const leaf = (name: string, line: number): DocumentSymbol => ({
+    name,
+    kind: 13,
+    range: { start: { line, character: 2 }, end: { line, character: 12 } },
+    selectionRange: { start: { line, character: 2 }, end: { line, character: 7 } },
+  })
+  const document: DocumentSymbol[] = [
+    {
+      name: 'main',
+      kind: 12,
+      range: { start: { line: 0, character: 0 }, end: { line: 9, character: 0 } },
+      selectionRange: { start: { line: 0, character: 8 }, end: { line: 0, character: 12 } },
+      children: [leaf('Level', 2), leaf('Enable', 3), leaf('State', 7)],
+    },
+  ]
+
+  it('lists the declarations before the body, bound to the outline navigator on the current line', async () => {
+    const navigate = jest.fn(() => true)
+    const { model, sendRequest, symbols } = makeHarness({ navigateOutline: navigate }, 4)
+    sendRequest.mockResolvedValue(document)
+
+    const result = (await symbols.provideDocumentSymbols(model, token)) as monaco.languages.DocumentSymbol[]
+
+    expect(result.map((s) => s.name)).toEqual(['Level', 'Enable', 'State'])
+    expect(result[0].range).toEqual({
+      startLineNumber: 4,
+      startColumn: OUTLINE_TARGET_COLUMN_BASE,
+      endLineNumber: 4,
+      endColumn: OUTLINE_TARGET_COLUMN_BASE,
+    })
+    expect(outlineBindingFor(POU, result[1].range)).toMatchObject({ target: { uri: POU, lineLsp: 3, characterLsp: 2 } })
+    expect(result[2].range).toMatchObject({ startLineNumber: 3, startColumn: 3 })
+  })
+
+  it('drops them when no outline navigator is configured', async () => {
+    const { model, sendRequest, symbols } = makeHarness({})
+    sendRequest.mockResolvedValue(document)
+
+    const result = (await symbols.provideDocumentSymbols(model, token)) as monaco.languages.DocumentSymbol[]
+
+    expect(result.map((s) => s.name)).toEqual(['State'])
+  })
+
+  it('leaves a windowed view to its window, bound entries or not', async () => {
+    const { model, sendRequest, symbols } = makeHarness({
+      navigateOutline: () => true,
+      resolveLspContext: () => ({ lspUri: POU, lineOffset: 1, lineWindow: { startLine: 1, endLineExclusive: 5 } }),
+    })
+    sendRequest.mockResolvedValue(document)
+
+    const result = (await symbols.provideDocumentSymbols(model, token)) as monaco.languages.DocumentSymbol[]
+
+    expect(result.map((s) => s.name)).toEqual(['Level', 'Enable'])
+    expect(result.every((s) => s.range.startColumn < OUTLINE_TARGET_COLUMN_BASE)).toBe(true)
+  })
+})

--- a/src/frontend/services/lsp-shared/__tests__/providers.test.ts
+++ b/src/frontend/services/lsp-shared/__tests__/providers.test.ts
@@ -158,6 +158,28 @@ describe('provideDocumentSymbols', () => {
     expect(result[2].range).toMatchObject({ startLineNumber: 3, startColumn: 3 })
   })
 
+  it('rewraps a flat SymbolInformation response the same way', async () => {
+    const navigate = jest.fn(() => true)
+    const { model, sendRequest, symbols } = makeHarness({ navigateOutline: navigate }, 2)
+    const flat = (name: string, line: number) => ({
+      name,
+      kind: 13,
+      containerName: 'main',
+      location: { uri: POU, range: { start: { line, character: 2 }, end: { line, character: 12 } } },
+    })
+    sendRequest.mockResolvedValue([flat('Level', 2), flat('State', 7)])
+
+    const result = (await symbols.provideDocumentSymbols(model, token)) as monaco.languages.DocumentSymbol[]
+
+    expect(result.map((s) => [s.name, s.detail])).toEqual([
+      ['Level', 'main'],
+      ['State', 'main'],
+    ])
+    expect(result[0].range).toMatchObject({ startLineNumber: 2, startColumn: OUTLINE_TARGET_COLUMN_BASE })
+    expect(outlineBindingFor(POU, result[0].range)).toMatchObject({ target: { uri: POU, lineLsp: 2, characterLsp: 2 } })
+    expect(result[1].range).toMatchObject({ startLineNumber: 3, startColumn: 3 })
+  })
+
   it('drops them when no outline navigator is configured', async () => {
     const { model, sendRequest, symbols } = makeHarness({})
     sendRequest.mockResolvedValue(document)

--- a/src/frontend/services/lsp-shared/index.ts
+++ b/src/frontend/services/lsp-shared/index.ts
@@ -43,9 +43,12 @@ export {
   type DiagnosticsBridge,
   type DiagnosticsMirror,
 } from './diagnostics'
+export { createLspDocumentMirror, type LspDocumentMirror, lspMirrorUri, parseLspMirrorUri } from './lsp-mirror'
+export { type NavigateToTarget, navTargetForResource, registerDefinitionOpener } from './navigation'
 export {
-  type DefinitionInterceptor,
+  type DefinitionLocationMapper,
   type LspContext,
+  type MappedLocation,
   type ProviderHooks,
   registerLspProviders,
   type RegisterLspProvidersOptions,

--- a/src/frontend/services/lsp-shared/internal/line-window.ts
+++ b/src/frontend/services/lsp-shared/internal/line-window.ts
@@ -85,6 +85,7 @@ export function symbolsBeforeWindow(symbols: LspDocumentSymbol[], lineWindow: Ls
       before.push(...symbolsBeforeWindow(sym.children, lineWindow))
       continue
     }
+    if (sym.range.end.line >= lineWindow.startLine) continue
     before.push(sym)
   }
   return before

--- a/src/frontend/services/lsp-shared/internal/line-window.ts
+++ b/src/frontend/services/lsp-shared/internal/line-window.ts
@@ -72,6 +72,25 @@ export function clipSymbolsToWindow(symbols: LspDocumentSymbol[], lineWindow?: L
 }
 
 /**
+ * The leaf symbols the window leaves out above it. A container reaching
+ * into the window (the POU wrapping a body editor's slice) is not itself
+ * an entry, and neither is one holding earlier children: their leaves
+ * are. Body editors list these as bound outline entries.
+ */
+export function symbolsBeforeWindow(symbols: LspDocumentSymbol[], lineWindow: LspLineWindow): LspDocumentSymbol[] {
+  const before: LspDocumentSymbol[] = []
+  for (const sym of symbols) {
+    if (sym.range.start.line >= lineWindow.startLine) continue
+    if (sym.children && sym.children.length > 0) {
+      before.push(...symbolsBeforeWindow(sym.children, lineWindow))
+      continue
+    }
+    before.push(sym)
+  }
+  return before
+}
+
+/**
  * True when the model's rendering of the window matches the LSP
  * document's own lines. Formatting edits carry columns computed
  * against the LSP document, so a drifted buffer must not apply them.

--- a/src/frontend/services/lsp-shared/lsp-mirror.ts
+++ b/src/frontend/services/lsp-shared/lsp-mirror.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * A Monaco model per LSP document, under a URI of its own.
+ *
+ * Monaco resolves a definition target through its model service: the
+ * Ctrl+hover preview reads the target line from a model, and the peek
+ * widget embeds one. The documents the workers analyse had no such model
+ * — a body editor renders a slice of its POU document, and the synthesized
+ * documents (data types, globals, axes) have no editor at all — so a target
+ * inside them had nowhere to resolve. The mirror gives every LSP document
+ * a plaintext model holding the exact text the worker saw. Plaintext, so
+ * no language provider ever runs against it; the preview still colours by
+ * the URI's extension. Navigating to it goes through the editor opener
+ * (`navigation.ts`), never through Monaco's own in-model jump.
+ */
+
+import type * as monaco from 'monaco-editor'
+
+const MIRROR_PREFIX = 'inmemory://lsp-mirror/'
+
+/** `inmemory://pou/main.st` → `inmemory://lsp-mirror/inmemory/pou/main.st`. */
+export function lspMirrorUri(lspUri: string): string {
+  return `${MIRROR_PREFIX}${lspUri.replace('://', '/')}`
+}
+
+/** Inverse of {@link lspMirrorUri}; null for any other URI. */
+export function parseLspMirrorUri(uri: string): string | null {
+  if (!uri.startsWith(MIRROR_PREFIX)) return null
+  const rest = uri.slice(MIRROR_PREFIX.length)
+  const slash = rest.indexOf('/')
+  if (slash <= 0) return null
+  return `${rest.slice(0, slash)}://${rest.slice(slash + 1)}`
+}
+
+export interface LspDocumentMirror {
+  /** The document was opened or changed; the mirror holds `text` from now on. */
+  set(lspUri: string, text: string): void
+  /** The document was closed. */
+  delete(lspUri: string): void
+  dispose(): void
+}
+
+export function createLspDocumentMirror(monacoApi: typeof monaco): LspDocumentMirror {
+  const models = new Map<string, monaco.editor.ITextModel>()
+  return {
+    set(lspUri, text) {
+      const uri = monacoApi.Uri.parse(lspMirrorUri(lspUri))
+      const model =
+        models.get(lspUri) ?? monacoApi.editor.getModel(uri) ?? monacoApi.editor.createModel(text, 'plaintext', uri)
+      if (model.getValue() !== text) model.setValue(text)
+      models.set(lspUri, model)
+    },
+    delete(lspUri) {
+      models.get(lspUri)?.dispose()
+      models.delete(lspUri)
+    },
+    dispose() {
+      for (const model of models.values()) model.dispose()
+      models.clear()
+    },
+  }
+}

--- a/src/frontend/services/lsp-shared/navigation.ts
+++ b/src/frontend/services/lsp-shared/navigation.ts
@@ -126,14 +126,21 @@ export function attachOutlineActivation(monacoApi: typeof monaco): void {
   activatedApis.add(monacoApi)
   const patch = (editor: monaco.editor.ICodeEditor) => {
     const original = editor.setSelection.bind(editor)
-    editor.setSelection = ((selection: monaco.IRange | monaco.ISelection, source?: string) => {
-      if (source === JUMP_SOURCE && 'startLineNumber' in selection) {
+    editor.setSelection = (
+      selection: monaco.IRange | monaco.Range | monaco.ISelection | monaco.Selection,
+      source?: string,
+    ) => {
+      if (!('startLineNumber' in selection)) {
+        original(selection, source)
+        return
+      }
+      if (source === JUMP_SOURCE) {
         const modelUri = editor.getModel()?.uri.toString()
         const binding = modelUri ? outlineBindingFor(modelUri, selection) : null
         if (binding && binding.navigate(binding.target)) return
       }
-      original(selection as monaco.IRange, source)
-    }) as typeof editor.setSelection
+      original(selection, source)
+    }
   }
   for (const editor of monacoApi.editor.getEditors()) patch(editor)
   monacoApi.editor.onDidCreateEditor(patch)

--- a/src/frontend/services/lsp-shared/navigation.ts
+++ b/src/frontend/services/lsp-shared/navigation.ts
@@ -56,6 +56,8 @@ export function registerDefinitionOpener(monacoApi: typeof monaco, navigate: Nav
     openCodeEditor(source, resource, selectionOrPosition) {
       const resourceUri = resource.toString()
       if (source.getModel()?.uri.toString() === resourceUri) return false
+      // True names the source editor as the target too, so Monaco flashes its
+      // symbol highlight there at the target's range. Cosmetic, inherent to an opener.
       return navigate(navTargetForResource(resourceUri, startOf(selectionOrPosition)))
     },
   })

--- a/src/frontend/services/lsp-shared/navigation.ts
+++ b/src/frontend/services/lsp-shared/navigation.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Where navigation actually happens.
+ *
+ * The providers answer "where is this?" and nothing more. The tab switch,
+ * view toggle and cursor placement run only from here, on a real
+ * activation: Monaco asking to open a target (Ctrl/Cmd+click, F12, the
+ * peek widget), or a Go to Symbol entry being accepted. Ctrl+hover resolves
+ * definitions to draw its link and preview and never reaches this file.
+ */
+
+import type * as monaco from 'monaco-editor'
+
+import { getBodyLineOffset } from './body-offsets'
+import type { NavTarget } from './definition-redirect'
+import { parseLspMirrorUri } from './lsp-mirror'
+
+/** Route `target` (LSP coordinates) into the application; true when handled. */
+export type NavigateToTarget = (target: NavTarget) => boolean
+
+/**
+ * The LSP target behind a resource Monaco wants opened. A mirror URI
+ * carries LSP coordinates as they are; a body model's line is
+ * body-relative and shifts back by its document's preamble.
+ */
+export function navTargetForResource(resourceUri: string, position: monaco.IPosition): NavTarget {
+  const mirrored = parseLspMirrorUri(resourceUri)
+  if (mirrored !== null) {
+    return { uri: mirrored, lineLsp: position.lineNumber - 1, characterLsp: position.column - 1 }
+  }
+  return {
+    uri: resourceUri,
+    lineLsp: position.lineNumber - 1 + getBodyLineOffset(resourceUri),
+    characterLsp: position.column - 1,
+  }
+}
+
+function startOf(selectionOrPosition?: monaco.IRange | monaco.IPosition): monaco.IPosition {
+  if (!selectionOrPosition) return { lineNumber: 1, column: 1 }
+  if ('startLineNumber' in selectionOrPosition) {
+    return { lineNumber: selectionOrPosition.startLineNumber, column: selectionOrPosition.startColumn }
+  }
+  return selectionOrPosition
+}
+
+/**
+ * Handle Monaco's "open this target" for one language service. A target
+ * inside the source model itself is left to Monaco, a plain in-editor
+ * jump; everything else is `navigate`d. Openers run before Monaco's
+ * default and in any order, so one that does not own the URI returns
+ * false and the request moves on.
+ */
+export function registerDefinitionOpener(monacoApi: typeof monaco, navigate: NavigateToTarget): monaco.IDisposable {
+  return monacoApi.editor.registerEditorOpener({
+    openCodeEditor(source, resource, selectionOrPosition) {
+      const resourceUri = resource.toString()
+      if (source.getModel()?.uri.toString() === resourceUri) return false
+      return navigate(navTargetForResource(resourceUri, startOf(selectionOrPosition)))
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Outline entries that point outside the model
+// ---------------------------------------------------------------------------
+
+/** No real line is this wide, so a column past it can only be a bound entry. */
+export const OUTLINE_TARGET_COLUMN_BASE = 1 << 20
+
+interface OutlineBinding {
+  target: NavTarget
+  navigate: NavigateToTarget
+}
+
+const outlineBindings = new Map<string, OutlineBinding[]>()
+
+/** Forget the bindings of `modelUri` before a provider lists them afresh. */
+export function resetOutlineTargets(modelUri: string): void {
+  outlineBindings.delete(modelUri)
+}
+
+/**
+ * Give an outline entry that points outside the model a range Monaco can
+ * hold, and remember where it really points. The range sits on `line`
+ * with a column past any real text: accepting the entry is recognisable
+ * in `setSelection`, and previewing it reveals nothing but that line.
+ */
+export function bindOutlineTarget(
+  modelUri: string,
+  line: number,
+  target: NavTarget,
+  navigate: NavigateToTarget,
+): monaco.IRange {
+  let bindings = outlineBindings.get(modelUri)
+  if (!bindings) {
+    bindings = []
+    outlineBindings.set(modelUri, bindings)
+  }
+  const column = OUTLINE_TARGET_COLUMN_BASE + bindings.length
+  bindings.push({ target, navigate })
+  return { startLineNumber: line, startColumn: column, endLineNumber: line, endColumn: column }
+}
+
+/** The binding a Go to Symbol accept encoded into `range`, if any. */
+export function outlineBindingFor(modelUri: string, range: monaco.IRange): OutlineBinding | null {
+  const index = range.startColumn - OUTLINE_TARGET_COLUMN_BASE
+  if (index < 0) return null
+  return outlineBindings.get(modelUri)?.[index] ?? null
+}
+
+/** Monaco's `TextEditorSelectionSource.JUMP`, the source Go to Symbol selects with. */
+const JUMP_SOURCE = 'code.jump'
+
+const activatedApis = new WeakSet<typeof monaco>()
+
+/**
+ * Go to Symbol accepts an entry by selecting its range with the jump
+ * source. Catch that on every editor and, when the range is a bound one,
+ * navigate instead of selecting: the real target lives in a document
+ * this editor does not render. Installed once per Monaco namespace, for
+ * the life of the page.
+ */
+export function attachOutlineActivation(monacoApi: typeof monaco): void {
+  if (activatedApis.has(monacoApi)) return
+  activatedApis.add(monacoApi)
+  const patch = (editor: monaco.editor.ICodeEditor) => {
+    const original = editor.setSelection.bind(editor)
+    editor.setSelection = ((selection: monaco.IRange | monaco.ISelection, source?: string) => {
+      if (source === JUMP_SOURCE && 'startLineNumber' in selection) {
+        const modelUri = editor.getModel()?.uri.toString()
+        const binding = modelUri ? outlineBindingFor(modelUri, selection) : null
+        if (binding && binding.navigate(binding.target)) return
+      }
+      original(selection as monaco.IRange, source)
+    }) as typeof editor.setSelection
+  }
+  for (const editor of monacoApi.editor.getEditors()) patch(editor)
+  monacoApi.editor.onDidCreateEditor(patch)
+}

--- a/src/frontend/services/lsp-shared/providers.ts
+++ b/src/frontend/services/lsp-shared/providers.ts
@@ -155,6 +155,9 @@ const defaultResolveLspContext = (modelUri: string): LspContext => ({
 const defaultFilterFormattingEdits = (edits: LspTextEdit[], offset: number): LspTextEdit[] =>
   edits.filter((e) => e.range.start.line >= offset && e.range.end.line >= offset)
 
+const isDocumentSymbols = (result: DocumentSymbol[] | SymbolInformation[]): result is DocumentSymbol[] =>
+  result.length === 0 || 'range' in result[0]
+
 // Location URIs may refer to any document, so the offset is the target's own.
 const defaultMapDefinitionLocation: DefinitionLocationMapper = (loc) => ({
   uri: loc.uri,
@@ -320,16 +323,15 @@ export function registerLspProviders(opts: RegisterLspProvidersOptions): monaco.
         // hierarchy) or SymbolInformation[] (flat list with
         // containerName).  Monaco's outline view wants
         // DocumentSymbol[] — flat lists get rewrapped.
-        const symbols: DocumentSymbol[] =
-          'range' in result[0]
-            ? (result as DocumentSymbol[])
-            : (result as SymbolInformation[]).map((s) => ({
-                name: s.name,
-                detail: s.containerName,
-                kind: s.kind,
-                range: s.location.range,
-                selectionRange: s.location.range,
-              }))
+        const symbols: DocumentSymbol[] = isDocumentSymbols(result)
+          ? result
+          : result.map((s) => ({
+              name: s.name,
+              detail: s.containerName,
+              kind: s.kind,
+              range: s.location.range,
+              selectionRange: s.location.range,
+            }))
         const shown = clipSymbolsToWindow(symbols, visible).map((s) => lspDocumentSymbolToMonaco(s, lineOffset))
         // A body editor's declarations live before its slice. Listed anyway,
         // each bound to where it really points, so accepting one navigates

--- a/src/frontend/services/lsp-shared/providers.ts
+++ b/src/frontend/services/lsp-shared/providers.ts
@@ -7,10 +7,12 @@
  * the response back into Monaco's expected shape.
  *
  * The shape parameters (`languageId`, trigger characters, optional
- * URI/offset resolver and definition interceptors) come from the
- * caller — see {@link RegisterLspProvidersOptions} below.  Anything
- * language-specific (ST's `pouvars://` URI rewriting, store-driven
- * definition redirects) plugs in via hooks rather than living here.
+ * URI/offset resolver, definition-target mapping and outline routing)
+ * come from the caller — see {@link RegisterLspProvidersOptions} below.
+ * Anything language-specific (ST's `pouvars://` URI rewriting, where a
+ * definition target is shown, where an activation navigates) plugs in
+ * via hooks rather than living here. The providers themselves only
+ * answer questions; navigation runs from `navigation.ts` on activation.
  *
  * Every provider walks the same translation pattern:
  *
@@ -47,7 +49,9 @@ import {
   lspCompletionListToMonaco,
   lspHoverToMonaco,
   lspLocationsToMonaco,
+  lspRangeToMonaco,
   lspSignatureHelpToMonaco,
+  lspSymbolKindToMonaco,
   lspTextEditToMonaco,
   monacoPositionToLsp,
 } from './converters'
@@ -57,12 +61,14 @@ import {
   lspLineInWindow,
   type LspLineWindow,
   modelMatchesDocumentWindow,
+  symbolsBeforeWindow,
 } from './internal/line-window'
 import {
   lspDocumentSymbolToMonaco,
   normaliseLocationResponse,
-  symbolInformationToDocumentSymbol,
+  suppressNoDefinitionFound,
 } from './internal/symbol-helpers'
+import { attachOutlineActivation, bindOutlineTarget, type NavigateToTarget, resetOutlineTargets } from './navigation'
 
 /**
  * Resolved LSP context for a given Monaco model URI.  Default
@@ -83,20 +89,14 @@ export interface LspContext {
 }
 
 /**
- * Definition redirect.  Run in registration order; the first hook
- * to return a non-`undefined` value wins and the LSP response is
- * never converted.  Returning `null` claims the navigation
- * (Monaco's "no definition found" banner is suppressed but no
- * navigation happens here — the redirect does its own thing).
- * Returning `undefined` lets the next hook (or the default LSP
- * conversion) handle the result.
+ * Where a definition target is shown before it is activated: the URI
+ * Monaco resolves for its hover preview and hands to the editor opener,
+ * and the range in that model's own frame. Null drops a target the
+ * editor cannot reach.
  */
-export type DefinitionInterceptor = (
-  locations: LspLocation[],
-  model: monaco.editor.ITextModel,
-  position: monaco.IPosition,
-  monacoApi: typeof monaco,
-) => monaco.languages.Definition | null | undefined
+export type MappedLocation = { uri: string; range: monaco.IRange } | null
+
+export type DefinitionLocationMapper = (loc: LspLocation, source: LspContext & { modelUri: string }) => MappedLocation
 
 export interface ProviderHooks {
   /**
@@ -106,10 +106,16 @@ export interface ProviderHooks {
    */
   resolveLspContext?: (modelUri: string) => LspContext
   /**
-   * Hooks called for each `provideDefinition` result before the
-   * default LSP-to-Monaco conversion runs.  Run in array order.
+   * Map each LSP definition target to the location Monaco shows.
+   * Default: the target as-is, shifted to its model's body view.
    */
-  definitionInterceptors?: DefinitionInterceptor[]
+  mapDefinitionLocation?: DefinitionLocationMapper
+  /**
+   * Route for outline entries that sit before the model's slice — a body
+   * editor's VAR declarations. When set they are listed and bound to it;
+   * when absent they are dropped, as a windowed view's are.
+   */
+  navigateOutline?: NavigateToTarget
   /**
    * Filter the formatting edits returned by the worker before they
    * reach Monaco.  Default: keep edits whose entire range sits at
@@ -149,16 +155,24 @@ const defaultResolveLspContext = (modelUri: string): LspContext => ({
 const defaultFilterFormattingEdits = (edits: LspTextEdit[], offset: number): LspTextEdit[] =>
   edits.filter((e) => e.range.start.line >= offset && e.range.end.line >= offset)
 
+// Location URIs may refer to any document, so the offset is the target's own.
+const defaultMapDefinitionLocation: DefinitionLocationMapper = (loc) => ({
+  uri: loc.uri,
+  range: lspRangeToMonaco(loc.range, getBodyLineOffset(loc.uri)),
+})
+
 export function registerLspProviders(opts: RegisterLspProvidersOptions): monaco.IDisposable {
   const { connection, monacoApi, languageId } = opts
   const resolveLspContext = opts.hooks?.resolveLspContext ?? defaultResolveLspContext
-  const definitionInterceptors = opts.hooks?.definitionInterceptors ?? []
+  const mapDefinitionLocation = opts.hooks?.mapDefinitionLocation ?? defaultMapDefinitionLocation
+  const navigateOutline = opts.hooks?.navigateOutline
   const filterFormattingEdits = opts.hooks?.filterFormattingEdits ?? defaultFilterFormattingEdits
   const getLspDocumentText = opts.hooks?.getLspDocumentText
   const completionTriggerCharacters = opts.completionTriggerCharacters ?? []
   const signatureHelpTriggerCharacters = opts.signatureHelpTriggerCharacters ?? []
 
   const disposables: monaco.IDisposable[] = []
+  if (navigateOutline) attachOutlineActivation(monacoApi)
 
   // -------------------------------------------------------------------------
   // Completion
@@ -235,25 +249,30 @@ export function registerLspProviders(opts: RegisterLspProvidersOptions): monaco.
   disposables.push(
     monacoApi.languages.registerDefinitionProvider(languageId, {
       provideDefinition: async (model, position) => {
-        const { lspUri, lineOffset, lineWindow } = resolveLspContext(model.uri.toString())
-        const lspPosition = monacoPositionToLsp(position, lineOffset)
-        if (!lspLineInWindow(lspPosition.line, lineWindow)) return null
+        const modelUri = model.uri.toString()
+        const context = resolveLspContext(modelUri)
+        const lspPosition = monacoPositionToLsp(position, context.lineOffset)
+        if (!lspLineInWindow(lspPosition.line, context.lineWindow)) return null
         const result = await connection.sendRequest(DefinitionRequest.type, {
-          textDocument: { uri: lspUri },
+          textDocument: { uri: context.lspUri },
           position: lspPosition,
         })
         // DefinitionRequest may resolve to Location, Location[], or
-        // LocationLink[].  Normalise to Location[] first so the
-        // interceptors see a uniform shape.
+        // LocationLink[].  Normalise to Location[] first so the mapper
+        // sees a uniform shape.
         const normalised = normaliseLocationResponse(result as LspLocation | LspLocation[] | LocationLink[] | null)
         if (!normalised) return null
 
         const locations = Array.isArray(normalised) ? normalised : [normalised]
-        for (const intercept of definitionInterceptors) {
-          const claimed = intercept(locations, model, position, monacoApi)
-          if (claimed !== undefined) return claimed
+        const mapped: monaco.languages.Location[] = []
+        for (const loc of locations) {
+          const shown = mapDefinitionLocation(loc, { ...context, modelUri })
+          if (shown) mapped.push({ uri: monacoApi.Uri.parse(shown.uri), range: shown.range })
         }
-        return lspLocationsToMonaco(normalised, monacoApi) ?? null
+        // Every target unreachable (a typeshed stub, say): still claim the
+        // definition, or Monaco shows its banner and peeks references.
+        if (mapped.length === 0) return suppressNoDefinitionFound(model, position, monacoApi)
+        return mapped
       },
     }),
   )
@@ -285,7 +304,9 @@ export function registerLspProviders(opts: RegisterLspProvidersOptions): monaco.
   disposables.push(
     monacoApi.languages.registerDocumentSymbolProvider(languageId, {
       provideDocumentSymbols: async (model) => {
-        const { lspUri, lineOffset, lineWindow } = resolveLspContext(model.uri.toString())
+        const modelUri = model.uri.toString()
+        const { lspUri, lineOffset, lineWindow } = resolveLspContext(modelUri)
+        resetOutlineTargets(modelUri)
         const result = await connection.sendRequest(DocumentSymbolRequest.type, {
           textDocument: { uri: lspUri },
         })
@@ -299,14 +320,44 @@ export function registerLspProviders(opts: RegisterLspProvidersOptions): monaco.
         // hierarchy) or SymbolInformation[] (flat list with
         // containerName).  Monaco's outline view wants
         // DocumentSymbol[] — flat lists get rewrapped.
-        if ('range' in result[0]) {
-          return clipSymbolsToWindow(result as DocumentSymbol[], visible).map((s) =>
-            lspDocumentSymbolToMonaco(s, lineOffset),
-          )
-        }
-        return (result as SymbolInformation[])
-          .filter((s) => lspLineInWindow(s.location.range.start.line, visible))
-          .map((s) => symbolInformationToDocumentSymbol(s, lineOffset))
+        const symbols: DocumentSymbol[] =
+          'range' in result[0]
+            ? (result as DocumentSymbol[])
+            : (result as SymbolInformation[]).map((s) => ({
+                name: s.name,
+                detail: s.containerName,
+                kind: s.kind,
+                range: s.location.range,
+                selectionRange: s.location.range,
+              }))
+        const shown = clipSymbolsToWindow(symbols, visible).map((s) => lspDocumentSymbolToMonaco(s, lineOffset))
+        // A body editor's declarations live before its slice. Listed anyway,
+        // each bound to where it really points, so accepting one navigates
+        // there instead of selecting a line this editor does not have.
+        if (!navigateOutline || lineWindow) return shown
+        const line =
+          monacoApi.editor
+            .getEditors()
+            .find((e) => e.getModel() === model)
+            ?.getPosition()?.lineNumber ?? 1
+        const bound = symbolsBeforeWindow(symbols, visible).map((s): monaco.languages.DocumentSymbol => {
+          const target = {
+            uri: lspUri,
+            lineLsp: s.selectionRange.start.line,
+            characterLsp: s.selectionRange.start.character,
+          }
+          const range = bindOutlineTarget(modelUri, line, target, navigateOutline)
+          return {
+            name: s.name,
+            detail: s.detail ?? '',
+            kind: lspSymbolKindToMonaco(s.kind),
+            range,
+            selectionRange: range,
+            tags: [],
+            children: [],
+          }
+        })
+        return [...bound, ...shown]
       },
     }),
   )

--- a/src/frontend/services/lsp-shared/start-language-service.ts
+++ b/src/frontend/services/lsp-shared/start-language-service.ts
@@ -35,7 +35,8 @@ import {
 } from 'vscode-languageserver-protocol'
 
 import { attachDiagnosticsBridge, type DiagnosticsMirror } from './diagnostics'
-import { type DefinitionInterceptor, type LspContext, registerLspProviders } from './providers'
+import type { NavigateToTarget } from './navigation'
+import { type DefinitionLocationMapper, type LspContext, registerLspProviders } from './providers'
 import {
   registerLspSemanticTokens,
   type ResolveSemanticTokensViewport,
@@ -125,7 +126,8 @@ export interface StartLanguageServiceOptions {
   completionTriggerCharacters?: string[]
   signatureHelpTriggerCharacters?: string[]
   resolveLspContext?: (modelUri: string) => LspContext
-  definitionInterceptors?: DefinitionInterceptor[]
+  mapDefinitionLocation?: DefinitionLocationMapper
+  navigateOutline?: NavigateToTarget
   filterFormattingEdits?: (edits: LspTextEdit[], offset: number) => LspTextEdit[]
   getLspDocumentText?: (lspUri: string) => string | undefined
   resolveSemanticTokensViewport?: ResolveSemanticTokensViewport
@@ -204,7 +206,8 @@ export function startLanguageService(opts: StartLanguageServiceOptions): Languag
     completionTriggerCharacters,
     signatureHelpTriggerCharacters,
     resolveLspContext,
-    definitionInterceptors,
+    mapDefinitionLocation,
+    navigateOutline,
     filterFormattingEdits,
     getLspDocumentText,
     resolveSemanticTokensViewport,
@@ -276,7 +279,8 @@ export function startLanguageService(opts: StartLanguageServiceOptions): Languag
         ...(signatureHelpTriggerCharacters ? { signatureHelpTriggerCharacters } : {}),
         hooks: {
           ...(resolveLspContext ? { resolveLspContext } : {}),
-          ...(definitionInterceptors ? { definitionInterceptors } : {}),
+          ...(mapDefinitionLocation ? { mapDefinitionLocation } : {}),
+          ...(navigateOutline ? { navigateOutline } : {}),
           ...(filterFormattingEdits ? { filterFormattingEdits } : {}),
           ...(getLspDocumentText ? { getLspDocumentText } : {}),
         },

--- a/src/frontend/services/python-lsp/__tests__/index.test.ts
+++ b/src/frontend/services/python-lsp/__tests__/index.test.ts
@@ -2,6 +2,13 @@
  * @jest-environment jsdom
  */
 import type { PLCVariable } from '../../../../middleware/shared/ports/types'
+import {
+  __clearBodyLineOffsetsForTests,
+  getBodyLineOffset as mockGetBodyLineOffset,
+  setBodyLineOffset as mockRealSetBodyLineOffset,
+} from '../../lsp-shared/body-offsets'
+import { lspRangeToMonaco as mockLspRangeToMonaco } from '../../lsp-shared/converters'
+import { lspMirrorUri as mockLspMirrorUri } from '../../lsp-shared/lsp-mirror'
 
 // Mock the shared orchestrator BEFORE importing the service so the
 // service module pulls in the mock.  The mock returns a stub
@@ -12,17 +19,25 @@ const setBodyLineOffset = jest.fn()
 const deleteBodyLineOffset = jest.fn()
 
 jest.mock('../../lsp-shared', () => {
-  // Re-export everything else by re-requiring the real module under a
-  // different specifier — keeps imports of types / converters live for
-  // anything we haven't mocked.  But for the names we DO mock, route
-  // through the jest.fn so each test can introspect call args.
+  // The orchestrator and the offset writes go through jest.fns so each
+  // test can introspect call args; the offset also reaches the real
+  // registry, and the pure helpers are the real ones, so the definition
+  // mapper under test computes what it would in the app.
   return {
     startLanguageService: (opts: unknown) => startLanguageService(opts),
-    setBodyLineOffset: (...args: unknown[]) => setBodyLineOffset(...args),
+    setBodyLineOffset: (uri: string, offset: number) => {
+      setBodyLineOffset(uri, offset)
+      mockRealSetBodyLineOffset(uri, offset)
+    },
     deleteBodyLineOffset: (...args: unknown[]) => deleteBodyLineOffset(...args),
+    getBodyLineOffset: (uri: string) => mockGetBodyLineOffset(uri),
+    lspRangeToMonaco: (range: unknown, offset: number) =>
+      mockLspRangeToMonaco(range as Parameters<typeof mockLspRangeToMonaco>[0], offset),
+    lspMirrorUri: (uri: string) => mockLspMirrorUri(uri),
   }
 })
 
+import type { StartLanguageServiceOptions } from '../../lsp-shared/start-language-service'
 import { startPythonLsp } from '../index'
 
 interface MockLanguageService {
@@ -91,6 +106,7 @@ const POU_NAME = 'MyPou'
 
 beforeEach(() => {
   jest.clearAllMocks()
+  __clearBodyLineOffsetsForTests()
 })
 
 describe('startPythonLsp configuration', () => {
@@ -321,5 +337,53 @@ describe('dispose', () => {
     service.dispose()
 
     expect(mockService.dispose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('definition targets', () => {
+  const at = (uri: string, line: number) => ({
+    uri,
+    range: { start: { line, character: 0 }, end: { line, character: 9 } },
+  })
+
+  function attachedMapper() {
+    installMockSharedService()
+    const service = startPythonLsp({ workerUrl: 'about:blank' })
+    service.attachPou(POU_URI, POU_NAME, [makeBoolVar('red_light')], 'print(red_light)\n')
+    const opts = startLanguageService.mock.calls[0][0] as StartLanguageServiceOptions
+    const preambleLines = mockGetBodyLineOffset(POU_LSP_URI)
+    const source = { modelUri: POU_URI, lspUri: POU_LSP_URI, lineOffset: preambleLines }
+    return { map: opts.mapDefinitionLocation!, navigate: opts.navigateOutline!, source, preambleLines }
+  }
+
+  it('keeps a body target in the source model, shifted past the preamble', () => {
+    const { map, source, preambleLines } = attachedMapper()
+    expect(preambleLines).toBeGreaterThan(0)
+
+    expect(map(at(POU_LSP_URI, preambleLines + 2), source)).toEqual({
+      uri: POU_URI,
+      range: { startLineNumber: 3, startColumn: 1, endLineNumber: 3, endColumn: 10 },
+    })
+  })
+
+  it('sends a preamble target to the document mirror, unshifted', () => {
+    const { map, source, preambleLines } = attachedMapper()
+
+    expect(map(at(POU_LSP_URI, preambleLines - 1), source)).toEqual({
+      uri: mockLspMirrorUri(POU_LSP_URI),
+      range: { startLineNumber: preambleLines, startColumn: 1, endLineNumber: preambleLines, endColumn: 10 },
+    })
+  })
+
+  it('drops a target outside the source document, such as a typeshed stub', () => {
+    const { map, source } = attachedMapper()
+
+    expect(map(at('file:///typeshed/stdlib/builtins.pyi', 40), source)).toBeNull()
+  })
+
+  it('declines to navigate a document it never attached', () => {
+    const { navigate } = attachedMapper()
+
+    expect(navigate({ uri: 'file:///Other.py', lineLsp: 0, characterLsp: 0 })).toBe(false)
   })
 })

--- a/src/frontend/services/python-lsp/goto-definition-redirect.ts
+++ b/src/frontend/services/python-lsp/goto-definition-redirect.ts
@@ -38,7 +38,12 @@
 import type { Location, LocationLink } from 'vscode-languageserver-protocol'
 
 import { getBodyLineOffset } from '../lsp-shared/body-offsets'
-import { normaliseLocation, routeToPouBody, routeToPouPreamble } from '../lsp-shared/definition-redirect'
+import {
+  type NavTarget,
+  normaliseLocation,
+  routeToPouBody,
+  routeToPouPreamble,
+} from '../lsp-shared/definition-redirect'
 
 export interface PythonRedirectContext {
   /** The Monaco model URI the user clicked Go to Definition from. */
@@ -63,8 +68,11 @@ export interface PythonRedirectContext {
  * caller can fall back to the URI-reachability filter.
  */
 export function redirectPythonDefinitionToStore(loc: Location | LocationLink, ctx: PythonRedirectContext): boolean {
-  const target = normaliseLocation(loc)
+  return redirectPythonNavTarget(normaliseLocation(loc), ctx)
+}
 
+/** Same routing for a target already in LSP coordinates. */
+export function redirectPythonNavTarget(target: NavTarget, ctx: PythonRedirectContext): boolean {
   // Cross-file navigation isn't supported yet — every reachable
   // Python definition target lives in the source URI.  Anything
   // else (a typeshed stub click, an external import) falls through

--- a/src/frontend/services/python-lsp/index.ts
+++ b/src/frontend/services/python-lsp/index.ts
@@ -30,15 +30,18 @@
 import { getIecVariableLineMap } from '../../utils/generate-iec-variables-to-string'
 import { generatePythonLspPreamble, type PythonLspPreamble } from '../../utils/python/generatePythonLspPreamble'
 import {
+  createLspDocumentMirror,
   deleteBodyLineOffset,
   getBodyLineOffset,
   type LanguageService,
-  lspLocationsToMonaco,
+  lspMirrorUri,
+  lspRangeToMonaco,
+  type NavigateToTarget,
+  registerDefinitionOpener,
   setBodyLineOffset,
   startLanguageService,
-  suppressNoDefinitionFound,
 } from '../lsp-shared'
-import { redirectPythonDefinitionToStore } from './goto-definition-redirect'
+import { redirectPythonNavTarget } from './goto-definition-redirect'
 import type { PythonLspService, PythonLspStartOptions } from './types'
 
 const PYTHON_LANGUAGE_ID = 'python'
@@ -96,6 +99,23 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
     return preamble.text + body
   }
 
+  // Every document Pyright sees, as a model Monaco can preview.
+  const mirror = monacoApi ? createLspDocumentMirror(monacoApi) : null
+
+  // Activation-time navigation: a preamble target crosses into the IEC
+  // variables text through the entry's maps, a body target lands in the body.
+  const navigateToStore: NavigateToTarget = (target) => {
+    const entry = [...entryByUri.values()].find((e) => e.lspUri === target.uri)
+    if (!entry) return false
+    return redirectPythonNavTarget(target, {
+      sourceUri: entry.lspUri,
+      sourcePouName: entry.pouName,
+      variableNameByPreambleLine: entry.preamble.variableNameByPreambleLine,
+      iecVariableLineMap: entry.iecVariableLineMap,
+    })
+  }
+  const opener = monacoApi ? registerDefinitionOpener(monacoApi, navigateToStore) : null
+
   const sharedService: LanguageService = startLanguageService({
     languageId: PYTHON_LANGUAGE_ID,
     workerName: PYTHON_WORKER_NAME,
@@ -124,67 +144,23 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
     },
     resolveDiagnosticsModelUri: modelUriFor,
 
-    // Go-to-definition routing.  Two layers, in order:
-    //
-    //   1. **Store redirect** (`redirectPythonDefinitionToStore`):
-    //      for targets in the source URI's preamble, open the POU
-    //      tab, switch the variables panel to code mode, and place
-    //      the variables-code-editor cursor at the declaration.
-    //      Mirrors the ST LSP's `redirectDefinitionToStore`.  Body
-    //      targets in the same URI route through `routeToPouBody`
-    //      so the navigation goes through the store and the tab
-    //      list stays consistent.
-    //
-    //   2. **URI-reachability filter** (fallback):
-    //
-    //        - Click on a stdlib name (`print`, `os.path`, …) →
-    //          Pyright returns a Location targeting the bundled
-    //          typeshed (`file:///typeshed/stdlib/builtins.pyi`).
-    //          Monaco has no model for that URI, so opening the
-    //          peek widget throws `Model not found` and crashes
-    //          the renderer.  Drop those before they reach Monaco.
-    //        - Anything that survives the drop is a navigable
-    //          in-model target the redirect didn't claim — hand it
-    //          to Monaco unchanged.
-    //
-    // Returning `suppressNoDefinitionFound` keeps Monaco quiet
-    // (no banner, no peek) when there's nowhere navigable to go.
-    definitionInterceptors: [
-      (locations, model, position, monacoApi) => {
-        const modelUri = model.uri.toString()
-        const entry = entryByUri.get(modelUri)
-
-        // Pyright's Locations come back with the LSP URI (model URI
-        // + `.py`).  Compare against entry.lspUri inside the
-        // redirect so the "same document?" check matches; the
-        // routeTo* helpers only need the POU name + IEC line/col
-        // they get from the maps.
-        if (entry) {
-          for (const loc of locations) {
-            const handled = redirectPythonDefinitionToStore(loc, {
-              sourceUri: entry.lspUri,
-              sourcePouName: entry.pouName,
-              variableNameByPreambleLine: entry.preamble.variableNameByPreambleLine,
-              iecVariableLineMap: entry.iecVariableLineMap,
-            })
-            if (handled) return suppressNoDefinitionFound(model, position, monacoApi)
-          }
-        }
-
-        // Nothing redirectable.  Fall back to filtering out targets
-        // Monaco can't open (typeshed stubs, external imports).
-        // Pyright reports targets in LSP-URI space (with `.py`); the
-        // model lookup needs the extension-less Monaco model URI.
-        const navigable = locations.filter((loc) =>
-          monacoApi.editor.getModels().some((m) => m.uri.toString() === modelUriFor(loc.uri)),
-        )
-
-        if (navigable.length === 0) {
-          return suppressNoDefinitionFound(model, position, monacoApi)
-        }
-        return lspLocationsToMonaco(navigable, monacoApi) ?? null
-      },
-    ],
+    // Go-to-definition targets.  Pyright answers in LSP-URI space (model
+    // URI + `.py`).  A body target stays in the source model; a preamble
+    // target resolves to the document mirror, so the preview shows the
+    // declaration Pyright saw; anything outside the source document
+    // (typeshed stubs, external imports) is dropped — Monaco has no
+    // model for it, and Python POUs are single-document.  Navigation
+    // runs from `navigateToStore` on activation only.
+    mapDefinitionLocation: (loc, source) => {
+      const entry = entryByUri.get(source.modelUri)
+      if (!entry || loc.uri !== entry.lspUri) return null
+      const bodyOffset = getBodyLineOffset(entry.lspUri)
+      if (loc.range.start.line >= bodyOffset) {
+        return { uri: source.modelUri, range: lspRangeToMonaco(loc.range, bodyOffset) }
+      }
+      return { uri: lspMirrorUri(loc.uri), range: lspRangeToMonaco(loc.range, 0) }
+    },
+    navigateOutline: navigateToStore,
 
     markerOwner: MARKER_OWNER,
     diagnosticSource: DIAGNOSTIC_SOURCE,
@@ -322,12 +298,16 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
       entryByUri.set(uri, { pouName, lspUri, preamble, iecVariableLineMap })
       setBodyLineOffset(lspUri, preamble.lineCount)
       void pyrightConnection?.sendNotification('pyright/createFile', { kind: 'create', uri: lspUri })
-      sharedService.openDocument(lspUri, augmentedDocument(uri, bodyText))
+      const text = augmentedDocument(uri, bodyText)
+      mirror?.set(lspUri, text)
+      sharedService.openDocument(lspUri, text)
     },
 
     notifyBodyChange(uri, bodyText) {
       const lspUri = lspUriFor(uri)
-      sharedService.changeDocument(lspUri, augmentedDocument(uri, bodyText))
+      const text = augmentedDocument(uri, bodyText)
+      mirror?.set(lspUri, text)
+      sharedService.changeDocument(lspUri, text)
     },
 
     notifyVariablesChange(uri, variables, bodyText, dataTypes = []) {
@@ -344,7 +324,9 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
       const iecVariableLineMap = getIecVariableLineMap(variables)
       entryByUri.set(uri, { pouName: existing?.pouName ?? '', lspUri, preamble, iecVariableLineMap })
       setBodyLineOffset(lspUri, preamble.lineCount)
-      sharedService.changeDocument(lspUri, augmentedDocument(uri, bodyText))
+      const text = augmentedDocument(uri, bodyText)
+      mirror?.set(lspUri, text)
+      sharedService.changeDocument(lspUri, text)
     },
 
     detachPou(uri) {
@@ -352,6 +334,7 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
       // file from pyright's in-memory FS so the workspace member
       // count returns to zero when no Python POU is open.
       const lspUri = lspUriFor(uri)
+      mirror?.delete(lspUri)
       sharedService.closeDocument(lspUri)
       void pyrightConnection?.sendNotification('pyright/deleteFile', { kind: 'delete', uri: lspUri })
       entryByUri.delete(uri)
@@ -359,6 +342,8 @@ export function startPythonLsp(opts: PythonLspStartOptions): PythonLspService {
     },
 
     dispose() {
+      opener?.dispose()
+      mirror?.dispose()
       sharedService.dispose()
       entryByUri.clear()
     },

--- a/src/frontend/services/st-lsp/__tests__/definition-locations.test.ts
+++ b/src/frontend/services/st-lsp/__tests__/definition-locations.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { Location as LspLocation } from 'vscode-languageserver-protocol'
+
+import { __clearBodyLineOffsetsForTests, setBodyLineOffset } from '../../lsp-shared/body-offsets'
+import { lspMirrorUri } from '../../lsp-shared/lsp-mirror'
+import { mapStDefinitionLocation } from '../definition-locations'
+import { DATA_TYPES_URI, GLOBAL_VARIABLE_LISTS_URI, pouUri, stubUri } from '../types'
+
+const at = (uri: string, line: number, character = 2): LspLocation => ({
+  uri,
+  range: { start: { line, character }, end: { line, character: character + 5 } },
+})
+
+// pou://main: declaration line 0, VAR lines 1..4, body from line 5.
+beforeEach(() => {
+  __clearBodyLineOffsetsForTests()
+  setBodyLineOffset(pouUri('main'), 5)
+  setBodyLineOffset(stubUri('Ladder'), 3)
+})
+
+describe('mapStDefinitionLocation', () => {
+  it('keeps a body target in the POU model, shifted to the body view', () => {
+    expect(mapStDefinitionLocation(at(pouUri('main'), 6))).toEqual({
+      uri: pouUri('main'),
+      range: { startLineNumber: 2, startColumn: 3, endLineNumber: 2, endColumn: 8 },
+    })
+  })
+
+  it('sends a VAR-block target to the document mirror, unshifted', () => {
+    expect(mapStDefinitionLocation(at(pouUri('main'), 2))).toEqual({
+      uri: lspMirrorUri(pouUri('main')),
+      range: { startLineNumber: 3, startColumn: 3, endLineNumber: 3, endColumn: 8 },
+    })
+  })
+
+  it('sends the declaration line to the mirror too', () => {
+    expect(mapStDefinitionLocation(at(pouUri('main'), 0))?.uri).toBe(lspMirrorUri(pouUri('main')))
+  })
+
+  it('sends every target of a POU whose body line is not registered yet to the mirror', () => {
+    expect(mapStDefinitionLocation(at(pouUri('Unknown'), 9))?.uri).toBe(lspMirrorUri(pouUri('Unknown')))
+  })
+
+  it('sends stubs and the synthesized documents to the mirror', () => {
+    expect(mapStDefinitionLocation(at(stubUri('Ladder'), 7))?.uri).toBe(lspMirrorUri(stubUri('Ladder')))
+    expect(mapStDefinitionLocation(at(DATA_TYPES_URI, 2))?.uri).toBe(lspMirrorUri(DATA_TYPES_URI))
+    expect(mapStDefinitionLocation(at(GLOBAL_VARIABLE_LISTS_URI, 4))?.uri).toBe(lspMirrorUri(GLOBAL_VARIABLE_LISTS_URI))
+  })
+
+  it('passes an unknown URI through with its own offset', () => {
+    expect(mapStDefinitionLocation(at('stlib://oscat/basic.st', 40))).toEqual({
+      uri: 'stlib://oscat/basic.st',
+      range: { startLineNumber: 41, startColumn: 3, endLineNumber: 41, endColumn: 8 },
+    })
+  })
+})

--- a/src/frontend/services/st-lsp/__tests__/index.test.ts
+++ b/src/frontend/services/st-lsp/__tests__/index.test.ts
@@ -7,6 +7,7 @@ import type { Diagnostic } from 'vscode-languageserver-protocol'
 import type { PLCPou } from '../../../../middleware/shared/ports/types'
 import { openPLCStoreBase } from '../../../store'
 import { __clearBodyLineOffsetsForTests, getBodyLineOffset, setBodyLineOffset } from '../../lsp-shared/body-offsets'
+import type { NavTarget } from '../../lsp-shared/definition-redirect'
 import type { StartLanguageServiceOptions } from '../../lsp-shared/start-language-service'
 import type { StlibSourcePort } from '../../../../middleware/shared/ports/stlib-source-port'
 
@@ -16,7 +17,9 @@ const mockRequestSemanticTokens = jest.fn()
 const mockGetSemanticTokensLegend = jest.fn()
 const mockRefreshSemanticTokens = jest.fn()
 const mockGetSyncedDocumentText = jest.fn<string | undefined, [string]>()
+const mockMirror = { set: jest.fn(), delete: jest.fn(), dispose: jest.fn() }
 let mockCapturedOptions: StartLanguageServiceOptions | undefined
+let mockCapturedNavigate: ((target: NavTarget) => boolean) | undefined
 
 // `vscode-languageserver-protocol`'s Node entry point is ESM-only and Jest's
 // CJS transform can't parse it; index.ts only needs `CompletionRequest.type`
@@ -51,13 +54,18 @@ jest.mock('../../lsp-shared', () => ({
     message: d.message,
   }),
   shiftSemanticTokensToBody: (data: unknown) => data,
-  suppressNoDefinitionFound: jest.fn(),
+  createLspDocumentMirror: () => mockMirror,
+  registerDefinitionOpener: (_api: unknown, navigate: (target: NavTarget) => boolean) => {
+    mockCapturedNavigate = navigate
+    return { dispose: jest.fn() }
+  },
 }))
 
 jest.mock('../project-sync', () => ({
   getSyncedDocumentText: (uri: string) => mockGetSyncedDocumentText(uri),
 }))
 
+import { mapStDefinitionLocation } from '../definition-locations'
 import { startStLsp } from '../index'
 import { getPrintSemanticTokensApi } from '../print-tokens-api'
 import { pouUri, pouVarsUri, stubUri } from '../types'
@@ -282,5 +290,55 @@ describe('pouvars view sync', () => {
 
     updateMain((p) => ({ ...p, interface: { ...p.interface, variables: [] } }))
     expect(mockRefreshSemanticTokens).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('definition navigation', () => {
+  beforeEach(() => {
+    __clearBodyLineOffsetsForTests()
+    mockMirror.set.mockReset()
+    mockMirror.delete.mockReset()
+    mockCapturedOptions = undefined
+    mockCapturedNavigate = undefined
+    openPLCStoreBase.setState((s) => ({
+      project: { ...s.project, data: { ...s.project.data, pous: [makeStPou('main')] } },
+    }))
+  })
+
+  it('hands the providers the ST target mapper and routes the outline through the store', () => {
+    start(makeMonacoStub().api)
+
+    expect(mockCapturedOptions?.mapDefinitionLocation).toBe(mapStDefinitionLocation)
+    expect(mockCapturedOptions?.navigateOutline).toBeDefined()
+  })
+
+  it('mirrors every document project-sync opens, changes and closes', () => {
+    const service = start(makeMonacoStub().api)
+
+    service.openDocument(pouUri('main'), 'PROGRAM main\nEND_PROGRAM')
+    service.changeDocument(pouUri('main'), 'PROGRAM main\nx := 1;\nEND_PROGRAM', 2)
+    service.closeDocument(pouUri('main'))
+
+    expect(mockMirror.set.mock.calls).toEqual([
+      [pouUri('main'), 'PROGRAM main\nEND_PROGRAM'],
+      [pouUri('main'), 'PROGRAM main\nx := 1;\nEND_PROGRAM'],
+    ])
+    expect(mockMirror.delete).toHaveBeenCalledWith(pouUri('main'))
+  })
+
+  it('registers an opener whose navigation goes through the store, and declines URIs it does not own', () => {
+    start(makeMonacoStub().api)
+
+    expect(mockCapturedNavigate?.({ uri: pouUri('main'), lineLsp: 0, characterLsp: 0 })).toBe(true)
+    expect(openPLCStoreBase.getState().tabs.some((t) => t.name === 'main')).toBe(true)
+    expect(mockCapturedNavigate?.({ uri: 'file:///elsewhere.py', lineLsp: 3, characterLsp: 0 })).toBe(false)
+  })
+
+  it('does not register an opener or a mirror without a Monaco namespace', () => {
+    const service = start()
+
+    expect(mockCapturedNavigate).toBeUndefined()
+    service.openDocument(pouUri('main'), 'PROGRAM main')
+    expect(mockMirror.set).not.toHaveBeenCalled()
   })
 })

--- a/src/frontend/services/st-lsp/definition-locations.ts
+++ b/src/frontend/services/st-lsp/definition-locations.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * Where an ST definition target is shown before it is activated.
+ *
+ * A body target stays a body location: Monaco previews and jumps inside
+ * the POU model as it would in any file. Everything the body editor does
+ * not render — the declaration line, the VAR blocks, a stub, the
+ * synthesized documents — resolves to the mirror of its document, so the
+ * hover preview shows the real declaration and the opener gets the LSP
+ * coordinates back untouched (`goto-definition-redirect.ts` turns them
+ * into the tab, panel and cursor the user expects).
+ */
+
+import type { Location as LspLocation } from 'vscode-languageserver-protocol'
+
+import { getBodyLineOffset } from '../lsp-shared/body-offsets'
+import { lspRangeToMonaco } from '../lsp-shared/converters'
+import { lspMirrorUri } from '../lsp-shared/lsp-mirror'
+import type { MappedLocation } from '../lsp-shared/providers'
+import {
+  DATA_TYPES_URI,
+  GLOBAL_VARIABLE_LISTS_URI,
+  parsePouUri,
+  RESOURCE_GLOBALS_URI,
+  SOFTMOTION_GLOBALS_URI,
+} from './types'
+
+const SYNTHESIZED_URIS = new Set([
+  DATA_TYPES_URI,
+  RESOURCE_GLOBALS_URI,
+  SOFTMOTION_GLOBALS_URI,
+  GLOBAL_VARIABLE_LISTS_URI,
+])
+
+export function mapStDefinitionLocation(loc: LspLocation): MappedLocation {
+  const parsed = parsePouUri(loc.uri)
+  if (parsed?.kind === 'pou') {
+    const bodyOffset = getBodyLineOffset(loc.uri)
+    if (bodyOffset > 0 && loc.range.start.line >= bodyOffset) {
+      return { uri: loc.uri, range: lspRangeToMonaco(loc.range, bodyOffset) }
+    }
+  }
+  if (parsed || SYNTHESIZED_URIS.has(loc.uri)) {
+    return { uri: lspMirrorUri(loc.uri), range: lspRangeToMonaco(loc.range, 0) }
+  }
+  return { uri: loc.uri, range: lspRangeToMonaco(loc.range, getBodyLineOffset(loc.uri)) }
+}

--- a/src/frontend/services/st-lsp/goto-definition-redirect.ts
+++ b/src/frontend/services/st-lsp/goto-definition-redirect.ts
@@ -42,7 +42,13 @@ import { CreateEditorObjectFromTab } from '../../store/slices/tabs/utils'
 import { dataTypeLineSpans } from '../../utils/PLC/data-type-serializer'
 import { serializeGlobalVariableListsToTypes } from '../../utils/PLC/global-variable-list-serializer'
 import { getBodyLineOffset } from '../lsp-shared/body-offsets'
-import { normaliseLocation, routeToPou, routeToPouBody, routeToPouPreamble } from '../lsp-shared/definition-redirect'
+import {
+  type NavTarget,
+  normaliseLocation,
+  routeToPou,
+  routeToPouBody,
+  routeToPouPreamble,
+} from '../lsp-shared/definition-redirect'
 import {
   DATA_TYPES_URI,
   DT_VIEW_FRAME_LINE_COUNT,
@@ -287,8 +293,11 @@ function redirectGlobalVariableList(lineLsp: number): boolean {
 }
 
 export function redirectDefinitionToStore(loc: Location | LocationLink): boolean {
-  const target = normaliseLocation(loc)
+  return redirectNavTargetToStore(normaliseLocation(loc))
+}
 
+/** Route a target in LSP coordinates through the store; false when nothing here owns its URI. */
+export function redirectNavTargetToStore(target: NavTarget): boolean {
   // Resource-globals doc → open the Resource editor (globals table) rather than
   // the synthesised (non-editable) CONFIGURATION declaration.
   if (target.uri === RESOURCE_GLOBALS_URI) {

--- a/src/frontend/services/st-lsp/index.ts
+++ b/src/frontend/services/st-lsp/index.ts
@@ -13,8 +13,10 @@
  *     under webpack; injected for tests).
  *   - Provider hooks: the `pouvars://` URI rewrite (variables-text
  *     view targets a different LSP doc than its Monaco model);
- *     definition redirects to the Zustand store / graphical
- *     editor.
+ *     definition targets mapped onto the document mirror.
+ *   - Navigation into the Zustand store / graphical editor, run from
+ *     the editor opener and outline activation only — never while
+ *     a definition is merely being resolved.
  *   - Diagnostics mirror onto the `pouvars://` model so var-block
  *     errors surface in the variables editor too, replayed when that
  *     model mounts after the last publish.
@@ -32,7 +34,6 @@ import {
   type CompletionList,
   CompletionRequest,
   type Diagnostic,
-  type Location as LspLocation,
   type MessageConnection,
 } from 'vscode-languageserver-protocol'
 
@@ -40,16 +41,19 @@ import { openPLCStoreBase } from '../../store'
 import { dataTypeLineSpans, serializeDataTypeToText } from '../../utils/PLC/data-type-serializer'
 import { serializePouScopeForQuery } from '../../utils/PLC/pou-signature-serializer'
 import {
+  createLspDocumentMirror,
   getBodyLineOffset,
   type LanguageService,
   lspDiagnosticToMonaco,
+  type NavigateToTarget,
+  registerDefinitionOpener,
   shiftSemanticTokensToBody,
   startLanguageService,
-  suppressNoDefinitionFound,
 } from '../lsp-shared'
 import { parseScopedCompletionType } from './completion-type'
+import { mapStDefinitionLocation } from './definition-locations'
 import { diagnosticsInSpan, dtViewLineOffset, dtViewSpan, dtViewWindow } from './dtview-context'
-import { redirectDefinitionToStore } from './goto-definition-redirect'
+import { redirectNavTargetToStore } from './goto-definition-redirect'
 import { redirectToGraphicalPou } from './graphical-redirect'
 import { diagnosticsInVarBlocks, pouVarsTokenViewport } from './pouvars-context'
 import { type PrintSemanticTokens, registerPrintSemanticTokensApi } from './print-tokens-api'
@@ -159,6 +163,13 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
 
   let serviceConnection: MessageConnection | null = null
 
+  // Every document the worker sees, as a model Monaco can preview.
+  const mirror = monacoApi ? createLspDocumentMirror(monacoApi) : null
+
+  // Graphical stubs open their editor; everything else goes through the store.
+  const navigateToStore: NavigateToTarget = (target) =>
+    redirectToGraphicalPou(target.uri) || redirectNavTargetToStore(target)
+
   const sharedService: LanguageService = startLanguageService({
     languageId: ST_LANGUAGE_ID,
     workerName: ST_WORKER_NAME,
@@ -170,25 +181,8 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
     signatureHelpTriggerCharacters: ['(', ','],
     resolveLspContext: resolveStLspContext,
     getLspDocumentText: getSyncedDocumentText,
-    definitionInterceptors: monacoApi
-      ? [
-          // Reroute graphical-POU stubs to the graphical editor.
-          (locations: LspLocation[], model, position) => {
-            const stubLocation = locations.find((l) => redirectToGraphicalPou(l.uri))
-            if (stubLocation) return suppressNoDefinitionFound(model, position, monacoApi)
-            return undefined
-          },
-          // Route variable-declaration and cross-POU targets through
-          // the Zustand store.
-          (locations, model, position) => {
-            const primary = locations[0]
-            if (primary && redirectDefinitionToStore(primary)) {
-              return suppressNoDefinitionFound(model, position, monacoApi)
-            }
-            return undefined
-          },
-        ]
-      : [],
+    mapDefinitionLocation: mapStDefinitionLocation,
+    navigateOutline: navigateToStore,
 
     // Rename intentionally not configured.  Default capabilities
     // advertise prepareSupport, but no Monaco rename provider is
@@ -294,6 +288,8 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
       if (varsPou !== null) applyPouVarsDiagnostics(api, varsPou, MARKER_OWNER, DIAGNOSTIC_SOURCE)
     })
     viewSyncDisposables.push(() => onModelAdded.dispose())
+    const opener = registerDefinitionOpener(api, navigateToStore)
+    viewSyncDisposables.push(() => opener.dispose())
   }
 
   // ---------------------------------------------------------------------------
@@ -544,14 +540,17 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
     },
 
     openDocument(uri, content) {
+      mirror?.set(uri, content)
       sharedService.openDocument(uri, content)
     },
 
     changeDocument(uri, content, externalVersion) {
+      mirror?.set(uri, content)
       sharedService.changeDocument(uri, content, externalVersion)
     },
 
     closeDocument(uri) {
+      mirror?.delete(uri)
       sharedService.closeDocument(uri)
     },
 
@@ -562,6 +561,7 @@ export function startStLsp(opts: StLspStartOptions): StLspService {
       viewSyncDisposables.length = 0
       lastDataTypeDiagnostics = []
       lastPouDiagnostics.clear()
+      mirror?.dispose()
       sharedService.dispose()
     },
   }

--- a/src/frontend/services/st-lsp/resolve-context.ts
+++ b/src/frontend/services/st-lsp/resolve-context.ts
@@ -11,6 +11,7 @@ import { openPLCStoreBase } from '../../store'
 import { getBodyLineOffset } from '../lsp-shared/body-offsets'
 import type { LspContext } from '../lsp-shared/providers'
 import { dtViewLineOffset, dtViewSpan, dtViewWindow } from './dtview-context'
+import { pouVarsWindow } from './pouvars-context'
 import { DATA_TYPES_URI, parseDtViewUri, parsePouVarsUri, POU_DECLARATION_LINE_COUNT, pouUri, stubUri } from './types'
 
 /**
@@ -38,13 +39,7 @@ export function resolveStLspContext(modelUri: string): LspContext {
     const pou = openPLCStoreBase.getState().project.data.pous.find((p) => p.name === varsPou)
     const isStLanguage = pou?.body.language === 'st'
     const lspUri = isStLanguage ? pouUri(varsPou) : stubUri(varsPou)
-    // Skipped until project-sync registers the body line: an
-    // unpopulated registry reads as 0 and would window the view to nothing.
-    const bodyLine = getBodyLineOffset(lspUri)
-    const varsWindow =
-      bodyLine > POU_DECLARATION_LINE_COUNT
-        ? { startLine: POU_DECLARATION_LINE_COUNT, endLineExclusive: bodyLine }
-        : null
+    const varsWindow = pouVarsWindow(getBodyLineOffset(lspUri))
     return {
       lspUri,
       lineOffset: POU_DECLARATION_LINE_COUNT,


### PR DESCRIPTION
Fixes [DOPE-551](https://autonomylogic.atlassian.net/browse/DOPE-551).

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/744

Bug fix: no Requirements Gathering page, and no Cybersecurity Risk Assessment trigger area is touched — frontend navigation only.

## Problem

Holding Ctrl/Cmd over a symbol in an ST editor navigated: tab switch, variables panel flipped to code mode, cursor moved. Go-to-definition ran as a **side effect inside `provideDefinition`** — the `definitionInterceptors` mutated the store and returned a dummy self location — and Monaco calls `provideDefinition` on Ctrl/Cmd+hover to decide whether to underline the token and to render the preview. Resolving *was* navigating. Every redirect branch was affected (cross-POU, variable declaration, resource global, SoftMotion axis, data type, Global Variable List), and the Python LSP shared the same layer.

Added scope from the card: after DOPE-590 the body editor's Go to Symbol lost the POU's VAR declarations (they sit in the preamble the editor does not render; before DOPE-590 accepting one crashed with `Illegal value for lineNumber`).

## Fix — option A from the card

**Providers are pure.** `definitionInterceptors` is gone. `provideDefinition` maps each LSP target through a per-language `mapDefinitionLocation` hook and returns locations, nothing else. When every target is unreachable (a typeshed stub) it returns the same self location as before — still without side effects — so Monaco shows no banner.

**Navigation runs on activation** in new `lsp-shared/navigation.ts`. `registerDefinitionOpener` wraps `monaco.editor.registerEditorOpener`. Monaco registers openers with `unshift`, so ours runs before its default handler for every target: a target inside the source model returns false (Monaco's native in-editor jump), anything else goes to `navigate`, which is the existing `redirectDefinitionToStore` / `redirectToGraphicalPou` logic unchanged, now fed a `NavTarget` (`redirectNavTargetToStore`). Each language service registers its own opener and declines URIs it does not own.

**LSP document mirror** in new `lsp-shared/lsp-mirror.ts`. Monaco resolves a definition target through its model service: the Ctrl+hover preview reads the target line from a model, and VAR blocks, stubs and the synthesized documents had none (`Model not found` into `onUnexpectedError`, no underline), while preamble lines in the body model clamp to line 1. The mirror keeps one **plaintext** model per LSP document at `inmemory://lsp-mirror/…`, holding the exact text the worker saw, fed from the ST service's `openDocument`/`changeDocument`/`closeDocument` (the funnel project-sync uses) and from Python's `attachPou`/`notify*`/`detachPou`. Plaintext because Monaco requests semantic tokens for every model of a language, attached to an editor or not; the preview still colours by the `.st`/`.py` extension. `mapStDefinitionLocation` (new `st-lsp/definition-locations.ts`) keeps body targets native and sends the declaration line, VAR blocks, stubs and synthesized documents to the mirror unshifted; the opener decodes a mirror URI straight back to LSP coordinates.

**Outline binding.** For body editors (no `lineWindow`), `provideDocumentSymbols` lists the leaves before the window (`symbolsBeforeWindow`) with a sentinel range on the editor's current line at column `1<<20 + k`, registered against the real target. Go to Symbol accepts an entry via `editor.setSelection(range, 'code.jump')` on the **unvalidated** range (`AbstractEditorNavigationQuickAccessProvider.gotoLocation`), so `attachOutlineActivation` patches `setSelection` on every editor (existing + `onDidCreateEditor`, once per Monaco namespace) and, for a `code.jump` on a bound range, navigates instead of selecting. The sentinel line is the current line so the picker's preview reveal does not scroll; it must be a valid line because Monaco also calls `getLineContent(range.startLineNumber)` on the raw range. `dtview://` and `pouvars://` outlines keep DOPE-590's behaviour (windowed views bind nothing).

**Python** follows the same shape: body target → source model shifted; preamble target → mirror; anything outside the source document (typeshed, external imports) dropped — Python POUs are single-document, cross-document targets were never navigable. `redirectPythonNavTarget` is the core, the `Location` wrapper stays.

Also folded in: `resolve-context.ts` reuses `pouVarsWindow` (CodeRabbit follow-up from DOPE-552).

Not touched: `variables-code-editor`, `monaco/index.tsx`, `definition-redirect.ts`, `symbol-helpers.ts`. References peek still returns raw `pou://` locations — same class of defect, separate follow-up if wanted.

## Behaviour changes worth knowing

- Ctrl/Cmd+hover preview now shows the real declaration line (variable, struct field, global, `FUNCTION_BLOCK X`) instead of the current line.
- Peek Definition (Alt+F12) shows the mirror document, plaintext.
- Body editor Go to Symbol lists the POU's variables again; accepting one opens the variables panel at that declaration.
- Known trade-off: the bound entries' sentinel line is the cursor line at outline time, and Monaco caches the outline by model version, so after a cursor-only move the picker's preview reveals the previous line until the next edit. Navigation itself is unaffected.

## Tests

- New `lsp-mirror.test.ts` (URI round-trip, model lifecycle), `navigation.test.ts` (target decoding, opener same-model/mirror/decline, sentinel binding, `setSelection` patch), `providers.test.ts` — first harness for `registerLspProviders` (mapper, unreachable suppression, bound outline entries, windowed views untouched), `st-lsp/definition-locations.test.ts`.
- `line-window.test.ts` +4 (`symbolsBeforeWindow`); `st-lsp/index.test.ts` +4 (hooks wiring, mirror calls, opener navigate); `python-lsp/index.test.ts` +4 (mapper on a real attached entry).
- The 27 `redirectDefinitionToStore` tests and the Python redirect tests run unchanged.

Local gate in both repos: prettier, eslint, tsc, architecture validation; `st-lsp` + `lsp-shared` + `python-lsp` suites green (web 263, editor 283). `scripts/compare-surfaces.py` between the branches: `total_diffs: 0`.

Validated manually by João on the dev build: all six ST target kinds on hover (underline + preview, no navigation) and on click/F12 (navigates), Go to Symbol in the body editor, `.dt` and pouvars outlines unchanged, and the Python surface on the fixture `plc-projects/dope-551-python`.

Shared surface: `src/frontend/**` only, byte-identical with the sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOPE-551]: https://autonomylogic.atlassian.net/browse/DOPE-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Go to Definition navigation across declarations, body sections, generated documents, and related source files.
  - Added support for navigating to symbols outside the current editor view.
  - Improved document outlines, including symbols declared before windowed views.
  - Added synchronized document previews for language-service content.
  - Improved Python and Structured Text navigation and routing.

- **Bug Fixes**
  - Prevented unsupported definition targets from producing misleading navigation results.
  - Applied correct line offsets when navigating between declarations and body sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->