### PR TITLE
fix(store): warn before deleting a data type that is still referenced (DOPE-553)

### DIFF
--- a/src/frontend/components/_molecules/rename-impact-modal/data-type-delete-impact-modal.tsx
+++ b/src/frontend/components/_molecules/rename-impact-modal/data-type-delete-impact-modal.tsx
@@ -1,0 +1,50 @@
+import { useOpenPLCStore } from '../../../store'
+import { toast } from '../../_features/[app]/toast/use-toast'
+import { RenameImpactModal } from '.'
+
+/**
+ * Store-driven host for the data type delete flow: `datatypeActions.deleteRequest`
+ * parks a still-referenced type in `pendingDatatypeDelete`, this renders the
+ * impact modal for it, and confirm/cancel go through `respondToPendingDelete`.
+ * References are left in place on purpose — the modal is the warning.
+ */
+export const DataTypeDeleteImpactModal = () => {
+  const pending = useOpenPLCStore((s) => s.pendingDatatypeDelete)
+  const respondToPendingDelete = useOpenPLCStore((s) => s.datatypeActions.respondToPendingDelete)
+
+  if (!pending) return null
+
+  const { name, impact } = pending
+  const count = impact.totalReferences
+  const references = count === 1 ? '1 reference now points' : `${count} references now point`
+
+  const handleConfirm = () => {
+    respondToPendingDelete(true)
+    toast({
+      title: 'Data type deleted',
+      description: `"${name}" was deleted. ${references} to a missing type.`,
+      variant: 'default',
+    })
+  }
+
+  return (
+    <RenameImpactModal
+      open
+      title='Data Type Delete: Impact Analysis'
+      impact={impact}
+      description={
+        <>
+          Deleting <span className='font-semibold'>{name}</span> will leave these references without a type:
+        </>
+      }
+      affectedListLabel='Affected locations:'
+      byKindLabel='By reference kind:'
+      confirmLabel='Yes, delete anyway'
+      confirmDescription='The data type is removed and the listed references keep its name until you retype them'
+      cancelLabel='No, keep data type'
+      cancelDescription='Nothing is changed'
+      onConfirm={handleConfirm}
+      onCancel={() => respondToPendingDelete(false)}
+    />
+  )
+}

--- a/src/frontend/components/_molecules/rename-impact-modal/index.tsx
+++ b/src/frontend/components/_molecules/rename-impact-modal/index.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 import type { ReferenceImpactAnalysis } from '../../../utils/variable-references/types'
 import { Modal, ModalContent, ModalFooter, ModalHeader, ModalTitle } from '../modal'
 
