### PR TITLE
fix(store): gate globals, servers and remote devices against every other element name [DOPE-598 + DOPE-600]

### DIFF
--- a/src/frontend/components/_features/[workspace]/create-element/element-card/index.tsx
+++ b/src/frontend/components/_features/[workspace]/create-element/element-card/index.tsx
@@ -220,7 +220,12 @@ const ElementCard = (props: ElementCardProps): ReactNode => {
   const handleCreateServer: SubmitHandler<CreateServerFormProps> = (data) => {
     const result = createServer({ name: data.name, protocol: data.protocol })
     if (!result.ok) {
-      serverSetError('name', { type: 'already-exists' })
+      serverSetError('name', { type: 'already-exists', message: result.message })
+      toast({
+        title: 'Server not created',
+        description: result.message ?? "You can't create a server with this name.",
+        variant: 'fail',
+      })
       return
     }
     toast({ title: 'Server created successfully', description: 'The server has been created', variant: 'default' })
@@ -231,7 +236,12 @@ const ElementCard = (props: ElementCardProps): ReactNode => {
   const handleCreateRemoteDevice: SubmitHandler<CreateRemoteDeviceFormProps> = (data) => {
     const result = createRemoteDevice({ name: data.name, protocol: data.protocol })
     if (!result.ok) {
-      remoteDeviceSetError('name', { type: 'already-exists' })
+      remoteDeviceSetError('name', { type: 'already-exists', message: result.message })
+      toast({
+        title: 'Remote device not created',
+        description: result.message ?? "You can't create a remote device with this name.",
+        variant: 'fail',
+      })
       return
     }
     toast({
@@ -511,7 +521,7 @@ const ElementCard = (props: ElementCardProps): ReactNode => {
                         />
                         {serverErrors.name?.type === 'already-exists' && (
                           <span className='flex-1 text-start font-caption text-cp-xs font-normal text-red-500 opacity-65'>
-                            * Server name already exists or protocol already in use
+                            * {serverErrors.name.message ?? 'Server name already exists or protocol already in use'}
                           </span>
                         )}
                         <span className='flex-1 text-start font-caption text-cp-xs font-normal text-neutral-1000 opacity-65 dark:text-neutral-300'>
@@ -646,7 +656,7 @@ const ElementCard = (props: ElementCardProps): ReactNode => {
                         />
                         {remoteDeviceErrors.name?.type === 'already-exists' && (
                           <span className='flex-1 text-start font-caption text-cp-xs font-normal text-red-500 opacity-65'>
-                            * Device name already exists
+                            * {remoteDeviceErrors.name.message ?? 'Device name already exists'}
                           </span>
                         )}
                         <span className='flex-1 text-start font-caption text-cp-xs font-normal text-neutral-1000 opacity-65 dark:text-neutral-300'>

--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/index.tsx
@@ -5,9 +5,10 @@ import { enrichDeviceData } from '@root/backend/shared/ethercat/enrich-device-da
 import type { EtherCATMasterConfig } from '@root/backend/shared/types/PLC/open-plc'
 import { Modal, ModalContent, ModalTitle } from '@root/frontend/components/_molecules/modal'
 import { useOpenPLCStore } from '@root/frontend/store'
+import { elementNameCollision } from '@root/frontend/store/slices/shared/name-collision'
 import { cn } from '@root/frontend/utils/cn'
 import { getShortDeviceName } from '@root/frontend/utils/short-device-name'
-import { collectAllSlaveNames, generateUniqueSlaveName } from '@root/frontend/utils/unique-slave-name'
+import { generateUniqueSlaveName } from '@root/frontend/utils/unique-slave-name'
 import type {
   ConfiguredEtherCATDevice,
   ESIDeviceRef,
@@ -421,9 +422,10 @@ const EtherCATEditor = () => {
     const unmatched: ScannedDeviceMatch['device'][] = []
     const existingPositions = new Set(configuredDevices.map((d) => d.position))
     const usedAddresses = buildClaimedAddressSet(project.data.remoteDevices, vendorScreenData)
-    // Names already taken across every master — extended as we add each
-    // device so the batch can't collide with itself either.
-    const takenNames = collectAllSlaveNames(project.data.remoteDevices)
+    // Every element name in the project, plus the batch so it cannot collide with itself.
+    const batch = new Set<string>()
+    const nameTaken = (name: string) =>
+      batch.has(name) || elementNameCollision(useOpenPLCStore.getState(), name, 'ethercat-slave') !== null
 
     for (const position of selectedScannedDevices) {
       // Skip devices already configured at this position
@@ -454,8 +456,8 @@ const EtherCATEditor = () => {
       // SoftMotion drive names become axis variable names — keep them valid.
       const rawName = getShortDeviceName(bestMatch.esiDevice)
       const baseName = enriched.cia402?.enabled ? sanitizeAxisName(rawName) : rawName
-      const uniqueName = generateUniqueSlaveName(baseName, takenNames)
-      takenNames.add(uniqueName)
+      const uniqueName = generateUniqueSlaveName(baseName, nameTaken)
+      batch.add(uniqueName)
 
       newDevices.push({
         id: uuidv4(),
@@ -530,7 +532,10 @@ const EtherCATEditor = () => {
       // code, so it must be a valid IEC identifier from the start.
       const rawName = getShortDeviceName(device)
       const baseName = enriched.cia402?.enabled ? sanitizeAxisName(rawName) : rawName
-      const uniqueName = generateUniqueSlaveName(baseName, collectAllSlaveNames(project.data.remoteDevices))
+      const uniqueName = generateUniqueSlaveName(
+        baseName,
+        (name) => elementNameCollision(useOpenPLCStore.getState(), name, 'ethercat-slave') !== null,
+      )
 
       const newDevice: ConfiguredEtherCATDevice = {
         id: uuidv4(),

--- a/src/frontend/components/_molecules/global-variables-table/editable-cell.tsx
+++ b/src/frontend/components/_molecules/global-variables-table/editable-cell.tsx
@@ -9,6 +9,7 @@ import type { PLCGlobalVariable } from '../../../../middleware/shared/ports/type
 import { pinSelectors, remoteDeviceSelectors, vendorIoSelectors } from '../../../hooks/use-store-selectors'
 import { useOpenPLCStore } from '../../../store'
 import type { ProjectResponse } from '../../../store/slices/project'
+import { elementNameCollision } from '../../../store/slices/shared/name-collision'
 import { cn } from '../../../utils/cn'
 import { isLegalIdentifier, sanitizeVariableInput } from '../../../utils/keywords'
 import { buildRemoteDeviceOptionGroups, buildVendorIoOptionGroups } from '../../../utils/remote-device-options'
@@ -43,6 +44,8 @@ type IEditableCellProps = CellContext<PLCGlobalVariable, unknown> & {
    * `propagateGlobalVariableListRename`'s job.
    */
   skipReferenceImpact?: boolean
+  /** A Resource global is a top-level symbol; a list member is not, so only the former is gated by name. */
+  isResourceGlobal?: boolean
 }
 const EditableNameCell = ({
   getValue,
@@ -51,6 +54,7 @@ const EditableNameCell = ({
   table,
   editable = true,
   skipReferenceImpact = false,
+  isResourceGlobal = true,
 }: IEditableCellProps) => {
   const initialValue = getValue<string>()
   const { toast } = useToast()
@@ -93,6 +97,16 @@ const EditableNameCell = ({
       setCellValue(oldName)
       setIsEditing(false)
       return
+    }
+
+    if (isResourceGlobal) {
+      const collision = elementNameCollision(useOpenPLCStore.getState(), newName, 'resource-global', oldName)
+      if (collision) {
+        toast({ title: 'Variable already exists', description: collision, variant: 'fail' })
+        setCellValue(oldName)
+        setIsEditing(false)
+        return
+      }
     }
 
     const impact: ReferenceImpactAnalysis = skipReferenceImpact

--- a/src/frontend/components/_molecules/global-variables-table/index.tsx
+++ b/src/frontend/components/_molecules/global-variables-table/index.tsx
@@ -37,7 +37,13 @@ const buildColumns = ({
   includeDebug = true,
   includeLocation = true,
   skipReferenceImpact = false,
-}: { includeDebug?: boolean; includeLocation?: boolean; skipReferenceImpact?: boolean } = {}) => [
+  isResourceGlobal = true,
+}: {
+  includeDebug?: boolean
+  includeLocation?: boolean
+  skipReferenceImpact?: boolean
+  isResourceGlobal?: boolean
+} = {}) => [
   columnHelper.display({
     id: 'rowNumber',
     header: '#',
@@ -53,7 +59,9 @@ const buildColumns = ({
     size: 300,
     minSize: 150,
     maxSize: 300,
-    cell: (props) => <EditableNameCell {...props} skipReferenceImpact={skipReferenceImpact} />,
+    cell: (props) => (
+      <EditableNameCell {...props} skipReferenceImpact={skipReferenceImpact} isResourceGlobal={isResourceGlobal} />
+    ),
   }),
   columnHelper.accessor('class', {
     header: 'Class',
@@ -107,7 +115,12 @@ const buildColumns = ({
 const resourceColumns = buildColumns()
 
 /** A list's columns: no address, no debugger watch, no bare-name reference rewriting. */
-const listColumns = buildColumns({ includeDebug: false, includeLocation: false, skipReferenceImpact: true })
+const listColumns = buildColumns({
+  includeDebug: false,
+  includeLocation: false,
+  skipReferenceImpact: true,
+  isResourceGlobal: false,
+})
 
 type PLCVariablesTableProps = {
   tableData: PLCGlobalVariable[]

--- a/src/frontend/components/_molecules/project-tree/index.tsx
+++ b/src/frontend/components/_molecules/project-tree/index.tsx
@@ -33,9 +33,9 @@ import { STIcon } from '../../../assets/icons/project/ST'
 import { StructureIcon } from '../../../assets/icons/project/Structure'
 import { UsersIcon } from '../../../assets/icons/project/Users'
 import { useOpenPLCStore } from '../../../store'
+import { elementNameCollision, type NamedElementKind } from '../../../store/slices/shared/name-collision'
 import { WorkspaceProjectTreeLeafType } from '../../../store/slices/workspace/types'
 import { cn } from '../../../utils/cn'
-import { collectAllSlaveNames } from '../../../utils/unique-slave-name'
 import { isUnsaved, unsavedLabel } from '../../../utils/unsaved-label'
 import { HighlightedText } from '../../_atoms/highlighted-text'
 import { toast } from '../../_features/[app]/toast/use-toast'
@@ -306,6 +306,7 @@ const ProjectTreeExpandableLeaf = ({
     const res = renameRemoteDevice(label, renamed)
     if (!res.ok) {
       setNewLabel(label || '')
+      toast({ title: 'Rename failed', description: res.message ?? `"${label}" could not be renamed.`, variant: 'fail' })
       return
     }
     // Soft, unsaved change: renameElement flags the workspace dirty; the rename
@@ -545,9 +546,6 @@ const ProjectTreeLeaf = ({
     },
     ethercatDeviceActions: { delete: deleteEthercatDevice, rename: renameEthercatDevice },
     fileActions: { getFile },
-    project: {
-      data: { pous, dataTypes, globalVariableLists, servers, remoteDevices },
-    },
   } = useOpenPLCStore()
 
   const [isEditing, setIsEditing] = useState(false)
@@ -676,41 +674,28 @@ const ProjectTreeLeaf = ({
     }
   }
 
-  /**
-   * Every element name the project has, in one list.
-   *
-   * File state, tabs and editor models are all keyed by raw element name, across kinds,
-   * so a candidate has to be free of ALL of them and not only of its own collection.
-   * Checking same-kind names alone let a duplicated POU called `Pump_copy` take over the
-   * `files['Pump_copy']` entry of a data type that already had that name.
-   */
-  const allElementNames = useMemo(
-    () => [
-      ...pous.map((pou) => pou.name),
-      ...dataTypes.map((dataType) => dataType.name),
-      ...(globalVariableLists ?? []).map((list) => list.name),
-      ...(servers ?? []).map((server) => server.name),
-      ...(remoteDevices ?? []).map((device) => device.name),
-      ...collectAllSlaveNames(remoteDevices),
-    ],
-    [pous, dataTypes, globalVariableLists, servers, remoteDevices],
-  )
+  const copyKind = (): NamedElementKind => {
+    if (isAPou) return 'pou'
+    if (isDatatype) return 'data-type'
+    if (isGlobalVariableList) return 'global-variable-list'
+    if (isServer) return 'server'
+    return 'remote-device'
+  }
 
   /**
-   * `<label>_copy`, then `_copy_2`, `_copy_3`… against every name in use.
-   *
-   * Duplicating twice used to call the action with the same `_copy` name both times;
-   * the second call failed on the collision and the result was discarded, so the menu
-   * item simply did nothing. Picking a free name up front is what makes the second
-   * duplicate behave like the first.
+   * `<label>_copy`, then `_copy_2`, `_copy_3`… — the first name the gate accepts
+   * for this kind, so the duplicate lands on the first try instead of failing on
+   * a name the menu could not know was taken.
    */
   const nextCopyName = (base: string): string => {
-    const used = new Set(allElementNames.map((n) => n.toLowerCase()))
+    const state = useOpenPLCStore.getState()
+    const kind = copyKind()
+    const free = (candidate: string) => elementNameCollision(state, candidate, kind) === null
     const first = `${base}_copy`
-    if (!used.has(first.toLowerCase())) return first
+    if (free(first)) return first
     for (let n = 2; ; n++) {
       const candidate = `${first}_${n}`
-      if (!used.has(candidate.toLowerCase())) return candidate
+      if (free(candidate)) return candidate
     }
   }
 

--- a/src/frontend/components/_organisms/global-variables-editor/index.tsx
+++ b/src/frontend/components/_organisms/global-variables-editor/index.tsx
@@ -9,6 +9,7 @@ import { StickArrowIcon } from '../../../assets/icons/interface/StickArrow'
 import { TableIcon } from '../../../assets/icons/interface/TableIcon'
 import { useOpenPLCStore } from '../../../store'
 import type { GlobalVariablesTableType } from '../../../store/slices/editor'
+import { elementNameCollision } from '../../../store/slices/shared/name-collision'
 import { cn } from '../../../utils/cn'
 import {
   duplicateVariableNameMessage,
@@ -225,7 +226,7 @@ const GlobalVariablesEditor = () => {
     const selectedRow = parseInt(editorVariables.selectedRow)
 
     if (variables.length === 0) {
-      createVariable({
+      const created = createVariable({
         scope: 'global',
         data: {
           name: 'GlobalVar',
@@ -236,6 +237,10 @@ const GlobalVariablesEditor = () => {
           debug: false,
         },
       })
+      if (!created.ok) {
+        toast({ title: created.title ?? 'Error', description: created.message, variant: 'fail' })
+        return
+      }
       updateModelVariables({
         display: 'table',
         selectedRow: 0,
@@ -259,7 +264,11 @@ const GlobalVariablesEditor = () => {
     }
 
     if (selectedRow === ROWS_NOT_SELECTED) {
-      createVariable({ scope: 'global', data: newVarData })
+      const appended = createVariable({ scope: 'global', data: newVarData })
+      if (!appended.ok) {
+        toast({ title: appended.title ?? 'Error', description: appended.message, variant: 'fail' })
+        return
+      }
       updateModelVariables({
         display: 'table',
         selectedRow: variables.length,
@@ -268,11 +277,15 @@ const GlobalVariablesEditor = () => {
       return
     }
 
-    createVariable({
+    const inserted = createVariable({
       scope: 'global',
       data: newVarData,
       rowToInsert: selectedRow + 1,
     })
+    if (!inserted.ok) {
+      toast({ title: inserted.title ?? 'Error', description: inserted.message, variant: 'fail' })
+      return
+    }
     updateModelVariables({
       display: 'table',
       selectedRow: selectedRow + 1,
@@ -341,6 +354,14 @@ const GlobalVariablesEditor = () => {
       const newVariables = parseIecStringToVariables(editorCode)
       const duplicate = findDuplicateVariableName(newVariables)
       if (duplicate) throw new Error(`Variable already exists: ${duplicateVariableNameMessage(duplicate)}`)
+
+      // The text is where a global gets a new name, so the namespace gate sits
+      // here; the setter below also serves undo, which must never be refused.
+      const state = useOpenPLCStore.getState()
+      for (const variable of newVariables) {
+        const collision = elementNameCollision(state, variable.name, 'resource-global')
+        if (collision) throw new Error(`Variable already exists: ${collision}`)
+      }
 
       const response = setGlobalVariables({
         variables: newVariables,

--- a/src/frontend/components/_organisms/global-variables-editor/index.tsx
+++ b/src/frontend/components/_organisms/global-variables-editor/index.tsx
@@ -9,7 +9,7 @@ import { StickArrowIcon } from '../../../assets/icons/interface/StickArrow'
 import { TableIcon } from '../../../assets/icons/interface/TableIcon'
 import { useOpenPLCStore } from '../../../store'
 import type { GlobalVariablesTableType } from '../../../store/slices/editor'
-import { elementNameCollision } from '../../../store/slices/shared/name-collision'
+import { newGlobalNameCollision } from '../../../store/slices/shared/name-collision'
 import { cn } from '../../../utils/cn'
 import {
   duplicateVariableNameMessage,
@@ -348,6 +348,7 @@ const GlobalVariablesEditor = () => {
   }
 
   const commitCode = (): boolean => {
+    let title = 'Syntax error'
     try {
       pushToHistory(editor.meta.name)
 
@@ -357,10 +358,13 @@ const GlobalVariablesEditor = () => {
 
       // The text is where a global gets a new name, so the namespace gate sits
       // here; the setter below also serves undo, which must never be refused.
-      const state = useOpenPLCStore.getState()
-      for (const variable of newVariables) {
-        const collision = elementNameCollision(state, variable.name, 'resource-global')
-        if (collision) throw new Error(`Variable already exists: ${collision}`)
+      const collision = newGlobalNameCollision(
+        useOpenPLCStore.getState(),
+        newVariables.map((variable) => variable.name),
+      )
+      if (collision) {
+        title = 'Variable already exists'
+        throw new Error(collision)
       }
 
       const response = setGlobalVariables({
@@ -379,7 +383,7 @@ const GlobalVariablesEditor = () => {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unexpected syntax error.'
       setParseError(message)
-      toast({ title: 'Syntax error', description: message, variant: 'fail' })
+      toast({ title, description: message, variant: 'fail' })
       return false
     }
   }

--- a/src/frontend/store/__tests__/element-duplicate.test.ts
+++ b/src/frontend/store/__tests__/element-duplicate.test.ts
@@ -400,3 +400,86 @@ describe('pouActions.duplicate', () => {
     expect(useOpenPLCStore.getState().pouActions.duplicate('Nope', 'Nope_copy').ok).toBe(false)
   })
 })
+
+describe('servers, remote devices and globals share the element namespace', () => {
+  const state = () => useOpenPLCStore.getState()
+
+  it('refuses a server or device named after a POU, and a POU named after either', () => {
+    expect(state().pouActions.create({ type: 'program', name: 'Pump', language: 'st' }).ok).toBe(true)
+    expect(state().serverActions.create({ name: 'pump', protocol: 'modbus-tcp' })).toEqual({
+      ok: false,
+      message: '"pump" is already the name of a POU',
+    })
+    expect(state().remoteDeviceActions.create({ name: 'PUMP', protocol: 'modbus-tcp' }).ok).toBe(false)
+
+    expect(state().serverActions.create({ name: 'Srv', protocol: 'modbus-tcp' }).ok).toBe(true)
+    expect(state().remoteDeviceActions.create({ name: 'Dev', protocol: 'modbus-tcp' }).ok).toBe(true)
+    expect(state().pouActions.create({ type: 'program', name: 'srv', language: 'st' })).toEqual({
+      ok: false,
+      message: '"srv" is already the name of a server',
+    })
+    expect(state().pouActions.create({ type: 'program', name: 'dev', language: 'st' })).toEqual({
+      ok: false,
+      message: '"dev" is already the name of a remote device',
+    })
+  })
+
+  it('refuses a server duplicated onto a remote device name, and the reverse', () => {
+    state().serverActions.create({ name: 'Srv', protocol: 'modbus-tcp' })
+    state().remoteDeviceActions.create({ name: 'Dev', protocol: 'modbus-tcp' })
+
+    expect(state().serverActions.duplicate('Srv', 'dev').ok).toBe(false)
+    expect(state().remoteDeviceActions.duplicate('Dev', 'srv').ok).toBe(false)
+  })
+
+  it('refuses a global named after a POU instead of auto-renaming it, and a POU named after a global', () => {
+    state().pouActions.create({ type: 'program', name: 'Motor', language: 'st' })
+    const refused = state().projectActions.createVariable({
+      scope: 'global',
+      data: {
+        name: 'motor',
+        class: 'global',
+        type: { definition: 'base-type', value: 'INT' },
+        location: '',
+        documentation: '',
+      },
+    })
+    expect(refused).toMatchObject({
+      ok: false,
+      title: 'Variable already exists',
+      message: '"motor" is already the name of a POU',
+    })
+    expect(state().project.data.configurations.resource.globalVariables).toEqual([])
+
+    state().projectActions.createVariable({
+      scope: 'global',
+      data: {
+        name: 'Level',
+        class: 'global',
+        type: { definition: 'base-type', value: 'INT' },
+        location: '',
+        documentation: '',
+      },
+    })
+    expect(state().pouActions.create({ type: 'program', name: 'level', language: 'st' })).toEqual({
+      ok: false,
+      message: '"level" is already the name of a global variable',
+    })
+  })
+
+  it('lets a global and a server share a name: neither sees the other', () => {
+    state().serverActions.create({ name: 'Modbus', protocol: 'modbus-tcp' })
+    const created = state().projectActions.createVariable({
+      scope: 'global',
+      data: {
+        name: 'Modbus',
+        class: 'global',
+        type: { definition: 'base-type', value: 'INT' },
+        location: '',
+        documentation: '',
+      },
+    })
+    expect(created.ok).toBe(true)
+    expect(state().remoteDeviceActions.create({ name: 'modbus', protocol: 'modbus-tcp' }).ok).toBe(false)
+  })
+})

--- a/src/frontend/store/__tests__/element-duplicate.test.ts
+++ b/src/frontend/store/__tests__/element-duplicate.test.ts
@@ -432,9 +432,22 @@ describe('servers, remote devices and globals share the element namespace', () =
     expect(state().remoteDeviceActions.duplicate('Dev', 'srv').ok).toBe(false)
   })
 
-  it('refuses a global named after a POU instead of auto-renaming it, and a POU named after a global', () => {
+  it("names a duplicated bus's slaves past every element, not only the other slaves", () => {
+    state().pouActions.create({ type: 'program', name: 'EK1100_01', language: 'st' })
+    state().projectActions.createRemoteDevice({ data: { name: 'Bus', protocol: 'ethercat' } })
+    state().projectActions.updateEthercatConfig('Bus', {
+      masterConfig: { networkInterface: 'eth0', cycleTimeUs: 1000, watchdogTimeoutCycles: 3 },
+      devices: [{ id: 'slave-1', name: 'EK1100' }] as never,
+    })
+
+    expect(state().remoteDeviceActions.duplicate('Bus', 'Bus_copy').ok).toBe(true)
+    const copy = state().project.data.remoteDevices?.find((d) => d.name === 'Bus_copy')
+    expect(copy?.ethercatConfig?.devices?.map((d) => d.name)).toEqual(['EK1100_02'])
+  })
+
+  it('steps a new global past a POU name, and refuses a POU named after a global', () => {
     state().pouActions.create({ type: 'program', name: 'Motor', language: 'st' })
-    const refused = state().projectActions.createVariable({
+    const stepped = state().projectActions.createVariable({
       scope: 'global',
       data: {
         name: 'motor',
@@ -444,12 +457,8 @@ describe('servers, remote devices and globals share the element namespace', () =
         documentation: '',
       },
     })
-    expect(refused).toMatchObject({
-      ok: false,
-      title: 'Variable already exists',
-      message: '"motor" is already the name of a POU',
-    })
-    expect(state().project.data.configurations.resource.globalVariables).toEqual([])
+    expect(stepped.ok).toBe(true)
+    expect(state().project.data.configurations.resource.globalVariables.map((v) => v.name)).toEqual(['motor0'])
 
     state().projectActions.createVariable({
       scope: 'global',

--- a/src/frontend/store/__tests__/name-collision.test.ts
+++ b/src/frontend/store/__tests__/name-collision.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it } from '@jest/globals'
+
+import { useOpenPLCStore } from '../index'
+import { elementNameCollision, type NamedElementKind } from '../slices/shared/name-collision'
+
+/**
+ * The gate on the real store, so the bundled library archives the test shim
+ * seeds are in play. One element of each kind, then every kind asks for every
+ * other kind's name.
+ */
+const seed = () => {
+  useOpenPLCStore.getState().projectActions.setProject({
+    meta: { name: 'test', type: 'plc-project', path: '' },
+    data: {
+      dataTypes: [{ name: 'Speed', derivation: 'enumerated', values: [{ description: 'SLOW' }], initialValue: 'SLOW' }],
+      globalVariableLists: [{ name: 'Plant', variables: [] }],
+      pous: [{ name: 'Main', pouType: 'program', body: { language: 'st', value: '' }, interface: { variables: [] } }],
+      configurations: {
+        resource: {
+          tasks: [],
+          instances: [],
+          globalVariables: [
+            {
+              name: 'Setpoint',
+              class: 'global',
+              type: { definition: 'base-type', value: 'INT' },
+              location: '',
+              documentation: '',
+            },
+          ],
+        },
+      },
+      servers: [{ name: 'Modbus', protocol: 'modbus-tcp' }],
+      remoteDevices: [{ name: 'Drive', protocol: 'modbus-tcp' }],
+      libraries: [],
+    },
+  })
+  useOpenPLCStore.getState().projectActions.setUnparsedDataTypeFiles([])
+}
+
+const gate = (name: string, kind: NamedElementKind, ignoring?: string) =>
+  elementNameCollision(useOpenPLCStore.getState(), name, kind, ignoring)
+
+const KINDS: NamedElementKind[] = [
+  'pou',
+  'data-type',
+  'global-variable-list',
+  'server',
+  'remote-device',
+  'resource-global',
+]
+const OWNER: Record<NamedElementKind, string> = {
+  pou: 'Main',
+  'data-type': 'Speed',
+  'global-variable-list': 'Plant',
+  server: 'Modbus',
+  'remote-device': 'Drive',
+  'resource-global': 'Setpoint',
+}
+const LABEL: Record<NamedElementKind, string> = {
+  pou: 'POU',
+  'data-type': 'data type',
+  'global-variable-list': 'global variable list',
+  server: 'server',
+  'remote-device': 'remote device',
+  'resource-global': 'global variable',
+}
+// Compiler namespace: pou, data type, list, global. Workspace registry: pou, data type, list, server, device.
+const DISJOINT = new Set(['server:resource-global', 'remote-device:resource-global'])
+const shares = (a: NamedElementKind, b: NamedElementKind) => !DISJOINT.has(`${a}:${b}`) && !DISJOINT.has(`${b}:${a}`)
+
+beforeEach(seed)
+
+describe('elementNameCollision across kinds', () => {
+  for (const kind of KINDS) {
+    for (const owner of KINDS.filter((k) => k !== kind)) {
+      const expected = shares(kind, owner)
+        ? `"${OWNER[owner].toLowerCase()}" is already the name of a ${LABEL[owner]}`
+        : null
+      it(`${kind} asking for the ${owner} name ${expected ? 'is refused' : 'is allowed'}`, () => {
+        expect(gate(OWNER[owner].toLowerCase(), kind)).toBe(expected)
+      })
+    }
+  }
+
+  it('reports a same-kind duplicate with the message the forms already show', () => {
+    expect(gate('main', 'pou')).toBe('POU name already exists')
+    expect(gate('speed', 'data-type')).toBe('Data type name already exists')
+    expect(gate('plant', 'global-variable-list')).toBe('Global variable list name already exists')
+    expect(gate('modbus', 'server')).toBe('Server already exists')
+    expect(gate('drive', 'remote-device')).toBe('Remote device already exists')
+  })
+
+  it('leaves same-table duplicates of globals to the variables table', () => {
+    expect(gate('setpoint', 'resource-global')).toBeNull()
+  })
+
+  it('accepts a free name for every kind', () => {
+    for (const kind of KINDS) expect(gate('Fresh', kind)).toBeNull()
+  })
+})
+
+describe('elementNameCollision and the element being renamed', () => {
+  it('lets a file-owning kind keep its exact name and refuses a case-only rename', () => {
+    expect(gate('Modbus', 'server', 'Modbus')).toBeNull()
+    expect(gate('MODBUS', 'server', 'Modbus')).toBe('Server already exists')
+    expect(gate('DRIVE', 'remote-device', 'Drive')).toBe('Remote device already exists')
+  })
+
+  it('lets a kind without a file rename case-only onto itself', () => {
+    expect(gate('PLANT', 'global-variable-list', 'Plant')).toBeNull()
+    expect(gate('SETPOINT', 'resource-global', 'Setpoint')).toBeNull()
+  })
+
+  it('still refuses a rename onto another element', () => {
+    expect(gate('Main', 'server', 'Modbus')).toBe('"Main" is already the name of a POU')
+    expect(gate('Speed', 'resource-global', 'Setpoint')).toBe('"Speed" is already the name of a data type')
+  })
+})
+
+describe('elementNameCollision beyond the project elements', () => {
+  it('refuses a library symbol for compiler-visible kinds only', () => {
+    // SCALE is a function in oscat-basic; a server called that compiles fine.
+    expect(gate('Scale', 'resource-global')).toMatch(/is a function in the .* library$/)
+    expect(gate('Scale', 'pou')).toMatch(/is a function in the .* library$/)
+    expect(gate('Scale', 'server')).toBeNull()
+    expect(gate('Scale', 'remote-device')).toBeNull()
+  })
+
+  it("refuses an unreadable .dt file's name for workspace kinds only", () => {
+    useOpenPLCStore
+      .getState()
+      .projectActions.setUnparsedDataTypeFiles([{ relativePath: 'datatypes/Broken.dt', content: 'TYPE' }])
+    expect(gate('broken', 'server')).toMatch(/could not be read/)
+    expect(gate('broken', 'pou')).toMatch(/could not be read/)
+    expect(gate('broken', 'resource-global')).toBeNull()
+  })
+
+  it("refuses a list's type name for compiler-visible kinds", () => {
+    expect(gate('Plant_TYPE', 'pou')).toBe('"Plant_TYPE" is the type name of global variable list "Plant"')
+    expect(gate('Plant_TYPE', 'resource-global')).toBe('"Plant_TYPE" is the type name of global variable list "Plant"')
+    expect(gate('Plant_TYPE', 'server')).toBeNull()
+  })
+
+  it('keeps the derived-name rules for a new list', () => {
+    expect(gate('Speed', 'global-variable-list')).toBe('"Speed" is already the name of a data type')
+    useOpenPLCStore.getState().projectActions.setProject({
+      ...useOpenPLCStore.getState().project,
+      data: {
+        ...useOpenPLCStore.getState().project.data,
+        dataTypes: [{ name: 'Tank_TYPE', derivation: 'enumerated', values: [{ description: 'A' }], initialValue: 'A' }],
+      },
+    })
+    expect(gate('Tank', 'global-variable-list')).toBe(
+      '"Tank" needs the type name "Tank_TYPE", which a data type already uses',
+    )
+  })
+})

--- a/src/frontend/store/__tests__/name-collision.test.ts
+++ b/src/frontend/store/__tests__/name-collision.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from '@jest/globals'
 
 import { useOpenPLCStore } from '../index'
-import { elementNameCollision, type NamedElementKind } from '../slices/shared/name-collision'
+import { elementNameCollision, type NamedElementKind, newGlobalNameCollision } from '../slices/shared/name-collision'
 
 /**
  * The gate on the real store, so the bundled library archives the test shim
@@ -31,7 +31,17 @@ const seed = () => {
         },
       },
       servers: [{ name: 'Modbus', protocol: 'modbus-tcp' }],
-      remoteDevices: [{ name: 'Drive', protocol: 'modbus-tcp' }],
+      remoteDevices: [
+        { name: 'Drive', protocol: 'modbus-tcp' },
+        {
+          name: 'Bus',
+          protocol: 'ethercat',
+          ethercatConfig: {
+            masterConfig: { networkInterface: 'eth0', cycleTimeUs: 1000, watchdogTimeoutCycles: 3 },
+            devices: [{ id: 'slave-1', name: 'Axis1' }] as never,
+          },
+        },
+      ],
       libraries: [],
     },
   })
@@ -47,6 +57,7 @@ const KINDS: NamedElementKind[] = [
   'global-variable-list',
   'server',
   'remote-device',
+  'ethercat-slave',
   'resource-global',
 ]
 const OWNER: Record<NamedElementKind, string> = {
@@ -55,18 +66,20 @@ const OWNER: Record<NamedElementKind, string> = {
   'global-variable-list': 'Plant',
   server: 'Modbus',
   'remote-device': 'Drive',
+  'ethercat-slave': 'Axis1',
   'resource-global': 'Setpoint',
 }
 const LABEL: Record<NamedElementKind, string> = {
-  pou: 'POU',
-  'data-type': 'data type',
-  'global-variable-list': 'global variable list',
-  server: 'server',
-  'remote-device': 'remote device',
-  'resource-global': 'global variable',
+  pou: 'a POU',
+  'data-type': 'a data type',
+  'global-variable-list': 'a global variable list',
+  server: 'a server',
+  'remote-device': 'a remote device',
+  'ethercat-slave': 'an EtherCAT slave',
+  'resource-global': 'a global variable',
 }
-// Compiler namespace: pou, data type, list, global. Workspace registry: pou, data type, list, server, device.
-const DISJOINT = new Set(['server:resource-global', 'remote-device:resource-global'])
+// Compiler namespace: pou, data type, list, global. Workspace registry: pou, data type, list, server, device, slave.
+const DISJOINT = new Set(['server:resource-global', 'remote-device:resource-global', 'ethercat-slave:resource-global'])
 const shares = (a: NamedElementKind, b: NamedElementKind) => !DISJOINT.has(`${a}:${b}`) && !DISJOINT.has(`${b}:${a}`)
 
 beforeEach(seed)
@@ -75,7 +88,7 @@ describe('elementNameCollision across kinds', () => {
   for (const kind of KINDS) {
     for (const owner of KINDS.filter((k) => k !== kind)) {
       const expected = shares(kind, owner)
-        ? `"${OWNER[owner].toLowerCase()}" is already the name of a ${LABEL[owner]}`
+        ? `"${OWNER[owner].toLowerCase()}" is already the name of ${LABEL[owner]}`
         : null
       it(`${kind} asking for the ${owner} name ${expected ? 'is refused' : 'is allowed'}`, () => {
         expect(gate(OWNER[owner].toLowerCase(), kind)).toBe(expected)
@@ -89,6 +102,7 @@ describe('elementNameCollision across kinds', () => {
     expect(gate('plant', 'global-variable-list')).toBe('Global variable list name already exists')
     expect(gate('modbus', 'server')).toBe('Server already exists')
     expect(gate('drive', 'remote-device')).toBe('Remote device already exists')
+    expect(gate('axis1', 'ethercat-slave')).toBe('An EtherCAT slave named "axis1" already exists in this project')
   })
 
   it('leaves same-table duplicates of globals to the variables table', () => {
@@ -108,6 +122,7 @@ describe('elementNameCollision and the element being renamed', () => {
   })
 
   it('lets a kind without a file rename case-only onto itself', () => {
+    expect(gate('AXIS1', 'ethercat-slave', 'Axis1')).toBeNull()
     expect(gate('PLANT', 'global-variable-list', 'Plant')).toBeNull()
     expect(gate('SETPOINT', 'resource-global', 'Setpoint')).toBeNull()
   })
@@ -132,6 +147,7 @@ describe('elementNameCollision beyond the project elements', () => {
       .getState()
       .projectActions.setUnparsedDataTypeFiles([{ relativePath: 'datatypes/Broken.dt', content: 'TYPE' }])
     expect(gate('broken', 'server')).toMatch(/could not be read/)
+    expect(gate('broken', 'ethercat-slave')).toMatch(/could not be read/)
     expect(gate('broken', 'pou')).toMatch(/could not be read/)
     expect(gate('broken', 'resource-global')).toBeNull()
   })
@@ -154,5 +170,60 @@ describe('elementNameCollision beyond the project elements', () => {
     expect(gate('Tank', 'global-variable-list')).toBe(
       '"Tank" needs the type name "Tank_TYPE", which a data type already uses',
     )
+  })
+
+  it('refuses the list/global pair on the derived name whichever is created first', () => {
+    expect(gate('Plant_TYPE', 'resource-global')).toBe('"Plant_TYPE" is the type name of global variable list "Plant"')
+    holdGlobals('Tank_TYPE')
+    expect(gate('Tank', 'global-variable-list')).toBe(
+      '"Tank" needs the type name "Tank_TYPE", which a global variable already uses',
+    )
+  })
+
+  it('does not stand in the way of opening a project that already carries a collision', () => {
+    const { project } = useOpenPLCStore.getState()
+    useOpenPLCStore.getState().projectActions.setProject({
+      ...project,
+      data: { ...project.data, servers: [{ name: 'Plant', protocol: 'modbus-tcp' }] },
+    })
+    const { data } = useOpenPLCStore.getState().project
+    expect(data.servers?.map((s) => s.name)).toEqual(['Plant'])
+    expect(data.globalVariableLists?.map((l) => l.name)).toEqual(['Plant'])
+    expect(gate('Plant', 'server')).toBe('Server already exists')
+  })
+})
+
+const holdGlobals = (...names: string[]) =>
+  useOpenPLCStore.getState().projectActions.setGlobalVariables({
+    variables: names.map((name) => ({
+      name,
+      class: 'global' as const,
+      type: { definition: 'base-type' as const, value: 'INT' },
+      location: '',
+      documentation: '',
+    })),
+  })
+
+describe('newGlobalNameCollision, the code view commit gate', () => {
+  const check = (...names: string[]) => newGlobalNameCollision(useOpenPLCStore.getState(), names)
+
+  it('leaves names the table already holds alone, even ones the gate would refuse today', () => {
+    holdGlobals('Scale')
+    expect(gate('Scale', 'resource-global')).not.toBeNull()
+    expect(check('Scale', 'Level')).toBeNull()
+  })
+
+  it('gates only the names a commit introduces', () => {
+    holdGlobals('Scale')
+    expect(check('Scale', 'Main')).toBe('"Main" is already the name of a POU')
+  })
+
+  it('matches held names case-insensitively', () => {
+    holdGlobals('Scale')
+    expect(check('SCALE')).toBeNull()
+  })
+
+  it('accepts a commit that only renames onto free names', () => {
+    expect(check('Setpoint', 'Level')).toBeNull()
   })
 })

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -810,18 +810,19 @@ describe('createProjectSlice', () => {
       expect((result.data as { name: string }).name).not.toBe('gx')
     })
 
-    it('refuses a global named after a POU instead of auto-renaming it', () => {
+    it('steps a new global past a POU name the same way it steps past its own table', () => {
       seedPou(store, makePou('Motor'))
       const result = store.getState().projectActions.createVariable({
         scope: 'global',
         data: makeVariable('motor', 'global'),
       })
-      expect(result).toMatchObject({ ok: false, title: 'Variable already exists' })
-      expect(result.message).toBe('"motor" is already the name of a POU')
-      expect(store.getState().project.data.configurations.resource.globalVariables).toEqual([])
+      expect(result.ok).toBe(true)
+      expect(store.getState().project.data.configurations.resource.globalVariables.map((v) => v.name)).toEqual([
+        'motor0',
+      ])
     })
 
-    it('checks the auto-incremented name, so a cloned row still lands beside a POU-named global', () => {
+    it('keeps incrementing a clone while the candidate is a POU, a type or a list', () => {
       // A clone of `Motor` auto-increments to `Motor0`, which a POU already owns.
       seedPou(store, makePou('Motor0'))
       store.getState().projectActions.createVariable({ scope: 'global', data: makeVariable('Motor', 'global') })
@@ -829,8 +830,37 @@ describe('createProjectSlice', () => {
         scope: 'global',
         data: makeVariable('Motor', 'global'),
       })
-      expect(result.ok).toBe(false)
-      expect(result.message).toBe('"Motor0" is already the name of a POU')
+      expect(result.ok).toBe(true)
+      expect(store.getState().project.data.configurations.resource.globalVariables.map((v) => v.name)).toEqual([
+        'Motor',
+        'Motor1',
+      ])
+    })
+
+    it('seeds an empty table even when a POU already holds the default name', () => {
+      seedPou(store, makePou('GlobalVar'))
+      const result = store.getState().projectActions.createVariable({
+        scope: 'global',
+        data: makeVariable('GlobalVar', 'global'),
+      })
+      expect(result.ok).toBe(true)
+      expect(store.getState().project.data.configurations.resource.globalVariables.map((v) => v.name)).toEqual([
+        'GlobalVar0',
+      ])
+    })
+
+    it('leaves a local variable that shares a POU name to the POU validator', () => {
+      seedPou(store, makePou('Motor'))
+      seedPou(store, makePou('Main', 'program', []))
+      const result = store.getState().projectActions.createVariable({
+        scope: 'local',
+        associatedPou: 'Main',
+        data: makeVariable('Motor'),
+      })
+      expect(result.ok).toBe(true)
+      expect(store.getState().project.data.pous.find((p) => p.name === 'Main')?.interface?.variables[0].name).toBe(
+        'Motor',
+      )
     })
 
     it('fails for local scope when POU interface is missing', () => {
@@ -1080,6 +1110,15 @@ describe('createProjectSlice', () => {
         .projectActions.updateVariable({ scope: 'global', variableId: 'gx', data: { name: 'GX' } })
       expect(result.ok).toBe(true)
       expect(store.getState().project.data.configurations.resource.globalVariables[0].name).toBe('GX')
+    })
+
+    it('reports a missing row before judging its new name', () => {
+      seedPou(store, makePou('Motor'))
+      const result = store
+        .getState()
+        .projectActions.updateVariable({ scope: 'global', variableId: 'gone', data: { name: 'motor' } })
+      expect(result.ok).toBe(false)
+      expect(result.title).toBe('Variable not found')
     })
 
     it('leaves a local variable rename to the POU validator', () => {

--- a/src/frontend/store/__tests__/project-slice.test.ts
+++ b/src/frontend/store/__tests__/project-slice.test.ts
@@ -810,6 +810,29 @@ describe('createProjectSlice', () => {
       expect((result.data as { name: string }).name).not.toBe('gx')
     })
 
+    it('refuses a global named after a POU instead of auto-renaming it', () => {
+      seedPou(store, makePou('Motor'))
+      const result = store.getState().projectActions.createVariable({
+        scope: 'global',
+        data: makeVariable('motor', 'global'),
+      })
+      expect(result).toMatchObject({ ok: false, title: 'Variable already exists' })
+      expect(result.message).toBe('"motor" is already the name of a POU')
+      expect(store.getState().project.data.configurations.resource.globalVariables).toEqual([])
+    })
+
+    it('checks the auto-incremented name, so a cloned row still lands beside a POU-named global', () => {
+      // A clone of `Motor` auto-increments to `Motor0`, which a POU already owns.
+      seedPou(store, makePou('Motor0'))
+      store.getState().projectActions.createVariable({ scope: 'global', data: makeVariable('Motor', 'global') })
+      const result = store.getState().projectActions.createVariable({
+        scope: 'global',
+        data: makeVariable('Motor', 'global'),
+      })
+      expect(result.ok).toBe(false)
+      expect(result.message).toBe('"Motor0" is already the name of a POU')
+    })
+
     it('fails for local scope when POU interface is missing', () => {
       const pou: PLCPou = { name: 'NoIface', pouType: 'program', body: makeBody() }
       seedPou(store, pou)
@@ -1036,6 +1059,39 @@ describe('createProjectSlice', () => {
       })
       expect(result.ok).toBe(true)
       expect(store.getState().project.data.pous[0].interface?.variables[0].name).toBe('Counter')
+    })
+  })
+
+  describe('updateVariable — resource globals in the element namespace', () => {
+    it('refuses renaming a global onto a POU name', () => {
+      seedPou(store, makePou('Motor'))
+      store.getState().projectActions.createVariable({ scope: 'global', data: makeVariable('gx', 'global') })
+      const result = store
+        .getState()
+        .projectActions.updateVariable({ scope: 'global', variableId: 'gx', data: { name: 'motor' } })
+      expect(result).toMatchObject({ ok: false, title: 'Variable already exists' })
+      expect(store.getState().project.data.configurations.resource.globalVariables[0].name).toBe('gx')
+    })
+
+    it('lets a global change only its case', () => {
+      store.getState().projectActions.createVariable({ scope: 'global', data: makeVariable('gx', 'global') })
+      const result = store
+        .getState()
+        .projectActions.updateVariable({ scope: 'global', variableId: 'gx', data: { name: 'GX' } })
+      expect(result.ok).toBe(true)
+      expect(store.getState().project.data.configurations.resource.globalVariables[0].name).toBe('GX')
+    })
+
+    it('leaves a local variable rename to the POU validator', () => {
+      seedPou(store, makePou('Motor'))
+      seedPou(store, makePou('Main', 'program', [makeVariable('x')]))
+      const result = store.getState().projectActions.updateVariable({
+        scope: 'local',
+        associatedPou: 'Main',
+        variableId: 'x',
+        data: { name: 'motor' },
+      })
+      expect(result.ok).toBe(true)
     })
   })
 

--- a/src/frontend/store/__tests__/project-validation-variables.test.ts
+++ b/src/frontend/store/__tests__/project-validation-variables.test.ts
@@ -246,6 +246,22 @@ describe('createVariableValidation', () => {
     expect(result.name).toBe('Var2')
   })
 
+  it('steps over names the caller reports as taken outside the table', () => {
+    const taken = new Set(['GlobalVar', 'GlobalVar0'])
+    const result = createVariableValidation([], makeVariable('GlobalVar'), (name) => taken.has(name))
+    expect(result.name).toBe('GlobalVar1')
+  })
+
+  it('walks the table and the caller together to the first free name', () => {
+    const result = createVariableValidation([makeVariable('Motor')], makeVariable('Motor'), (name) => name === 'Motor0')
+    expect(result.name).toBe('Motor1')
+  })
+
+  it('stops at the iteration bound when every candidate is taken', () => {
+    const result = createVariableValidation([], makeVariable('X'), () => true)
+    expect(result.name).toBe('X8191')
+  })
+
   it('returns same location when location is empty and conflicts exist', () => {
     const existing = [makeVariable('Other', 'INT', '')]
     const variable = makeVariable('NewVar', 'INT', '')

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -1457,7 +1457,25 @@ describe('createSharedSlice', () => {
         addServer('ExistingServer')
         const result = store.getState().serverActions.rename('OldServer', 'ExistingServer')
         expect(result.ok).toBe(false)
-        expect(result.message).toBe('Server name already exists')
+        expect(result.message).toBe('Server already exists')
+      })
+
+      it('leaves the file registry alone when the rename is refused', () => {
+        addServer('ExistingServer')
+        store.getState().serverActions.rename('OldServer', 'ExistingServer')
+
+        const state = store.getState()
+        expect(state.files['OldServer']).toBeDefined()
+        expect(state.project.data.servers?.map((s) => s.name)).toEqual(['OldServer', 'ExistingServer'])
+      })
+
+      it('refuses a case-only rename, which would overwrite the file on a case-folding disk', () => {
+        expect(store.getState().serverActions.rename('OldServer', 'oldserver').ok).toBe(false)
+      })
+
+      it('treats a rename to the identical name as a no-op', () => {
+        expect(store.getState().serverActions.rename('OldServer', 'OldServer')).toEqual({ ok: true })
+        expect(store.getState().pendingDeletions).toEqual([])
       })
     })
   })
@@ -1602,7 +1620,7 @@ describe('createSharedSlice', () => {
         addRemoteDevice('ExistingDevice')
         const result = store.getState().remoteDeviceActions.rename('OldDevice', 'ExistingDevice')
         expect(result.ok).toBe(false)
-        expect(result.message).toBe('Device name already exists')
+        expect(result.message).toBe('Remote device already exists')
       })
     })
   })

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -1460,22 +1460,19 @@ describe('createSharedSlice', () => {
         expect(result.message).toBe('Server already exists')
       })
 
-      it('leaves the file registry alone when the rename is refused', () => {
-        addServer('ExistingServer')
-        store.getState().serverActions.rename('OldServer', 'ExistingServer')
+      it('refuses a case-only rename and leaves the registry alone: on a case-folding disk it is the same file', () => {
+        const result = store.getState().serverActions.rename('OldServer', 'oldserver')
+        expect(result.ok).toBe(false)
 
         const state = store.getState()
         expect(state.files['OldServer']).toBeDefined()
-        expect(state.project.data.servers?.map((s) => s.name)).toEqual(['OldServer', 'ExistingServer'])
+        expect(state.files['oldserver']).toBeUndefined()
+        expect(state.project.data.servers?.[0].name).toBe('OldServer')
+        expect(state.pendingDeletions).toEqual([])
       })
 
-      it('refuses a case-only rename, which would overwrite the file on a case-folding disk', () => {
-        expect(store.getState().serverActions.rename('OldServer', 'oldserver').ok).toBe(false)
-      })
-
-      it('treats a rename to the identical name as a no-op', () => {
+      it('treats a rename to the identical name as a no-op instead of a duplicate of itself', () => {
         expect(store.getState().serverActions.rename('OldServer', 'OldServer')).toEqual({ ok: true })
-        expect(store.getState().pendingDeletions).toEqual([])
       })
     })
   })
@@ -1622,6 +1619,28 @@ describe('createSharedSlice', () => {
         expect(result.ok).toBe(false)
         expect(result.message).toBe('Remote device already exists')
       })
+
+      it('refuses a case-only rename and leaves the registry alone: on a case-folding disk it is the same file', () => {
+        const result = store.getState().remoteDeviceActions.rename('OldDevice', 'olddevice')
+        expect(result.ok).toBe(false)
+
+        const state = store.getState()
+        expect(state.files['OldDevice']).toBeDefined()
+        expect(state.files['olddevice']).toBeUndefined()
+        expect(state.project.data.remoteDevices?.[0].name).toBe('OldDevice')
+        expect(state.pendingDeletions).toEqual([])
+      })
+
+      it('treats a rename to the identical name as a no-op instead of a duplicate of itself', () => {
+        expect(store.getState().remoteDeviceActions.rename('OldDevice', 'OldDevice')).toEqual({ ok: true })
+      })
+
+      it('refuses a rename onto a POU name and says so', () => {
+        store.getState().pouActions.create({ type: 'program', name: 'Pump', language: 'st' })
+        const result = store.getState().remoteDeviceActions.rename('OldDevice', 'pump')
+        expect(result).toEqual({ ok: false, message: '"pump" is already the name of a POU' })
+        expect(store.getState().files['OldDevice']).toBeDefined()
+      })
     })
   })
 
@@ -1737,6 +1756,23 @@ describe('createSharedSlice', () => {
       it('allows renaming to the same name (no-op)', () => {
         const result = store.getState().ethercatDeviceActions.rename('bus1', 'slave-1', 'EK1100')
         expect(result).toEqual({ ok: true })
+      })
+
+      it('rejects renaming a slave onto a POU name, and says which', () => {
+        store.getState().pouActions.create({ type: 'program', name: 'Pump', language: 'st' })
+        const result = store.getState().ethercatDeviceActions.rename('bus1', 'slave-1', 'pump')
+        expect(result).toEqual({ ok: false, message: '"pump" is already the name of a POU' })
+      })
+
+      it('keeps a slave name out of reach of the other workspace kinds', () => {
+        expect(store.getState().pouActions.create({ type: 'program', name: 'EK1100', language: 'st' })).toEqual({
+          ok: false,
+          message: '"EK1100" is already the name of an EtherCAT slave',
+        })
+        expect(store.getState().serverActions.create({ name: 'el1809', protocol: 'modbus-tcp' })).toEqual({
+          ok: false,
+          message: '"el1809" is already the name of an EtherCAT slave',
+        })
       })
 
       it('returns error when the bus does not exist', () => {

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -1043,17 +1043,22 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       // to the next free slot to avoid duplicate-address compile errors
       // (forum thread "openplc-420-teething-bugs", v4.2.0).
       const sourceVariables = scopedVariables(getState().project.data, scope, associatedPou, dto.associatedList) ?? []
-      const validated = createVariableValidation(sourceVariables, data)
+      // A global is a top-level symbol next to POUs and types, so its clone has
+      // to step over those names too, not only its own table.
+      const nameTaken =
+        scope === 'global'
+          ? (name: string) => elementNameCollision(getState(), name, 'resource-global') !== null
+          : undefined
+      const validated = createVariableValidation(sourceVariables, data, nameTaken)
       // Single-field location model: `location` is the binding itself — an
       // alias name OR a literal `%addr`. It is stored verbatim (no
       // address→alias auto-adoption); alias→address resolution happens at
       // compile time. The legacy `alias` field is unused.
       data = { ...data, ...validated }
 
-      // A global is a top-level symbol next to POUs and types. Checked after the
-      // validator so a cloned row auto-increments away from its own table first.
       if (scope === 'global') {
         const collision = elementNameCollision(getState(), data.name, 'resource-global')
+        /* istanbul ignore next -- only when every auto-increment candidate is taken */
         if (collision) return fail(collision, 'Variable already exists')
       }
 
@@ -1110,8 +1115,10 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       if (scope === 'global' && updates.name !== undefined) {
         const globals = getState().project.data.configurations.resource.globalVariables
         const current = getVariableBasedOnRowIdOrVariableId(globals, rowId, variableId)
-        const collision = elementNameCollision(getState(), updates.name, 'resource-global', current?.variable.name)
-        if (collision) return fail(collision, 'Variable already exists')
+        if (current) {
+          const collision = elementNameCollision(getState(), updates.name, 'resource-global', current.variable.name)
+          if (collision) return fail(collision, 'Variable already exists')
+        }
       }
 
       let response: ProjectResponse = { ok: true }

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -56,6 +56,7 @@ import { renameGlobalVariableListInPou } from '../../../utils/PLC/global-variabl
 import { serializeGlobalVariableListToText } from '../../../utils/PLC/global-variable-list-serializer'
 import { parseGlobalVariableListFromText } from '../../../utils/PLC/global-variable-list-text-parser'
 import { getExtensionFromLanguage, getFolderFromPouType } from '../../../utils/PLC/pou-file-extensions'
+import { elementNameCollision } from '../shared/name-collision'
 import type { ProjectResponse, ProjectSlice, ProjectSliceRoot, VariableScope } from './types'
 import { getVariableBasedOnRowIdOrVariableId } from './utils'
 import { createVariableValidation, updateVariableValidation } from './validation/variables'
@@ -1049,6 +1050,13 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       // compile time. The legacy `alias` field is unused.
       data = { ...data, ...validated }
 
+      // A global is a top-level symbol next to POUs and types. Checked after the
+      // validator so a cloned row auto-increments away from its own table first.
+      if (scope === 'global') {
+        const collision = elementNameCollision(getState(), data.name, 'resource-global')
+        if (collision) return fail(collision, 'Variable already exists')
+      }
+
       let response: ProjectResponse = { ok: true }
       setState(
         produce((slice: ProjectSlice) => {
@@ -1097,6 +1105,13 @@ const createProjectSlice: StateCreator<ProjectSliceRoot, [], [], ProjectSlice> =
       if (scope === 'local') {
         const reconcile = reconcileVariablesText(associatedPou, getState, setState)
         if (!reconcile.ok) return reconcile
+      }
+
+      if (scope === 'global' && updates.name !== undefined) {
+        const globals = getState().project.data.configurations.resource.globalVariables
+        const current = getVariableBasedOnRowIdOrVariableId(globals, rowId, variableId)
+        const collision = elementNameCollision(getState(), updates.name, 'resource-global', current?.variable.name)
+        if (collision) return fail(collision, 'Variable already exists')
       }
 
       let response: ProjectResponse = { ok: true }

--- a/src/frontend/store/slices/project/validation/variables.ts
+++ b/src/frontend/store/slices/project/validation/variables.ts
@@ -329,6 +329,7 @@ const MAX_AUTO_INCREMENT_ITERATIONS = 8192
 const createVariableValidation = (
   variables: PLCVariable[],
   variable: PLCVariable,
+  nameTaken: (name: string) => boolean = () => false,
 ): { name: string; location: string } => {
   const { name: variableName } = variable
   // Interface-class variables cannot carry a physical location — the ST
@@ -338,9 +339,14 @@ const createVariableValidation = (
   const variableLocation = DISALLOWED_LOCATION_CLASSES.includes(variable.class) ? '' : variable.location
   const response = { name: variableName, location: variableLocation }
 
-  if (checkIfVariableExists(variables, variableName)) {
+  const taken = (name: string) => checkIfVariableExists(variables, name) || nameTaken(name)
+  if (taken(variableName)) {
     const { name: variableNameWithoutNumber, number } = checkVariableName(variables, variableName)
-    response.name = `${variableNameWithoutNumber}${number}`
+    let candidate = `${variableNameWithoutNumber}${number}`
+    for (let i = 1; taken(candidate) && i < MAX_AUTO_INCREMENT_ITERATIONS; i++) {
+      candidate = `${variableNameWithoutNumber}${number + i}`
+    }
+    response.name = candidate
   }
 
   const slots = slotsClaimedBy(variable)

--- a/src/frontend/store/slices/shared/name-collision.ts
+++ b/src/frontend/store/slices/shared/name-collision.ts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Autonomy / OpenPLC Project
+/**
+ * The one place a candidate element name is checked against everything
+ * that already owns it.
+ *
+ * Two namespaces overlap here. IEC puts POUs, derived types, global
+ * variables and library symbols in ONE identifier namespace, so a
+ * collision across those kinds is a duplicate symbol the compiler reports
+ * against a name the user never typed. The workspace keys `files[name]`,
+ * tabs, editor models and `undoRedo[name]` by raw element name across
+ * every kind that has a tab — POUs, data types, global variable lists,
+ * servers and remote devices — so one entry ends up serving two elements
+ * and edits land on the wrong one. A kind is checked against every other
+ * kind it shares a namespace with, and against nothing else: a server
+ * named like a library function compiles, a global variable named like a
+ * server saves.
+ */
+
+import type { LibraryPouType } from '../../../../middleware/shared/ports/library-types'
+import { globalVariableListTypeName } from '../../../utils/PLC/global-variable-list-serializer'
+import type { LibrarySlice } from '../library'
+import type { ProjectSlice } from '../project'
+
+export type NameCollisionState = Pick<ProjectSlice, 'project' | 'unparsedDataTypeFiles'> &
+  Pick<LibrarySlice, 'libraries'>
+
+/**
+ * Element names are compared case-insensitively: IEC identifiers are, and a
+ * data type becomes a `datatypes/<Name>.dt` path, a POU a
+ * `pous/<folder>/<Name><ext>` one, and macOS/Windows fold filename case.
+ */
+export const nameMatches = (a: string, b: string): boolean => a.toLowerCase() === b.toLowerCase()
+
+export type NamedElementKind =
+  | 'pou'
+  | 'data-type'
+  | 'global-variable-list'
+  | 'server'
+  | 'remote-device'
+  | 'resource-global'
+
+/** Kinds the compiler sees as top-level identifiers. */
+const COMPILER_SYMBOL: Record<NamedElementKind, boolean> = {
+  pou: true,
+  'data-type': true,
+  'global-variable-list': true,
+  'resource-global': true,
+  server: false,
+  'remote-device': false,
+}
+
+/** Kinds with a tab, and so an entry in the name-keyed workspace registries. */
+const WORKSPACE_ELEMENT: Record<NamedElementKind, boolean> = {
+  pou: true,
+  'data-type': true,
+  'global-variable-list': true,
+  server: true,
+  'remote-device': true,
+  'resource-global': false,
+}
+
+/**
+ * Kinds that own a file path named after them. A case-only rename would write
+ * the new file over the old one on a case-folding filesystem, so the element's
+ * own entry stays eligible to collide with the new spelling.
+ */
+const OWNS_FILE: Record<NamedElementKind, boolean> = {
+  pou: true,
+  'data-type': true,
+  server: true,
+  'remote-device': true,
+  'global-variable-list': false,
+  'resource-global': false,
+}
+
+const SAME_KIND_TAKEN: Record<Exclude<NamedElementKind, 'resource-global'>, string> = {
+  pou: 'POU name already exists',
+  'data-type': 'Data type name already exists',
+  'global-variable-list': 'Global variable list name already exists',
+  server: 'Server already exists',
+  'remote-device': 'Remote device already exists',
+}
+
+const KIND_LABEL: Record<NamedElementKind, string> = {
+  pou: 'POU',
+  'data-type': 'data type',
+  'global-variable-list': 'global variable list',
+  server: 'server',
+  'remote-device': 'remote device',
+  'resource-global': 'global variable',
+}
+
+const LIBRARY_SYMBOL_KIND: Record<LibraryPouType, string> = {
+  function: 'function',
+  'function-block': 'function block',
+}
+
+interface NamedElement {
+  kind: NamedElementKind
+  name: string
+}
+
+function namedElements(state: NameCollisionState): NamedElement[] {
+  const { pous, dataTypes, globalVariableLists, servers, remoteDevices, configurations } = state.project.data
+  return [
+    ...pous.map((pou): NamedElement => ({ kind: 'pou', name: pou.name })),
+    ...dataTypes.map((dataType): NamedElement => ({ kind: 'data-type', name: dataType.name })),
+    ...(globalVariableLists ?? []).map((list): NamedElement => ({ kind: 'global-variable-list', name: list.name })),
+    ...(servers ?? []).map((server): NamedElement => ({ kind: 'server', name: server.name })),
+    ...(remoteDevices ?? []).map((device): NamedElement => ({ kind: 'remote-device', name: device.name })),
+    ...(configurations.resource.globalVariables ?? []).map(
+      (variable): NamedElement => ({ kind: 'resource-global', name: variable.name }),
+    ),
+  ]
+}
+
+const sharesNamespace = (a: NamedElementKind, b: NamedElementKind): boolean =>
+  (COMPILER_SYMBOL[a] && COMPILER_SYMBOL[b]) || (WORKSPACE_ELEMENT[a] && WORKSPACE_ELEMENT[b])
+
+/**
+ * The library symbol, if any, that already owns `name`.
+ *
+ * Library functions and function blocks are declared in the same generated
+ * namespace as the project's own elements, and the bundled archives are in
+ * every build regardless of the project's `libraries` list — so no setting
+ * makes such a name safe. The whole installed pool counts, not just the
+ * bundled set: enabling a library later must not turn a project that
+ * compiles into one that does not.
+ */
+function librarySymbolOwning(state: NameCollisionState, name: string): { library: string; kind: string } | null {
+  for (const library of state.libraries.system) {
+    const symbol = library.pous.find((pou) => nameMatches(pou.name, name))
+    if (symbol) return { library: library.name, kind: LIBRARY_SYMBOL_KIND[symbol.type] }
+  }
+  return null
+}
+
+/**
+ * A raw `datatypes/<Name>.dt` file that failed to parse still owns its name:
+ * it is echoed to disk verbatim on save, and it keeps its `files[name]`
+ * entry, so any element taking the name would share both.
+ */
+function unparsedDataTypeFileOwning(state: NameCollisionState, name: string): string | null {
+  const collides = state.unparsedDataTypeFiles.some(
+    (f) => f.relativePath.split('/').pop()?.replace(/\.dt$/i, '').toLowerCase() === name.toLowerCase(),
+  )
+  return collides
+    ? `A data type file named "${name}.dt" exists on disk but could not be read — fix or remove it first`
+    : null
+}
+
+/**
+ * Why an element of `kind` may not be called `name`, or `null` when it may.
+ *
+ * `ignoring` is the element being renamed, so it does not collide with
+ * itself. Same-kind duplicates of resource globals are not this gate's
+ * business: the variables table owns them, and the "+" button relies on
+ * cloning a row and auto-incrementing the clash away.
+ */
+export function elementNameCollision(
+  state: NameCollisionState,
+  name: string,
+  kind: NamedElementKind,
+  ignoring?: string,
+): string | null {
+  const isSelf = (candidate: string): boolean =>
+    ignoring !== undefined && (OWNS_FILE[kind] ? candidate === ignoring : nameMatches(candidate, ignoring))
+  if (isSelf(name)) return null
+
+  // A file-owning element stays in the pool: its own entry is what a case-only
+  // rename has to collide with.
+  const others = OWNS_FILE[kind]
+    ? namedElements(state)
+    : namedElements(state).filter((element) => !(element.kind === kind && isSelf(element.name)))
+
+  if (kind !== 'resource-global' && others.some((o) => o.kind === kind && nameMatches(o.name, name))) {
+    return SAME_KIND_TAKEN[kind]
+  }
+  const taken = others.find((o) => o.kind !== kind && sharesNamespace(kind, o.kind) && nameMatches(o.name, name))
+  if (taken) return `"${name}" is already the name of a ${KIND_LABEL[taken.kind]}`
+
+  if (WORKSPACE_ELEMENT[kind]) {
+    const unparsed = unparsedDataTypeFileOwning(state, name)
+    if (unparsed) return unparsed
+  }
+  if (!COMPILER_SYMBOL[kind]) return null
+
+  // A list occupies TWO symbols: the instance keeps the user's name, the struct
+  // backing it takes `<name>_TYPE`.
+  const lists = others.filter((o) => o.kind === 'global-variable-list')
+  const listOwningTheName = lists.find((list) => nameMatches(globalVariableListTypeName(list.name), name))
+  if (listOwningTheName) {
+    return `"${name}" is the type name of global variable list "${listOwningTheName.name}"`
+  }
+
+  const librarySymbol = librarySymbolOwning(state, name)
+  if (librarySymbol) {
+    return `"${name}" is a ${librarySymbol.kind} in the ${librarySymbol.library} library`
+  }
+
+  if (kind !== 'global-variable-list') return null
+
+  const derived = globalVariableListTypeName(name)
+  if (others.some((o) => o.kind === 'data-type' && nameMatches(o.name, derived))) {
+    return `"${name}" needs the type name "${derived}", which a data type already uses`
+  }
+  if (others.some((o) => o.kind === 'pou' && nameMatches(o.name, derived))) {
+    return `"${name}" needs the type name "${derived}", which a POU already uses`
+  }
+  // Against the other lists' own names as well as their derived ones: the pair
+  // `GVL` / `GVL_TYPE` collides whichever of the two is created first.
+  if (lists.some((list) => nameMatches(list.name, derived))) {
+    return `"${name}" needs the type name "${derived}", which a global variable list already uses`
+  }
+  if (lists.some((list) => nameMatches(globalVariableListTypeName(list.name), derived))) {
+    return `"${name}" needs the type name "${derived}", which another global variable list already uses`
+  }
+  // An unreadable `.dt` is echoed to disk verbatim on save, so the type it declares is
+  // still in the build — the generated struct would be a second declaration of it.
+  if (unparsedDataTypeFileOwning(state, derived)) {
+    return `"${name}" needs the type name "${derived}", which a data type file already uses`
+  }
+  const derivedLibrarySymbol = librarySymbolOwning(state, derived)
+  if (derivedLibrarySymbol) {
+    return `"${name}" needs the type name "${derived}", which is a ${derivedLibrarySymbol.kind} in the ${derivedLibrarySymbol.library} library`
+  }
+  return null
+}

--- a/src/frontend/store/slices/shared/name-collision.ts
+++ b/src/frontend/store/slices/shared/name-collision.ts
@@ -4,17 +4,13 @@
  * The one place a candidate element name is checked against everything
  * that already owns it.
  *
- * Two namespaces overlap here. IEC puts POUs, derived types, global
- * variables and library symbols in ONE identifier namespace, so a
- * collision across those kinds is a duplicate symbol the compiler reports
- * against a name the user never typed. The workspace keys `files[name]`,
- * tabs, editor models and `undoRedo[name]` by raw element name across
- * every kind that has a tab — POUs, data types, global variable lists,
- * servers and remote devices — so one entry ends up serving two elements
- * and edits land on the wrong one. A kind is checked against every other
- * kind it shares a namespace with, and against nothing else: a server
- * named like a library function compiles, a global variable named like a
- * server saves.
+ * Two namespaces overlap. IEC puts POUs, derived types, global variables
+ * and library symbols in one identifier namespace, so a collision across
+ * those kinds is a duplicate symbol. The workspace keys `files[name]`,
+ * tabs, editor models and `undoRedo[name]` by element name for POUs, data
+ * types, global variable lists, servers, remote devices and EtherCAT slaves,
+ * so one entry would serve two elements. A kind is checked against every other kind it
+ * shares a namespace with, and against nothing else.
  */
 
 import type { LibraryPouType } from '../../../../middleware/shared/ports/library-types'
@@ -38,6 +34,7 @@ export type NamedElementKind =
   | 'global-variable-list'
   | 'server'
   | 'remote-device'
+  | 'ethercat-slave'
   | 'resource-global'
 
 /** Kinds the compiler sees as top-level identifiers. */
@@ -48,6 +45,7 @@ const COMPILER_SYMBOL: Record<NamedElementKind, boolean> = {
   'resource-global': true,
   server: false,
   'remote-device': false,
+  'ethercat-slave': false,
 }
 
 /** Kinds with a tab, and so an entry in the name-keyed workspace registries. */
@@ -57,6 +55,7 @@ const WORKSPACE_ELEMENT: Record<NamedElementKind, boolean> = {
   'global-variable-list': true,
   server: true,
   'remote-device': true,
+  'ethercat-slave': true,
   'resource-global': false,
 }
 
@@ -71,10 +70,11 @@ const OWNS_FILE: Record<NamedElementKind, boolean> = {
   server: true,
   'remote-device': true,
   'global-variable-list': false,
+  'ethercat-slave': false,
   'resource-global': false,
 }
 
-const SAME_KIND_TAKEN: Record<Exclude<NamedElementKind, 'resource-global'>, string> = {
+const SAME_KIND_TAKEN: Record<Exclude<NamedElementKind, 'resource-global' | 'ethercat-slave'>, string> = {
   pou: 'POU name already exists',
   'data-type': 'Data type name already exists',
   'global-variable-list': 'Global variable list name already exists',
@@ -82,13 +82,17 @@ const SAME_KIND_TAKEN: Record<Exclude<NamedElementKind, 'resource-global'>, stri
   'remote-device': 'Remote device already exists',
 }
 
+const sameKindTaken = (kind: Exclude<NamedElementKind, 'resource-global'>, name: string): string =>
+  kind === 'ethercat-slave' ? `An EtherCAT slave named "${name}" already exists in this project` : SAME_KIND_TAKEN[kind]
+
 const KIND_LABEL: Record<NamedElementKind, string> = {
-  pou: 'POU',
-  'data-type': 'data type',
-  'global-variable-list': 'global variable list',
-  server: 'server',
-  'remote-device': 'remote device',
-  'resource-global': 'global variable',
+  pou: 'a POU',
+  'data-type': 'a data type',
+  'global-variable-list': 'a global variable list',
+  server: 'a server',
+  'remote-device': 'a remote device',
+  'ethercat-slave': 'an EtherCAT slave',
+  'resource-global': 'a global variable',
 }
 
 const LIBRARY_SYMBOL_KIND: Record<LibraryPouType, string> = {
@@ -109,6 +113,11 @@ function namedElements(state: NameCollisionState): NamedElement[] {
     ...(globalVariableLists ?? []).map((list): NamedElement => ({ kind: 'global-variable-list', name: list.name })),
     ...(servers ?? []).map((server): NamedElement => ({ kind: 'server', name: server.name })),
     ...(remoteDevices ?? []).map((device): NamedElement => ({ kind: 'remote-device', name: device.name })),
+    ...(remoteDevices ?? []).flatMap((device) =>
+      (device.ethercatConfig?.devices ?? []).map(
+        (slave): NamedElement => ({ kind: 'ethercat-slave', name: slave.name }),
+      ),
+    ),
     ...(configurations.resource.globalVariables ?? []).map(
       (variable): NamedElement => ({ kind: 'resource-global', name: variable.name }),
     ),
@@ -136,11 +145,7 @@ function librarySymbolOwning(state: NameCollisionState, name: string): { library
   return null
 }
 
-/**
- * A raw `datatypes/<Name>.dt` file that failed to parse still owns its name:
- * it is echoed to disk verbatim on save, and it keeps its `files[name]`
- * entry, so any element taking the name would share both.
- */
+/** An unreadable `datatypes/<Name>.dt` keeps its `files[name]` entry, so its name stays taken in the workspace. */
 function unparsedDataTypeFileOwning(state: NameCollisionState, name: string): string | null {
   const collides = state.unparsedDataTypeFiles.some(
     (f) => f.relativePath.split('/').pop()?.replace(/\.dt$/i, '').toLowerCase() === name.toLowerCase(),
@@ -175,10 +180,10 @@ export function elementNameCollision(
     : namedElements(state).filter((element) => !(element.kind === kind && isSelf(element.name)))
 
   if (kind !== 'resource-global' && others.some((o) => o.kind === kind && nameMatches(o.name, name))) {
-    return SAME_KIND_TAKEN[kind]
+    return sameKindTaken(kind, name)
   }
   const taken = others.find((o) => o.kind !== kind && sharesNamespace(kind, o.kind) && nameMatches(o.name, name))
-  if (taken) return `"${name}" is already the name of a ${KIND_LABEL[taken.kind]}`
+  if (taken) return `"${name}" is already the name of ${KIND_LABEL[taken.kind]}`
 
   if (WORKSPACE_ELEMENT[kind]) {
     const unparsed = unparsedDataTypeFileOwning(state, name)
@@ -208,6 +213,9 @@ export function elementNameCollision(
   if (others.some((o) => o.kind === 'pou' && nameMatches(o.name, derived))) {
     return `"${name}" needs the type name "${derived}", which a POU already uses`
   }
+  if (others.some((o) => o.kind === 'resource-global' && nameMatches(o.name, derived))) {
+    return `"${name}" needs the type name "${derived}", which a global variable already uses`
+  }
   // Against the other lists' own names as well as their derived ones: the pair
   // `GVL` / `GVL_TYPE` collides whichever of the two is created first.
   if (lists.some((list) => nameMatches(list.name, derived))) {
@@ -216,14 +224,29 @@ export function elementNameCollision(
   if (lists.some((list) => nameMatches(globalVariableListTypeName(list.name), derived))) {
     return `"${name}" needs the type name "${derived}", which another global variable list already uses`
   }
-  // An unreadable `.dt` is echoed to disk verbatim on save, so the type it declares is
-  // still in the build — the generated struct would be a second declaration of it.
   if (unparsedDataTypeFileOwning(state, derived)) {
     return `"${name}" needs the type name "${derived}", which a data type file already uses`
   }
   const derivedLibrarySymbol = librarySymbolOwning(state, derived)
   if (derivedLibrarySymbol) {
     return `"${name}" needs the type name "${derived}", which is a ${derivedLibrarySymbol.kind} in the ${derivedLibrarySymbol.library} library`
+  }
+  return null
+}
+
+/**
+ * The first collision among `names` that the globals table does not already
+ * hold. Names already in the table were accepted when written; only what a
+ * commit introduces is gated.
+ */
+export function newGlobalNameCollision(state: NameCollisionState, names: string[]): string | null {
+  const held = new Set(
+    (state.project.data.configurations.resource.globalVariables ?? []).map((variable) => variable.name.toLowerCase()),
+  )
+  for (const name of names) {
+    if (held.has(name.toLowerCase())) continue
+    const collision = elementNameCollision(state, name, 'resource-global')
+    if (collision) return collision
   }
   return null
 }

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -13,7 +13,7 @@ import { isLegalIdentifier } from '../../../utils/keywords'
 import { newUuid } from '../../../utils/new-uuid'
 import { findGlobalVariableListReferences } from '../../../utils/PLC/global-variable-list-references'
 import { restampFlowLibraryVariants } from '../../../utils/PLC/restamp-library-variants'
-import { collectAllSlaveNames, generateUniqueSlaveName } from '../../../utils/unique-slave-name'
+import { generateUniqueSlaveName, type NameTaken } from '../../../utils/unique-slave-name'
 import type { FBDFlowType } from '../fbd'
 import type { FileSliceDataObject } from '../file'
 import type { LadderFlowType } from '../ladder'
@@ -149,7 +149,7 @@ function syncAfterDatatypePropagation(state: SharedRootState, impact: DataTypeRe
  * Everything else — host, port, cycle times, PDO layouts, SDO startup parameters, CiA 402
  * axis config — is what the user duplicated the device for, and is copied verbatim.
  */
-function duplicateRemoteDeviceIdentity(device: PLCRemoteDevice, takenSlaveNames: Set<string>): PLCRemoteDevice {
+function duplicateRemoteDeviceIdentity(device: PLCRemoteDevice, slaveNameTaken: NameTaken): PLCRemoteDevice {
   const next: PLCRemoteDevice = { ...device }
 
   if (next.modbusTcpConfig) {
@@ -170,16 +170,17 @@ function duplicateRemoteDeviceIdentity(device: PLCRemoteDevice, takenSlaveNames:
 
   if (next.ethercatConfig) {
     // A slave's NAME is its key in tabs, editor models and the file registry — not its
-    // id — so two slaves sharing one means the second silently takes over the first's
-    // entries. `generateUniqueSlaveName` is the same `_01`, `_02`… strategy the add
-    // path uses; `taken` grows as we go so the copies do not collide with each other
-    // either.
-    const taken = new Set(takenSlaveNames)
+    // id. Same `_01`, `_02`… strategy as the add path; `copied` keeps the copies from
+    // colliding with each other.
+    const copied = new Set<string>()
     next.ethercatConfig = {
       ...next.ethercatConfig,
       devices: (next.ethercatConfig.devices ?? []).map((slave) => {
-        const name = generateUniqueSlaveName(slave.name, taken)
-        taken.add(name)
+        const name = generateUniqueSlaveName(
+          slave.name,
+          (candidate) => copied.has(candidate) || slaveNameTaken(candidate),
+        )
+        copied.add(name)
         return {
           ...slave,
           id: newUuid(),
@@ -699,8 +700,7 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
 
     rename: (oldName, newName) => {
       const state = getState()
-      // `updateServerName` queues the old file for deletion, so a no-op rename
-      // would mark the server's own file deleted on the next save.
+      // Same name: nothing to rename, and not a duplicate of itself.
       if (oldName === newName) return { ok: true }
 
       const collision = elementNameCollision(state, newName, 'server', oldName)
@@ -787,8 +787,7 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
 
     rename: (oldName, newName) => {
       const state = getState()
-      // `updateRemoteDeviceName` queues the old file for deletion, so a no-op
-      // rename would mark the device's own file deleted on the next save.
+      // Same name: nothing to rename, and not a duplicate of itself.
       if (oldName === newName) return { ok: true }
 
       const collision = elementNameCollision(state, newName, 'remote-device', oldName)
@@ -811,7 +810,7 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       const copy = {
         ...duplicateRemoteDeviceIdentity(
           structuredClone(source),
-          collectAllSlaveNames(state.project.data.remoteDevices),
+          (name) => elementNameCollision(state, name, 'ethercat-slave') !== null,
         ),
         name: newName,
       }
@@ -883,13 +882,9 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
           message: `"${newName}" is not a valid axis name. Use letters, digits, and underscores, starting with a letter or underscore.`,
         }
       }
-      // Only *rejecting* enforcement of slave-name uniqueness — scan-bus add
-      // auto-suffixes instead. Tabs/editor/file slices are name-keyed and break
-      // silently on duplicates, so new write paths must replicate one strategy.
-      // Same-name rename is allowed (the action stays idempotent).
-      if (newName !== oldName && collectAllSlaveNames(state.project.data.remoteDevices).has(newName)) {
-        return { ok: false, message: `An EtherCAT slave named "${newName}" already exists in this project` }
-      }
+      // Rejecting here; scan-bus add auto-suffixes instead. Same-name rename stays idempotent.
+      const collision = elementNameCollision(state, newName, 'ethercat-slave', oldName)
+      if (collision) return { ok: false, message: collision }
       const updatedDevices = devices.map((d) => (d.id === deviceId ? { ...d, name: newName } : d))
       state.projectActions.updateEthercatConfig(busName, {
         masterConfig: remoteDevice.ethercatConfig?.masterConfig ?? {

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -1,7 +1,6 @@
 import { produce } from 'immer'
 import { StateCreator } from 'zustand'
 
-import type { LibraryPouType } from '../../../../middleware/shared/ports/library-types'
 import type { PLCRemoteDevice } from '../../../../middleware/shared/ports/types'
 import { isValidIecIdentifier } from '../../../../middleware/shared/utils/ethercat'
 import { findAllReferencesToDataType } from '../../../utils/data-type-references'
@@ -13,7 +12,6 @@ import { syncNodesWithVariables, syncNodesWithVariablesFBD } from '../../../util
 import { isLegalIdentifier } from '../../../utils/keywords'
 import { newUuid } from '../../../utils/new-uuid'
 import { findGlobalVariableListReferences } from '../../../utils/PLC/global-variable-list-references'
-import { globalVariableListTypeName } from '../../../utils/PLC/global-variable-list-serializer'
 import { restampFlowLibraryVariants } from '../../../utils/PLC/restamp-library-variants'
 import { collectAllSlaveNames, generateUniqueSlaveName } from '../../../utils/unique-slave-name'
 import type { FBDFlowType } from '../fbd'
@@ -28,6 +26,7 @@ import {
   LIBRARY_MANIFEST_TAB_NAME,
 } from '../tabs/utils'
 import { cancelFlowWriteBacks, flushFlowWriteBacks } from './flow-writeback'
+import { elementNameCollision, nameMatches } from './name-collision'
 import type { PouHistorySnapshot, SharedRootState, SharedSlice } from './types'
 import {
   createDatatypeObject,
@@ -76,32 +75,6 @@ function deleteElement(
 function validateElementName(name: string): { ok: true } | { ok: false; message: string } {
   const [legal, reason] = isLegalIdentifier(name)
   return legal ? { ok: true } : { ok: false, message: `'${name}' ${reason}` }
-}
-
-/**
- * Element names are compared case-insensitively: a data type becomes a
- * `datatypes/<Name>.dt` path and a POU a `pous/<folder>/<Name><ext>` one,
- * and macOS/Windows fold filename case, so `Foo` and `foo` would silently
- * overwrite each other on save. IEC identifiers are case-insensitive anyway.
- */
-const nameMatches = (a: string, b: string): boolean => a.toLowerCase() === b.toLowerCase()
-
-/**
- * A raw datatypes/<Name>.dt file that failed to parse still owns its
- * name: letting a new data type take it would make the save emit two
- * specs for one path (and the raw echo would win). Case-insensitive —
- * the file name is the identity and common filesystems fold case.
- */
-function collidesWithUnparsedDataTypeFile(state: SharedRootState, name: string): { ok: boolean; message?: string } {
-  const collides = state.unparsedDataTypeFiles.some(
-    (f) => f.relativePath.split('/').pop()?.replace(/\.dt$/i, '').toLowerCase() === name.toLowerCase(),
-  )
-  return collides
-    ? {
-        ok: false,
-        message: `A data type file named "${name}.dt" exists on disk but could not be read — fix or remove it first`,
-      }
-    : { ok: true }
 }
 
 /**
@@ -155,132 +128,6 @@ function syncAfterDatatypePropagation(state: SharedRootState, impact: DataTypeRe
       code: generateIecVariablesToString(pou.interface?.variables ?? []),
     })
   }
-}
-
-const LIBRARY_SYMBOL_KIND: Record<LibraryPouType, string> = {
-  function: 'function',
-  'function-block': 'function block',
-}
-
-/**
- * The library symbol, if any, that already owns `name`.
- *
- * Library functions and function blocks are declared in the same generated namespace as
- * the project's own elements, and the bundled archives are in every build regardless of
- * the project's `libraries` list — so no setting makes such a name safe. The whole
- * installed pool counts, not just the bundled set: enabling a library later must not
- * turn a project that compiles into one that does not.
- */
-function librarySymbolOwning(state: SharedRootState, name: string): { library: string; kind: string } | null {
-  for (const library of state.libraries.system) {
-    const symbol = library.pous.find((pou) => nameMatches(pou.name, name))
-    if (symbol) return { library: library.name, kind: LIBRARY_SYMBOL_KIND[symbol.type] }
-  }
-  return null
-}
-
-type NamedElementKind = 'pou' | 'data-type' | 'global-variable-list'
-
-const SAME_KIND_TAKEN: Record<NamedElementKind, string> = {
-  pou: 'POU name already exists',
-  'data-type': 'Data type name already exists',
-  'global-variable-list': 'Global variable list name already exists',
-}
-
-/**
- * Why an element of `kind` may not be called `name`, or `null` when it may.
- *
- * POUs, data types and Global Variable Lists share ONE identifier namespace — IEC gives
- * types and variables the same one — and a list occupies TWO symbols in it: the instance
- * keeps the user's name, the struct backing it takes `<name>_TYPE`. Checking each
- * collection only against itself covered a third of a rule with three parts. Library
- * functions and function blocks occupy that same namespace — see `librarySymbolOwning`.
- *
- * The workspace makes a collision worse than the duplicate symbol the compiler would
- * report: `files[name]`, tabs, editor models and `undoRedo[name]` are keyed by raw
- * element name, so one entry ends up serving two elements and edits land on the wrong one.
- *
- * `ignoring` is the element being renamed, so it does not collide with itself. It is
- * matched EXACTLY for POUs and data types: each owns a file path
- * (`pous/<folder>/<Name><ext>`, `datatypes/<Name>.dt`) and macOS/Windows fold filename
- * case, so a case-only rename writes the new file over the old one. Refusing that means
- * the element's own entry has to stay eligible to collide. A list has no file of its
- * own, so it matches case-insensitively and a case-only rename remains a no-op.
- */
-function elementNameCollision(
-  state: SharedRootState,
-  name: string,
-  kind: NamedElementKind,
-  ignoring?: string,
-): string | null {
-  const renamedOntoItself = kind === 'global-variable-list' ? nameMatches(name, ignoring ?? '') : name === ignoring
-  if (ignoring !== undefined && renamedOntoItself) return null
-
-  const { pous, dataTypes } = state.project.data
-  const allLists = state.project.data.globalVariableLists ?? []
-  const lists =
-    kind === 'global-variable-list' ? allLists.filter((list) => !nameMatches(list.name, ignoring ?? '')) : allLists
-
-  const takenBySameKind =
-    kind === 'pou'
-      ? pous.some((pou) => nameMatches(pou.name, name))
-      : kind === 'data-type'
-        ? dataTypes.some((dataType) => nameMatches(dataType.name, name))
-        : lists.some((list) => nameMatches(list.name, name))
-  if (takenBySameKind) return SAME_KIND_TAKEN[kind]
-
-  if (kind !== 'pou' && pous.some((pou) => nameMatches(pou.name, name))) {
-    return `"${name}" is already the name of a POU`
-  }
-  if (kind !== 'data-type' && dataTypes.some((dataType) => nameMatches(dataType.name, name))) {
-    return `"${name}" is already the name of a data type`
-  }
-  if (kind !== 'global-variable-list' && lists.some((list) => nameMatches(list.name, name))) {
-    return `"${name}" is already the name of a global variable list`
-  }
-  // A `.dt` that failed to parse still owns its `files[name]` entry — the registry is
-  // keyed by raw name across every kind — so any element taking that name would share
-  // the entry and misroute its save.
-  const unparsedCollision = collidesWithUnparsedDataTypeFile(state, name)
-  if (!unparsedCollision.ok) return unparsedCollision.message ?? `"${name}" is already taken by a data type file`
-
-  const listOwningTheName = lists.find((list) => nameMatches(globalVariableListTypeName(list.name), name))
-  if (listOwningTheName) {
-    return `"${name}" is the type name of global variable list "${listOwningTheName.name}"`
-  }
-
-  const librarySymbol = librarySymbolOwning(state, name)
-  if (librarySymbol) {
-    return `"${name}" is a ${librarySymbol.kind} in the ${librarySymbol.library} library`
-  }
-
-  if (kind !== 'global-variable-list') return null
-
-  const derived = globalVariableListTypeName(name)
-  if (dataTypes.some((dataType) => nameMatches(dataType.name, derived))) {
-    return `"${name}" needs the type name "${derived}", which a data type already uses`
-  }
-  if (pous.some((pou) => nameMatches(pou.name, derived))) {
-    return `"${name}" needs the type name "${derived}", which a POU already uses`
-  }
-  // Against the other lists' own names as well as their derived ones: the pair
-  // `GVL` / `GVL_TYPE` collides whichever of the two is created first.
-  if (lists.some((list) => nameMatches(list.name, derived))) {
-    return `"${name}" needs the type name "${derived}", which a global variable list already uses`
-  }
-  if (lists.some((list) => nameMatches(globalVariableListTypeName(list.name), derived))) {
-    return `"${name}" needs the type name "${derived}", which another global variable list already uses`
-  }
-  // An unreadable `.dt` is echoed to disk verbatim on save, so the type it declares is
-  // still in the build — the generated struct would be a second declaration of it.
-  if (!collidesWithUnparsedDataTypeFile(state, derived).ok) {
-    return `"${name}" needs the type name "${derived}", which a data type file already uses`
-  }
-  const derivedLibrarySymbol = librarySymbolOwning(state, derived)
-  if (derivedLibrarySymbol) {
-    return `"${name}" needs the type name "${derived}", which is a ${derivedLibrarySymbol.kind} in the ${derivedLibrarySymbol.library} library`
-  }
-  return null
 }
 
 /**
@@ -821,9 +668,8 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
   serverActions: {
     create: ({ name, protocol }) => {
       const state = getState()
-      /* istanbul ignore next -- defensive: servers is always initialized as [] */
-      const servers = state.project.data.servers ?? []
-      if (servers.some((s) => s.name === name)) return { ok: false, message: 'Server already exists' }
+      const collision = elementNameCollision(state, name, 'server')
+      if (collision) return { ok: false, message: collision }
 
       const nameCheck = validateElementName(name)
       if (!nameCheck.ok) return nameCheck
@@ -851,17 +697,25 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
 
     delete: (name) => deleteElement(getState(), name, (n) => getState().projectActions.deleteServer(n)),
 
-    rename: (oldName, newName) =>
-      renameElement(getState(), oldName, newName, (o, n) => getState().projectActions.updateServerName(o, n)),
+    rename: (oldName, newName) => {
+      const state = getState()
+      // `updateServerName` queues the old file for deletion, so a no-op rename
+      // would mark the server's own file deleted on the next save.
+      if (oldName === newName) return { ok: true }
+
+      const collision = elementNameCollision(state, newName, 'server', oldName)
+      if (collision) return { ok: false, message: collision }
+
+      return renameElement(state, oldName, newName, (o, n) => state.projectActions.updateServerName(o, n))
+    },
 
     duplicate: (sourceName, newName) => {
       const state = getState()
       const source = (state.project.data.servers ?? []).find((s) => s.name === sourceName)
       if (!source) return { ok: false, message: 'Server not found' }
 
-      if ((state.project.data.servers ?? []).some((s) => nameMatches(s.name, newName))) {
-        return { ok: false, message: 'Server name already exists' }
-      }
+      const collision = elementNameCollision(state, newName, 'server')
+      if (collision) return { ok: false, message: collision }
 
       const nameCheck = validateElementName(newName)
       if (!nameCheck.ok) return nameCheck
@@ -887,9 +741,8 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
   remoteDeviceActions: {
     create: ({ name, protocol }) => {
       const state = getState()
-      /* istanbul ignore next -- defensive: remoteDevices is always initialized as [] */
-      const devices = state.project.data.remoteDevices ?? []
-      if (devices.some((d) => d.name === name)) return { ok: false, message: 'Remote device already exists' }
+      const collision = elementNameCollision(state, name, 'remote-device')
+      if (collision) return { ok: false, message: collision }
 
       const nameCheck = validateElementName(name)
       if (!nameCheck.ok) return nameCheck
@@ -932,17 +785,25 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       return deleteElement(getState(), name, (n) => getState().projectActions.deleteRemoteDevice(n))
     },
 
-    rename: (oldName, newName) =>
-      renameElement(getState(), oldName, newName, (o, n) => getState().projectActions.updateRemoteDeviceName(o, n)),
+    rename: (oldName, newName) => {
+      const state = getState()
+      // `updateRemoteDeviceName` queues the old file for deletion, so a no-op
+      // rename would mark the device's own file deleted on the next save.
+      if (oldName === newName) return { ok: true }
+
+      const collision = elementNameCollision(state, newName, 'remote-device', oldName)
+      if (collision) return { ok: false, message: collision }
+
+      return renameElement(state, oldName, newName, (o, n) => state.projectActions.updateRemoteDeviceName(o, n))
+    },
 
     duplicate: (sourceName, newName) => {
       const state = getState()
       const source = (state.project.data.remoteDevices ?? []).find((d) => d.name === sourceName)
       if (!source) return { ok: false, message: 'Remote device not found' }
 
-      if ((state.project.data.remoteDevices ?? []).some((d) => nameMatches(d.name, newName))) {
-        return { ok: false, message: 'Remote device name already exists' }
-      }
+      const collision = elementNameCollision(state, newName, 'remote-device')
+      if (collision) return { ok: false, message: collision }
 
       const nameCheck = validateElementName(newName)
       if (!nameCheck.ok) return nameCheck

--- a/src/frontend/utils/__tests__/unique-slave-name.test.ts
+++ b/src/frontend/utils/__tests__/unique-slave-name.test.ts
@@ -54,4 +54,8 @@ describe('generateUniqueSlaveName', () => {
   it('accepts a Set directly as the existing argument', () => {
     expect(generateUniqueSlaveName('EL1809', new Set(['EL1809']))).toBe('EL1809_01')
   })
+
+  it('accepts a predicate for what counts as taken', () => {
+    expect(generateUniqueSlaveName('EL1809', (name) => name === 'EL1809' || name === 'EL1809_01')).toBe('EL1809_02')
+  })
 })

--- a/src/frontend/utils/unique-slave-name.ts
+++ b/src/frontend/utils/unique-slave-name.ts
@@ -28,16 +28,19 @@ export function collectAllSlaveNames(remoteDevices: RemoteDeviceForNameCollectio
   return names
 }
 
+export type NameTaken = (name: string) => boolean
+
 /**
  * Return `base` if unused, otherwise the first `${base}_NN` (two-digit padded)
- * not present in `existing`. Two-digit pad doesn't truncate, so 3+ digit
+ * that `existing` does not hold. Two-digit pad doesn't truncate, so 3+ digit
  * indices pass through unchanged.
  */
-export function generateUniqueSlaveName(base: string, existing: Iterable<string>): string {
-  const taken = new Set(existing)
+export function generateUniqueSlaveName(base: string, existing: Iterable<string> | NameTaken): string {
+  const names = typeof existing === 'function' ? null : new Set(existing)
+  const taken: NameTaken = names ? (name) => names.has(name) : (existing as NameTaken)
   let candidate = base
   let i = 0
-  while (taken.has(candidate)) {
+  while (taken(candidate)) {
     i++
     candidate = `${base}_${String(i).padStart(2, '0')}`
   }


### PR DESCRIPTION
Fixes [DOPE-598](https://autonomylogic.atlassian.net/browse/DOPE-598) and [DOPE-600](https://autonomylogic.atlassian.net/browse/DOPE-600).

Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/746

Bug fix: no Requirements Gathering page, and no Cybersecurity Risk Assessment trigger area is touched — store validation and one toast in the globals editor.

## Problem

Two holes in element-name uniqueness, one card each:

- **DOPE-598** — a resource global variable could take the name of a POU, a data type or a Global Variable List. `createVariable` / `updateVariable` only checked the globals table itself, and the globals code view committed whatever parsed. The compiler then saw two symbols with one name.
- **DOPE-600** — servers and remote devices were only checked against their own kind, and **rename had no check at all**. Renaming a server onto an existing server's name left `files[]` keyed by the stale name (the old file was never dropped, the new name pointed at nothing), and renaming a server to its own name queued its own file for deletion on the next save.

Both cards are the last two children of the DOPE-577 family, so they land together: they share the gate, and fixing one without the other leaves the same class of collision open from the other side.

## Fix

**The gate moves to its own module** — `store/slices/shared/name-collision.ts` — so the project slice and the globals editor can call it (it lived inside `shared/slice.ts`, unreachable from `project/slice.ts` without a cycle). `elementNameCollision(state, name, kind, ignoring?)` is the single entry point; `nameMatches` is re-exported for the callers that still need a plain compare.

**Two namespaces, not one pool.** A kind is checked only against the kinds it shares a namespace with:

| kind | compiler symbol | workspace element |
|---|---|---|
| POU, data type, Global Variable List | yes | yes |
| server, remote device, EtherCAT slave | — | yes |
| resource global | yes | — |

So a server may still be named like a resource global or like a library function (`Scale`), because neither reaches the compiler through the server; a resource global named `Scale`, or after a POU, a type or a list, is refused. The `<name>_TYPE` list check, the library-symbol check and the unparsed `.dt` file check keep their existing scope and messages verbatim.

**Servers and remote devices** go through the gate on create, rename and duplicate. Rename checks the new name with the old one as `ignoring`; a same-name rename is an explicit no-op (without it `updateServerName` matches the element against itself and reports a duplicate). Since both kinds own a file, **case-only renames are refused** like they are for POUs — the file systems we ship on fold case, so `Modbus` → `modbus` would push `devices/servers/Modbus.json` onto `pendingDeletions` while writing the same file under the new spelling. The same-kind messages are `Server already exists` / `Remote device already exists`. The create form and the EtherCAT bus rename now carry the gate's reason to the user instead of a fixed "already exists" or a silent snap-back, and Duplicate picks its `_copy` name through the gate so the second duplicate lands on the first try.

**Resource globals** are gated at both store entry points. `createVariable` feeds the gate into the row validator's auto-increment (`createVariableValidation` takes a `nameTaken` predicate, bounded like the location loop), so the "+" button's clone steps past POU, type, list and library names the same way it steps past its own table — a POU named `GlobalVar` no longer blocks the first row forever. `updateVariable` checks only when `name` changes and only once the row is found, ignoring the row's current name so a case-only edit of a global stays allowed (globals own no file). The globals **code view** runs `newGlobalNameCollision` at its commit boundary: only names the commit *introduces* are gated, names the table already holds pass, so a project that already carries a global named after a library symbol stays editable through that view; the undo path through `setGlobalVariables` stays ungated. The table's name cell checks the gate before asking about reference propagation. The three "+" paths in the editor surface a refusal as a toast; they used to drop the response silently.

Not touched: undo/redo, project load (a project already carrying a collision still opens), the Requirements/CRA pages, any backend.

## Behaviour changes worth knowing

- A server or remote device can no longer be renamed onto an existing name, to a case variant of its own name, or to a POU / data type / list name. Same-name rename is a no-op (no dirty flag).
- A resource global can no longer be named after a POU, a data type, a Global Variable List or a library symbol — from the table or from the code view; the "+" button auto-increments past those names. An unreadable `.dt` file is *not* in a global's way: it is echoed to disk but never compiled, so the two do not meet.
- A Global Variable List can no longer take a name whose `<name>_TYPE` a resource global already holds, in either creation order.
- A POU, data type or list can no longer be named after a server, a remote device or a resource global.
- Server ↔ resource global, and server ↔ library symbol, remain allowed.

## Tests

- New `store/__tests__/name-collision.test.ts`: the full 6×5 kind matrix on the real store (every kind against every other, both directions), same-kind messages, self / case-only rules per kind, library `Scale`, unparsed `.dt`, list type name, derived-name rules in both creation orders, `newGlobalNameCollision` (held names pass, introduced names are gated), and a project already carrying a server/list collision still loading.
- `element-duplicate.test.ts` +4; `shared-slice.test.ts`: the case-only rename test for servers *and* remote devices now pins the registry (`files`, element name, `pendingDeletions`), plus same-name no-op and cross-kind refusal for devices; `project-slice.test.ts`: global clone steps past a POU name, past `Motor0`, seeds an empty table past a POU named `GlobalVar`, missing row reported before its new name; `project-validation-variables.test.ts` +3 for the `nameTaken` loop and its bound.

Local gate in both repos: prettier, eslint, tsc, architecture validation; full suite with coverage thresholds — web vitest 393 files / 8095 tests, editor jest 396 suites / 8197 tests. `scripts/compare-surfaces.py` between the branches: `total_diffs: 0`.

Validated manually by João on the dev build against the fixture `plc-projects/dope-598-600-name-gate` (POU `Pump`, type `TankT`, list `Recipes`, servers `Modbus` + `Recipes`, remote device `Drive`, global `LineEnable`): the create/rename/duplicate refusals per kind, the allowed pairs, the server rename paths, and a legacy project carrying a server/list collision still opening. The review round below was re-validated on the same fixture.

## Review round 1

From Gustavo's review: the derived `_TYPE` arm now checks resource globals (order-independent); the globals "+" auto-increments against the whole namespace instead of dead-ending; the server/device create form and the EtherCAT bus rename report the gate's reason; the code view gates only introduced names; Duplicate's `_copy` name goes through the gate; the table cell checks the name before the rename-impact modal; `updateVariable` reports a missing row before judging its name; comments and this description corrected (unparsed `.dt` vs globals, the no-op rename reason). **EtherCAT slaves join the workspace namespace** as their own kind: `ethercatDeviceActions.rename`, scan-bus add, repository add and bus duplication all go through the gate (`generateUniqueSlaveName` takes a predicate, so auto-suffixing still steps past a taken name instead of refusing), and every other workspace kind refuses a slave's name. The same-kind message for slaves is unchanged.

Shared surface: `src/frontend/**` only, byte-identical with the sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




[DOPE-598]: https://autonomylogic.atlassian.net/browse/DOPE-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOPE-600]: https://autonomylogic.atlassian.net/browse/DOPE-600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent name-collision checks across POUs, data types, global variables, servers, remote devices, EtherCAT slaves, and related project elements.
  * Added server and remote-device rename validation, including no-op handling for unchanged names.
  * Global-variable creation now automatically selects the next available name when conflicts occur.
* **Bug Fixes**
  * Prevented duplicate or case-insensitive conflicting names during creation and renaming.
  * Improved collision error messages and notifications.
  * Variable creation failures now show an error notification without updating the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->