@@ -10,9 +12,12 @@ type RenameImpactModalProps = {
   impact: ReferenceImpactAnalysis<unknown>
   // Copy overrides — defaults keep the original variable-rename wording.
   title?: string
+  /** Replaces the "Renaming X to Y will affect:" line. */
+  description?: ReactNode
   affectedListLabel?: string
   byKindLabel?: string
   confirmLabel?: string
+  confirmDescription?: string
   cancelLabel?: string
   cancelDescription?: string
   onConfirm: () => void
@@ -26,9 +31,11 @@ export const RenameImpactModal = ({
   changes,
   impact,
   title = 'Variable Changes: Impact Analysis',
+  description,
   affectedListLabel = 'Affected POUs:',
   byKindLabel = 'By Editor Type:',
   confirmLabel = 'Yes, rename references',
+  confirmDescription = 'All references will be updated to use the new name',
   cancelLabel = 'No, keep references unchanged',
   cancelDescription = 'References will remain with the old name and will no longer match the renamed variable, causing them to become unresolved references',
   onConfirm,
@@ -51,7 +58,9 @@ export const RenameImpactModal = ({
 
         <div className='flex flex-col gap-3 overflow-y-auto'>
           <div className='text-xs text-neutral-600 dark:text-neutral-50'>
-            {hasMultipleChanges ? (
+            {description !== undefined ? (
+              <p className='mb-2'>{description}</p>
+            ) : hasMultipleChanges ? (
               <>
                 <p className='mb-2 font-medium'>The following variable changes will affect:</p>
                 <ul className='mb-2 list-inside list-disc space-y-1'>
@@ -134,8 +143,7 @@ export const RenameImpactModal = ({
             <p className='font-medium'>What would you like to do?</p>
             <ul className='mt-2 list-inside list-disc space-y-1'>
               <li>
-                <span className='font-semibold'>{confirmLabel}:</span> All references will be updated to use the new
-                name
+                <span className='font-semibold'>{confirmLabel}:</span> {confirmDescription}
               </li>
               <li>
                 <span className='font-semibold'>{cancelLabel}:</span> {cancelDescription}

--- a/src/frontend/components/_templates/app-layout.tsx
+++ b/src/frontend/components/_templates/app-layout.tsx
@@ -9,6 +9,7 @@ import { ResolutionWarning } from '../_atoms/resolution-warning-message'
 import Toaster from '../_features/[app]/toast/toaster'
 import { ProjectModal } from '../_features/[start]/new-project/project-modal'
 import { AIConsentModal } from '../_features/[workspace]/editor/monaco/ai-consent-modal'
+import { DataTypeDeleteImpactModal } from '../_molecules/rename-impact-modal/data-type-delete-impact-modal'
 import { DataTypeRenameImpactModal } from '../_molecules/rename-impact-modal/data-type-rename-impact-modal'
 import AboutModal from '../_organisms/about-modal'
 import {
@@ -143,6 +144,7 @@ const AppLayout = ({ children, ...rest }: AppLayoutProps): ReactNode => {
             <ConfirmDeleteProjectModal isOpen={modals['confirm-delete-project'].open} />
           )}
           <DataTypeRenameImpactModal />
+          <DataTypeDeleteImpactModal />
           {modals?.['confirm-plcopen-import']?.open === true && (
             <ConfirmPlcopenImportModal isOpen={modals['confirm-plcopen-import'].open} />
           )}

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -850,7 +850,7 @@ describe('createSharedSlice', () => {
         const second = await store.getState().datatypeActions.rename('Chassis', 'Frame')
 
         expect(second.ok).toBe(false)
-        expect(second.message).toBe('Another data type rename is awaiting confirmation')
+        expect(second.message).toBe('Another data type change is awaiting confirmation')
         // The first request's resolver is untouched and still completes.
         expect(store.getState().pendingDatatypeRename).toBe(pendingBefore)
         store.getState().datatypeActions.respondToPendingRename(true)
@@ -1023,6 +1023,54 @@ describe('createSharedSlice', () => {
       it('respondToPendingDelete without a pending request is a no-op', () => {
         store.getState().datatypeActions.respondToPendingDelete(true)
         expect(dataTypeNames()).toEqual(['OldDT', 'Chassis'])
+      })
+
+      it('refuses a delete request while a rename is awaiting confirmation', async () => {
+        const rename = store.getState().datatypeActions.rename('OldDT', 'NewDT')
+        const pendingRename = store.getState().pendingDatatypeRename
+
+        store.getState().datatypeActions.deleteRequest('OldDT')
+
+        expect(store.getState().pendingDatatypeDelete).toBeNull()
+        expect(store.getState().modalActions.getModalState('confirm-delete-element').open).toBe(false)
+        expect(store.getState().pendingDatatypeRename).toBe(pendingRename)
+
+        store.getState().datatypeActions.respondToPendingRename(false)
+        await rename
+      })
+
+      it('refuses a rename while a delete is awaiting confirmation', async () => {
+        store.getState().datatypeActions.deleteRequest('OldDT')
+
+        const result = await store.getState().datatypeActions.rename('OldDT', 'NewDT')
+
+        expect(result).toEqual({ ok: false, message: 'Another data type change is awaiting confirmation' })
+        expect(store.getState().pendingDatatypeDelete?.name).toBe('OldDT')
+        expect(dataTypeNames()).toEqual(['OldDT', 'Chassis'])
+      })
+
+      it('drops a pending delete when the project is closed', () => {
+        store.getState().datatypeActions.deleteRequest('OldDT')
+        expect(store.getState().pendingDatatypeDelete).not.toBeNull()
+
+        store.getState().sharedWorkspaceActions.clearStatesOnCloseProject()
+
+        expect(store.getState().pendingDatatypeDelete).toBeNull()
+      })
+
+      it('cancels a pending rename when the project is closed', async () => {
+        const rename = store.getState().datatypeActions.rename('OldDT', 'NewDT')
+        expect(store.getState().pendingDatatypeRename).not.toBeNull()
+
+        store.getState().sharedWorkspaceActions.clearStatesOnCloseProject()
+
+        expect(store.getState().pendingDatatypeRename).toBeNull()
+        // Without the resolver being fired, this await would never settle.
+        await expect(rename).resolves.toEqual({
+          ok: false,
+          cancelled: true,
+          message: 'Rename cancelled',
+        })
       })
 
       it('skips the modal when nothing references the type', () => {

--- a/src/frontend/store/__tests__/shared-slice.test.ts
+++ b/src/frontend/store/__tests__/shared-slice.test.ts
@@ -948,6 +948,94 @@ describe('createSharedSlice', () => {
       })
     })
 
+    describe('deleteRequest with references (impact modal)', () => {
+      beforeEach(() => {
+        store.getState().datatypeActions.create({ name: 'OldDT', derivation: 'structure' })
+        store.getState().datatypeActions.create({ name: 'Chassis', derivation: 'structure' })
+        store.getState().projectActions.updateDatatype('Chassis', {
+          name: 'Chassis',
+          derivation: 'structure',
+          variable: [{ name: 'front', type: { definition: 'user-data-type', value: 'OldDT' } }],
+        })
+        store.getState().pouActions.create({ type: 'program', name: 'Main', language: 'st' })
+        store.getState().projectActions.setPouVariables({
+          pouName: 'Main',
+          variables: [
+            {
+              name: 'motor',
+              class: 'local',
+              type: { definition: 'user-data-type', value: 'olddt' },
+              location: '',
+              documentation: '',
+            },
+          ],
+        })
+      })
+
+      const dataTypeNames = () => store.getState().project.data.dataTypes.map((d) => d.name)
+
+      it('parks a pending delete instead of opening the confirm modal', () => {
+        store.getState().datatypeActions.deleteRequest('OldDT')
+
+        const pending = store.getState().pendingDatatypeDelete
+        expect(pending?.name).toBe('OldDT')
+        expect(pending?.impact.totalReferences).toBe(2)
+        expect(Array.from(pending?.impact.byPou.entries() ?? [])).toEqual([
+          ['Main', 1],
+          ['Chassis', 1],
+        ])
+        expect(store.getState().modalActions.getModalState('confirm-delete-element').open).toBe(false)
+        expect(dataTypeNames()).toEqual(['OldDT', 'Chassis'])
+      })
+
+      it('confirm deletes the type and leaves the references in place', () => {
+        store.getState().datatypeActions.deleteRequest('OldDT')
+        store.getState().datatypeActions.respondToPendingDelete(true)
+
+        const state = store.getState()
+        expect(state.pendingDatatypeDelete).toBeNull()
+        expect(dataTypeNames()).toEqual(['Chassis'])
+        expect(state.pendingDeletions).toContain('datatypes/OldDT.dt')
+        expect(state.files['OldDT']).toBeUndefined()
+        expect(state.project.data.pous[0].interface?.variables[0].type.value).toBe('olddt')
+        expect(state.project.data.dataTypes[0]).toMatchObject({
+          variable: [{ name: 'front', type: { definition: 'user-data-type', value: 'OldDT' } }],
+        })
+      })
+
+      it('cancel leaves the store untouched', () => {
+        store.getState().datatypeActions.deleteRequest('OldDT')
+        store.getState().datatypeActions.respondToPendingDelete(false)
+
+        expect(store.getState().pendingDatatypeDelete).toBeNull()
+        expect(dataTypeNames()).toEqual(['OldDT', 'Chassis'])
+        expect(store.getState().pendingDeletions).toHaveLength(0)
+      })
+
+      it('ignores a second request while one is awaiting confirmation', () => {
+        store.getState().datatypeActions.deleteRequest('OldDT')
+        store.getState().datatypeActions.deleteRequest('Chassis')
+
+        expect(store.getState().pendingDatatypeDelete?.name).toBe('OldDT')
+        expect(store.getState().modalActions.getModalState('confirm-delete-element').open).toBe(false)
+      })
+
+      it('respondToPendingDelete without a pending request is a no-op', () => {
+        store.getState().datatypeActions.respondToPendingDelete(true)
+        expect(dataTypeNames()).toEqual(['OldDT', 'Chassis'])
+      })
+
+      it('skips the modal when nothing references the type', () => {
+        store.getState().datatypeActions.deleteRequest('Chassis')
+
+        expect(store.getState().pendingDatatypeDelete).toBeNull()
+        expect(store.getState().modalActions.getModalState('confirm-delete-element').data).toEqual({
+          name: 'Chassis',
+          elementType: 'datatype',
+        })
+      })
+    })
+
     // -----------------------------------------------------------------------
     // duplicate
     // -----------------------------------------------------------------------

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -243,6 +243,7 @@ function renameElement(
 const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (setState, getState) => ({
   undoRedo: {},
   pendingDatatypeRename: null,
+  pendingDatatypeDelete: null,
 
   pouActions: {
     create: ({ type, name, language }) => {
@@ -574,7 +575,20 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
     },
 
     deleteRequest: (name) => {
-      getState().modalActions.openModal('confirm-delete-element', { name, elementType: 'datatype' })
+      const state = getState()
+      if (state.pendingDatatypeDelete) return
+      const impact = findAllReferencesToDataType(
+        name,
+        state.project.data.pous,
+        state.project.data.configurations.resource.globalVariables,
+        state.project.data.dataTypes,
+        state.project.data.globalVariableLists ?? [],
+      )
+      if (impact.totalReferences > 0) {
+        setState({ pendingDatatypeDelete: { name, impact } })
+        return
+      }
+      state.modalActions.openModal('confirm-delete-element', { name, elementType: 'datatype' })
     },
 
     delete: (name) => deleteElement(getState(), name, (n) => getState().projectActions.deleteDatatype(n)),
@@ -637,6 +651,13 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
       if (!pending) return
       setState({ pendingDatatypeRename: null })
       pending.resolve(confirmed)
+    },
+
+    respondToPendingDelete: (confirmed) => {
+      const pending = getState().pendingDatatypeDelete
+      if (!pending) return
+      setState({ pendingDatatypeDelete: null })
+      if (confirmed) getState().datatypeActions.delete(pending.name)
     },
 
     duplicate: (sourceName, newName) => {

--- a/src/frontend/store/slices/shared/slice.ts
+++ b/src/frontend/store/slices/shared/slice.ts
@@ -576,7 +576,7 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
 
     deleteRequest: (name) => {
       const state = getState()
-      if (state.pendingDatatypeDelete) return
+      if (state.pendingDatatypeDelete || state.pendingDatatypeRename) return
       const impact = findAllReferencesToDataType(
         name,
         state.project.data.pous,
@@ -623,8 +623,8 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
         if (impact.totalReferences > 0) {
           // Overwriting a pending request would drop its resolver and strand
           // the first caller's await forever (e.g. Enter + blur double-fire).
-          if (getState().pendingDatatypeRename) {
-            return { ok: false, message: 'Another data type rename is awaiting confirmation' }
+          if (getState().pendingDatatypeRename || getState().pendingDatatypeDelete) {
+            return { ok: false, message: 'Another data type change is awaiting confirmation' }
           }
           const confirmed = await new Promise<boolean>((resolve) => {
             setState({ pendingDatatypeRename: { oldName, newName, impact, resolve } })
@@ -1019,6 +1019,11 @@ const createSharedSlice: StateCreator<SharedRootState, [], [], SharedSlice> = (s
     },
 
     clearStatesOnCloseProject: () => {
+      // A confirmation parked against the closing project must not answer for the next
+      // one, and a dropped rename resolver would strand its caller's await forever.
+      const pendingRename = getState().pendingDatatypeRename
+      setState({ pendingDatatypeRename: null, pendingDatatypeDelete: null })
+      pendingRename?.resolve(false)
       getState().editorActions.clearEditor()
       getState().tabsActions.clearTabs()
       getState().libraryActions.clearUserLibraries()

--- a/src/frontend/store/slices/shared/types.ts
+++ b/src/frontend/store/slices/shared/types.ts
@@ -109,6 +109,13 @@ export type PendingDatatypeRename = {
   resolve: (confirmed: boolean) => void
 }
 
+/** A delete waiting on the reference-impact modal. Nothing awaits it, so
+ *  no resolver: confirm runs `datatypeActions.delete`, cancel drops it. */
+export type PendingDatatypeDelete = {
+  name: string
+  impact: DataTypeReferenceImpactAnalysis
+}
+
 /** Global Variable Lists — the object CODESYS calls a GVL. */
 export type GlobalVariableListActions = {
   /** Create the list and open its tab, as every other + button element does. */
@@ -122,13 +129,17 @@ export type GlobalVariableListActions = {
 
 export type DatatypeActions = {
   create: (args: { name: string; derivation: 'array' | 'enumerated' | 'structure' }) => SharedResponse
+  /** Opens the confirm modal — or the reference-impact modal when the type is still referenced. */
   deleteRequest: (name: string) => void
+  /** Unconditional; the reference gate lives in `deleteRequest`. */
   delete: (name: string) => SharedResponse
   /** Async: a rename of a referenced type awaits the impact modal before
    *  propagating the new name into every reference. Cancel = no state change. */
   rename: (oldName: string, newName: string) => Promise<DatatypeRenameResponse>
   /** Confirm (`true`) or cancel (`false`) the pending rename's impact modal. */
   respondToPendingRename: (confirmed: boolean) => void
+  /** Confirm (`true`) or cancel (`false`) the pending delete's impact modal. */
+  respondToPendingDelete: (confirmed: boolean) => void
   duplicate: (sourceName: string, newName: string) => SharedResponse
 }
 
@@ -249,6 +260,7 @@ export type SharedWorkspaceActions = {
 export type SharedSlice = {
   undoRedo: Record<string, PouHistory>
   pendingDatatypeRename: PendingDatatypeRename | null
+  pendingDatatypeDelete: PendingDatatypeDelete | null
   pouActions: PouActions
   datatypeActions: DatatypeActions
   globalVariableListActions: GlobalVariableListActions


### PR DESCRIPTION
Mirror of https://github.com/Autonomy-Logic/openplc-web/pull/748

Closes DOPE-553.

## The defect

Deleting a data type never consulted its references. `deleteDatatype` queued the `.dt` path and dropped the entry, leaving every POU variable, resource global, global variable list member and struct field that named the type pointing at nothing, with no warning. DOPE-536 built the reference finder, the impact modal and the propagation pass, but wired them to rename only.

## The change

`datatypeActions.deleteRequest` now runs `findAllReferencesToDataType`. When the type is still referenced it parks the request in `pendingDatatypeDelete` and shows the impact modal **instead of** the generic confirm dialog, so a delete is answered by one dialog rather than two. Confirm runs the existing unconditional `delete` and toasts how many references went stale; cancel changes nothing. An unreferenced type keeps today's silent, immediate path.

The references are left dangling on purpose. A cascade would delete the user's own variables and struct fields, and refusing the delete outright would block the legitimate delete-then-fix-the-users workflow. `delete` itself stays unguarded, so the gate covers the project tree context menu and the Delete-key accelerator alike, and the finder already covers global variable lists, so those come along for free.

The shared impact modal gained `description` and `confirmDescription` props: its fallback copy and its confirm bullet were hard-coded rename wording.

## Known limitation, not fixed here

The card reports that diagnostics for **every** data type go silent after such a delete. That is upstream, filed as **RTOP-286**. strucpp merges every open document into one AST and skips its entire semantic validation pass whenever type checking errored anywhere, so the synthesized datatypes document publishes an empty array instead of reporting the dangling reference. Verified against the pinned v0.6.6 build. Until that ships, the card's "diagnostics keep working after a confirmed delete" criterion holds only when no POU body type-checks against the missing type.

## Verification

- Web vitest: 393 files / 8131 tests green, including 6 new cases on the delete gate. Coverage on every new line of `store/slices/shared/slice.ts`.
- Editor jest: `shared-slice.test.ts` 248 green.
- `tsc`, eslint and prettier clean in both repos.
- Driven in the browser against a seeded dev project: referenced delete opens the modal listing the POU variable and the struct field, confirm deletes and toasts, cancel keeps the type, unreferenced delete gives the plain dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an impact review dialog when deleting referenced data types.
  * Users can review affected references, cancel deletion, or confirm it.
  * Confirmed deletions preserve references and notify users that they point to a missing type.
  * Added customizable descriptions for rename and deletion confirmation dialogs.

* **Bug Fixes**
  * Prevented duplicate or conflicting rename and deletion requests while confirmation is pending.
  * Unreferenced data types continue through the standard deletion flow.
  * Pending changes are cleared when closing a project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->