### PR TITLE
feat(cli): author, check and configure a whole project headlessly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,14 +232,18 @@ Platform-specific binaries in `/resources/bin/[platform]/[arch]/`. Board configs
 - **Framework:** Jest + jsdom
 - **Test files:** `*.test.ts(x)`, `*.spec.ts(x)`, or `__tests__/` directories
 - **E2E:** Playwright (`/e2e`), Chromium only
-- **Coverage thresholds** (100% functions/lines/statements required):
-  - `src/frontend/store/slices/`
-  - `src/frontend/utils/`
-  - `src/backend/shared/`
-  - `src/middleware/adapters/editor/`
+- **Coverage thresholds** — per-directory aggregates, not 100%. Branches are not
+  enforced anywhere. From `jest.config.json`, as functions/lines/statements:
+  - `src/frontend/store/slices/` — 98 / 98 / 97
+  - `src/frontend/utils/` — 97 / 95 / 95
+  - `src/backend/shared/` — 76 / 77 / 75
+  - `src/middleware/adapters/editor/` — 87 / 85 / 85
+  - `src/cli/` is **not collected at all**, so it faces no threshold
 - **Mocks:** `configs/mocks/` for file stubs; `identity-obj-proxy` for CSS modules
 
-When adding new code to covered directories, you must add corresponding tests to maintain 100% coverage.
+The thresholds are aggregates over the whole directory, so an untested new file
+drags its bucket below the line and fails the run. Add tests alongside new code
+in those directories.
 
 ## Code Style
 
@@ -330,7 +334,7 @@ on its `main` push. (Ideally `package.json.version` should be derived from
 1. Create `types.ts`, `slice.ts`, `index.ts` in `src/frontend/store/slices/<name>/`
 2. Add the slice type to `RootState` union in `src/frontend/store/index.ts`
 3. Spread the slice creator in `createOpenPLCStore()`
-4. Add tests to maintain 100% coverage
+4. Add tests to keep the directory's coverage bucket above its threshold
 
 ### When adding a new POU language or type:
 1. Update project parser (`src/backend/shared/utils/parse-project-files.ts`)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -191,17 +191,70 @@ Machine-readable when stdout is not a terminal, human-readable when it is;
 
 ### Exit codes
 
-| Code | Meaning                                                |
-| ---- | ------------------------------------------------------ |
-| 0    | ok                                                     |
-| 2    | usage — unknown command, missing or malformed argument |
-| 3    | not found — project, file or session                   |
-| 4    | compile failed                                         |
-| 5    | connection — could not reach the target, or lost it    |
-| 6    | auth — credentials refused                             |
-| 7    | target error — the device reported failure             |
-| 8    | timeout                                                |
-| 70   | internal — a bug in the CLI                            |
+| Code | Meaning                                                                                |
+| ---- | -------------------------------------------------------------------------------------- |
+| 0    | ok                                                                                     |
+| 2    | usage — unknown command, missing or malformed argument                                 |
+| 3    | not found — project, file or session                                                   |
+| 4    | compile failed                                                                         |
+| 5    | connection — could not reach the target, or lost it                                    |
+| 6    | auth — credentials refused                                                             |
+| 7    | target error — the device reported failure, or the project on disk refuses the command |
+| 8    | timeout                                                                                |
+| 70   | internal — a bug in the CLI                                                            |
+
+## Protocols
+
+A project's `servers` and `remoteDevices` are part of the `apply` spec, and
+`describe` emits them back. The runtime decides which protocol plugins to load
+from which `conf/*.json` files the upload carries, and offers no way to read a
+configuration back, so:
+
+```sh
+openplc-cli check ./project --lint --protocols
+```
+
+runs the same generators the upload runs and prints the exact file set. That
+file set is the enable state.
+
+```
+Protocol configs this project would upload:
+  modbusSlave    conf/modbus_slave.json
+  modbusMaster   conf/modbus_master.json
+  s7comm         conf/s7comm.json
+  opcua          (not generated — the plugin stays off)
+  ethercat       (not generated — the plugin stays off)
+```
+
+Three things that are not obvious:
+
+- A server's `enabled: false` means "no config file" for Modbus and OPC-UA, and
+  the plugin never starts. **S7comm still ships its config**, by design: that
+  plugin reads the flag itself and declines to serve.
+- `describe` **redacts** `security.serverPrivateKeyCustom` and every
+  `users[].passwordHash`; `apply` **preserves** them when the spec omits them, so
+  a round trip does not destroy a key. Write the field to change it.
+- Allocated addresses — a Modbus point's `iecLocation`, an EtherCAT channel's —
+  are reported under a sibling `protocolAddresses` key, never inside `spec`.
+  Allocation decides them, so a spec carrying them would stop round-tripping.
+
+A server or remote-device file that does not load is a **refusal**, not a
+warning: `describe` and `apply` both exit 7 with `protocol_file_unreadable`
+rather than reporting a project that is not the one on disk, or overwriting a
+config nobody read.
+
+### EtherCAT devices
+
+An EtherCAT slave is authored from the vendor's ESI file, which the project
+keeps in its own repository:
+
+```sh
+openplc-cli esi import ./EL7041.xml --project ./project   # adds the file
+openplc-cli esi list --project ./project                  # ids and device indices
+```
+
+`esi list` prints what a spec needs: the repository id (a file name works too)
+and the `deviceIndex` of each device inside the file.
 
 ## Credentials
 
@@ -258,24 +311,27 @@ point of naming a timeout is that the default was wrong for this run.
 
 ### Flags, by command
 
-| Flag                   | Command                             | Meaning                                                                                             |
-| ---------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `--session <id>`       | any `debug` subcommand              | which session, when several are open                                                                |
-| `--idle-timeout <ms>`  | `debug open`                        | idle budget; `0` disables (see above)                                                               |
-| `--force-new`          | `debug open`                        | start a session even if one is already open for this project and target                             |
-| `--upload-if-needed`   | `debug open`                        | upload first when the target's program does not match                                               |
-| `--var <name>`         | `read`, `force`, `unforce`           | the variable, when you would rather not pass it positionally                                        |
-| `--value <literal>`    | `force`                             | the value — `16#FF`, `TRUE`, `T#5s`, all as the GUI accepts them                                    |
-| `--filter <substring>` | `list-vars`                         | only variables whose path contains it                                                               |
-| `--interval <ms>`      | `watch`                             | sampling cadence; floor 20 ms                                                                       |
-| `--since <seq>`        | `poll`                              | only samples after this sequence number                                                             |
-| `--keep-forces`        | `close`                             | leave forced variables pinned                                                                       |
-| `--all`                | `close`                             | every session, not just one                                                                         |
-| `--keep-going`         | `exec`                              | run the remaining lines after one fails                                                             |
-| `--force`              | `create`                            | overwrite an existing destination                                                                   |
-| `--clean`              | `compile`, `upload`                 | discard the build directory first                                                                   |
-| `-y`, `--yes`          | `upload`                            | skip the confirmation                                                                               |
-| `--create-user`        | `upload`, `debug open`              | permission to create the FIRST user on a fresh runtime v4, using the credentials you already passed |
+| Flag                   | Command                    | Meaning                                                                                                      |
+| ---------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `--session <id>`       | any `debug` subcommand     | which session, when several are open                                                                         |
+| `--idle-timeout <ms>`  | `debug open`               | idle budget; `0` disables (see above)                                                                        |
+| `--force-new`          | `debug open`               | start a session even if one is already open for this project and target                                      |
+| `--upload-if-needed`   | `debug open`               | upload first when the target's program does not match                                                        |
+| `--var <name>`         | `read`, `force`, `unforce` | the variable, when you would rather not pass it positionally                                                 |
+| `--value <literal>`    | `force`                    | the value — `16#FF`, `TRUE`, `T#5s`, all as the GUI accepts them                                             |
+| `--filter <substring>` | `list-vars`                | only variables whose path contains it                                                                        |
+| `--interval <ms>`      | `watch`                    | sampling cadence; floor 20 ms                                                                                |
+| `--since <seq>`        | `poll`                     | drops samples up to this sequence number; the buffer is drained either way, so it is not a rewindable cursor |
+| `--keep-forces`        | `close`                    | leave forced variables pinned                                                                                |
+| `--all`                | `close`                    | every session, not just one                                                                                  |
+| `--keep-going`         | `exec`                     | run the remaining lines after one fails                                                                      |
+| `--force`              | `create`                   | overwrite an existing destination                                                                            |
+| `--clean`              | `compile`, `upload`        | discard the build directory first                                                                            |
+| `-y`, `--yes`          | `upload`                   | skip the confirmation                                                                                        |
+| `--create-user`        | `upload`                   | permission to create the FIRST user on a fresh runtime v4, using the credentials you already passed          |
+| `--protocols`          | `check`                    | which `conf/*.json` the upload would carry — the runtime's enable state, computed without a device           |
+| `--prune`              | `apply`                    | delete what the spec stopped mentioning, including servers and remote devices                                |
+| `--project <dir>`      | `esi`                      | the project whose ESI repository to read or add to                                                           |
 
 `watch` **records** into a buffer inside the session rather than streaming, so a
 transient that happens between two of your own commands is still there when you

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -4,7 +4,11 @@
   "asar": true,
   "asarUnpack": "**\\*.{node,dll}",
   "generateUpdatesFilesForAllChannels": true,
-  "files": ["dist", "node_modules", "package.json"],
+  "files": [
+    "dist",
+    "node_modules",
+    "package.json"
+  ],
   "afterSign": "scripts/notarize.js",
   "directories": {
     "app": "release/app",
@@ -20,6 +24,10 @@
     {
       "from": "./node_modules/strucpp/libs",
       "to": "./strucpp/libs"
+    },
+    {
+      "from": "./resources/skills",
+      "to": "./skills"
     }
   ],
   "mac": {
@@ -35,7 +43,10 @@
     ],
     "target": {
       "target": "default",
-      "arch": ["arm64", "x64"]
+      "arch": [
+        "arm64",
+        "x64"
+      ]
     },
     "extendInfo": {
       "CFBundleDisplayName": "OpenPLC Editor",
@@ -79,7 +90,9 @@
     "target": [
       {
         "target": "nsis",
-        "arch": ["x64"]
+        "arch": [
+          "x64"
+        ]
       }
     ],
     "artifactName": "${productName}_${version}.${ext}"
@@ -98,7 +111,9 @@
     "target": [
       {
         "target": "AppImage",
-        "arch": ["x64"]
+        "arch": [
+          "x64"
+        ]
       }
     ],
     "category": "Development",

--- a/resources/skills/openplc/SKILL.md
+++ b/resources/skills/openplc/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: openplc
+description: Author, check, compile, upload and debug OpenPLC projects from the command line. Use when creating or editing PLC logic (POUs, variables, data types, Ladder, FBD, Structured Text, IL, Python, C/C++) in an OpenPLC project.
+---
+
+# OpenPLC projects from the command line
+
+`openplc-cli` ships inside the OpenPLC Editor. It can read a project, author
+one, check it in about a second, then compile, upload and debug against real
+hardware.
+
+Run `openplc-cli --help` for the full surface. Everything below is the loop that
+matters.
+
+## The loop
+
+```
+describe -> edit -> apply --dry-run -> apply -> check --emit-st -> READ THE ST -> compile
+```
+
+1. **`describe <project> --json`** — read the project as a spec document.
+2. Edit that document.
+3. **`apply <spec.json> --project <dir> --dry-run`** — validate and list the
+   changes without writing.
+4. **`apply <spec.json> --project <dir>`** — write them.
+5. **`check <project> --lint --emit-st`** — transpile, run the real compiler's
+   semantic pass, and check the logic actually does something. Seconds, no
+   toolchain. **Always pass `--lint`.**
+6. **Read the ST it emits and confirm it is the logic you meant.** The linter
+   catches the common failures; it cannot know what you intended.
+7. **`compile <project> --target <board>`** — the real build.
+
+Before uploading to a device you have not used before, ask what it is:
+**`runtime info --host <address>`** needs no login and reports the runtime
+version and what it supports — notably whether `flag: "retain"` will actually
+retain. Everything else that talks to a device changes it.
+
+## `check --lint`
+
+`check` alone answers "does this compile". A timer nothing drives, a coil two
+rungs write, a program touching no I/O — all compile. `--lint` reads the
+generated ST and reports them:
+
+| rule                             | severity | means                                                                                                                           |
+| -------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `block-primary-input-unassigned` | error    | The block is called but its first input is never assigned, so it does nothing. Usually the EN/ENO trap.                         |
+| `variable-driven-twice`          | error    | Two unconditional statements write it; only the last survives. A double coil. A SET/RESET pair is not this and is not reported. |
+| `no-io-referenced`               | error    | No POU references any global bound to an IEC address — the program reads no inputs and drives no outputs.                       |
+| `block-outputs-unread`           | warning  | Nothing reads any output of the block; its result goes nowhere.                                                                 |
+| `located-global-unreferenced`    | warning  | A global is bound to an address but no POU uses it.                                                                             |
+
+`--lint` also checks the protocol configuration, which has the same problem in a
+different place — all of these save, upload and half-exist:
+
+| rule                                     | severity | means                                                                                                       |
+| ---------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `duplicate-protocol-server`              | error    | Two enabled servers of one protocol; the runtime takes one config, so the second is dropped.                |
+| `server-port-conflict`                   | error    | Two enabled servers on one port.                                                                            |
+| `modbus-device-without-io-groups`        | error    | The generator drops the device: it uploads cleanly and polls nothing.                                       |
+| `modbus-rtu-without-serial-port`         | error    | Same, for an RTU device with no `serialPort`.                                                               |
+| `located-global-collides-with-remote-io` | error    | A global's hand-written address was also handed to a device, which overwrites it every poll. Bind by alias. |
+| `opcua-config-invalid`                   | error    | The OPC-UA generator's own validator — usually a node naming a variable the program does not have.          |
+| `opcua-node-id-is-an-identifier`         | error    | `nodeId` carries a whole node id; the server adds its own namespace, so the id you wrote is unreachable.    |
+| `ethercat-config-invalid`                | error    | The EtherCAT config could not be generated or did not validate.                                             |
+| `modbus-rtu-serial-port-shared`          | warning  | Two RTU masters on one serial line.                                                                         |
+| `ethercat-master-without-slaves`         | warning  | No config is generated for the bus.                                                                         |
+| `ethercat-slave-without-channels`        | warning  | The slave exchanges no data.                                                                                |
+
+An error fails the command (exit 4); a warning does not. So `--lint` is safe to
+leave on in a pipeline.
+
+## Close the loop: read the ST you generated
+
+A ladder or FBD body is a graph. You wrote the graph; the ST is what that graph
+actually _means_. Those are not the same thing, and a body can draw correctly,
+validate, and compile while doing nothing at all.
+
+So after `check --emit-st`, read the ST for every graphical POU you touched and
+confirm each one against what you intended. If it does not match, fix the spec
+and go round again. This is the only check that catches wrong logic — the
+diagram renders either way and the compiler is happy either way.
+
+What to look for, all of which have happened:
+
+- **A block whose input is never assigned.** `holdOff(EN := Run, PT := HoldTime)`
+  with no `IN :=` is a timer that never runs. Rung power through EN/ENO only
+  gates the call; it does not drive the block. See `references/ladder.md`.
+- **A block output nothing reads.** If `.Q` never appears on the right of an
+  assignment, the block's result is going nowhere.
+- **The same variable assigned by two rungs.** The last one wins and the earlier
+  rung is dead. Search the POU body for each coil name.
+- **A variable read but never written**, or written but never read. Usually a
+  rung wired to the wrong name.
+- **Self-referencing nonsense** — `Permit := NOT(Permit) AND ...` oscillates
+  every scan. Legal ST, useless logic.
+- **Nothing touching the outside.** If no POU references a global bound to a
+  `%IX`/`%QX` address, the program reads no inputs and drives no outputs
+  whatever else it does.
+- **Statement order.** Rungs execute top to bottom in one scan. A rung consuming
+  a value a later rung produces is using last scan's value — sometimes intended,
+  usually not.
+
+## Before you author anything
+
+**Read the block catalogue.** `describe <project> --libraries --json` lists every
+installed block with its exact pin names and types, and a `call` string ready to
+paste. Do not guess whether a timer's preset pin is `PT` or `PRESET` — look.
+
+**Do not invent names.** A name is checked against every other element, every
+block of every INSTALLED library, and the IEC reserved words. Installed, not
+enabled: library symbols are declared on every build regardless of the project's
+`libraries` list, so a name is taken whether or not you use that library. Real
+collisions seen in practice: `Limit` and `Log` (functions in
+`iec-std-functions`) and `Scale` (a block in `oscat-basic`). If `apply` refuses
+a name, rename it — do not try to force it.
+
+**Pin names must be exact.** `apply` refuses a pin the block does not have and
+lists the ones it does, so a wrong guess is an error rather than a wire that
+silently does nothing. `describe --libraries` gives you the real list.
+
+## Writing a spec
+
+One document describes the whole project. It is upsert-by-name and idempotent:
+applying it twice leaves the same project. `--prune` deletes what the document
+does not mention.
+
+See `references/spec-schema.md` for every field. The schema is strict — a
+misspelled key is an error naming the path, not a silently ignored field.
+
+## Languages
+
+| Language                    | Body                                                                 |
+| --------------------------- | -------------------------------------------------------------------- |
+| `st`, `il`, `python`, `cpp` | `{ "text": "..." }` — verbatim                                       |
+| `ld`                        | `{ "rungs": [...] }` — see `references/ladder.md`                    |
+| `fbd`                       | `{ "nodes": [...], "connections": [...] }` — see `references/fbd.md` |
+| `sfc`                       | Not supported by the transpiler. `apply` refuses it.                 |
+
+Extensible blocks accept more inputs than they declare: wire the next `IN<n>`
+and the block grows to fit. The catalogue's fifteen are `ADD`, `MUL`, `AND`,
+`OR`, `XOR`, `MIN`, `MAX`, `CONCAT`, `EQ`, `NE`, `LT`, `LE`, `GT`, `GE` — all of
+which declare `IN1`/`IN2`, so the next pin is `IN3` — and `MUX`, which declares
+`K`, `IN0`, `IN1`, so its next pin is `IN2`. `describe --libraries` marks each
+one `extensible`. Every other block rejects a pin it does not declare.
+
+Generic pins (`ANY`, `ANY_NUM`, `ANY_REAL`) take their concrete type from what
+you wire to them.
+
+Python and C/C++ POUs carry their source as text. A C/C++ body needs `setup()`
+and `loop()`; `check` reports it if they are missing.
+
+## Retained variables
+
+`flag: "retain"` on a variable keeps its value across a power cycle — the right
+thing for a setpoint. Two rules:
+
+**It does nothing on its own.** The project must also switch the store on:
+
+```json
+"device": { "persistentStorage": { "enabled": true, "flushSeconds": 5 } }
+```
+
+Without that the upload carries no `retain.conf` and the runtime's store stays
+off, so a variable flagged `retain` retains nothing.
+
+**Do not try to throttle the writes yourself.** The runtime already buffers: it
+is handed the retained blob every scan and commits it on `flushSeconds`
+(default 5, range 1-3600). That buffering is what keeps it from writing at scan
+rate and wearing the flash out. Tune the period instead — lower loses less state
+to a power cut and works the storage harder; higher is gentler. Adding your own
+"only write when changed" guard in ladder or ST does not reduce flash writes,
+because the commit is on a timer, not on your assignment.
+
+`flag: "constant"` is the other qualifier; the two are mutually exclusive.
+
+## Protocols
+
+`servers` and `remoteDevices` connect the program to the outside world — Modbus
+slave and master, S7comm, OPC-UA, EtherCAT. See `references/protocols.md`.
+
+The rule worth knowing before you write any of it: **the runtime decides which
+protocol plugins to load from which `conf/*.json` files the upload carries**, and
+nothing reads a configuration back off a device. So check what would ship:
+
+```sh
+openplc-cli check ./project --lint --protocols
+```
+
+That runs the same generators the upload runs and prints the exact file set,
+which _is_ the enable state — no device needed.
+
+## Things that will catch you out
+
+**Do not list a bundled library in `libraries`.** The blocks in
+`additional-function-blocks`, `iec-standard-fb`, `iec-std-functions`,
+`oscat-basic` and `plcopen-softmotion` are usable without declaring anything —
+just `call` them. The `libraries` list is for libraries INSTALLED through the
+Library Manager, which the build resolves to an archive on disk; a bundled library has no archive, so naming one there stops the
+build with "enables libraries that are not installed". `apply` now refuses it
+with that explanation, but the shape of the document invites the mistake.
+
+**A pin name is per block, not per POU.** Three motion blocks can each declare
+`POSITION`; `inputs` and `outputs` are read against the block they sit on.
+
+**In-out pins are not optional.** SoftMotion blocks carry an `AXIS` pin of class
+`inOut`; name it through `inputs` like any other. The compiler refuses a call
+that leaves an in-out unassigned, so a missing `AXIS` is an error, not a default.
+`describe --libraries` lists a pin's `class` — read it.
+
+- **`check` is not optional.** It runs the same preparation a build does and
+  then the compiler's semantic pass, so it catches undeclared variables, wrong
+  pin names and type errors. A project that passes `check` usually compiles.
+- **An instance references a task and a program by name and validates neither
+  at creation.** `apply` checks them for you; a hand-edited `project.json` will
+  not be checked until the build fails.
+- **A task interval is IEC duration syntax** — `T#20ms`, not `20ms`.
+- **A variable may be renamed under you.** Asking for a name that is taken gets
+  you `Motor1`. `apply` reports it in the change list; read it.
+- **Ladder and FBD bodies that `describe` cannot express** come back with
+  `bodyLossy: true` and a reason. Do not re-apply such a POU — you would
+  overwrite a diagram with an approximation of it.
+
+## Output
+
+JSON when stdout is not a terminal, human-readable when it is; `--json` /
+`--no-json` override. Progress goes to stderr, so stdout carries exactly one
+JSON document.
+
+Exit codes: `0` ok, `2` usage, `3` not found, `4` compile or spec failed,
+`5` connection, `6` auth, `7` target error, `8` timeout, `70` internal.
+
+## Further reading
+
+- `references/spec-schema.md` — every field of the apply spec
+- `references/ladder.md` — rungs, series, parallels, coil variants
+- `references/fbd.md` — nodes, pins, connections
+- `references/native.md` — Python and C/C++ POUs
+- `references/debug.md` — sessions, reading and forcing variables
+- `references/protocols.md` — servers, remote devices, EtherCAT, and what each `enabled` does

--- a/resources/skills/openplc/SKILL.md
+++ b/resources/skills/openplc/SKILL.md
@@ -52,19 +52,20 @@ generated ST and reports them:
 `--lint` also checks the protocol configuration, which has the same problem in a
 different place — all of these save, upload and half-exist:
 
-| rule                                     | severity | means                                                                                                       |
-| ---------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `duplicate-protocol-server`              | error    | Two enabled servers of one protocol; the runtime takes one config, so the second is dropped.                |
-| `server-port-conflict`                   | error    | Two enabled servers on one port.                                                                            |
-| `modbus-device-without-io-groups`        | error    | The generator drops the device: it uploads cleanly and polls nothing.                                       |
-| `modbus-rtu-without-serial-port`         | error    | Same, for an RTU device with no `serialPort`.                                                               |
-| `located-global-collides-with-remote-io` | error    | A global's hand-written address was also handed to a device, which overwrites it every poll. Bind by alias. |
-| `opcua-config-invalid`                   | error    | The OPC-UA generator's own validator — usually a node naming a variable the program does not have.          |
-| `opcua-node-id-is-an-identifier`         | error    | `nodeId` carries a whole node id; the server adds its own namespace, so the id you wrote is unreachable.    |
-| `ethercat-config-invalid`                | error    | The EtherCAT config could not be generated or did not validate.                                             |
-| `modbus-rtu-serial-port-shared`          | warning  | Two RTU masters on one serial line.                                                                         |
-| `ethercat-master-without-slaves`         | warning  | No config is generated for the bus.                                                                         |
-| `ethercat-slave-without-channels`        | warning  | The slave exchanges no data.                                                                                |
+| rule                                     | severity | means                                                                                                        |
+| ---------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| `duplicate-protocol-server`              | error    | Two enabled servers of one protocol; the runtime takes one config, so the second is dropped.                 |
+| `server-port-conflict`                   | error    | Two enabled servers on one port.                                                                             |
+| `modbus-device-without-io-groups`        | error    | The generator drops the device: it uploads cleanly and polls nothing.                                        |
+| `modbus-rtu-without-serial-port`         | error    | Same, for an RTU device with no `serialPort`.                                                                |
+| `located-global-collides-with-remote-io` | error    | A global's hand-written address was also handed to a device, which overwrites it every poll. Bind by alias.  |
+| `opcua-config-invalid`                   | error    | The OPC-UA generator's own validator — usually a node naming a variable the program does not have.           |
+| `opcua-node-id-is-an-identifier`         | error    | `nodeId` carries a whole node id; the server adds its own namespace, so the id you wrote is unreachable.     |
+| `ethercat-config-invalid`                | error    | The EtherCAT config could not be generated or did not validate.                                              |
+| `opcua-server-unauthenticated`           | warning  | An enabled server whose every enabled profile is None/None + Anonymous — open to any client that reaches it. |
+| `modbus-rtu-serial-port-shared`          | warning  | Two RTU masters on one serial line.                                                                          |
+| `ethercat-master-without-slaves`         | warning  | No config is generated for the bus.                                                                          |
+| `ethercat-slave-without-channels`        | warning  | The slave exchanges no data.                                                                                 |
 
 An error fails the command (exit 4); a warning does not. So `--lint` is safe to
 leave on in a pipeline.

--- a/resources/skills/openplc/references/debug.md
+++ b/resources/skills/openplc/references/debug.md
@@ -1,0 +1,59 @@
+# Debugging
+
+A debug session is long-lived; each command is a one-shot that attaches to it.
+
+```sh
+openplc-cli debug open <project> --target <board> (--host <address> | --port <serial>)
+openplc-cli debug list
+openplc-cli debug list-vars
+openplc-cli debug read --session <id>
+openplc-cli debug force <variable> <value>
+openplc-cli debug unforce <variable>
+openplc-cli debug start | stop
+openplc-cli debug watch | poll | unwatch
+openplc-cli debug close --session <id> | --all
+```
+
+`debug open` returns a `session_id`. A session closes itself after 30 minutes
+idle.
+
+`debug read` and `force` reach any variable in the program's debug map —
+`debug list-vars` prints the whole list. A variable's `debug: true` flag ticks it
+into the EDITOR's chart and is not needed here.
+
+Paths use a colon between the POU and the variable: `PlantLogic:levelPct`, and
+`Config0:gPump` for a resource global. Members and array elements use dots and
+brackets from there — `AnalogChain:counter.Cfg.Trend[0]`.
+
+## Credentials
+
+Targets reached over a runtime API need them; a board flashed over USB does not.
+
+```sh
+--credentials user:pass          # or --user / --password
+OPENPLC_CREDENTIALS=user:pass    # or OPENPLC_USER + OPENPLC_PASSWORD
+```
+
+Prefer the environment form: a flag lands in shell history and job logs.
+
+See `docs/CLI.md` in the editor repository for the session protocol and the full
+flag list.
+
+## Forcing an enumerated variable does not take
+
+Reading one works. Forcing one is accepted, reads back as forced, and the
+program never sees the new value — verified on three members of one structure:
+
+| member      | type       | forced | seen by the program |
+| ----------- | ---------- | ------ | ------------------- |
+| `Cfg.Id`    | INT        | 99     | 99                  |
+| `Cfg.Speed` | REAL       | 3.25   | 3.25                |
+| `Cfg.Mode`  | enumerated | 2      | 0                   |
+
+The cause is in the debug map, which STruC++ generates: an enumerated variable
+is published as `INT` of 2 bytes while the generated C++ declares
+`enum class` (4 bytes). Reads survive that on a little-endian target for small
+ordinals; a write does not land.
+
+So drive an enum from logic, or from a plain INT you force, rather than by
+forcing the enum itself.

--- a/resources/skills/openplc/references/fbd.md
+++ b/resources/skills/openplc/references/fbd.md
@@ -1,0 +1,80 @@
+# FBD bodies
+
+```json
+"body": { "nodes": [...], "connections": [...] }
+```
+
+No coordinates. Nodes are placed by signal flow — each sits to the right of
+everything feeding it.
+
+## nodes[]
+
+| Field      | Notes                                                                             |
+| ---------- | --------------------------------------------------------------------------------- |
+| `label`    | Your name for the node, used only inside this document.                           |
+| `kind`     | `block` \| `input-variable` \| `output-variable` \| `inout-variable` \| `comment` |
+| `call`     | Blocks only: `system/<library>/<block>` or `user/<pou>`.                          |
+| `instance` | Blocks only: the instance variable's name.                                        |
+| `variable` | Variable nodes: the variable's name.                                              |
+| `text`     | Comments only.                                                                    |
+
+Get `call` from `describe --libraries`, which prints it ready to paste.
+
+## connections[]
+
+```json
+{ "from": "inCmd", "to": "timer.IN" }
+```
+
+`from` and `to` are a `label`, or `label.PIN` for a block. **`PIN` is the pin's
+name exactly as the library declares it** — `IN`, `PT`, `Q`, `ET`. A variable
+node needs no pin; its direction settles it.
+
+**Feedback loops are refused.** FBD is a left-to-right data flow, and a diagram
+cannot feed a block from something downstream of it. To carry a value back, write
+it to a variable and read that variable — a variable holds its value to the next
+scan, which is what a feedback path actually needs. `apply` names the two nodes
+involved.
+
+## Worked example
+
+```json
+{
+  "nodes": [
+    { "label": "inCmd", "kind": "input-variable", "variable": "Cmd" },
+    { "label": "inPT", "kind": "input-variable", "variable": "Delay" },
+    { "label": "timer", "kind": "block", "call": "system/iec-standard-fb/TON", "instance": "t0" },
+    { "label": "outQ", "kind": "output-variable", "variable": "Held" }
+  ],
+  "connections": [
+    { "from": "inCmd", "to": "timer.IN" },
+    { "from": "inPT", "to": "timer.PT" },
+    { "from": "timer.Q", "to": "outQ" }
+  ]
+}
+```
+
+transpiles to
+
+```
+t0(IN := Cmd, PT := Delay);
+Held := t0.Q;
+```
+
+## executionOrder and executionControl
+
+Both are block-only and both are optional.
+
+`executionOrder` is the number the Block Properties dialog sets — the order
+blocks are evaluated in. Leave it out (or 0) and the block is unordered, which is
+what you want unless a data dependency is ambiguous.
+
+`executionControl: true` adds EN/ENO so the block's execution can be gated by a
+wire. Unlike ladder there is no rung power here, so every pin is wired
+explicitly and EN is just another input.
+
+Also unlike ladder, FBD never adds EN/ENO on its own: omit the flag and the pins
+are removed, whatever the block's first input and output types are. The forcing
+rule in `references/ladder.md` is a ladder rule only — it exists because a rung
+has to enter the block somewhere, and FBD has no rung. `describe` reports the
+flag when it is on.

--- a/resources/skills/openplc/references/ladder.md
+++ b/resources/skills/openplc/references/ladder.md
@@ -1,0 +1,173 @@
+# Ladder bodies
+
+```json
+"body": { "rungs": [ { "comment": "...", "logic": {...}, "outputs": [...] } ] }
+```
+
+No coordinates. A rung is a series-parallel network, and the editor's own layout
+solver places it.
+
+## logic
+
+Three forms, nestable:
+
+```json
+{ "contact": { "variable": "Start", "variant": "default" } }
+
+{ "series": [ ..., ... ] }
+
+{ "parallel": [ ..., ... ] }
+```
+
+`logic` is optional — omit it for a rung driven straight from the rail.
+
+**Contact variants**, spelled exactly like this:
+
+| `variant`     | Passes power when                 |
+| ------------- | --------------------------------- |
+| `default`     | the variable is TRUE (NO, `[ ]`)  |
+| `negated`     | the variable is FALSE (NC, `[/]`) |
+| `risingEdge`  | it goes FALSE → TRUE (`[P]`)      |
+| `fallingEdge` | it goes TRUE → FALSE (`[N]`)      |
+
+A `parallel` needs at least two branches. Three or more nest automatically.
+
+## outputs
+
+At least one. Either a coil:
+
+```json
+{ "coil": { "variable": "Run", "variant": "default" } }
+```
+
+**Coil variants:** the four contact variants plus `set` and `reset`.
+
+| `variant`     | Does                                                    |
+| ------------- | ------------------------------------------------------- |
+| `default`     | writes the rung's power state (`( )`)                   |
+| `negated`     | writes the inverse of it (`(/)`)                        |
+| `set`         | TRUE when energised, otherwise leaves it alone (`(S)`)  |
+| `reset`       | FALSE when energised, otherwise leaves it alone (`(R)`) |
+| `risingEdge`  | TRUE for one scan on a rising power edge (`(P)`)        |
+| `fallingEdge` | TRUE for one scan on a falling power edge (`(N)`)       |
+
+`set` and `reset` are the latch/unlatch pair — use them together on one variable
+rather than a `default` coil in two rungs, which is a double drive.
+
+Or a block:
+
+```json
+{ "block": { "call": "system/iec-standard-fb/TON", "instance": "t0" } }
+```
+
+`instance` names a variable of that block's type, which the POU must declare
+(`{ "definition": "derived", "value": "TON" }`).
+
+### More than two branches
+
+A parallel node pair brackets exactly two paths — one straight through, one
+down — because that is what the node model carries. So `parallel` with three or
+more entries is stored as nested pairs, and `describe` reports the nesting:
+
+```
+written:  { "parallel": [A, B, C] }
+described: { "parallel": [A, { "parallel": [B, C] }] }
+```
+
+The two mean the same thing and apply identically. `describe` -> `apply` ->
+`describe` is stable; only the first pass normalises the shorthand.
+
+### How rung power reaches a block
+
+By default power goes in the block's **first boolean input** and out its **first
+boolean output** — `IN` and `Q` on a timer. That is what drives it, and it is how
+the same rung is drawn by hand.
+
+```json
+{
+  "logic": { "contact": { "variable": "Run", "variant": "default" } },
+  "outputs": [
+    {
+      "block": {
+        "call": "system/iec-standard-fb/TON",
+        "instance": "holdOff",
+        "inputs": { "PT": "HoldTime" },
+        "outputs": { "ET": "Elapsed" }
+      }
+    },
+    { "coil": { "variable": "Settled", "variant": "default" } }
+  ]
+}
+```
+
+Power drives `IN`, `Q` carries on to the coil, and `ET` is captured:
+
+```
+holdOff(IN := Run, PT := HoldTime);
+Settled := holdOff.Q;
+Elapsed := holdOff.ET;
+```
+
+`inputs` and `outputs` name the pins that are **not** carrying rung power. A
+value in `inputs` is a variable name or a literal (`"100"`).
+
+**`executionControl: true`** adds EN/ENO and runs power through those instead.
+That only _gates the call_ — the block's own inputs stay open, so a timer wired
+this way never times:
+
+```
+holdOff(EN := Run, PT := HoldTime);   (* IN is never assigned *)
+Settled := holdOff.ENO;               (* ENO just mirrors EN *)
+```
+
+Use it only when you mean "run this block while the rung is true". The editor
+turns it on by itself, and you cannot turn it off, for any block that has no
+inputs, no outputs, a first input that is not BOOL, or a first output that is
+not BOOL — `ADD` and most functions. `describe` reports it when it is on.
+
+Either way, read the ST afterwards and confirm the block's inputs are assigned
+and its outputs are read.
+
+## Worked example
+
+A start/stop seal-in with a rising-edge alarm:
+
+```json
+{
+  "rungs": [
+    {
+      "comment": "Start/stop seal-in.",
+      "logic": {
+        "series": [
+          {
+            "parallel": [
+              { "contact": { "variable": "Start", "variant": "default" } },
+              { "contact": { "variable": "Run", "variant": "default" } }
+            ]
+          },
+          { "contact": { "variable": "Stop", "variant": "negated" } }
+        ]
+      },
+      "outputs": [{ "coil": { "variable": "Run", "variant": "default" } }]
+    },
+    {
+      "comment": "Fault lamp.",
+      "logic": { "contact": { "variable": "Run", "variant": "risingEdge" } },
+      "outputs": [{ "coil": { "variable": "Fault", "variant": "set" } }]
+    }
+  ]
+}
+```
+
+transpiles to
+
+```
+Run := NOT(Stop) AND (Run OR Start);
+R_TRIG1(CLK := Run);
+IF R_TRIG1.Q THEN
+  Fault := TRUE; (*set*)
+END_IF;
+```
+
+The `R_TRIG1` instance is declared for you — a `risingEdge` contact or coil adds
+the edge-detect block it needs, so it is not in the POU's `variables`.

--- a/resources/skills/openplc/references/native.md
+++ b/resources/skills/openplc/references/native.md
@@ -1,0 +1,198 @@
+# Python and C/C++ POUs
+
+Both carry their source as text, exactly like ST. The POU's `variables` are its
+IEC interface — the pins other POUs wire to — and the body is the implementation.
+
+```json
+{
+  "name": "Sampler",
+  "kind": "function-block",
+  "language": "cpp",
+  "variables": [{ "name": "Trigger", "class": "input", "type": { "definition": "base-type", "value": "BOOL" } }],
+  "body": { "text": "void setup() {}\nvoid loop() {}\n" }
+}
+```
+
+The two languages differ in the one way that matters most:
+
+|         | C/C++                   | Python                           |
+| ------- | ----------------------- | -------------------------------- |
+| Runs    | **inside** the PLC scan | in its own **process**           |
+| Cadence | every scan              | ~100 ms, independent of the scan |
+| A crash | takes the scan with it  | does not stop the PLC            |
+
+So put anything timing-critical in C/C++ or an IEC language, and use Python for
+work with no timing constraint.
+
+## C/C++
+
+**A body needs `void setup()` and `void loop()`.** `apply` refuses a body missing
+either, and `check` reports it too.
+
+- `setup()` runs exactly once, on the first scan after the PLC starts.
+- `loop()` runs on every scan after that.
+
+Local state that must survive between scans is an ordinary C++ variable at file
+scope — it does NOT go in `variables`, which is only the IEC interface.
+
+## Python
+
+**A Python POU is a Function Block.** The editor offers no other type, so use
+`"kind": "function-block"` and call it from an IEC POU. (`apply` does not
+currently refuse `program` or `function`, but nothing in the editor makes one.)
+
+**A body must define `block_init()` and `block_loop()`.** `apply` refuses one
+that does not. A human gets both from the editor's template; a POU authored from
+a spec never sees that template, and bare top-level statements run once at import
+and then never again — the block would compile, upload, and do nothing.
+
+- `block_init()` runs exactly once, when the Python process starts.
+- `block_loop()` runs about every 100 ms. Not configurable. Measured at 100 ms on
+  a Runtime v4 (152 loops in 15.2 s).
+
+**Keep the four template imports**, even though your code appears not to use
+them — the generated wrapper uses all four and does not import them itself:
+
+```python
+from multiprocessing import shared_memory
+import struct
+import time
+import os
+```
+
+Dropping one fails in a way that sends you to the wrong place: the block exits
+after about a second and the log says `[Python] PLC runtime has stopped.` The
+runtime has not stopped — the wrapper's liveness check calls
+`os.kill(plc_pid, 0)` and raises `NameError` because `os` was never imported. If
+you see that message while the PLC is plainly running, check the imports first.
+
+### The one hard rule: `block_loop()` must return
+
+Inputs are refreshed before each call and outputs are sent back after it. A
+`block_loop()` that never returns stops exchanging data with the PLC entirely.
+
+Blocking work (network, file I/O, `time.sleep`) is otherwise fine — it delays
+only your block, not the scan. For something genuinely long-running, start a
+thread in `block_init()` and let `block_loop()` return, guarding any Variables
+Table value the thread touches with a `threading.Lock` (those values are
+refreshed every cycle).
+
+### Pins
+
+Pins are module globals, named exactly as `variables` declares them. Reads need
+nothing; assigning an output needs `global`, which is Python's own rule:
+
+```python
+from multiprocessing import shared_memory
+import struct
+import time
+import os
+
+def block_init():
+    global Peak
+    Peak = 0
+
+def block_loop():
+    global Peak
+    if Clear:
+        Peak = 0
+    elif Sample > Peak:
+        Peak = Sample
+```
+
+Which classes cross, and which are refused:
+
+| `class`                       | In a Python block                                  |
+| ----------------------------- | -------------------------------------------------- |
+| `input`, `inOut`, `external`  | sent in each cycle                                 |
+| `output`, `inOut`, `external` | sent back each cycle                               |
+| `local`                       | crosses BOTH ways — it is not private to the block |
+| `temp`                        | **refused.** Use `local` instead                   |
+
+`apply`'s own schema accepts `temp`; the compiler is what rejects it, with
+"VAR_TEMP has no meaning in a Python block — its variables are module globals in
+a process that outlives the scan."
+
+Constraints worth knowing before you write a body:
+
+- **Assigning to an INPUT does nothing.** The next cycle overwrites it.
+- **`STRING` is capped at 126 characters** on the way back to the PLC.
+- **Arrays keep their declared length and their IEC indices**, lower bound
+  included — no `append`/`pop`.
+- **`TIME`, `TOD` and `DT` arrive as integer nanoseconds.** `T#5s` is
+  `5_000_000_000`.
+- Structures, enumerations and arrays all cross; see the vendor page below.
+
+### Reading a global from Python is safe; accumulating into one is not
+
+A Python block can declare a `VAR_EXTERNAL` and reach a configuration global, but
+because the block runs in another process the read and the write happen a cycle
+apart. The PLC sends the value in with your inputs and stores your copy back
+afterwards; anything that writes that global in between is lost.
+
+```python
+def block_loop():
+    global shared_count
+    shared_count = shared_count + 1   # NOT safe if anything else writes it
+```
+
+The same line is atomic in ST, LD, FBD, IL and C++, because those run inside the
+scan under the global's lock. So:
+
+- **Give every global a single writer.** That case is exact.
+- **Read freely** — you may get a value one cycle old, never a corrupt one.
+- **Never accumulate into a shared global from Python.** Have each writer own a
+  variable and let an ST block add them up, where the addition is atomic.
+- **Never use a global as a lock or semaphore** across the boundary.
+
+### Function block instances
+
+A Python block may declare an instance (`ton0 : TON`) and use its pins — but it
+must not _call_ it. The instance lives in the PLC's process, and the PLC calls it
+once per scan on your behalf.
+
+```python
+def block_loop():
+    global elapsed, finished
+    ton0.IN = start_signal
+    ton0.PT = 5_000_000_000     # T#5s in nanoseconds
+    finished = ton0.Q           # the PREVIOUS cycle's value
+    elapsed = ton0.ET
+```
+
+- Pin names are **upper-cased** (`ton0.IN`, not `ton0.in`).
+- Inputs and in-outs are read/write; **outputs are read-only**; internal state is
+  not exposed.
+- **Outputs are one cycle behind.** Setting a pin and reading a pin on adjacent
+  lines looks synchronous and is not. If that matters, use an ST block.
+- An **array of instances** and a **generic pin** (`ANY_NUM` and friends) are
+  both refused.
+
+### Libraries
+
+The full Python 3 standard library is always available. Third-party packages are
+whatever is `pip install`ed **on the target device**, so a project can work on one
+device and fail to import on another. A block cannot install its own
+dependencies, and cannot import other `.py` files from the project.
+
+## Targets
+
+Python blocks run on targets that embed an interpreter — the OpenPLC Runtime, and
+the Simulator, which stubs them. **An arduino-cli board rejects them**, and
+`check` says so when you name such a target rather than letting the board's C++
+toolchain fail confusingly later.
+
+## Checking
+
+`check` runs the same preparation a build does, so a native POU is validated the
+way the compiler would validate it. Use it before every compile.
+
+## Source
+
+The execution model, constraints and type mappings above are the editor's
+documented behaviour:
+
+- <https://edge.autonomylogic.com/docs/openplc-editor/custom-languages/python-blocks/python-basics>
+- <https://edge.autonomylogic.com/docs/openplc-editor/custom-languages/python-blocks/python-restrictions>
+- <https://edge.autonomylogic.com/docs/openplc-editor/custom-languages/python-blocks/python-data-types>
+- <https://edge.autonomylogic.com/docs/openplc-editor/custom-languages/cpp-blocks/cpp-structure>

--- a/resources/skills/openplc/references/protocols.md
+++ b/resources/skills/openplc/references/protocols.md
@@ -172,7 +172,7 @@ be large enough to reach the address you care about — 32 bytes to see `%QX10.0
 }
 ```
 
-Four things that are easy to get wrong:
+Five things that are easy to get wrong:
 
 - **`nodeId` is the identifier, not a node id.** The server adds its own
   namespace, so `PLC.PlantLogic.levelPct` becomes
@@ -187,6 +187,12 @@ Four things that are easy to get wrong:
 - **Permissions are enforced.** An anonymous client is a `viewer`, so a node with
   `viewer: "r"` refuses its writes. Allow `Username` on a profile and give the
   user `operator` or `engineer` to write.
+- **Omitting `securityProfiles` leaves the server open.** The shipped default is
+  one enabled `None`/`None` Anonymous profile. In the editor that is harmless
+  because a new server starts disabled; a spec saying `enabled: true` without
+  naming a profile inherits it and serves `0.0.0.0:4840` to any client that can
+  reach it. `check --lint` warns (`opcua-server-unauthenticated`). Name a profile
+  with a policy and an auth method, or bind the server to one interface.
 - **Secrets are redacted by `describe` and preserved by `apply`.**
   `security.serverPrivateKeyCustom` and every `users[].passwordHash` are left out
   of `describe` output; applying a spec that omits them keeps what is stored.

--- a/resources/skills/openplc/references/protocols.md
+++ b/resources/skills/openplc/references/protocols.md
@@ -1,0 +1,314 @@
+# Protocols
+
+A project reaches the outside world through **servers** (things that listen on
+this PLC) and **remote devices** (things this PLC talks to). Both are sections of
+the `apply` spec, and `describe` emits them back in the same shape.
+
+```json
+{
+  "specVersion": 1,
+  "servers": [{ "name": "PlantModbus", "protocol": "modbus-tcp", "enabled": true }],
+  "remoteDevices": [{ "name": "FieldIO", "protocol": "modbus-tcp", "modbus": { "host": "10.0.0.5" } }]
+}
+```
+
+## The one thing to know first
+
+**The runtime decides which protocol plugins to load from which
+`conf/*.json` files the upload carries.** There is no endpoint that reports
+which protocols are on, and no way to read a configuration back off a device. So
+before uploading, ask the build:
+
+```sh
+openplc-cli check ./project --protocols
+```
+
+It runs the same generators the upload runs and prints the exact file set, which
+_is_ the enable state. Pair it with `--lint` and it also reports the
+configurations that would save, upload and then do nothing.
+
+## Servers
+
+One `enabled` per server. Stored, the flag lives somewhere different for each
+protocol; in a spec there is one place for it and the normalizer puts it where
+that protocol reads it. Absent means off, the same default the editor uses.
+
+| `protocol`   | Config key | `enabled: false` means                                                 |
+| ------------ | ---------- | ---------------------------------------------------------------------- |
+| `modbus-tcp` | `modbus`   | no `conf/modbus_slave.json` — the plugin never starts, port closed     |
+| `s7comm`     | `s7comm`   | the conf **still ships**; the plugin reads the flag and does not serve |
+| `opcua`      | `opcua`    | no `conf/opcua.json`                                                   |
+
+`ethernet-ip` is refused: the editor stores it but nothing generates a config
+for it.
+
+Everything below the name is optional and merges onto the same defaults the
+editor seeds. A whole Modbus server is two lines:
+
+```json
+{ "name": "PlantModbus", "protocol": "modbus-tcp", "enabled": true }
+```
+
+### Modbus slave
+
+```json
+{
+  "name": "PlantModbus",
+  "protocol": "modbus-tcp",
+  "enabled": true,
+  "modbus": {
+    "networkInterface": "0.0.0.0",
+    "port": 502,
+    "bufferMapping": { "coils": { "qxBits": 256 }, "holdingRegisters": { "qwCount": 64 } }
+  }
+}
+```
+
+`bufferMapping` is a window onto the PLC's own image, and every count it omits
+takes the runtime default.
+
+**Within each Modbus block the configured IEC segments are laid out
+sequentially from address 0 of that block**, sized in that block's addressable
+unit — bits for coils and discrete inputs, 16-bit registers for the register
+blocks. Bit addresses are `byte.bit`, so coil 8 rolls over to `%QX1.0`.
+
+| Block                      | Segments, in order                                                                                                                |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Coils (FC 1/5/15)          | `qxBits` of `%QX`, then `mxBits` of `%MX`                                                                                         |
+| Discrete inputs (FC 2)     | `ixBits` of `%IX` (max 8192)                                                                                                      |
+| Holding registers (3/6/16) | `qwCount` of `%QW`, then `mwCount` of `%MW`, then `mdCount` of `%MD` (**2 registers each**), then `mlCount` of `%ML` (**4 each**) |
+| Input registers (FC 4)     | `iwCount` of `%IW` (max 1024)                                                                                                     |
+
+So with the defaults, coil 80 is `%QX10.0` and holding register 10 is `%QW10` —
+but only while those indices fall inside the FIRST segment. Past `qxBits` the
+coils become `%MX`, and past `qwCount` the registers become `%MW`, then `%MD`,
+then `%ML`. Size the segment to cover the address you want before assuming it.
+
+**`%QD`, `%QB`, `%ID`, `%IB`, `%QL` and `%IL` are not reachable over Modbus at
+all** — the protocol indexes no separate byte/double/long output or input
+segment. Copy the value into a `%MD`/`%MW` in your program, or use S7comm, which
+maps all fourteen PLC-memory variants directly.
+
+A variable outside the window is simply not served, with no error anywhere. The
+Modbus Server screen's **Address Mapping Reference** computes the full table from
+the project's current sizes and is the source of truth when they are not default.
+
+Many off-the-shelf clients number coils 1-based, so coil 1 in the tool is coil 0
+on the wire.
+
+Only one Modbus server can be enabled: the runtime takes one config per
+protocol. A second is reported by `check --lint`, not silently dropped.
+
+### S7comm
+
+```json
+{
+  "name": "PlantS7",
+  "protocol": "s7comm",
+  "enabled": true,
+  "s7comm": {
+    "server": { "bindAddress": "0.0.0.0", "port": 102, "maxClients": 8 },
+    "plcIdentity": { "name": "Line 4" },
+    "dataBlocks": [
+      {
+        "dbNumber": 1,
+        "description": "Level",
+        "sizeBytes": 64,
+        "mapping": { "type": "int_output", "startBuffer": 0, "bitAddressing": false }
+      }
+    ]
+  }
+}
+```
+
+A data block is a window like the Modbus buffer mapping: `int_output` with
+`startBuffer: 0` makes DB1 word _N_ equal `%QW N`; `bool_output` with
+`bitAddressing` makes DB*n* byte _N_ bit _B_ equal `%QX N.B`. `sizeBytes` has to
+be large enough to reach the address you care about — 32 bytes to see `%QX10.0`.
+
+### OPC UA
+
+```json
+{
+  "name": "PlantOpcUa",
+  "protocol": "opcua",
+  "enabled": true,
+  "opcua": {
+    "server": { "bindAddress": "0.0.0.0", "port": 4840, "endpointPath": "/openplc/opcua" },
+    "securityProfiles": [
+      {
+        "name": "insecure",
+        "enabled": true,
+        "securityPolicy": "None",
+        "securityMode": "None",
+        "authMethods": ["Anonymous", "Username"]
+      }
+    ],
+    "users": [
+      {
+        "type": "password",
+        "username": "operator",
+        "passwordHash": "$2b$12$…",
+        "certificateId": null,
+        "role": "operator"
+      }
+    ],
+    "addressSpace": {
+      "nodes": [
+        {
+          "pouName": "PlantLogic",
+          "variablePath": "levelPct",
+          "variableType": "INT",
+          "nodeId": "PLC.PlantLogic.levelPct",
+          "browseName": "levelPct",
+          "displayName": "Level percent",
+          "description": "",
+          "permissions": { "viewer": "r", "operator": "rw", "engineer": "rw" },
+          "nodeType": "variable"
+        }
+      ]
+    }
+  }
+}
+```
+
+Four things that are easy to get wrong:
+
+- **`nodeId` is the identifier, not a node id.** The server adds its own
+  namespace, so `PLC.PlantLogic.levelPct` becomes
+  `ns=2;s=PLC.PlantLogic.levelPct`. Writing `ns=1;s=…` produces
+  `ns=2;s=ns=1;s=…`, which browses but cannot be read by the id you wrote.
+  `check --lint` reports it. Use the editor's own form, `PLC.<POU>.<path>`, so a
+  CLI-authored server matches a hand-authored one. Max 128 characters, and it
+  must be unique across every exposed node.
+- **`pouName` must be an instantiated program.** A node naming a resource global
+  or an uninstantiated POU cannot resolve; `check --lint` catches it before upload,
+  through the generator's own validator against the debug map.
+- **Permissions are enforced.** An anonymous client is a `viewer`, so a node with
+  `viewer: "r"` refuses its writes. Allow `Username` on a profile and give the
+  user `operator` or `engineer` to write.
+- **Secrets are redacted by `describe` and preserved by `apply`.**
+  `security.serverPrivateKeyCustom` and every `users[].passwordHash` are left out
+  of `describe` output; applying a spec that omits them keeps what is stored.
+  To change one, write it.
+
+## Remote devices
+
+| `protocol`   | Config key | Notes                                        |
+| ------------ | ---------- | -------------------------------------------- |
+| `modbus-tcp` | `modbus`   | TCP or RTU, by `transport`                   |
+| `ethercat`   | `ethercat` | a master plus slaves authored from ESI files |
+
+`ethernet-ip` and `profinet` are refused: the editor stores them, nothing
+generates a config.
+
+### Modbus master
+
+```json
+{
+  "name": "FieldIO",
+  "protocol": "modbus-tcp",
+  "modbus": {
+    "transport": "tcp",
+    "host": "10.0.0.5",
+    "port": 502,
+    "slaveId": 1,
+    "timeout": 1000,
+    "ioGroups": [
+      {
+        "name": "Inputs",
+        "functionCode": "2",
+        "cycleTime": 100,
+        "offset": "0x0000",
+        "length": 8,
+        "aliases": ["fStart", "fStop"]
+      }
+    ]
+  }
+}
+```
+
+**Name the points you want to read.** A group's points are allocated an IEC
+address by the editor, and `aliases` names them in order. A program reaches a
+polled value by putting the alias in a global's `location`:
+
+```json
+{
+  "name": "fieldStart",
+  "class": "global",
+  "type": { "definition": "base-type", "value": "BOOL" },
+  "location": "fStart"
+}
+```
+
+**Give the variable a different name from the alias.** Variables and aliases share
+one namespace, so a global named `fStart` bound to the alias `fStart` is refused.
+It only collides once the alias exists, so the same spec applied to an empty
+project appears to work and then fails the day a variable is added to a project
+that already has the device. `apply` reports it rather than renaming around it.
+
+Without an alias the point has an address and no name, and nothing can read it.
+Bind by alias rather than by writing the address yourself — the allocator does
+not know about hand-written addresses and will hand the same one to a device,
+which then overwrites the global every poll. `check --lint` reports that
+collision.
+
+`describe` lists what each point actually got under a sibling `protocolAddresses`
+key, outside `spec` — allocation decides those, so they are a report, not an input.
+
+Two shapes the generator drops without failing the compile, both refused here
+instead: a device with no I/O groups, and RTU with no `serialPort`. Slave ids are
+0–255 over TCP and 1–247 over RTU.
+
+### EtherCAT
+
+Import the vendor's ESI file first:
+
+```sh
+openplc-cli esi import ./EL7041.xml --project ./project
+openplc-cli esi list --project ./project          # ids and device indices
+```
+
+Then declare the bus. A slave is an ESI reference plus overrides — its channels,
+PDOs, SDOs, CiA 402 block and IEC addresses are all read out of the file:
+
+```json
+{
+  "name": "MotionBus",
+  "protocol": "ethercat",
+  "ethercat": {
+    "master": { "enabled": true, "networkInterface": "eth0", "cycleTimeUs": 1000 },
+    "slaves": [
+      {
+        "esiDeviceRef": { "repositoryItemId": "EL7041.xml", "deviceIndex": 0 },
+        "name": "Axis1",
+        "position": 0,
+        "config": { "addressing": { "ethercatAddress": 1001 } },
+        "cia402": { "enabled": true, "scaleFactor": 1048576 },
+        "aliases": { "0x1A00-0x6041-0x0": "AxisStatus" }
+      }
+    ]
+  }
+}
+```
+
+Master fields and their ranges: `cycleTimeUs` 100–100000 (default 1000),
+`watchdogTimeoutCycles` 1–100 (default 3), `taskPriority` 1–31.
+
+**Set `taskPriority` explicitly if you care about it.** The editor shows 1 as the
+default but stores nothing when you leave it alone, and the config generator
+falls back to **90** for an absent value — so a bus that looks like priority 1 in
+the editor ships 90 to the runtime. Writing the number you want removes the
+ambiguity. (This is upstream behaviour, not something the CLI introduces: a
+GUI-authored bus does the same.)
+
+`repositoryItemId` takes the file name or the id `esi import` printed. A slave
+name becomes a SoftMotion axis variable when the drive is CiA 402, so it is made
+a legal identifier. `conf/ethercat.json` is written only for a bus with an
+enabled master and at least one slave.
+
+## Renaming
+
+A rename reads as a delete plus a create, so `apply --prune` is what removes the
+old one. Without `--prune` both survive, and two enabled servers of one protocol
+is an error `check --lint` reports.

--- a/resources/skills/openplc/references/spec-schema.md
+++ b/resources/skills/openplc/references/spec-schema.md
@@ -1,0 +1,225 @@
+# The apply spec
+
+One JSON document describing a whole project. Every object is strict: an
+unrecognised key is an error naming its path.
+
+```json
+{
+  "specVersion": 1,
+  "device": { "board": "OpenPLC Runtime v4", "runtimeIpAddress": "localhost" },
+  "libraries": [{ "name": "node-uio", "version": "0.0.1" }],
+  "dataTypes": [],
+  "globalVariableLists": [],
+  "globalVariables": [],
+  "pous": [],
+  "tasks": [],
+  "instances": []
+}
+```
+
+## device
+
+The build target. Not part of the project data proper — it is a separate file —
+but it decides what the project compiles for, so set it rather than inheriting
+whatever `create` chose.
+
+| Field               | Notes                                                                                                                                                                                                                                                                                                                       |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `board`             | Exactly as the editor names it, e.g. `OpenPLC Runtime v4` or `OpenPLC Simulator`. `describe` reports the one a project already uses; the editor's board picker has the full list. A name nothing recognises is NOT rejected — `check` and `compile` accept it and resolve whatever the scaffold chose, so a typo is silent. |
+| `communicationPort` | Serial port, for a board flashed over USB.                                                                                                                                                                                                                                                                                  |
+| `runtimeIpAddress`  | Address of a runtime target.                                                                                                                                                                                                                                                                                                |
+| `persistentStorage` | `{ enabled, path?, flushSeconds? }` — where `retain` variables are kept. See below.                                                                                                                                                                                                                                         |
+
+### device.persistentStorage
+
+Delivered to the device as `retain.conf` with the program. Off by default, and a
+project that leaves it off uploads no `retain.conf` at all — so a variable
+flagged `retain` retains nothing until this is switched on.
+
+| Field          | Notes                                                                                                                                                                                        |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`      | Required.                                                                                                                                                                                    |
+| `path`         | Absolute path ON THE DEVICE. Empty or absent means the runtime's own default.                                                                                                                |
+| `flushSeconds` | Commit period, 1-3600, default 5. The runtime is handed the blob every scan; this is what stops it writing at scan rate. Lower loses less state on a power cut and works the storage harder. |
+
+## libraries
+
+Libraries the project compiles against, pinned by version. Replaces the list
+wholesale.
+
+## globalVariableLists
+
+A named group of globals whose members are reached as `List.Member`, with nothing
+declared in the POU that uses them.
+
+```json
+{
+  "name": "Plant",
+  "qualifier": "CONSTANT",
+  "variables": [{ "name": "MaxRpm", "type": { "definition": "base-type", "value": "INT" }, "initialValue": "1500" }]
+}
+```
+
+A POU referring to `Plant.MaxRpm` gets its `VAR_EXTERNAL` automatically — the
+generated ST declares `Plant : Plant_TYPE`. A list occupies TWO names: its own,
+and `<name>_TYPE` for the struct behind it, so neither is available for anything
+else.
+
+**`qualifier` is stored but NOT applied at build time.** It records the modifier
+that follows `VAR_GLOBAL` in the declaration and survives a round trip, but it
+does not make the members constant or retained. Setting `"RETAIN"` here retains
+nothing. For a variable that must actually be constant or retained, declare it in
+a POU or in `globalVariables` and set its `flag` there.
+
+Use `globalVariables` rather than a list when the variable needs a physical
+`location`, a retention flag, or exposure to a Modbus / OPC-UA / S7comm server.
+
+Every top-level section is optional except `specVersion`, which must be `1`. An
+absent section is not a request to delete: `--prune` only removes entities
+within sections the document declares.
+
+## pous[]
+
+| Field           | Notes                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------ |
+| `name`          | Checked against every other element AND every installed library block.                     |
+| `kind`          | `program` \| `function` \| `function-block`                                                |
+| `language`      | `st` \| `il` \| `ld` \| `fbd` \| `python` \| `cpp`. Fixed once the POU exists — see below. |
+| `returnType`    | Functions only.                                                                            |
+| `documentation` | Optional.                                                                                  |
+| `variables[]`   | See below.                                                                                 |
+| `body`          | Shape depends on `language`.                                                               |
+
+### Which kind, and what each one needs
+
+| `kind`           | Languages                        | Notes                                                                                              |
+| ---------------- | -------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `program`        | `st`, `il`, `ld`, `fbd`          | Top-level. Bound to a task by an `instance`. Keeps state between scans. May carry I/O `location`s. |
+| `function`       | `st`, `il`, `ld`, `fbd`          | Stateless — locals are a fresh frame per call. Needs `returnType`.                                 |
+| `function-block` | those four, plus `python`, `cpp` | Stateful. Instantiated as a variable with `definition: "derived"`.                                 |
+
+`python` and `cpp` POUs are Function Blocks; the editor offers no other kind for
+them. `apply` does not currently refuse `program` or `function` there, but
+nothing in the editor produces one.
+
+**A function returns by assigning to its own name**, which is the IEC
+convention — there is no `RETURN value`:
+
+```json
+{
+  "name": "CelsiusToF",
+  "kind": "function",
+  "language": "st",
+  "returnType": "REAL",
+  "variables": [{ "name": "TempC", "class": "input", "type": { "definition": "base-type", "value": "REAL" } }],
+  "body": { "text": "CelsiusToF := TempC * 1.8 + 32.0;\n" }
+}
+```
+
+**Always set `returnType` on a function.** Omitted, it silently becomes `BOOL` —
+the POU still applies and compiles, so the mistake shows up as a type error at
+the call site instead.
+
+**A POU's language is fixed once it exists.** The body is stored in a file named
+for the language (`Pump.st`, `Pump.ld`, `Pump.fbd`), so changing it would leave
+the old file behind and the project would load that one instead. `apply` refuses
+the change and says so; to switch languages, remove the POU and declare a new
+one (`--prune` removes a POU the document stops mentioning).
+
+## variables[]
+
+| Field                           | Notes                                                                                                                                                                                               |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                          | May be auto-renamed if taken — read the change list.                                                                                                                                                |
+| `class`                         | `input` \| `output` \| `inOut` \| `local` \| `temp` \| `external` \| `global`. Optional; defaults to `local` on a POU, `global` on the resource.                                                    |
+| `type`                          | `{ "definition": ..., "value": ... }`                                                                                                                                                               |
+| `location`                      | An alias name or a literal IEC address (`%IX0.0`).                                                                                                                                                  |
+| `initialValue`, `documentation` | Optional.                                                                                                                                                                                           |
+| `debug`                         | Optional. Ticks the variable into the EDITOR's debugger chart. `debug read` does not need it — the CLI reads anything in the debug map.                                                             |
+| `flag`                          | `constant` \| `retain`. The variables table's **Flags** column. Absent is a plain `VAR` (IEC `NON_RETAIN`). Mutually exclusive, hence one field. `retain` needs `device.persistentStorage.enabled`. |
+
+### Choosing a class
+
+| You want                                | Use                                                                   |
+| --------------------------------------- | --------------------------------------------------------------------- |
+| State a POU remembers between scans     | `local` — the default                                                 |
+| A Program to read or drive physical I/O | `local` **with a `location`** (`%IX0.0`). Still `local`.              |
+| A pin on a function block or function   | `input` / `output` / `inOut`                                          |
+| One value shared across POUs            | `global` on the resource + `external` in each POU, same name and type |
+| A scratch value that must not persist   | `temp` — reset to its initial value every scan                        |
+
+Two things that catch people out: a **Function's** locals are a fresh frame on
+every call and never persist, unlike a Program's or a Function Block's; and
+`temp` is refused outright in a Python POU (see `references/native.md`).
+
+`type.definition` is one of `base-type` (`BOOL`, `INT`, `REAL`, `TIME`, …),
+`user-data-type` (a type this project declares), `derived` (a function block
+type, e.g. `TON`), `array`, or `generic-type`.
+
+### An array variable
+
+`definition: "array"` needs `dimensions`, and `value` is the **element** type —
+not the rendered `ARRAY […] OF …`, which `apply` derives:
+
+```json
+{ "name": "Buf",  "type": { "definition": "array", "value": "INT",  "dimensions": ["0..3"] } }
+{ "name": "Grid", "type": { "definition": "array", "value": "REAL", "dimensions": ["0..3", "0..2"] } }
+```
+
+The element may be a base type or a type this project declares. An array without
+`dimensions`, or `dimensions` on a non-array, is refused.
+
+The alternative is an array **data type** (below) used as a variable's
+`user-data-type` — worth it when several variables share the shape.
+
+A function block instance is an ordinary variable with `definition: "derived"`
+and the block's name as its `value`.
+
+## dataTypes[]
+
+Every name a data type introduces — its own, each structure field, each
+enumerated value — must be a legal IEC identifier. `apply` refuses a reserved
+word (`Label`, `While`, …) or illegal characters, because a `.dt` written with
+one fails to parse on the next load: the editor preserves the file and warns,
+but the type is absent from the project and every reference to it then fails to
+compile as an undefined type.
+
+A structure field may itself be an array — give it `dimensions` exactly as a
+variable would.
+
+Three shapes, discriminated by `derivation`:
+
+```json
+{ "name": "Mode", "derivation": "enumerated", "values": ["IDLE", "RUN"], "initialValue": "IDLE" }
+
+{ "name": "Motor", "derivation": "structure",
+  "variables": [ { "name": "Speed", "type": { "definition": "base-type", "value": "INT" } } ] }
+
+{ "name": "Bank", "derivation": "array",
+  "baseType": { "definition": "base-type", "value": "INT" },
+  "dimensions": ["0..9"] }
+```
+
+## tasks[] and instances[]
+
+```json
+{ "name": "Fast", "triggering": "Cyclic", "interval": "T#20ms", "priority": 0 }
+{ "name": "inst0", "program": "main", "task": "Fast" }
+```
+
+`triggering` is `Cyclic` or `Interrupt`; almost everything is cyclic.
+
+`interval` is IEC duration syntax — `T#20ms`. A bare `20ms` produces a project
+that will not compile.
+
+**`priority` is 0-100 and LOWER means HIGHER priority.** 0 is the highest, 100
+the lowest; when two tasks come due in the same instant the lower number runs
+first. Leave it at 0 unless you have several tasks and a reason.
+
+An instance's `program` must name a POU of kind `program`; `apply` refuses a
+dangling reference rather than letting it surface as a compile error later.
+
+## Order
+
+`apply` handles ordering itself — data types, POUs, bodies, variables, tasks,
+then instances — so the document can list things in any order.

--- a/src/__architecture__/validate.ts
+++ b/src/__architecture__/validate.ts
@@ -392,10 +392,18 @@ const KNOWN_EXCEPTIONS: Record<string, LayerName[]> = {
 
   // FBD paste/duplicate helpers — needs molecule-level buildGenericNode from components
   'frontend/store/slices/fbd/utils/index.ts': ['components'],
+  // FBD graph builder — same buildGenericNode, for a diagram assembled from a
+  // description rather than from drops. Hosted in the store so the CLI can
+  // reach it; the builders themselves are component molecules.
+  'frontend/store/slices/fbd/utils/build-graph.ts': ['components'],
   // Ladder paste/duplicate helpers — needs nodesBuilder from component atoms
   'frontend/store/slices/ladder/utils/index.ts': ['components'],
   // Ladder slice — needs nodesBuilder + defaultCustomNodesStyles for rung creation
   'frontend/store/slices/ladder/slice.ts': ['components'],
+  // Ladder rung builder — same nodesBuilder, for a rung assembled from a
+  // series/parallel description rather than from clicks. Hosted in the store so
+  // the CLI can reach it; the builders themselves are component atoms.
+  'frontend/store/slices/ladder/utils/build-rung.ts': ['components'],
   // Device CONNECT flow (D72) — resolves RTU params from the board debug spec
   // via the shared `resolveDebugConnection` resolver, same as the activity bar's
   // debugger/post-flash paths.

--- a/src/backend/editor/ethercat/esi-service.ts
+++ b/src/backend/editor/ethercat/esi-service.ts
@@ -4,7 +4,11 @@ import { basename, dirname, join } from 'path'
 import { v4 as uuidv4 } from 'uuid'
 
 import { parseESILight } from '../../shared/ethercat/esi-parser-main'
-import { fileOrDirectoryExists } from '../utils'
+// Straight from the module, not the `../utils` barrel: the barrel re-exports
+// `path-picker`, which imports `electron`. The CLI reaches this service, and a
+// CI runner installing with `--ignore-scripts` has no Electron binary — the
+// import alone fails there, taking every test that touches `apply` with it.
+import { fileOrDirectoryExists } from '../utils/file-or-directory-exists'
 
 /**
  * ESI Repository Index stored in devices/esi/repository.json

--- a/src/backend/editor/skill/install-skill.ts
+++ b/src/backend/editor/skill/install-skill.ts
@@ -1,0 +1,72 @@
+/**
+ * Copy a shipped skill into a project's or a user's agent directory.
+ *
+ * Mirrors `install-shim`: the same four-outcome union, and the same
+ * marker-comment policy — a file this wrote is replaced, a file someone edited
+ * is left alone. Overwriting a hand-edited skill would be the one failure mode
+ * nobody could recover from.
+ */
+
+import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/** Present in every generated SKILL.md; its absence means a human edited it. */
+export const SKILL_MARKER = 'installed by OpenPLC Editor'
+
+export type InstallSkillResult =
+  | { status: 'installed'; path: string }
+  | { status: 'unchanged'; path: string }
+  | { status: 'skipped'; reason: string; path?: string }
+  | { status: 'failed'; error: string }
+
+export interface InstallSkillOptions {
+  /** Directory the skill is shipped in. */
+  source: string
+  scope: 'project' | 'user'
+  /** Project root for `project` scope; ignored for `user`. */
+  projectPath?: string
+  name: string
+  force?: boolean
+}
+
+export function skillDestination(options: InstallSkillOptions): string | null {
+  if (options.scope === 'user') return join(homedir(), '.claude', 'skills', options.name)
+  return options.projectPath ? join(options.projectPath, '.claude', 'skills', options.name) : null
+}
+
+export function installSkill(options: InstallSkillOptions): InstallSkillResult {
+  const destination = skillDestination(options)
+  if (!destination) return { status: 'skipped', reason: 'project scope needs --path <dir>' }
+
+  try {
+    const marker = join(destination, 'SKILL.md')
+    if (existsSync(marker) && !options.force) {
+      const existing = readFileSync(marker, 'utf-8')
+      if (!existing.includes(SKILL_MARKER)) {
+        return { status: 'skipped', reason: 'a hand-edited skill is already installed there', path: destination }
+      }
+      if (existing === stamped(join(options.source, 'SKILL.md'))) {
+        return { status: 'unchanged', path: destination }
+      }
+    }
+
+    mkdirSync(destination, { recursive: true })
+    cpSync(options.source, destination, { recursive: true })
+    // Re-write SKILL.md with the marker so the next install can tell its own
+    // work from a human's.
+    writeStamped(join(options.source, 'SKILL.md'), join(destination, 'SKILL.md'))
+    return { status: 'installed', path: destination }
+  } catch (err) {
+    return { status: 'failed', error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+function stamped(sourceSkillMd: string): string {
+  const body = readFileSync(sourceSkillMd, 'utf-8')
+  return `${body}\n<!-- ${SKILL_MARKER}. Regenerated on update; edits will be lost. -->\n`
+}
+
+function writeStamped(sourceSkillMd: string, destinationSkillMd: string): void {
+  writeFileSync(destinationSkillMd, stamped(sourceSkillMd), 'utf-8')
+}

--- a/src/backend/editor/skill/install-skill.ts
+++ b/src/backend/editor/skill/install-skill.ts
@@ -7,9 +7,9 @@
  * nobody could recover from.
  */
 
-import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { join, relative, sep } from 'node:path'
 
 /** Present in every generated SKILL.md; its absence means a human edited it. */
 export const SKILL_MARKER = 'installed by OpenPLC Editor'
@@ -41,16 +41,26 @@ export function installSkill(options: InstallSkillOptions): InstallSkillResult {
 
   try {
     const marker = join(destination, 'SKILL.md')
-    if (existsSync(marker) && !options.force) {
+    const owned = existsSync(marker)
+    if (owned && !options.force) {
       const existing = readFileSync(marker, 'utf-8')
       if (!existing.includes(SKILL_MARKER)) {
         return { status: 'skipped', reason: 'a hand-edited skill is already installed there', path: destination }
       }
-      if (existing === stamped(join(options.source, 'SKILL.md'))) {
+      // The WHOLE tree, not just SKILL.md. A reference file that changed — or
+      // one added to a newer build — leaves SKILL.md byte-identical, so
+      // comparing only the marker file reports `unchanged` over a stale
+      // install.
+      if (sameTree(options.source, destination)) {
         return { status: 'unchanged', path: destination }
       }
     }
 
+    // Replace rather than merge: `cpSync` overwrites and adds, but leaves a file
+    // the newer skill no longer ships. Only ever removes a destination this
+    // wrote — a hand-edited one returned above, and a missing one has nothing
+    // to lose.
+    if (owned) rmSync(destination, { recursive: true, force: true })
     mkdirSync(destination, { recursive: true })
     cpSync(options.source, destination, { recursive: true })
     // Re-write SKILL.md with the marker so the next install can tell its own
@@ -60,6 +70,34 @@ export function installSkill(options: InstallSkillOptions): InstallSkillResult {
   } catch (err) {
     return { status: 'failed', error: err instanceof Error ? err.message : String(err) }
   }
+}
+
+/** Every file under `root`, as paths relative to it, `/`-separated and sorted. */
+function filesUnder(root: string, directory: string = root, found: string[] = []): string[] {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const full = join(directory, entry.name)
+    if (entry.isDirectory()) filesUnder(root, full, found)
+    else if (entry.isFile()) found.push(relative(root, full).split(sep).join('/'))
+  }
+  return found.sort()
+}
+
+/**
+ * True when the installed skill is the shipped one, file for file.
+ *
+ * `SKILL.md` is compared against its STAMPED form, because that is what the
+ * installer writes; every other file is compared verbatim.
+ */
+function sameTree(source: string, destination: string): boolean {
+  const shipped = filesUnder(source)
+  if (shipped.join('\n') !== filesUnder(destination).join('\n')) return false
+
+  return shipped.every((file) => {
+    const installed = readFileSync(join(destination, file), 'utf-8')
+    return file === 'SKILL.md'
+      ? installed === stamped(join(source, 'SKILL.md'))
+      : installed === readFileSync(join(source, file), 'utf-8')
+  })
 }
 
 function stamped(sourceSkillMd: string): string {

--- a/src/backend/editor/skill/skill-source.ts
+++ b/src/backend/editor/skill/skill-source.ts
@@ -40,7 +40,11 @@ export function resolveSkillRoot(environment: SkillSourceEnvironment): string | 
 export function resolveSkillPath(environment: SkillSourceEnvironment, name: string): string | null {
   const root = resolveSkillRoot(environment)
   if (!root) return null
-  // A name is a single path segment; anything else is not a skill we ship.
+  // A name is a single path segment naming a real skill. `''` and `'.'` both
+  // join to the skills ROOT, which exists — the caller would then read
+  // `<root>/SKILL.md`, which does not, and fail instead of reporting a skill
+  // it does not ship.
+  if (name.length === 0 || name === '.') return null
   if (name.includes('/') || name.includes('\\') || name.includes('..')) return null
   const path = join(root, name)
   return existsSync(path) ? path : null

--- a/src/backend/editor/skill/skill-source.ts
+++ b/src/backend/editor/skill/skill-source.ts
@@ -1,0 +1,47 @@
+/**
+ * Where the packaged skill files live.
+ *
+ * Packaged, they sit under `process.resourcesPath` — `electron-builder` copies
+ * `resources/skills` there through `extraResources`. In development
+ * `app.getAppPath()` is the BUILD directory, not the repo root, so a fixed
+ * `../../` offset resolves somewhere that does not exist on one of the two.
+ * Walking up to the nearest directory that actually contains `resources/skills`
+ * works for both, and is the same approach `main.ts` takes to find the app name.
+ */
+
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+export interface SkillSourceEnvironment {
+  packaged: boolean
+  resourcesPath: string
+  appPath: string
+}
+
+/** Absolute path of the skills directory, or null when it is not shipped. */
+export function resolveSkillRoot(environment: SkillSourceEnvironment): string | null {
+  if (environment.packaged) {
+    const packaged = join(environment.resourcesPath, 'skills')
+    return existsSync(packaged) ? packaged : null
+  }
+
+  let directory = environment.appPath
+  // Bounded by reaching the filesystem root, where `dirname` stops changing.
+  for (;;) {
+    const candidate = join(directory, 'resources', 'skills')
+    if (existsSync(candidate)) return candidate
+    const parent = dirname(directory)
+    if (parent === directory) return null
+    directory = parent
+  }
+}
+
+/** Directory holding one named skill, or null when that skill is not shipped. */
+export function resolveSkillPath(environment: SkillSourceEnvironment, name: string): string | null {
+  const root = resolveSkillRoot(environment)
+  if (!root) return null
+  // A name is a single path segment; anything else is not a skill we ship.
+  if (name.includes('/') || name.includes('\\') || name.includes('..')) return null
+  const path = join(root, name)
+  return existsSync(path) ? path : null
+}

--- a/src/backend/shared/compile/pipeline.ts
+++ b/src/backend/shared/compile/pipeline.ts
@@ -573,7 +573,7 @@ async function runCompilePipelineInner(
         opcUa: confs.opcUa,
         // `generateRuntimeConfs` validated EtherCAT before returning;
         // null here means "no EtherCAT devices" → composer skips.
-        ethercat: confs.ethercat ?? '',
+        ethercat: confs.ethercat,
       },
     })
     emit({

--- a/src/backend/shared/compile/steps/generate-confs.ts
+++ b/src/backend/shared/compile/steps/generate-confs.ts
@@ -119,7 +119,9 @@ export function generateRuntimeConfs(input: GenerateConfsInput): GenerateConfsOu
   // Type assertions match the editor's call sites — the generators
   // accept a narrower shape than `PLCServer[]` / `PLCRemoteDevice[]`
   // but the runtime values are compatible.
-  const modbusSlave = generateModbusSlaveConfig(servers as Parameters<typeof generateModbusSlaveConfig>[0])
+  const modbusSlave = generateModbusSlaveConfig(servers as Parameters<typeof generateModbusSlaveConfig>[0], (msg) =>
+    log(msg, 'warning'),
+  )
   const modbusMaster = generateModbusMasterConfig(
     remoteDevices as Parameters<typeof generateModbusMasterConfig>[0],
     (msg) => log(msg, 'warning'),

--- a/src/backend/shared/protocol/__tests__/normalize-ethercat-slave.test.ts
+++ b/src/backend/shared/protocol/__tests__/normalize-ethercat-slave.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Driven against the real CiA 402 ESI fixture, not a hand-written stub: the
+ * whole point of this module is that the channels, PDOs and SDOs come out of a
+ * vendor file. A stub would only prove the spread operators work.
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { normalizeEthercatSlave } from '../normalize-ethercat-slave'
+import type { SpecEtherCATSlave } from '../types'
+
+const XML = readFileSync(join(__dirname, '../../ethercat/__tests__/fixtures/cia402-servo-esi.xml'), 'utf8')
+
+const build = (spec: SpecEtherCATSlave, overrides: Partial<Parameters<typeof normalizeEthercatSlave>[0]> = {}) =>
+  normalizeEthercatSlave({
+    spec,
+    xml: XML,
+    usedAddresses: new Set<string>(),
+    takenNames: new Set<string>(),
+    fallbackPosition: 0,
+    id: 'slave-1',
+    ...overrides,
+  })
+
+const ref = { repositoryItemId: 'oss-servo', deviceIndex: 0 }
+
+describe('authoring a slave from a real ESI file', () => {
+  it('carries the vendor, product and revision off the file', () => {
+    const result = build({ esiDeviceRef: ref })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    // The parser normalizes the ESI's `#x` literals to `0x`, so these are the
+    // bytes that reach the runtime's startup checks.
+    expect(result.value.vendorId).toBe('0x00000B95')
+    expect(result.value.productCode).toBe('0x00020192')
+    expect(result.value.revisionNo).toBe('0x42')
+    expect(result.value.addedFrom).toBe('repository')
+  })
+
+  it('produces channel mappings with IEC locations', () => {
+    const result = build({ esiDeviceRef: ref })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(result.value.channelMappings.length).toBeGreaterThan(0)
+    for (const mapping of result.value.channelMappings) {
+      expect(mapping.iecLocation).toMatch(/^%[IQ][XBWDL]\d+/)
+    }
+  })
+
+  it('carries the PDOs and channel info the runtime binds to', () => {
+    const result = build({ esiDeviceRef: ref })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(result.value.rxPdos?.length).toBeGreaterThan(0)
+    expect(result.value.txPdos?.length).toBeGreaterThan(0)
+    expect(result.value.channelInfo?.length).toBe(result.value.channelMappings.length)
+  })
+
+  it('recognizes the CiA 402 drive and gives it a legal axis name', () => {
+    const result = build({ esiDeviceRef: ref })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(result.value.cia402?.enabled).toBe(true)
+    // A SoftMotion axis name becomes an IEC identifier.
+    expect(result.value.name).toMatch(/^[A-Za-z_][A-Za-z0-9_]*$/)
+  })
+
+  it('never reuses an address across two slaves on the same bus', () => {
+    const usedAddresses = new Set<string>()
+    const takenNames = new Set<string>()
+    const first = build({ esiDeviceRef: ref }, { usedAddresses, takenNames, id: 'a' })
+    const second = build({ esiDeviceRef: ref }, { usedAddresses, takenNames, id: 'b', fallbackPosition: 1 })
+
+    expect(first.ok && second.ok).toBe(true)
+    if (!first.ok || !second.ok) return
+
+    const firstLocations = first.value.channelMappings.map((m) => m.iecLocation)
+    const secondLocations = second.value.channelMappings.map((m) => m.iecLocation)
+    expect(firstLocations.some((location) => secondLocations.includes(location))).toBe(false)
+    expect(second.value.name).not.toBe(first.value.name)
+  })
+
+  it('takes the name, position and slave config the spec overrides', () => {
+    const result = build({
+      esiDeviceRef: ref,
+      name: 'Axis1',
+      position: 7,
+      config: { addressing: { ethercatAddress: 1002 }, timeouts: { sdoTimeoutMs: 2500 } },
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(result.value.name).toBe('Axis1')
+    expect(result.value.position).toBe(7)
+    expect(result.value.config.addressing.ethercatAddress).toBe(1002)
+    expect(result.value.config.timeouts.sdoTimeoutMs).toBe(2500)
+    // An override of one field leaves its siblings at the default.
+    expect(result.value.config.startupChecks.checkVendorId).toBe(true)
+  })
+
+  it('applies an alias to the channel it names, and only that one', () => {
+    const plain = build({ esiDeviceRef: ref })
+    expect(plain.ok).toBe(true)
+    if (!plain.ok) return
+    const channelId = plain.value.channelMappings[0].channelId
+
+    const result = build({ esiDeviceRef: ref, aliases: { [channelId]: 'DriveStatus' } })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(result.value.channelMappings[0].alias).toBe('DriveStatus')
+    expect(result.value.channelMappings.filter((m) => m.alias === 'DriveStatus')).toHaveLength(1)
+  })
+
+  it('turns CiA 402 off when the spec says so', () => {
+    const result = build({ esiDeviceRef: ref, name: 'Drive One', cia402: { enabled: false } })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(result.value.cia402?.enabled).toBe(false)
+    // Not an axis any more, so the name is left as written.
+    expect(result.value.name).toBe('Drive One')
+  })
+
+  it('reports a device index the file does not have', () => {
+    const result = build({ esiDeviceRef: { repositoryItemId: 'oss-servo', deviceIndex: 99 } })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors[0]).toContain('could not read device 99')
+  })
+
+  it('reports an ESI file that is not ESI at all', () => {
+    const result = build({ esiDeviceRef: ref }, { xml: '<nope/>' })
+    expect(result.ok).toBe(false)
+  })
+})

--- a/src/backend/shared/protocol/__tests__/normalize-remote-device-spec.test.ts
+++ b/src/backend/shared/protocol/__tests__/normalize-remote-device-spec.test.ts
@@ -1,0 +1,182 @@
+/**
+ * The error cases here are the ones the Modbus master generator drops WITHOUT
+ * failing the compile: a device with no I/O groups and an RTU device with no
+ * serial port both upload cleanly and then never poll anything.
+ */
+
+import { PLCRemoteDeviceSchema } from '../../types/PLC/open-plc'
+import { normalizeRemoteDeviceSpec } from '../normalize-remote-device-spec'
+import type { SpecRemoteDevice } from '../types'
+
+const ok = (spec: SpecRemoteDevice) => {
+  const result = normalizeRemoteDeviceSpec(spec)
+  if (!result.ok) throw new Error(`expected ok, got: ${result.errors.join(' | ')}`)
+  expect(PLCRemoteDeviceSchema.safeParse(result.value.device).success).toBe(true)
+  return result.value
+}
+
+const errorsOf = (spec: SpecRemoteDevice) => {
+  const result = normalizeRemoteDeviceSpec(spec)
+  return result.ok ? [] : result.errors
+}
+
+describe('a Modbus TCP remote device', () => {
+  it('builds from nothing but a name and a protocol', () => {
+    const { device } = ok({ name: 'FieldIO', protocol: 'modbus-tcp' })
+    expect(device.modbusTcpConfig).toMatchObject({
+      transport: 'tcp',
+      host: '127.0.0.1',
+      port: 502,
+      slaveId: 1,
+      timeout: 1000,
+      ioGroups: [],
+    })
+  })
+
+  it('returns I/O groups beside the device, not inside it', () => {
+    // The store allocates their points and addresses; a device carrying
+    // pre-built groups would bypass that.
+    const { device, ioGroups } = ok({
+      name: 'FieldIO',
+      protocol: 'modbus-tcp',
+      modbus: {
+        host: '10.0.0.5',
+        ioGroups: [{ name: 'Inputs', functionCode: '2', cycleTime: 100, offset: '0x0000', length: 8 }],
+      },
+    })
+
+    expect(device.modbusTcpConfig?.ioGroups).toEqual([])
+    expect(ioGroups).toHaveLength(1)
+    expect(ioGroups[0]).toMatchObject({ id: 'group-Inputs', length: 8, errorHandling: 'keep-last-value', ioPoints: [] })
+  })
+
+  it('accepts a single-element function code at length 1', () => {
+    const { ioGroups } = ok({
+      name: 'FieldIO',
+      protocol: 'modbus-tcp',
+      modbus: { ioGroups: [{ name: 'Trip', functionCode: '5', cycleTime: 100, offset: '0x0000', length: 1 }] },
+    })
+    expect(ioGroups[0].length).toBe(1)
+  })
+
+  it('refuses a longer one rather than silently truncating it', () => {
+    // The GUI disables the Length field for FC 5/6, so this is only reachable
+    // from a spec. Clamping to 1 would leave the author reading a config that
+    // does not say what they wrote.
+    expect(
+      errorsOf({
+        name: 'FieldIO',
+        protocol: 'modbus-tcp',
+        modbus: { ioGroups: [{ name: 'Trip', functionCode: '5', cycleTime: 100, offset: '0x0000', length: 9 }] },
+      }).join(' '),
+    ).toContain('FC 5 addresses at most 1')
+  })
+
+  it('refuses a group longer than its function code can request', () => {
+    expect(
+      errorsOf({
+        name: 'FieldIO',
+        protocol: 'modbus-tcp',
+        modbus: { ioGroups: [{ name: 'Big', functionCode: '3', cycleTime: 100, offset: '0x0000', length: 200 }] },
+      }).join(' '),
+    ).toContain('at most 125')
+  })
+
+  it('refuses two groups with the same name', () => {
+    expect(
+      errorsOf({
+        name: 'FieldIO',
+        protocol: 'modbus-tcp',
+        modbus: {
+          ioGroups: [
+            { name: 'Inputs', functionCode: '2', cycleTime: 100, offset: '0x0000', length: 8 },
+            { name: 'inputs', functionCode: '1', cycleTime: 100, offset: '0x0010', length: 8 },
+          ],
+        },
+      }).join(' '),
+    ).toContain('both named')
+  })
+})
+
+describe('a Modbus RTU remote device', () => {
+  it('builds when it has a serial port', () => {
+    const { device } = ok({
+      name: 'Serial',
+      protocol: 'modbus-tcp',
+      modbus: { transport: 'rtu', serialPort: '/dev/ttyUSB0', baudRate: 19200, parity: 'E', slaveId: 12 },
+    })
+    expect(device.modbusTcpConfig).toMatchObject({ transport: 'rtu', serialPort: '/dev/ttyUSB0', slaveId: 12 })
+  })
+
+  it('refuses one without a serial port, which the generator would drop silently', () => {
+    expect(errorsOf({ name: 'Serial', protocol: 'modbus-tcp', modbus: { transport: 'rtu' } }).join(' ')).toContain(
+      'needs a "serialPort"',
+    )
+  })
+
+  it('refuses a slave id outside the RTU range', () => {
+    expect(
+      errorsOf({
+        name: 'Serial',
+        protocol: 'modbus-tcp',
+        modbus: { transport: 'rtu', serialPort: '/dev/ttyUSB0', slaveId: 250 },
+      }).join(' '),
+    ).toContain('outside the RTU range 1..247')
+  })
+
+  it('allows that same slave id over TCP, where the range is wider', () => {
+    const { device } = ok({ name: 'Wide', protocol: 'modbus-tcp', modbus: { slaveId: 250 } })
+    expect(device.modbusTcpConfig?.slaveId).toBe(250)
+  })
+})
+
+describe('an EtherCAT remote device', () => {
+  it('builds a master with no slaves yet', () => {
+    const { device } = ok({ name: 'Bus', protocol: 'ethercat' })
+    // The device screen's own defaults, field for field.
+    expect(device.ethercatConfig?.masterConfig).toEqual({
+      networkInterface: 'eth0',
+      cycleTimeUs: 1000,
+      watchdogTimeoutCycles: 3,
+    })
+    expect(device.ethercatConfig?.devices).toEqual([])
+  })
+
+  it('takes the master overrides the spec gives', () => {
+    const { device } = ok({
+      name: 'Bus',
+      protocol: 'ethercat',
+      ethercat: { master: { networkInterface: 'enp3s0', cycleTimeUs: 500 } },
+    })
+    expect(device.ethercatConfig?.masterConfig?.networkInterface).toBe('enp3s0')
+    expect(device.ethercatConfig?.masterConfig?.cycleTimeUs).toBe(500)
+    expect(device.ethercatConfig?.masterConfig?.watchdogTimeoutCycles).toBe(3)
+  })
+
+  it('lets a master be switched off', () => {
+    const { device } = ok({ name: 'Bus', protocol: 'ethercat', ethercat: { master: { enabled: false } } })
+    expect(device.ethercatConfig?.masterConfig?.enabled).toBe(false)
+  })
+
+  it('rejects a cycle time the authoritative schema bounds', () => {
+    expect(
+      errorsOf({ name: 'Bus', protocol: 'ethercat', ethercat: { master: { cycleTimeUs: 5 } } }).join(' '),
+    ).toContain('cycleTimeUs')
+  })
+})
+
+describe('what it refuses', () => {
+  it.each(['ethernet-ip', 'profinet'])('refuses %s, which has no generator', (protocol) => {
+    expect(errorsOf({ name: 'X', protocol: protocol as never }).join(' ')).toContain('no configuration surface')
+  })
+
+  it('refuses a config block belonging to the other protocol', () => {
+    expect(errorsOf({ name: 'Bus', protocol: 'ethercat', modbus: { host: '1.2.3.4' } }).join(' ')).toContain(
+      'that block is ignored',
+    )
+  })
+
+  it('refuses a name that is not a legal identifier', () => {
+    expect(errorsOf({ name: '2Field', protocol: 'modbus-tcp' }).join(' ')).toContain('not a legal name')
+  })
+})

--- a/src/backend/shared/protocol/__tests__/normalize-server-spec.test.ts
+++ b/src/backend/shared/protocol/__tests__/normalize-server-spec.test.ts
@@ -1,0 +1,226 @@
+/**
+ * The normalizer's job is that a two-line spec becomes a server the project
+ * loader will accept. Every `ok: true` case therefore asserts against
+ * `PLCServerSchema`-shaped output, and the error cases are the ones where a
+ * config would otherwise save, upload and quietly do nothing.
+ */
+
+import { PLCServerSchema } from '../../types/PLC/open-plc'
+import { normalizeServerSpec } from '../normalize-server-spec'
+import type { SpecServer } from '../types'
+
+const ok = (spec: SpecServer) => {
+  const result = normalizeServerSpec(spec)
+  if (!result.ok) throw new Error(`expected ok, got: ${result.errors.join(' | ')}`)
+  // What the loader will do on the next open.
+  expect(PLCServerSchema.safeParse(result.value).success).toBe(true)
+  return result.value
+}
+
+const errorsOf = (spec: SpecServer) => {
+  const result = normalizeServerSpec(spec)
+  return result.ok ? [] : result.errors
+}
+
+describe('a Modbus TCP server', () => {
+  it('builds from nothing but a name and a protocol', () => {
+    const server = ok({ name: 'Plant', protocol: 'modbus-tcp' })
+    expect(server.modbusSlaveConfig).toEqual({ enabled: false, networkInterface: '0.0.0.0', port: 502 })
+  })
+
+  it('puts the single top-level enabled where Modbus reads it', () => {
+    expect(ok({ name: 'Plant', protocol: 'modbus-tcp', enabled: true }).modbusSlaveConfig?.enabled).toBe(true)
+  })
+
+  it('keeps the sibling defaults when the spec overrides one field', () => {
+    const server = ok({ name: 'Plant', protocol: 'modbus-tcp', modbus: { port: 1502 } })
+    expect(server.modbusSlaveConfig?.port).toBe(1502)
+    expect(server.modbusSlaveConfig?.networkInterface).toBe('0.0.0.0')
+  })
+
+  it('carries a partial bufferMapping through without filling it in', () => {
+    // The generator defaults each missing count; storing invented values here
+    // would make a project look like the author chose them.
+    const server = ok({ name: 'Plant', protocol: 'modbus-tcp', modbus: { bufferMapping: { coils: { qxBits: 16 } } } })
+    expect(server.modbusSlaveConfig?.bufferMapping).toEqual({ coils: { qxBits: 16 } })
+  })
+})
+
+describe('an S7comm server', () => {
+  it('builds the full default server, identity and logging', () => {
+    const server = ok({ name: 'S7', protocol: 's7comm' })
+    expect(server.s7commSlaveConfig?.server.port).toBe(102)
+    expect(server.s7commSlaveConfig?.server.pduSize).toBe(480)
+    expect(server.s7commSlaveConfig?.plcIdentity?.name).toBe('OpenPLC Runtime')
+    expect(server.s7commSlaveConfig?.dataBlocks).toEqual([])
+  })
+
+  it('puts the top-level enabled on server.enabled, which the plugin reads', () => {
+    expect(ok({ name: 'S7', protocol: 's7comm', enabled: true }).s7commSlaveConfig?.server.enabled).toBe(true)
+  })
+
+  it('takes data blocks whole', () => {
+    const server = ok({
+      name: 'S7',
+      protocol: 's7comm',
+      s7comm: {
+        dataBlocks: [
+          {
+            dbNumber: 1,
+            description: 'Process',
+            sizeBytes: 256,
+            mapping: { type: 'int_output', startBuffer: 0, bitAddressing: false },
+          },
+        ],
+      },
+    })
+    expect(server.s7commSlaveConfig?.dataBlocks).toHaveLength(1)
+    expect(server.s7commSlaveConfig?.dataBlocks[0].dbNumber).toBe(1)
+  })
+
+  it('refuses two data blocks on the same DB number', () => {
+    // The editor refuses `DB1 already exists`; letting two through means only
+    // one of them answers on the wire.
+    const block = (dbNumber: number) => ({
+      dbNumber,
+      description: 'x',
+      sizeBytes: 64,
+      mapping: { type: 'int_output' as const, startBuffer: 0, bitAddressing: false },
+    })
+    expect(
+      errorsOf({ name: 'S7', protocol: 's7comm', s7comm: { dataBlocks: [block(1), block(1)] } }).join(' '),
+    ).toContain('DB1 is declared more than once')
+  })
+
+  it('accepts two data blocks on different numbers', () => {
+    const block = (dbNumber: number) => ({
+      dbNumber,
+      description: 'x',
+      sizeBytes: 64,
+      mapping: { type: 'int_output' as const, startBuffer: 0, bitAddressing: false },
+    })
+    const server = ok({ name: 'S7', protocol: 's7comm', s7comm: { dataBlocks: [block(1), block(2)] } })
+    expect(server.s7commSlaveConfig?.dataBlocks).toHaveLength(2)
+  })
+
+  it('rejects a value the authoritative schema bounds', () => {
+    // pduSize is 240..960 — a spec-only check would have let this through.
+    expect(errorsOf({ name: 'S7', protocol: 's7comm', s7comm: { server: { pduSize: 12 } } }).join(' ')).toContain(
+      'pduSize',
+    )
+  })
+})
+
+describe('an OPC-UA server', () => {
+  it('builds the default profile, security and address space', () => {
+    const server = ok({ name: 'Ua', protocol: 'opcua' })
+    expect(server.opcuaServerConfig?.server.port).toBe(4840)
+    expect(server.opcuaServerConfig?.securityProfiles).toHaveLength(1)
+    expect(server.opcuaServerConfig?.security.serverPrivateKeyCustom).toBeNull()
+    expect(server.opcuaServerConfig?.addressSpace.nodes).toEqual([])
+  })
+
+  it('derives ids the GUI would have generated, so a round trip is stable', () => {
+    const server = ok({
+      name: 'Ua',
+      protocol: 'opcua',
+      opcua: {
+        securityProfiles: [
+          {
+            name: 'secure',
+            enabled: true,
+            securityPolicy: 'Basic256Sha256',
+            securityMode: 'SignAndEncrypt',
+            authMethods: ['Username'],
+          },
+        ],
+        users: [{ type: 'password', username: 'op', passwordHash: 'hash', certificateId: null, role: 'operator' }],
+        addressSpace: {
+          nodes: [
+            {
+              pouName: 'Main',
+              variablePath: 'Level',
+              variableType: 'INT',
+              nodeId: 'ns=1;s=Main.Level',
+              browseName: 'Level',
+              displayName: 'Level',
+              description: '',
+              permissions: { viewer: 'r', operator: 'rw', engineer: 'rw' },
+              nodeType: 'variable',
+            },
+          ],
+        },
+      },
+    })
+
+    expect(server.opcuaServerConfig?.securityProfiles[0].id).toBe('profile-secure')
+    expect(server.opcuaServerConfig?.users[0].id).toBe('user-op')
+    expect(server.opcuaServerConfig?.addressSpace.nodes[0].id).toBe('Main.Level')
+  })
+
+  it('leaves an id the spec supplies alone', () => {
+    const server = ok({
+      name: 'Ua',
+      protocol: 'opcua',
+      opcua: {
+        securityProfiles: [
+          {
+            id: 'kept',
+            name: 'secure',
+            enabled: true,
+            securityPolicy: 'None',
+            securityMode: 'None',
+            authMethods: ['Anonymous'],
+          },
+        ],
+      },
+    })
+    expect(server.opcuaServerConfig?.securityProfiles[0].id).toBe('kept')
+  })
+
+  it('replaces the default profile list rather than merging into it', () => {
+    // Arrays replace: otherwise removing the built-in insecure profile would be
+    // impossible to express.
+    const server = ok({
+      name: 'Ua',
+      protocol: 'opcua',
+      opcua: {
+        securityProfiles: [
+          {
+            name: 'only',
+            enabled: true,
+            securityPolicy: 'Basic256Sha256',
+            securityMode: 'Sign',
+            authMethods: ['Certificate'],
+          },
+        ],
+      },
+    })
+    expect(server.opcuaServerConfig?.securityProfiles).toHaveLength(1)
+    expect(server.opcuaServerConfig?.securityProfiles[0].name).toBe('only')
+  })
+})
+
+describe('what it refuses', () => {
+  it('refuses a protocol with no configuration surface', () => {
+    expect(errorsOf({ name: 'X', protocol: 'ethernet-ip' as never }).join(' ')).toContain('ethernet-ip')
+  })
+
+  it('refuses a name that is not a legal identifier', () => {
+    expect(errorsOf({ name: 'my server', protocol: 'modbus-tcp' }).join(' ')).toContain(
+      'not a legal name — it contains illegal characters',
+    )
+  })
+
+  it('refuses an empty name without crashing', () => {
+    expect(errorsOf({ name: '', protocol: 'modbus-tcp' })).toEqual(['A server needs a name.'])
+  })
+
+  it('refuses a config block belonging to another protocol', () => {
+    // Silently ignoring it is how an author spends an afternoon on a setting
+    // that was never read.
+    expect(errorsOf({ name: 'Plant', protocol: 'modbus-tcp', opcua: { cycleTimeMs: 50 } }).join(' ')).toContain(
+      'that block is ignored',
+    )
+  })
+})

--- a/src/backend/shared/protocol/merge.ts
+++ b/src/backend/shared/protocol/merge.ts
@@ -1,0 +1,28 @@
+/**
+ * Merge an author's overrides onto a default object.
+ *
+ * Objects merge key by key; arrays and every scalar replace. An array is a
+ * whole list in every protocol config that has one — data blocks, users,
+ * address-space nodes, I/O groups — so merging them element-wise would make
+ * "remove the second data block" impossible to express.
+ *
+ * `undefined` never overwrites: a spec that omits a key keeps the default,
+ * which is what lets `describe` redact a secret and `apply` preserve it.
+ * `null` DOES overwrite, because several config fields are nullable and
+ * clearing them has to be expressible.
+ */
+export function mergeOverrides<T>(base: T, overrides: unknown): T {
+  if (overrides === undefined) return base
+  if (!isPlainObject(base) || !isPlainObject(overrides)) return overrides as T
+
+  const merged: Record<string, unknown> = { ...base }
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) continue
+    merged[key] = key in merged ? mergeOverrides(merged[key], value) : value
+  }
+  return merged as T
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/backend/shared/protocol/normalize-ethercat-slave.ts
+++ b/src/backend/shared/protocol/normalize-ethercat-slave.ts
@@ -1,0 +1,99 @@
+/**
+ * Build an EtherCAT slave from an ESI file, the way the device screen does.
+ *
+ * The sequence mirrors the add-device handler in the EtherCAT editor: parse the
+ * device in full, enrich it (channels, PDOs, SDOs, CiA 402), reserve the
+ * addresses it just claimed so the next slave in the batch does not collide,
+ * then name it. Composed from the same helpers rather than reimplemented — the
+ * channel mappings and their IEC locations are what the runtime binds to, and a
+ * second implementation of that allocation is exactly the drift to avoid.
+ *
+ * Takes the XML as a string: reading `devices/esi/<id>.xml` is the caller's job,
+ * which keeps this pure and testable against a real vendor file.
+ */
+
+import { getShortDeviceName } from '../../../frontend/utils/short-device-name'
+import { generateUniqueSlaveName } from '../../../frontend/utils/unique-slave-name'
+import type { ConfiguredEtherCATDevice } from '../../../middleware/shared/ports/esi-types'
+import { sanitizeAxisName } from '../../../middleware/shared/utils/ethercat/softmotion-axis-naming'
+import { createDefaultSlaveConfig } from '../ethercat/device-config-defaults'
+import { enrichDeviceData } from '../ethercat/enrich-device-data'
+import { parseESIDeviceFull, parseESILight } from '../ethercat/esi-parser-main'
+import { mergeOverrides } from './merge'
+import type { NormalizeResult, SpecEtherCATSlave } from './types'
+
+export interface EthercatSlaveInput {
+  spec: SpecEtherCATSlave
+  /** Raw `devices/esi/<repositoryItemId>.xml`. */
+  xml: string
+  /** IEC addresses already claimed project-wide; grows as slaves are built. */
+  usedAddresses: Set<string>
+  /** Slave names already taken across every master. */
+  takenNames: Set<string>
+  /** Position on the bus when the spec leaves it out. */
+  fallbackPosition: number
+  /** Stable per-slave identity; the GUI uses a uuid. */
+  id: string
+}
+
+export function normalizeEthercatSlave(input: EthercatSlaveInput): NormalizeResult<ConfiguredEtherCATDevice> {
+  const { spec, xml, usedAddresses, takenNames } = input
+  const ref = spec.esiDeviceRef
+  const where = `EtherCAT slave "${spec.name ?? ref.repositoryItemId}"`
+  const deviceIndex = ref.deviceIndex ?? 0
+
+  const parsed = parseESIDeviceFull(xml, deviceIndex)
+  if (!parsed.success || !parsed.device) {
+    return {
+      ok: false,
+      errors: [`${where}: could not read device ${deviceIndex} from its ESI file — ${parsed.error ?? 'unknown error'}`],
+    }
+  }
+  const device = parsed.device
+
+  // The vendor id lives on the file, not the device, so the light parse is the
+  // only place to get it — the same value the repository shows in the GUI.
+  const light = parseESILight(xml)
+  if (!light.success || !light.vendor) {
+    return { ok: false, errors: [`${where}: its ESI file declares no vendor — ${light.error ?? 'unknown error'}`] }
+  }
+
+  const enriched = enrichDeviceData(device, usedAddresses)
+  for (const mapping of enriched.channelMappings) usedAddresses.add(mapping.iecLocation)
+
+  // A CiA 402 drive's name becomes a SoftMotion AXIS_REF variable, so it has to
+  // be a legal identifier.
+  const rawName = spec.name ?? getShortDeviceName(device)
+  const cia402 = spec.cia402 ? mergeOverrides(enriched.cia402 ?? DEFAULT_CIA402, spec.cia402) : enriched.cia402
+  const baseName = cia402?.enabled ? sanitizeAxisName(rawName) : rawName
+  const name = generateUniqueSlaveName(baseName, takenNames)
+  takenNames.add(name)
+
+  const channelMappings = spec.aliases
+    ? enriched.channelMappings.map((mapping) =>
+        spec.aliases?.[mapping.channelId] ? { ...mapping, alias: spec.aliases[mapping.channelId] } : mapping,
+      )
+    : enriched.channelMappings
+
+  return {
+    ok: true,
+    value: {
+      id: input.id,
+      position: spec.position ?? input.fallbackPosition,
+      name,
+      esiDeviceRef: { repositoryItemId: ref.repositoryItemId, deviceIndex },
+      vendorId: light.vendor.id,
+      productCode: device.type.productCode,
+      revisionNo: device.type.revisionNo,
+      // Authored from the repository, not read off a live bus.
+      addedFrom: 'repository',
+      config: mergeOverrides(createDefaultSlaveConfig(), spec.config),
+      ...enriched,
+      cia402,
+      channelMappings,
+    },
+  }
+}
+
+/** Only reached when a spec enables CiA 402 on a device the ESI does not mark. */
+const DEFAULT_CIA402 = { enabled: false, scaleNum: 1, scaleDenom: 1, scaleFactor: 1 }

--- a/src/backend/shared/protocol/normalize-ethercat-slave.ts
+++ b/src/backend/shared/protocol/normalize-ethercat-slave.ts
@@ -69,6 +69,22 @@ export function normalizeEthercatSlave(input: EthercatSlaveInput): NormalizeResu
   const name = generateUniqueSlaveName(baseName, takenNames)
   takenNames.add(name)
 
+  // An alias naming a channel the ESI does not have is dropped by the map
+  // below, so `apply` would report success and the next `describe` would simply
+  // not carry the alias. Name the channels instead.
+  const channelIds = new Set(enriched.channelMappings.map((mapping) => mapping.channelId))
+  const unknown = Object.keys(spec.aliases ?? {}).filter((channelId) => !channelIds.has(channelId))
+  if (unknown.length > 0) {
+    return {
+      ok: false,
+      errors: unknown.map(
+        (channelId) =>
+          `${where}: alias names channel "${channelId}", which this device does not have. ` +
+          `Its channels are: ${[...channelIds].join(', ')}.`,
+      ),
+    }
+  }
+
   const channelMappings = spec.aliases
     ? enriched.channelMappings.map((mapping) =>
         spec.aliases?.[mapping.channelId] ? { ...mapping, alias: spec.aliases[mapping.channelId] } : mapping,

--- a/src/backend/shared/protocol/normalize-remote-device-spec.ts
+++ b/src/backend/shared/protocol/normalize-remote-device-spec.ts
@@ -1,0 +1,195 @@
+/**
+ * Author-shaped remote-device spec → the `PLCRemoteDevice` the project stores.
+ *
+ * I/O groups come back SEPARATELY from the device rather than inside it: their
+ * points and IEC addresses are allocated by the store's `addIOGroup`, which
+ * reads the project-wide address pool. A device carrying pre-built groups would
+ * either skip that allocation or duplicate it.
+ */
+
+import { isLegalIdentifier } from '../../../frontend/utils/keywords'
+import { clampIOGroupLength, MAX_IO_GROUP_LENGTH_BY_FC } from '../../../frontend/utils/modbus/io-group'
+import { DEFAULT_MODBUS_TCP_DEVICE_CONFIG } from '../../../frontend/utils/protocol/server-defaults'
+import type { ModbusIOGroup, PLCRemoteDevice } from '../types/PLC/open-plc'
+import { PLCRemoteDeviceSchema } from '../types/PLC/open-plc'
+import { mergeOverrides } from './merge'
+import type { NormalizeResult, SpecIOGroup, SpecRemoteDevice } from './types'
+
+/** A Modbus RTU address is 1..247; TCP allows 0 (broadcast) and up to 255. */
+const SLAVE_ID_RANGE = { tcp: { min: 0, max: 255 }, rtu: { min: 1, max: 247 } }
+
+const DEVICE_PROTOCOLS = new Set(['modbus-tcp', 'ethercat'])
+
+export interface NormalizedRemoteDevice {
+  device: PLCRemoteDevice
+  /** Added one at a time by the driver, in this order. */
+  ioGroups: ModbusIOGroup[]
+  /** Point aliases per group id, positional — applied after allocation. */
+  aliasesByGroupId: Map<string, string[]>
+}
+
+export function normalizeRemoteDeviceSpec(spec: SpecRemoteDevice): NormalizeResult<NormalizedRemoteDevice> {
+  const errors: string[] = []
+  const where = `remote device "${spec.name}"`
+
+  if (!spec.name || spec.name.trim().length === 0) {
+    return { ok: false, errors: ['A remote device needs a name.'] }
+  }
+  const [legal, why] = isLegalIdentifier(spec.name)
+  if (!legal) {
+    errors.push(`${where}: "${spec.name}" is not a legal name — it ${why}.`)
+  }
+
+  if (!DEVICE_PROTOCOLS.has(spec.protocol)) {
+    errors.push(
+      `${where}: protocol "${spec.protocol}" has no configuration surface or runtime generator. ` +
+        `Use one of: ${[...DEVICE_PROTOCOLS].join(', ')}.`,
+    )
+    return { ok: false, errors }
+  }
+
+  if (spec.protocol === 'modbus-tcp' && spec.ethercat !== undefined) {
+    errors.push(`${where}: has an "ethercat" block but its protocol is "modbus-tcp" — that block is ignored.`)
+  }
+  if (spec.protocol === 'ethercat' && spec.modbus !== undefined) {
+    errors.push(`${where}: has a "modbus" block but its protocol is "ethercat" — that block is ignored.`)
+  }
+
+  const built =
+    spec.protocol === 'modbus-tcp'
+      ? buildModbusDevice(spec, errors)
+      : { device: buildEthercatDevice(spec), ioGroups: [], aliasesByGroupId: new Map<string, string[]>() }
+
+  const parsed = PLCRemoteDeviceSchema.safeParse(built.device)
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      errors.push(`${where}: ${issue.path.join('.') || '(root)'} — ${issue.message}`)
+    }
+  }
+
+  if (errors.length > 0) return { ok: false, errors }
+  return {
+    ok: true,
+    value: {
+      device: parsed.success ? parsed.data : built.device,
+      ioGroups: built.ioGroups,
+      aliasesByGroupId: built.aliasesByGroupId,
+    },
+  }
+}
+
+function buildModbusDevice(spec: SpecRemoteDevice, errors: string[]): NormalizedRemoteDevice {
+  const where = `remote device "${spec.name}"`
+  const transport = spec.modbus?.transport ?? 'tcp'
+
+  const base = { ...DEFAULT_MODBUS_TCP_DEVICE_CONFIG, ioGroups: [] as ModbusIOGroup[] }
+  const merged = mergeOverrides(base, { ...spec.modbus, ioGroups: undefined })
+  const config = { ...merged, transport, ioGroups: [] as ModbusIOGroup[] }
+
+  // The generator drops an RTU device with no serial port without producing a
+  // config entry for it, so the device would upload and simply never poll.
+  if (transport === 'rtu' && !spec.modbus?.serialPort) {
+    errors.push(`${where}: RTU transport needs a "serialPort" — without one the device is dropped at compile.`)
+  }
+  if (transport === 'tcp' && !config.host) {
+    errors.push(`${where}: TCP transport needs a "host".`)
+  }
+
+  const range = SLAVE_ID_RANGE[transport]
+  if (config.slaveId !== undefined && (config.slaveId < range.min || config.slaveId > range.max)) {
+    errors.push(
+      `${where}: slaveId ${config.slaveId} is outside the ${transport.toUpperCase()} range ` +
+        `${range.min}..${range.max}.`,
+    )
+  }
+
+  const ioGroups = normalizeIOGroups(spec.name, spec.modbus?.ioGroups ?? [], errors)
+
+  const aliasesByGroupId = new Map<string, string[]>()
+  const seenAliases = new Set<string>()
+  for (const group of spec.modbus?.ioGroups ?? []) {
+    if (!group.aliases) continue
+    if (group.aliases.length > group.length) {
+      errors.push(
+        `${where}: I/O group "${group.name}" names ${group.aliases.length} aliases for ${group.length} point(s).`,
+      )
+      continue
+    }
+    for (const alias of group.aliases) {
+      const [legalAlias, aliasWhy] = isLegalIdentifier(alias)
+      if (!legalAlias) errors.push(`${where}: alias "${alias}" is not a legal name — it ${aliasWhy}.`)
+      if (seenAliases.has(alias.toLowerCase())) errors.push(`${where}: alias "${alias}" is used twice.`)
+      seenAliases.add(alias.toLowerCase())
+    }
+    aliasesByGroupId.set(`group-${group.name}`, group.aliases)
+  }
+
+  return { device: { name: spec.name, protocol: 'modbus-tcp', modbusTcpConfig: config }, ioGroups, aliasesByGroupId }
+}
+
+/**
+ * Group ids are derived from the group's name rather than generated, so
+ * `describe → apply → describe` returns the same document. Nothing reads the
+ * id but the editor's own list keys.
+ */
+function normalizeIOGroups(deviceName: string, groups: SpecIOGroup[], errors: string[]): ModbusIOGroup[] {
+  const where = `remote device "${deviceName}"`
+  const seen = new Set<string>()
+  const normalized: ModbusIOGroup[] = []
+
+  for (const group of groups) {
+    if (!group.name || group.name.trim().length === 0) {
+      errors.push(`${where}: an I/O group has no name.`)
+      continue
+    }
+    const key = group.name.toLowerCase()
+    if (seen.has(key)) {
+      errors.push(`${where}: two I/O groups are both named "${group.name}".`)
+      continue
+    }
+    seen.add(key)
+
+    const max = MAX_IO_GROUP_LENGTH_BY_FC[group.functionCode]
+    if (max === undefined) {
+      errors.push(`${where}: I/O group "${group.name}" has an unknown function code "${group.functionCode}".`)
+      continue
+    }
+    if (group.length > max) {
+      errors.push(
+        `${where}: I/O group "${group.name}" asks for ${group.length} elements; ` +
+          `FC ${group.functionCode} addresses at most ${max} per request.`,
+      )
+      continue
+    }
+
+    normalized.push({
+      id: `group-${group.name}`,
+      name: group.name,
+      functionCode: group.functionCode,
+      cycleTime: group.cycleTime,
+      offset: group.offset,
+      length: clampIOGroupLength(group.functionCode, group.length),
+      errorHandling: group.errorHandling ?? 'keep-last-value',
+      // Allocated by `addIOGroup` against the project-wide address pool.
+      ioPoints: [],
+    })
+  }
+
+  return normalized
+}
+
+/**
+ * Slaves are attached by the driver, which needs the ESI files to build them.
+ *
+ * The master defaults are the device screen's own, field for field. It leaves
+ * `taskPriority` and `enabled` unset — the schema caps priority at 31 while the
+ * generator falls back to 90, so writing a default here would either fail
+ * validation or store a value the GUI never would.
+ */
+function buildEthercatDevice(spec: SpecRemoteDevice): PLCRemoteDevice {
+  const master = mergeOverrides(
+    { networkInterface: 'eth0', cycleTimeUs: 1000, watchdogTimeoutCycles: 3 },
+    spec.ethercat?.master,
+  )
+  return { name: spec.name, protocol: 'ethercat', ethercatConfig: { masterConfig: master, devices: [] } }
+}

--- a/src/backend/shared/protocol/normalize-server-spec.ts
+++ b/src/backend/shared/protocol/normalize-server-spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Author-shaped server spec → the `PLCServer` the project stores.
+ *
+ * Two stages on purpose. The spec is validated for typos by the CLI's own
+ * `.strict()` schema before it gets here; this merges onto the same defaults
+ * `createServer` seeds and then validates the RESULT against `PLCServerSchema`,
+ * which is what the project loader will later have to accept. Validating only
+ * the spec would let a config that parses as a spec fail to load as a project.
+ */
+
+import { isLegalIdentifier } from '../../../frontend/utils/keywords'
+import {
+  DEFAULT_MODBUS_SLAVE_CONFIG,
+  DEFAULT_OPCUA_SERVER_CONFIG,
+  DEFAULT_S7COMM_LOGGING,
+  DEFAULT_S7COMM_PLC_IDENTITY,
+  DEFAULT_S7COMM_SERVER_SETTINGS,
+} from '../../../frontend/utils/protocol/server-defaults'
+import type { OpcUaServerConfig, PLCServer, S7CommSlaveConfig } from '../types/PLC/open-plc'
+import { PLCServerSchema } from '../types/PLC/open-plc'
+import { mergeOverrides } from './merge'
+import type { NormalizeResult, SpecServer } from './types'
+
+const SERVER_PROTOCOLS = new Set(['modbus-tcp', 's7comm', 'opcua'])
+
+/** The config key each protocol reads, so a spec naming the wrong one is caught. */
+const CONFIG_KEY: Record<string, 'modbus' | 's7comm' | 'opcua'> = {
+  'modbus-tcp': 'modbus',
+  s7comm: 's7comm',
+  opcua: 'opcua',
+}
+
+export function normalizeServerSpec(spec: SpecServer): NormalizeResult<PLCServer> {
+  const errors: string[] = []
+  const where = `server "${spec.name}"`
+
+  if (!spec.name || spec.name.trim().length === 0) {
+    return { ok: false, errors: ['A server needs a name.'] }
+  }
+  // The name becomes `devices/servers/<name>.json` and, for OPC-UA, part of
+  // generated identifiers — so the identifier rule, not just "no slashes".
+  const [legal, why] = isLegalIdentifier(spec.name)
+  if (!legal) {
+    errors.push(`${where}: "${spec.name}" is not a legal name — it ${why}.`)
+  }
+
+  if (!SERVER_PROTOCOLS.has(spec.protocol)) {
+    errors.push(
+      `${where}: protocol "${spec.protocol}" is not one the editor can configure. ` +
+        `Use one of: ${[...SERVER_PROTOCOLS].join(', ')}.`,
+    )
+    return { ok: false, errors }
+  }
+
+  // A config block for a protocol this server is not is always a mistake, and
+  // silently ignoring it means the author never learns the setting did nothing.
+  const mine = CONFIG_KEY[spec.protocol]
+  for (const key of ['modbus', 's7comm', 'opcua'] as const) {
+    if (key !== mine && spec[key] !== undefined) {
+      errors.push(`${where}: has a "${key}" block but its protocol is "${spec.protocol}" — that block is ignored.`)
+    }
+  }
+
+  // The editor refuses `DB<n> already exists`; two blocks on one number would
+  // otherwise reach the runtime and only one of them would answer.
+  if (spec.protocol === 's7comm') {
+    const seen = new Set<number>()
+    for (const block of spec.s7comm?.dataBlocks ?? []) {
+      if (seen.has(block.dbNumber)) {
+        errors.push(`${where}: DB${block.dbNumber} is declared more than once.`)
+      }
+      seen.add(block.dbNumber)
+    }
+  }
+
+  const enabled = spec.enabled ?? false
+  const server = buildServer(spec, enabled)
+
+  const parsed = PLCServerSchema.safeParse(server)
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      errors.push(`${where}: ${issue.path.join('.') || '(root)'} — ${issue.message}`)
+    }
+  }
+
+  if (errors.length > 0) return { ok: false, errors }
+  return { ok: true, value: parsed.success ? parsed.data : server }
+}
+
+function buildServer(spec: SpecServer, enabled: boolean): PLCServer {
+  if (spec.protocol === 'modbus-tcp') {
+    return {
+      name: spec.name,
+      protocol: 'modbus-tcp',
+      modbusSlaveConfig: {
+        ...mergeOverrides({ ...DEFAULT_MODBUS_SLAVE_CONFIG }, spec.modbus),
+        enabled,
+      },
+    }
+  }
+
+  if (spec.protocol === 's7comm') {
+    const base: S7CommSlaveConfig = {
+      server: { ...DEFAULT_S7COMM_SERVER_SETTINGS },
+      plcIdentity: { ...DEFAULT_S7COMM_PLC_IDENTITY },
+      dataBlocks: [],
+      logging: { ...DEFAULT_S7COMM_LOGGING },
+    }
+    const merged = mergeOverrides(base, spec.s7comm)
+    return {
+      name: spec.name,
+      protocol: 's7comm',
+      // The plugin reads this key itself (unlike Modbus, whose config file is
+      // the switch), so a disabled S7comm server still ships a config.
+      s7commSlaveConfig: { ...merged, server: { ...merged.server, enabled } },
+    }
+  }
+
+  const base: OpcUaServerConfig = structuredClone(DEFAULT_OPCUA_SERVER_CONFIG)
+  const merged = mergeOverrides(base, withDerivedOpcUaIds(spec))
+  return {
+    name: spec.name,
+    protocol: 'opcua',
+    opcuaServerConfig: { ...merged, server: { ...merged.server, enabled } },
+  }
+}
+
+/**
+ * Fill in the ids the GUI generates with uuids.
+ *
+ * A uuid would make every `describe → apply → describe` differ, so each id is
+ * derived from something the author already wrote. They are opaque to the
+ * runtime — `generate-opcua-config` keys on `nodeId`, not on these.
+ */
+function withDerivedOpcUaIds(spec: SpecServer): SpecServer['opcua'] {
+  const opcua = spec.opcua
+  if (!opcua) return opcua
+
+  return {
+    ...opcua,
+    ...(opcua.securityProfiles
+      ? { securityProfiles: opcua.securityProfiles.map((p) => ({ ...p, id: p.id ?? `profile-${p.name}` })) }
+      : {}),
+    ...(opcua.users
+      ? {
+          users: opcua.users.map((u) => ({
+            ...u,
+            id: u.id ?? `user-${u.username ?? 'anonymous'}`,
+            // The stored shape requires the field. A redacted spec leaves it
+            // out; `apply` puts the real value back before saving.
+            passwordHash: u.passwordHash ?? null,
+          })),
+        }
+      : {}),
+    ...(opcua.addressSpace?.nodes
+      ? {
+          addressSpace: {
+            ...opcua.addressSpace,
+            nodes: opcua.addressSpace.nodes.map((n) => ({ ...n, id: n.id ?? `${n.pouName}.${n.variablePath}` })),
+          },
+        }
+      : {}),
+  }
+}

--- a/src/backend/shared/protocol/types.ts
+++ b/src/backend/shared/protocol/types.ts
@@ -1,0 +1,153 @@
+/**
+ * The shape a spec author writes, as opposed to the shape the project stores.
+ *
+ * It mirrors the stored types rather than inventing a parallel language, so
+ * `describe` can emit what `apply` accepts and a round trip is a comparison
+ * instead of a translation. Two deliberate differences:
+ *
+ *  - One `enabled` per server. Stored, it lives in a different place for each
+ *    protocol (`modbusSlaveConfig.enabled`, `s7commSlaveConfig.server.enabled`,
+ *    `opcuaServerConfig.server.enabled`), which is three chances to set the
+ *    wrong one.
+ *  - Everything below the name is optional. The normalizer merges onto the
+ *    same defaults `createServer` seeds, so a two-line server is legal.
+ *
+ * Derived fields are absent by construction: `ioPoints` and their IEC
+ * locations are allocated by the store, so an author never writes them.
+ */
+
+import type { EtherCATSlaveConfig } from '../../../middleware/shared/ports/esi-types'
+import type {
+  EtherCATMasterConfig,
+  ModbusErrorHandling,
+  ModbusFunctionCode,
+  ModbusParity,
+  ModbusSlaveBufferMapping,
+  ModbusTransportType,
+  OpcUaNodeConfig,
+  OpcUaSecurityConfig,
+  OpcUaSecurityProfile,
+  OpcUaServerSettings,
+  OpcUaUser,
+  S7CommDataBlock,
+  S7CommLogging,
+  S7CommPlcIdentity,
+  S7CommServerSettings,
+  S7CommSystemAreas,
+} from '../types/PLC/open-plc'
+
+/** Objects merge field by field; arrays are replaced whole. */
+export type DeepPartial<T> = T extends readonly (infer U)[]
+  ? U[]
+  : T extends object
+    ? { [K in keyof T]?: DeepPartial<T[K]> }
+    : T
+
+/** Protocols an author may declare. `ethernet-ip` has no generator. */
+export type SpecServerProtocol = 'modbus-tcp' | 's7comm' | 'opcua'
+
+/** Protocols an author may declare. `ethernet-ip` and `profinet` have none. */
+export type SpecRemoteDeviceProtocol = 'modbus-tcp' | 'ethercat'
+
+export interface SpecModbusSlave {
+  networkInterface?: string
+  port?: number
+  bufferMapping?: ModbusSlaveBufferMapping
+}
+
+export interface SpecS7Comm {
+  server?: DeepPartial<Omit<S7CommServerSettings, 'enabled'>>
+  plcIdentity?: DeepPartial<S7CommPlcIdentity>
+  dataBlocks?: S7CommDataBlock[]
+  systemAreas?: DeepPartial<S7CommSystemAreas>
+  logging?: DeepPartial<S7CommLogging>
+}
+
+/** A profile's `id` defaults to its name, so a round trip is stable. */
+export type SpecOpcUaSecurityProfile = Omit<OpcUaSecurityProfile, 'id'> & { id?: string }
+
+/** A user's `id` defaults to its username. `passwordHash` is redacted by
+ *  `describe`, so it is optional: omitting it on apply keeps the stored value. */
+export type SpecOpcUaUser = Omit<OpcUaUser, 'id' | 'passwordHash'> & { id?: string; passwordHash?: string | null }
+
+/** A node's `id` defaults to `<pouName>.<variablePath>`. */
+export type SpecOpcUaNode = Omit<OpcUaNodeConfig, 'id'> & { id?: string }
+
+export interface SpecOpcUa {
+  server?: DeepPartial<Omit<OpcUaServerSettings, 'enabled'>>
+  securityProfiles?: SpecOpcUaSecurityProfile[]
+  security?: DeepPartial<OpcUaSecurityConfig>
+  users?: SpecOpcUaUser[]
+  cycleTimeMs?: number
+  addressSpace?: { namespaceUri?: string; nodes?: SpecOpcUaNode[] }
+}
+
+export interface SpecServer {
+  name: string
+  protocol: SpecServerProtocol
+  /** Off unless said otherwise, matching `createServer`. */
+  enabled?: boolean
+  modbus?: SpecModbusSlave
+  s7comm?: SpecS7Comm
+  opcua?: SpecOpcUa
+}
+
+/** `id` is derived from the name; `ioPoints` are allocated by the store. */
+export interface SpecIOGroup {
+  name: string
+  functionCode: ModbusFunctionCode
+  cycleTime: number
+  offset: string
+  length: number
+  errorHandling?: ModbusErrorHandling
+  /**
+   * Alias per point, in order, for the points you want to name. A variable
+   * reaches a polled value by putting the alias in its `location`; without one
+   * the point has an allocated address and no name, so nothing can read it.
+   */
+  aliases?: string[]
+}
+
+export interface SpecModbusMaster {
+  transport?: ModbusTransportType
+  host?: string
+  port?: number
+  serialPort?: string
+  baudRate?: number
+  parity?: ModbusParity
+  stopBits?: number
+  dataBits?: number
+  timeout?: number
+  slaveId?: number
+  ioGroups?: SpecIOGroup[]
+}
+
+/**
+ * A slave is declared by its ESI reference plus overrides. Everything else —
+ * channels, PDOs, SDOs, the CiA 402 block, the IEC addresses — is read out of
+ * the ESI file and allocated, exactly as the device screen does it.
+ */
+export interface SpecEtherCATSlave {
+  esiDeviceRef: { repositoryItemId: string; deviceIndex?: number }
+  /** Defaults to the ESI's own short name, made unique across the bus. */
+  name?: string
+  position?: number
+  config?: DeepPartial<EtherCATSlaveConfig>
+  cia402?: { enabled?: boolean; scaleNum?: number; scaleDenom?: number; scaleFactor?: number }
+  /** Per-channel alias overrides, keyed by channel id. */
+  aliases?: Record<string, string>
+}
+
+export interface SpecEtherCAT {
+  master?: DeepPartial<EtherCATMasterConfig>
+  slaves?: SpecEtherCATSlave[]
+}
+
+export interface SpecRemoteDevice {
+  name: string
+  protocol: SpecRemoteDeviceProtocol
+  modbus?: SpecModbusMaster
+  ethercat?: SpecEtherCAT
+}
+
+export type NormalizeResult<T> = { ok: true; value: T } | { ok: false; errors: string[] }

--- a/src/backend/shared/types/PLC/open-plc.ts
+++ b/src/backend/shared/types/PLC/open-plc.ts
@@ -289,23 +289,36 @@ type PLCConfiguration = z.infer<typeof PLCConfigurationSchema>
 const PLCServerProtocolSchema = z.enum(['modbus-tcp', 's7comm', 'ethernet-ip', 'opcua'])
 type PLCServerProtocol = z.infer<typeof PLCServerProtocolSchema>
 
+/**
+ * Every field optional, matching `ModbusBufferMapping`.  A server file
+ * that fails this schema is skipped whole on load, so a partial mapping
+ * must parse; `generateModbusSlaveConfig` defaults each missing count.
+ */
 const ModbusSlaveBufferMappingSchema = z.object({
-  holdingRegisters: z.object({
-    qwCount: z.number(),
-    mwCount: z.number(),
-    mdCount: z.number(),
-    mlCount: z.number(),
-  }),
-  coils: z.object({
-    qxBits: z.number(),
-    mxBits: z.number(),
-  }),
-  discreteInputs: z.object({
-    ixBits: z.number(),
-  }),
-  inputRegisters: z.object({
-    iwCount: z.number(),
-  }),
+  holdingRegisters: z
+    .object({
+      qwCount: z.number().optional(),
+      mwCount: z.number().optional(),
+      mdCount: z.number().optional(),
+      mlCount: z.number().optional(),
+    })
+    .optional(),
+  coils: z
+    .object({
+      qxBits: z.number().optional(),
+      mxBits: z.number().optional(),
+    })
+    .optional(),
+  discreteInputs: z
+    .object({
+      ixBits: z.number().optional(),
+    })
+    .optional(),
+  inputRegisters: z
+    .object({
+      iwCount: z.number().optional(),
+    })
+    .optional(),
 })
 type ModbusSlaveBufferMapping = z.infer<typeof ModbusSlaveBufferMappingSchema>
 

--- a/src/backend/shared/utils/parse-project-files.ts
+++ b/src/backend/shared/utils/parse-project-files.ts
@@ -67,6 +67,15 @@ export class UnrecoverablePouError extends Error {
   }
 }
 
+/** The first few zod issues as `path: message`, for a one-line reason. */
+function describeZodIssues(error: { issues: { path: (string | number | symbol)[]; message: string }[] }): string {
+  const shown = error.issues
+    .slice(0, 3)
+    .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+    .join('; ')
+  return error.issues.length > 3 ? `${shown}; +${error.issues.length - 3} more` : shown
+}
+
 export interface ParsedProjectData {
   meta: {
     name: string
@@ -119,6 +128,11 @@ export interface ParsedProjectData {
    *  can echo them back verbatim — an unreadable file must never be
    *  silently dropped from disk. */
   unparsedDataTypeFiles?: RawProjectFile[]
+  /** Server / remote-device files that could not be read.  A skipped file is
+   *  invisible in `projectData`, so a caller that writes the project back
+   *  overwrites a config it never saw.  Separate from `warnings` so a caller
+   *  can refuse rather than parse prose. */
+  unreadableProtocolFiles?: { relativePath: string; reason: string }[]
   /** True when the project still carries its data types inline in
    *  `project.json` and has no `datatypes/*.dt` on disk — i.e. it predates
    *  DOPE-385 and has never been saved by a `.dt`-writing build. The save
@@ -613,6 +627,8 @@ export function parseProjectFiles(
   }
 
   // Parse server configs with Zod validation (matching old backend behavior)
+  const unreadableProtocolFiles: { relativePath: string; reason: string }[] = []
+
   const servers: PLCServer[] = []
   for (const file of serverFiles) {
     try {
@@ -623,9 +639,11 @@ export function parseProjectFiles(
       } else {
         console.error(`[parseProjectFiles] Server "${file.relativePath}" Zod errors:`, result.error.issues)
         warnings.push(`Server file "${file.relativePath}" has invalid configuration and was skipped.`)
+        unreadableProtocolFiles.push({ relativePath: file.relativePath, reason: describeZodIssues(result.error) })
       }
     } catch {
-      // Skip unparseable JSON files
+      warnings.push(`Server file "${file.relativePath}" is not valid JSON and was skipped.`)
+      unreadableProtocolFiles.push({ relativePath: file.relativePath, reason: 'not valid JSON' })
     }
   }
 
@@ -640,9 +658,11 @@ export function parseProjectFiles(
       } else {
         console.error(`[parseProjectFiles] Remote device "${file.relativePath}" Zod errors:`, result.error.issues)
         warnings.push(`Remote device file "${file.relativePath}" has invalid configuration and was skipped.`)
+        unreadableProtocolFiles.push({ relativePath: file.relativePath, reason: describeZodIssues(result.error) })
       }
     } catch {
-      // Skip unparseable JSON files
+      warnings.push(`Remote device file "${file.relativePath}" is not valid JSON and was skipped.`)
+      unreadableProtocolFiles.push({ relativePath: file.relativePath, reason: 'not valid JSON' })
     }
   }
 
@@ -744,6 +764,7 @@ export function parseProjectFiles(
     warnings: warnings.length > 0 ? warnings : undefined,
     fatalErrors: fatalErrors.length > 0 ? fatalErrors : undefined,
     ...(unparsedDataTypeFiles.length > 0 ? { unparsedDataTypeFiles } : {}),
+    ...(unreadableProtocolFiles.length > 0 ? { unreadableProtocolFiles } : {}),
     ...(dataTypeFiles.length === 0 && legacyDataTypes.length > 0 ? { dataTypesNeedMigration: true } : {}),
   }
 }

--- a/src/cli/__tests__/apply-array-types.test.ts
+++ b/src/cli/__tests__/apply-array-types.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Arrays, which the spec could not express at all until now.
+ *
+ * The store keeps an array twice over: `value` as rendered IEC text
+ * ("ARRAY [0..3] OF INT") and `data` as structured bounds. A caller writes
+ * neither — it gives the ELEMENT type and the dimensions, and `apply` derives
+ * both, so the two cannot disagree. `describe` has to hand back that same
+ * shape: reporting the rendered text would produce a document that, applied
+ * again, nests the array inside itself.
+ */
+
+import { parseApplySpec } from '../apply/schema'
+
+const spec = (type: unknown) => ({
+  specVersion: 1,
+  pous: [{ name: 'P', kind: 'program', language: 'st', variables: [{ name: 'Buf', type }] }],
+})
+
+describe('the array type in a spec', () => {
+  it('accepts an element type with dimensions', () => {
+    const parsed = parseApplySpec(spec({ definition: 'array', value: 'INT', dimensions: ['0..3'] }))
+    expect(parsed.ok).toBe(true)
+  })
+
+  it('accepts more than one dimension', () => {
+    const parsed = parseApplySpec(spec({ definition: 'array', value: 'REAL', dimensions: ['0..3', '0..2'] }))
+    expect(parsed.ok).toBe(true)
+  })
+
+  it('refuses an array with no dimensions — bounds are not optional', () => {
+    const parsed = parseApplySpec(spec({ definition: 'array', value: 'INT' }))
+    expect(parsed.ok).toBe(false)
+    if (parsed.ok) throw new Error('expected a refusal')
+    expect(parsed.issues.join(' ')).toContain('dimensions')
+  })
+
+  it('refuses dimensions on a type that is not an array', () => {
+    const parsed = parseApplySpec(spec({ definition: 'base-type', value: 'INT', dimensions: ['0..3'] }))
+    expect(parsed.ok).toBe(false)
+  })
+
+  it('still refuses the store’s internal shape, so the two cannot drift', () => {
+    // `data` is derived, never supplied: accepting it would let a caller give
+    // bounds that disagree with the rendered text.
+    const parsed = parseApplySpec(
+      spec({
+        definition: 'array',
+        value: 'INT',
+        dimensions: ['0..3'],
+        data: { baseType: { definition: 'base-type', value: 'INT' }, dimensions: [{ dimension: '0..3' }] },
+      }),
+    )
+    expect(parsed.ok).toBe(false)
+    if (parsed.ok) throw new Error('expected a refusal')
+    expect(parsed.issues.join(' ')).toContain('data')
+  })
+})

--- a/src/cli/__tests__/apply-data-types.test.ts
+++ b/src/cli/__tests__/apply-data-types.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Data types, and the two ways a spec could produce one the editor cannot read.
+ *
+ * Both were found by driving a project through `apply` -> `check` and reading
+ * the emitted TYPE block, which is the only place either showed up: the project
+ * saved without complaint in each case.
+ */
+
+import { openPLCStoreBase } from '@root/frontend/store'
+
+// The FBD body applier reaches the FBD component modules, which do not load
+// under jest. Nothing here applies an FBD body.
+jest.mock('../apply/fbd', () => ({ applyFbdBody: () => [] }))
+
+import { applySpec } from '../apply/plan'
+import type { ApplySpec } from '../apply/schema'
+
+const dataTypesIn = () => openPLCStoreBase.getState().project.data.dataTypes
+
+const apply = (dataTypes: unknown) =>
+  applySpec({ specVersion: 1, dataTypes } as ApplySpec, { prune: false, projectPath: '/does/not/matter' })
+
+describe('a structure member declared as an array', () => {
+  // The store keeps an array's bounds in `type.data`; the spec states them as
+  // `dimensions`. Passing the spec shape straight through left the member a
+  // scalar of the element type — `Trend : INT` where `ARRAY [0..2] OF INT` was
+  // asked for — and nothing reported it.
+  it('keeps its bounds', async () => {
+    const result = await apply([
+      {
+        derivation: 'structure',
+        name: 'HasArray',
+        variables: [{ name: 'Trend', type: { definition: 'array', value: 'INT', dimensions: ['0..2'] } }],
+      },
+    ])
+    expect(result.errors).toEqual([])
+
+    const stored = dataTypesIn().find((type) => type.name === 'HasArray')
+    const member = (stored as unknown as { variable: Array<{ type: Record<string, unknown> }> }).variable[0]
+
+    expect(member.type.value).toBe('ARRAY [0..2] OF INT')
+    expect(member.type.data).toEqual({
+      baseType: { definition: 'base-type', value: 'INT' },
+      dimensions: [{ dimension: '0..2' }],
+    })
+  })
+})
+
+describe('a data type whose name is not a legal identifier', () => {
+  // `createDatatype` accepts these. The `.dt` written for one then fails to
+  // parse on the next load: the editor preserves the file and warns, but the
+  // type is gone from the project and every reference to it fails to compile as
+  // an undefined type.
+  it('refuses a reserved structure field name', async () => {
+    const result = await apply([
+      {
+        derivation: 'structure',
+        name: 'BadField',
+        variables: [{ name: 'Label', type: { definition: 'base-type', value: 'STRING' } }],
+      },
+    ])
+
+    expect(result.errors.join(' ')).toContain('"Label" is a reserved word')
+    expect(dataTypesIn().some((type) => type.name === 'BadField')).toBe(false)
+  })
+
+  it('refuses a reserved enumerated value', async () => {
+    const result = await apply([{ derivation: 'enumerated', name: 'BadEnum', values: ['OK', 'WHILE'] }])
+
+    expect(result.errors.join(' ')).toContain('"WHILE"')
+    expect(dataTypesIn().some((type) => type.name === 'BadEnum')).toBe(false)
+  })
+
+  it('refuses a name with illegal characters', async () => {
+    const result = await apply([
+      {
+        derivation: 'structure',
+        name: 'Bad Name',
+        variables: [{ name: 'Ok', type: { definition: 'base-type', value: 'INT' } }],
+      },
+    ])
+
+    expect(result.errors.join(' ')).toContain('illegal characters')
+  })
+
+  it('accepts names that are legal', async () => {
+    const result = await apply([
+      {
+        derivation: 'structure',
+        name: 'GoodOne',
+        variables: [{ name: 'Tag', type: { definition: 'base-type', value: 'STRING' } }],
+      },
+    ])
+
+    expect(result.errors).toEqual([])
+    expect(dataTypesIn().some((type) => type.name === 'GoodOne')).toBe(true)
+  })
+})

--- a/src/cli/__tests__/apply-fbd-pins.test.ts
+++ b/src/cli/__tests__/apply-fbd-pins.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Pin resolution on an FBD block, and the one block that numbers its inputs
+ * from zero.
+ *
+ * Extensible blocks are grown to fit a wired `IN<n>`. The growth index used to
+ * be derived from how MANY `IN` pins a block declared, which is the same number
+ * as the next index only while the block is 1-based. `MUX` declares
+ * `K`, `IN0`, `IN1`, so `IN2` was accepted as legal and then never added — the
+ * connection survived to a pin that did not exist — and `IN3` left a hole at
+ * `IN2` that the transpiler emits as a missing argument.
+ *
+ * The catalogue has 15 extensible blocks and `MUX` is the only 0-based one, so
+ * nothing else would have caught it.
+ */
+
+import type { SystemLibrary } from '@root/middleware/shared/ports/library-types'
+
+/**
+ * `build-graph` reaches the FBD component modules, which do not load under jest.
+ * The stand-in also RECORDS the nodes it is handed: "no error" is not enough
+ * evidence here, because the bug this file exists for accepted a pin and then
+ * failed to add it. The grown pin list is the thing to assert on.
+ */
+const handed: { nodes: unknown[] } = { nodes: [] }
+jest.mock('@root/frontend/store/slices/fbd/utils/build-graph', () => ({
+  buildFbdGraph: (nodes: unknown[]) => {
+    handed.nodes = nodes
+    return { nodes: [], edges: [], brokenCycles: [], errors: [] }
+  },
+}))
+
+import { openPLCStoreBase } from '@root/frontend/store'
+
+import { applyFbdBody } from '../apply/fbd'
+import type { SpecFbdBody } from '../apply/schema'
+
+const input = (name: string) => ({ name, class: 'input', type: { definition: 'base-type', value: 'INT' } })
+const output = (name: string) => ({ name, class: 'output', type: { definition: 'base-type', value: 'INT' } })
+
+const LIB: SystemLibrary = {
+  name: 'iec-std-functions',
+  version: '1.0.0',
+  pous: [
+    // 1-based, the common shape.
+    { name: 'ADD', type: 'function', extensible: true, variables: [input('IN1'), input('IN2'), output('OUT')] },
+    // 0-based — the whole point of this file.
+    {
+      name: 'MUX',
+      type: 'function',
+      extensible: true,
+      variables: [input('K'), input('IN0'), input('IN1'), output('OUT')],
+    },
+    // Not extensible: a pin it does not declare is an error.
+    { name: 'SEL', type: 'function', variables: [input('G'), input('IN0'), output('OUT')] },
+  ],
+} as unknown as SystemLibrary
+
+beforeEach(() => {
+  openPLCStoreBase.getState().libraryActions.setSystemLibraries([LIB])
+})
+
+const wire = (call: string, pin: string): SpecFbdBody =>
+  ({
+    nodes: [
+      { label: 'src', kind: 'input-variable', variable: 'a' },
+      { label: 'blk', kind: 'block', call },
+    ],
+    connections: [{ from: 'src', to: `blk.${pin}` }],
+  }) as unknown as SpecFbdBody
+
+const errorsFor = (call: string, pin: string) => applyFbdBody('Main', wire(call, pin))
+
+/** The input pins the block ended up with, as handed to the graph builder. */
+const grownPins = (call: string, pin: string): string[] => {
+  handed.nodes = []
+  applyFbdBody('Main', wire(call, pin))
+  const block = (handed.nodes as { kind: string; variant?: { variables?: { name: string; class?: string }[] } }[]).find(
+    (node) => node.kind === 'block',
+  )
+  return (block?.variant?.variables ?? []).filter((v) => v.class === 'input').map((v) => v.name)
+}
+
+describe('a 1-based extensible block', () => {
+  it('accepts a declared pin', () => {
+    expect(errorsFor('system/iec-std-functions/ADD', 'IN2')).toEqual([])
+  })
+
+  it('grows to the next pin', () => {
+    expect(grownPins('system/iec-std-functions/ADD', 'IN3')).toEqual(['IN1', 'IN2', 'IN3'])
+  })
+
+  it('grows across a jump without leaving a hole', () => {
+    expect(grownPins('system/iec-std-functions/ADD', 'IN6')).toEqual(['IN1', 'IN2', 'IN3', 'IN4', 'IN5', 'IN6'])
+  })
+})
+
+describe('MUX, which numbers its inputs from zero', () => {
+  it('accepts its declared pins', () => {
+    expect(errorsFor('system/iec-std-functions/MUX', 'IN0')).toEqual([])
+    expect(errorsFor('system/iec-std-functions/MUX', 'K')).toEqual([])
+  })
+
+  it('ADDS IN2 — the next pin after IN1, not IN3', () => {
+    // The original bug: `IN2` was reported legal and never created, so the
+    // connection pointed at a pin the block did not have.
+    expect(grownPins('system/iec-std-functions/MUX', 'IN2')).toEqual(['K', 'IN0', 'IN1', 'IN2'])
+  })
+
+  it('fills the gap rather than leaving a hole at IN2', () => {
+    expect(grownPins('system/iec-std-functions/MUX', 'IN4')).toEqual(['K', 'IN0', 'IN1', 'IN2', 'IN3', 'IN4'])
+  })
+})
+
+describe('a block that is not extensible', () => {
+  it('refuses a pin it does not declare, and lists the ones it has', () => {
+    const errors = errorsFor('system/iec-std-functions/SEL', 'IN5')
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('has no input pin "IN5"')
+    expect(errors[0]).toContain('G, IN0, OUT')
+  })
+
+  it('accepts EN and ENO, which the editor adds itself', () => {
+    expect(errorsFor('system/iec-std-functions/SEL', 'EN')).toEqual([])
+  })
+})

--- a/src/cli/__tests__/apply-name-collision.test.ts
+++ b/src/cli/__tests__/apply-name-collision.test.ts
@@ -1,0 +1,101 @@
+/**
+ * A spec is a declaration: the name it asks for is the name the rest of the
+ * document refers to.
+ *
+ * The store's `createVariable` auto-increments a colliding name instead of
+ * refusing it — that is right for the "+" button in the variables table and
+ * wrong for `apply`, where it produced a silent, destructive combination: the
+ * renamed variable is not in the spec, so `--prune` deletes it on the same run,
+ * and the command still reports success. The failure only surfaced later as
+ * `VAR_EXTERNAL '<name>' has no matching VAR_GLOBAL`.
+ *
+ * Found by binding a global to a Modbus I/O point alias of the same name.
+ * Aliases, POUs, data types and globals share one namespace, so any of them can
+ * claim a name out from under a variable.
+ *
+ * A duplicate name WITHIN one spec is not this: the spec is upsert-by-name, so
+ * the second entry updates the first.
+ */
+
+import { openPLCStoreBase } from '@root/frontend/store'
+
+// The FBD body applier reaches the FBD component modules, which do not load
+// under jest. Nothing here applies an FBD body.
+jest.mock('../apply/fbd', () => ({ applyFbdBody: () => [] }))
+
+import { applySpec } from '../apply/plan'
+import type { ApplySpec } from '../apply/schema'
+
+const BOOL = { definition: 'base-type' as const, value: 'BOOL' }
+
+const apply = (spec: Partial<ApplySpec>, prune = false) =>
+  applySpec({ specVersion: 1, ...spec } as ApplySpec, { prune, projectPath: '/does/not/matter' })
+
+const globalsIn = () => openPLCStoreBase.getState().project.data.configurations.resource.globalVariables
+
+describe('a name another element already owns', () => {
+  it('reports it instead of accepting a renamed variable', async () => {
+    const result = await apply({
+      pous: [{ name: 'Level', kind: 'program', language: 'st', variables: [], body: { text: '' } }],
+      globalVariables: [{ name: 'Level', class: 'global', type: BOOL }],
+    } as Partial<ApplySpec>)
+
+    expect(result.errors.some((error) => error.includes('"Level" could not take that name'))).toBe(true)
+    // And it must say WHY. The store throws the reason away, so the driver asks
+    // the same gate again — a library block, a POU, a device alias and a
+    // reserved word all arrive here and send the reader somewhere different.
+    expect(result.errors.some((error) => error.includes('POU'))).toBe(true)
+  })
+
+  it('leaves no renamed survivor behind', async () => {
+    await apply({
+      pous: [{ name: 'Flow', kind: 'program', language: 'st', variables: [], body: { text: '' } }],
+      globalVariables: [{ name: 'Flow', class: 'global', type: BOOL }],
+    } as Partial<ApplySpec>)
+
+    // Whatever the store did with the name, the command failed — so a caller
+    // that reads `errors` never acts on a project it thinks has `Flow`.
+    expect(globalsIn().some((variable) => variable.name === 'Flow')).toBe(false)
+  })
+
+  it("refuses to change an existing POU's language rather than ignoring it", async () => {
+    // The body is stored in a file named for the language, so a change would
+    // write `X.st` beside the existing `X.ld` and the loader would keep reading
+    // the old one — the project silently compiles a body the spec no longer
+    // describes.
+    await apply({
+      pous: [{ name: 'Switcher', kind: 'program', language: 'st', variables: [], body: { text: '' } }],
+    } as Partial<ApplySpec>)
+
+    const result = await apply({
+      pous: [{ name: 'Switcher', kind: 'program', language: 'il', variables: [], body: { text: '' } }],
+    } as Partial<ApplySpec>)
+
+    expect(result.errors.some((error) => error.includes('cannot be changed in place'))).toBe(true)
+    expect(result.errors.some((error) => error.includes('is st and the spec asks for il'))).toBe(true)
+  })
+
+  it('says nothing when every name is honoured', async () => {
+    const result = await apply({
+      globalVariables: [
+        { name: 'LevelA', class: 'global', type: BOOL },
+        { name: 'LevelB', class: 'global', type: BOOL },
+      ],
+    })
+
+    expect(result.errors).toEqual([])
+    expect(globalsIn().map((variable) => variable.name)).toEqual(expect.arrayContaining(['LevelA', 'LevelB']))
+  })
+
+  it('treats a repeated name inside one spec as an upsert, not a collision', async () => {
+    const result = await apply({
+      globalVariables: [
+        { name: 'Repeated', class: 'global', type: BOOL },
+        { name: 'Repeated', class: 'global', type: BOOL },
+      ],
+    })
+
+    expect(result.errors).toEqual([])
+    expect(globalsIn().filter((variable) => variable.name === 'Repeated')).toHaveLength(1)
+  })
+})

--- a/src/cli/__tests__/describe-protocol.test.ts
+++ b/src/cli/__tests__/describe-protocol.test.ts
@@ -1,0 +1,115 @@
+/**
+ * `describe` output ends up in logs and diffs, so the two secrets OPC-UA stores
+ * must not be in it — and `apply` has to put them back, or the first round trip
+ * destroys the server's private key.
+ */
+
+import type { PLCRemoteDevice, PLCServer } from '@root/middleware/shared/ports/types'
+
+import { describeProtocols } from '../describe/protocol'
+
+const opcUa: PLCServer = {
+  name: 'Ua',
+  protocol: 'opcua',
+  opcuaServerConfig: {
+    server: {
+      enabled: true,
+      name: 'Server',
+      applicationUri: 'urn:a',
+      productUri: 'urn:b',
+      bindAddress: '0.0.0.0',
+      port: 4840,
+      endpointPath: '/openplc/opcua',
+    },
+    securityProfiles: [],
+    security: {
+      serverCertificateStrategy: 'custom',
+      serverCertificateCustom: 'PUBLIC CERT',
+      serverPrivateKeyCustom: 'THE PRIVATE KEY',
+      trustedClientCertificates: [],
+    },
+    users: [
+      { id: 'u1', type: 'password', username: 'op', passwordHash: 'THE HASH', certificateId: null, role: 'operator' },
+    ],
+    cycleTimeMs: 100,
+    addressSpace: { namespaceUri: 'urn:ns', nodes: [] },
+  },
+}
+
+const fieldIo: PLCRemoteDevice = {
+  name: 'FieldIO',
+  protocol: 'modbus-tcp',
+  modbusTcpConfig: {
+    transport: 'tcp',
+    host: '10.0.0.1',
+    port: 502,
+    timeout: 1000,
+    ioGroups: [
+      {
+        id: 'group-A',
+        name: 'A',
+        functionCode: '2',
+        cycleTime: 100,
+        offset: '0x0000',
+        length: 3,
+        errorHandling: 'keep-last-value',
+        ioPoints: [
+          { id: 'p0', name: 'A_0', type: 'Digital Input', iecLocation: '%IX0.0', alias: 'fStart' },
+          { id: 'p1', name: 'A_1', type: 'Digital Input', iecLocation: '%IX0.1' },
+          { id: 'p2', name: 'A_2', type: 'Digital Input', iecLocation: '%IX0.2', alias: 'fStop' },
+        ],
+      },
+    ],
+  },
+}
+
+describe('describing an OPC-UA server', () => {
+  const described = describeProtocols([opcUa], [])
+  const serialized = JSON.stringify(described.servers)
+
+  it('leaves the private key and every password hash out', () => {
+    expect(serialized).not.toContain('THE PRIVATE KEY')
+    expect(serialized).not.toContain('THE HASH')
+  })
+
+  it('keeps the public certificate, which is not a secret', () => {
+    expect(serialized).toContain('PUBLIC CERT')
+  })
+
+  it('hoists the enable flag out of its nested home', () => {
+    expect(described.servers[0].enabled).toBe(true)
+    expect(JSON.stringify(described.servers[0])).not.toContain('"enabled":true,"name":"Server"')
+  })
+})
+
+describe('describing a Modbus master', () => {
+  const described = describeProtocols([], [fieldIo])
+  const group = (described.remoteDevices[0].modbus as { ioGroups: Record<string, unknown>[] }).ioGroups[0]
+
+  it('emits the aliases, which are authored', () => {
+    expect(group.aliases).toEqual(['fStart', '', 'fStop'])
+  })
+
+  it('leaves out the derived id and the allocated points', () => {
+    expect('id' in group).toBe(false)
+    expect('ioPoints' in group).toBe(false)
+  })
+
+  it('reports the allocated addresses outside the spec', () => {
+    // Allocation decides these, so a spec carrying them would stop
+    // round-tripping the moment allocation differed.
+    expect(described.protocolAddresses).toEqual([
+      { device: 'FieldIO', group: 'A', point: 'A_0', type: 'Digital Input', iecLocation: '%IX0.0', alias: 'fStart' },
+      { device: 'FieldIO', group: 'A', point: 'A_1', type: 'Digital Input', iecLocation: '%IX0.1' },
+      { device: 'FieldIO', group: 'A', point: 'A_2', type: 'Digital Input', iecLocation: '%IX0.2', alias: 'fStop' },
+    ])
+  })
+
+  it('drops trailing unnamed points rather than padding the alias list', () => {
+    const trailing = structuredClone(fieldIo)
+    delete trailing.modbusTcpConfig!.ioGroups[0].ioPoints![2].alias
+    const only = describeProtocols([], [trailing])
+    const groups = (only.remoteDevices[0].modbus as { ioGroups: Record<string, unknown>[] }).ioGroups[0]
+    expect(groups.aliases).toEqual(['fStart'])
+  })
+})

--- a/src/cli/__tests__/force-settle.test.ts
+++ b/src/cli/__tests__/force-settle.test.ts
@@ -147,3 +147,66 @@ describe('force read-back', () => {
     expect(response.error.code).toBe(ErrorCode.NotConnected)
   })
 })
+
+/**
+ * A duration reads back as a formatted literal, never as the literal that was
+ * written: `T#1s` comes back `1s`, and `T#1500ms` comes back `1s500ms`. Compared
+ * as text those never agree, so a write that HAD landed was polled to the
+ * timeout and reported as a target error — and the variable was left changed but
+ * not marked forced.
+ */
+describe('force read-back of a duration', () => {
+  const oneSecondNs = (() => {
+    const bytes = new Uint8Array(8)
+    new DataView(bytes.buffer).setBigInt64(0, 1_000_000_000n, true)
+    return bytes
+  })()
+
+  const timeVariable: ResolvedVariable = { name: 'main:preset', index: 0, arr: 0, elem: 0, type: 'TIME', size: 8 }
+
+  function makeTimeCore() {
+    const channel = {
+      connect: () => Promise.resolve(),
+      disconnect: () => undefined,
+      getVariablesList: () => Promise.resolve({ success: true as const, tick: 1, lastIndex: 0, data: oneSecondNs }),
+      setVariable: () => Promise.resolve({ success: true as const }),
+      getMd5Hash: () => Promise.resolve({ success: true as const, md5: 'abc', targetEndian: 'le' as const }),
+    }
+    const index: DebugVariableIndex = {
+      md5: 'abc',
+      warnings: [],
+      all: [timeVariable],
+      byName: new Map([['MAIN:PRESET', timeVariable]]),
+      byIndex: new Map([[0, timeVariable]]),
+    }
+    let reads = 0
+    return new SessionCore({
+      sessionId: 'test',
+      projectPath: '/tmp/project',
+      target: 'Test Board',
+      transport: 'rtu',
+      descriptor: '/dev/null',
+      channel,
+      index,
+      plc,
+      programMd5: 'abc',
+      endian: 'le',
+      batchSize: 8,
+      now: () => (reads += 400),
+    })
+  }
+
+  it.each(['T#1s', 't#1000ms', 'TIME#1s'])('accepts %s rather than timing out', async (requested) => {
+    const response = await makeTimeCore().handle({ id: 1, kind: 'force', name: 'main:preset', value: requested })
+
+    expect(response.ok).toBe(true)
+  })
+
+  it('marks the variable forced', async () => {
+    const response = await makeTimeCore().handle({ id: 1, kind: 'force', name: 'main:preset', value: 'T#1s' })
+
+    expect(response.ok).toBe(true)
+    if (!response.ok) throw new Error('expected success')
+    expect(response).toMatchObject({ data: { value: { name: 'main:preset', value: '1s', forced: true } } })
+  })
+})

--- a/src/cli/__tests__/force-settle.test.ts
+++ b/src/cli/__tests__/force-settle.test.ts
@@ -209,4 +209,24 @@ describe('force read-back of a duration', () => {
     if (!response.ok) throw new Error('expected success')
     expect(response).toMatchObject({ data: { value: { name: 'main:preset', value: '1s', forced: true } } })
   })
+
+  it.each(['T#1s500ms', 'T#1500ms', 'TIME#1500MS'])('does not settle %s against a 1s read-back', async (requested) => {
+    // All three spell 1.5s — mixed units, a single unit, and a different case.
+    // Each parses to the same value, and none of them is the 1s this channel
+    // reads back, so none may settle.
+    const response = await makeTimeCore().handle({ id: 1, kind: 'force', name: 'main:preset', value: requested })
+
+    expect(response.ok).toBe(false)
+  })
+
+  it('refuses a duration that read back as a DIFFERENT value', async () => {
+    // The point of parsing rather than accepting any string: `T#2s` against a
+    // channel stuck at 1s is a force that did not land, and reporting it as
+    // settled hides exactly the failure this file exists to catch.
+    const response = await makeTimeCore().handle({ id: 1, kind: 'force', name: 'main:preset', value: 'T#2s' })
+
+    expect(response.ok).toBe(false)
+    if (response.ok) throw new Error('expected a failure')
+    expect(response.error.code).toBe(ErrorCode.TargetError)
+  })
 })

--- a/src/cli/__tests__/ladder-block-pins.test.ts
+++ b/src/cli/__tests__/ladder-block-pins.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Two blocks in one POU that declare the same pin name.
+ *
+ * The pin map used to be keyed on the pin name alone, for the whole POU, so
+ * three SoftMotion blocks each declaring `POSITION` collided and the last entry
+ * in the document silently won on all of them — a homing move and an index move
+ * both went to the current position. The diagram drew correctly and the project
+ * compiled; only the generated ST showed it.
+ */
+
+import { openPLCStoreBase } from '@root/frontend/store'
+
+import { applyLadderBody } from '../apply/ladder'
+import type { SpecLadderBody } from '../apply/schema'
+
+const TON = 'system/iec-standard-fb/TON'
+
+/** Both timers in ONE rung: power runs through the first and on into the second. */
+const body: SpecLadderBody = {
+  rungs: [
+    {
+      comment: 'two timers in series, each with its own preset',
+      logic: { contact: { variable: 'A', variant: 'default' } },
+      outputs: [
+        { block: { call: TON, instance: 't1', inputs: { PT: 'FirstPreset' } } },
+        { block: { call: TON, instance: 't2', inputs: { PT: 'SecondPreset' } } },
+      ],
+    },
+    {
+      comment: 'a third, in a rung of its own',
+      logic: { contact: { variable: 'B', variant: 'default' } },
+      outputs: [{ block: { call: TON, instance: 't3', inputs: { PT: 'ThirdPreset' } } }],
+    },
+  ],
+}
+
+describe('applyLadderBody — a pin name shared by two blocks', () => {
+  it('gives each block the variable the spec asked for', () => {
+    const state = openPLCStoreBase.getState()
+    state.pouActions.create({ name: 'Timers', type: 'program', language: 'ld' } as never)
+
+    const errors = applyLadderBody('Timers', body)
+    expect(errors).toEqual([])
+
+    const flow = openPLCStoreBase.getState().ladderFlows.find((entry) => entry.name === 'Timers')
+
+    /** Every `PT` element in a rung, in the order its owning block was placed. */
+    const presetsIn = (rung: number) => {
+      const nodes = flow?.rungs[rung].nodes ?? []
+      const blocks = nodes.filter((node) => node.type === 'block').map((node) => node.id)
+      return blocks.map((blockId) => {
+        const element = nodes.find((node) => {
+          const data = node.data as { block?: { id?: string; handleId?: string } }
+          return node.type === 'variable' && data.block?.id === blockId && data.block.handleId === 'PT'
+        })
+        return (element?.data as { variable?: { name?: string } } | undefined)?.variable?.name
+      })
+    }
+
+    // Two blocks in the same rung, each keeping its own preset.
+    expect(presetsIn(0)).toEqual(['FirstPreset', 'SecondPreset'])
+    // And a block in another rung is not reached by either.
+    expect(presetsIn(1)).toEqual(['ThirdPreset'])
+  })
+})
+
+/**
+ * Naming a pin's variable is only half of what the GUI does: it also records the
+ * connection on the BLOCK, in `data.connectedVariables`. That list is what tells
+ * the editor a pin already shows its own value — `BlockOutputDebugBadges` skips
+ * an output it finds there. Leaving it empty drew the debug value twice on every
+ * named output pin, once from the element and once from the block.
+ */
+describe('applyLadderBody — the connection recorded on the block', () => {
+  it('records each named pin, so the editor knows the pin shows its own value', () => {
+    const state = openPLCStoreBase.getState()
+    state.pouActions.create({ name: 'Recorded', type: 'program', language: 'ld' } as never)
+
+    const errors = applyLadderBody('Recorded', {
+      rungs: [
+        {
+          logic: { contact: { variable: 'A', variant: 'default' } },
+          outputs: [{ block: { call: TON, instance: 't1', inputs: { PT: 'Preset' }, outputs: { ET: 'Elapsed' } } }],
+        },
+      ],
+    } as SpecLadderBody)
+    expect(errors).toEqual([])
+
+    const flow = openPLCStoreBase.getState().ladderFlows.find((entry) => entry.name === 'Recorded')
+    const block = (flow?.rungs[0].nodes ?? []).find((node) => node.type === 'block')
+    const recorded = (block?.data as { connectedVariables?: Array<{ handleId: string; type: string }> })
+      .connectedVariables
+
+    expect(recorded).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ handleId: 'PT', type: 'input' }),
+        // The output is the one that matters: without it the value is drawn twice.
+        expect.objectContaining({ handleId: 'ET', type: 'output' }),
+      ]),
+    )
+  })
+})

--- a/src/cli/__tests__/lint-program.test.ts
+++ b/src/cli/__tests__/lint-program.test.ts
@@ -1,0 +1,261 @@
+/**
+ * The linter exists because all of this COMPILES. Every fixture here is a
+ * program `check` passes and a PLC would run doing nothing useful.
+ *
+ * The negative cases matter as much as the positive ones: a rule that fires on
+ * correct code teaches an agent to ignore the linter, which is worse than not
+ * having one.
+ */
+
+import type { SystemLibrary } from '@root/middleware/shared/ports/library-types'
+import type { PLCPou, PLCVariable } from '@root/middleware/shared/ports/types'
+
+import { lintProgram } from '../lint/program'
+
+const TON: SystemLibrary = {
+  name: 'iec-standard-fb',
+  version: '1.0.0',
+  pous: [
+    {
+      name: 'TON',
+      type: 'function-block',
+      variables: [
+        { name: 'IN', class: 'input', type: { definition: 'base-type', value: 'BOOL' } },
+        { name: 'PT', class: 'input', type: { definition: 'base-type', value: 'TIME' } },
+        { name: 'Q', class: 'output', type: { definition: 'base-type', value: 'BOOL' } },
+        { name: 'ET', class: 'output', type: { definition: 'base-type', value: 'TIME' } },
+      ],
+    },
+  ],
+} as unknown as SystemLibrary
+
+const pou = (name: string, variables: Array<Partial<PLCVariable>>): PLCPou =>
+  ({ name, interface: { variables } }) as unknown as PLCPou
+
+const timerPou = pou('Main', [
+  { name: 'holdOff', class: 'local', type: { definition: 'derived', value: 'TON' } },
+  { name: 'Run', class: 'local', type: { definition: 'base-type', value: 'BOOL' } },
+])
+
+const lint = (st: string, pous = [timerPou], globals: Array<Partial<PLCVariable>> = []) =>
+  lintProgram({ st, pous, systemLibraries: [TON], globals: globals as PLCVariable[] })
+
+const rules = (st: string, pous?: PLCPou[], globals?: Array<Partial<PLCVariable>>) =>
+  lint(st, pous, globals).map((finding) => finding.rule)
+
+describe('a block that is called but never driven', () => {
+  it('reports a timer wired EN/ENO with IN left open', () => {
+    const findings = lint(`PROGRAM Main
+  VAR holdOff : TON; END_VAR
+  holdOff(EN := Run, PT := HoldTime);
+  Settled := holdOff.ENO;
+END_PROGRAM`)
+
+    const primary = findings.find((finding) => finding.rule === 'block-primary-input-unassigned')
+    expect(primary?.severity).toBe('error')
+    expect(primary?.message).toContain('"IN"')
+    // The EN/ENO shape is the cause, so the message says so.
+    expect(primary?.message).toContain('EN/ENO')
+  })
+
+  it('says nothing when the input IS driven', () => {
+    expect(
+      rules(`PROGRAM Main
+  VAR holdOff : TON; END_VAR
+  holdOff(IN := Run, PT := HoldTime);
+  Settled := holdOff.Q;
+END_PROGRAM`),
+    ).toEqual([])
+  })
+
+  it('reports a block whose outputs nothing reads', () => {
+    expect(
+      rules(`PROGRAM Main
+  VAR holdOff : TON; END_VAR
+  holdOff(IN := Run, PT := HoldTime);
+END_PROGRAM`),
+    ).toContain('block-outputs-unread')
+  })
+})
+
+describe('a variable driven more than once', () => {
+  it('reports two unconditional assignments', () => {
+    const findings = lint(`PROGRAM Main
+  VAR holdOff : TON; END_VAR
+  holdOff(IN := Run, PT := HoldTime);
+  Settled := Ready;
+  Settled := holdOff.Q;
+END_PROGRAM`)
+
+    const doubled = findings.find((finding) => finding.rule === 'variable-driven-twice')
+    expect(doubled?.severity).toBe('error')
+    expect(doubled?.message).toContain('double coil')
+  })
+
+  it('does NOT report a SET and a RESET coil on the same variable', () => {
+    // The idiomatic ladder pair, which transpiles to two guarded assignments.
+    // Counting them as a double drive would fire on correct code.
+    expect(
+      rules(`PROGRAM Main
+  VAR holdOff : TON; END_VAR
+  holdOff(IN := Run, PT := HoldTime);
+  Settled := holdOff.Q;
+  R_TRIG1(CLK := Run);
+  IF R_TRIG1.Q THEN
+    Alarm := FALSE;
+  END_IF;
+  F_TRIG1(CLK := Run);
+  IF F_TRIG1.Q THEN
+    Alarm := TRUE;
+  END_IF;
+END_PROGRAM`),
+    ).toEqual([])
+  })
+
+  it('does NOT count writes to two members of the same structure', () => {
+    expect(
+      rules(`PROGRAM Main
+  VAR holdOff : TON; END_VAR
+  holdOff(IN := Run, PT := HoldTime);
+  Settled := holdOff.Q;
+  Cfg.MinLevel := 1;
+  Cfg.MaxLevel := 9;
+END_PROGRAM`),
+    ).toEqual([])
+  })
+})
+
+describe('reaching the outside world', () => {
+  const located = [
+    { name: 'gStart', location: '%IX0.0' },
+    { name: 'gPump', location: '%QX0.0' },
+  ]
+  const body = `PROGRAM Main
+  VAR holdOff : TON; END_VAR
+  holdOff(IN := Run, PT := HoldTime);
+  Settled := holdOff.Q;
+END_PROGRAM`
+
+  it('reports a program that touches no located global at all', () => {
+    const findings = lint(body, [timerPou], located)
+    const io = findings.find((finding) => finding.rule === 'no-io-referenced')
+    expect(io?.severity).toBe('error')
+    expect(io?.pou).toBeNull()
+  })
+
+  it('reports only the unreferenced one when some I/O is wired', () => {
+    const wired = body.replace('holdOff(IN := Run', 'holdOff(IN := gStart')
+    const findings = lint(wired, [timerPou], located)
+
+    expect(findings.map((finding) => finding.rule)).toEqual(['located-global-unreferenced'])
+    expect(findings[0].severity).toBe('warning')
+    expect(findings[0].message).toContain('gPump')
+  })
+
+  it('says nothing when every located global is referenced', () => {
+    const wired = body.replace('holdOff(IN := Run', 'holdOff(IN := gStart').replace('Settled :=', 'gPump :=')
+    expect(rules(wired, [timerPou], located)).toEqual([])
+  })
+
+  it('ignores a global a comment merely mentions', () => {
+    const commented = body.replace('holdOff(IN := Run', '(* gStart and gPump are spares *)\n  holdOff(IN := Run')
+    expect(rules(commented, [timerPou], located)).toContain('no-io-referenced')
+  })
+})
+
+/**
+ * The editor generates this POU itself when a project has SoftMotion axes, so
+ * anything it reports here is a finding no author can act on — the worst kind.
+ * Both fixtures are the real shape, copied from `--emit-st` output.
+ */
+describe('a call whose arguments are written one per line', () => {
+  const bridge = `PROGRAM __sm3_bridge
+  VAR Axis1_drive : SM_DRIVE; Axis2_drive : SM_DRIVE; END_VAR
+  Axis1.fScalefactor := 1048576.0;
+  Axis1_drive(
+  \tAxis := Axis1,
+  \twStatusWord := Axis1_statusWord,
+  \tbOnline := TRUE,
+  \twControlWord => Axis1_controlWord);
+  Axis2.fScalefactor := 1.0;
+  Axis2_drive(
+  \tAxis := Axis2,
+  \twStatusWord := Axis2_statusWord,
+  \tbOnline := TRUE,
+  \twControlWord => Axis2_controlWord);
+END_PROGRAM`
+
+  const drive = pou('__sm3_bridge', [
+    { name: 'Axis1_drive', class: 'local', type: { definition: 'derived', value: 'SM_DRIVE' } },
+    { name: 'Axis2_drive', class: 'local', type: { definition: 'derived', value: 'SM_DRIVE' } },
+  ])
+
+  const SM_DRIVE: SystemLibrary = {
+    name: 'softmotion',
+    version: '1.0.0',
+    pous: [
+      {
+        name: 'SM_DRIVE',
+        type: 'function-block',
+        variables: [
+          { name: 'Axis', class: 'inOut', type: { definition: 'derived', value: 'AXIS_REF_SM3' } },
+          { name: 'wStatusWord', class: 'input', type: { definition: 'base-type', value: 'UINT' } },
+          { name: 'bOnline', class: 'input', type: { definition: 'base-type', value: 'BOOL' } },
+          { name: 'wControlWord', class: 'output', type: { definition: 'base-type', value: 'UINT' } },
+        ],
+      },
+    ],
+  } as unknown as SystemLibrary
+
+  const findings = () => lintProgram({ st: bridge, pous: [drive], systemLibraries: [SM_DRIVE, TON], globals: [] })
+
+  it('does not read a named argument as an assignment', () => {
+    // `wStatusWord := Axis1_statusWord,` on its own line is an argument, not a
+    // statement; counting two calls as two drives of "WSTATUSWORD" fires on
+    // code the editor itself wrote.
+    expect(findings().map((finding) => finding.rule)).not.toContain('variable-driven-twice')
+  })
+
+  it('counts an output sent out by the call itself as read', () => {
+    expect(findings().map((finding) => finding.rule)).not.toContain('block-outputs-unread')
+  })
+
+  it('still reports a genuine double drive around a multi-line call', () => {
+    const doubled = bridge.replace(
+      'Axis2.fScalefactor := 1.0;',
+      'Axis1.fScalefactor := 1.0;\n  Spare := 1;\n  Spare := 2;',
+    )
+    const rules = lintProgram({
+      st: doubled,
+      pous: [drive],
+      systemLibraries: [SM_DRIVE, TON],
+      globals: [],
+    }).map((finding) => finding.rule)
+    expect(rules).toContain('variable-driven-twice')
+  })
+})
+
+describe('splitting the ST', () => {
+  it('ends a FUNCTION_BLOCK at END_FUNCTION_BLOCK, not at END_FUNCTION', () => {
+    // `FUNCTION` is a prefix of `FUNCTION_BLOCK`; matched in the wrong order the
+    // block's body is truncated and its calls disappear from the analysis.
+    const st = `FUNCTION_BLOCK Latch
+  VAR holdOff : TON; END_VAR
+  holdOff(EN := Run, PT := HoldTime);
+END_FUNCTION_BLOCK
+
+FUNCTION Scale : REAL
+  Scale := 1.0;
+END_FUNCTION`
+
+    const findings = lintProgram({
+      st,
+      pous: [pou('Latch', [{ name: 'holdOff', class: 'local', type: { definition: 'derived', value: 'TON' } }])],
+      systemLibraries: [TON],
+      globals: [],
+    })
+
+    expect(findings.map((finding) => finding.rule)).toContain('block-primary-input-unassigned')
+    expect(findings[0].pou).toBe('Latch')
+  })
+})

--- a/src/cli/__tests__/lint-protocol.test.ts
+++ b/src/cli/__tests__/lint-protocol.test.ts
@@ -195,3 +195,68 @@ describe('an EtherCAT bus', () => {
     expect(rules({ remoteDevices: [broken] })).toContain('ethercat-config-invalid')
   })
 })
+
+describe('an OPC-UA server left on the shipped profile', () => {
+  const opcuaServer = (profiles: { enabled: boolean; policy: string; mode: string; auth: string[] }[]): PLCServer =>
+    ({
+      name: 'OPC',
+      protocol: 'opc-ua',
+      opcuaServerConfig: {
+        server: {
+          enabled: true,
+          name: 'OpenPLC OPC UA Server',
+          applicationUri: 'urn:openplc:opcua:server',
+          productUri: 'urn:openplc:runtime',
+          bindAddress: '0.0.0.0',
+          port: 4840,
+          endpointPath: '/openplc/opcua',
+        },
+        securityProfiles: profiles.map((profile, index) => ({
+          id: `profile-${index}`,
+          name: `profile-${index}`,
+          enabled: profile.enabled,
+          securityPolicy: profile.policy,
+          securityMode: profile.mode,
+          authMethods: profile.auth,
+        })),
+        security: {
+          serverCertificateStrategy: 'auto_self_signed',
+          serverCertificateCustom: null,
+          serverPrivateKeyCustom: null,
+          trustedClientCertificates: [],
+        },
+        users: [],
+        cycleTimeMs: 100,
+        addressSpace: { namespaceUri: 'urn:openplc:opcua:namespace', nodes: [] },
+      },
+    }) as unknown as PLCServer
+
+  const anonymous = { enabled: true, policy: 'None', mode: 'None', auth: ['Anonymous'] }
+  const signed = { enabled: true, policy: 'Basic256Sha256', mode: 'SignAndEncrypt', auth: ['UserName'] }
+
+  it('warns when the only enabled profile is the shipped anonymous one', () => {
+    expect(rules({ servers: [opcuaServer([anonymous])] })).toContain('opcua-server-unauthenticated')
+  })
+
+  it('stays quiet once a real profile is enabled alongside it', () => {
+    expect(rules({ servers: [opcuaServer([anonymous, signed])] })).not.toContain('opcua-server-unauthenticated')
+  })
+
+  it('stays quiet when the anonymous profile is disabled', () => {
+    expect(rules({ servers: [opcuaServer([{ ...anonymous, enabled: false }, signed])] })).not.toContain(
+      'opcua-server-unauthenticated',
+    )
+  })
+
+  it('says the address and port, which is what makes the warning actionable', () => {
+    const finding = lintProtocols({
+      servers: [opcuaServer([anonymous])],
+      remoteDevices: [],
+      debugMapContent: '',
+      instances: [],
+      globals: [],
+    }).find((f) => f.rule === 'opcua-server-unauthenticated')
+    expect(finding?.message).toContain('0.0.0.0:4840')
+    expect(finding?.severity).toBe('warning')
+  })
+})

--- a/src/cli/__tests__/lint-protocol.test.ts
+++ b/src/cli/__tests__/lint-protocol.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Every fixture here is a project that saves, compiles and uploads. The
+ * negative cases carry as much weight as the positive ones: the collision rule
+ * in particular fired on correct code the first time it met a real project,
+ * because a global bound by ALIAS resolves to its device's own address.
+ */
+
+import type { PLCRemoteDevice, PLCServer, PLCVariable } from '@root/middleware/shared/ports/types'
+
+import { lintProtocols } from '../lint/protocol'
+
+const modbusServer = (name: string, enabled: boolean, port = 502): PLCServer => ({
+  name,
+  protocol: 'modbus-tcp',
+  modbusSlaveConfig: { enabled, networkInterface: '0.0.0.0', port },
+})
+
+const device = (name: string, overrides: Partial<PLCRemoteDevice['modbusTcpConfig']> = {}): PLCRemoteDevice => ({
+  name,
+  protocol: 'modbus-tcp',
+  modbusTcpConfig: {
+    transport: 'tcp',
+    host: '10.0.0.1',
+    port: 502,
+    timeout: 1000,
+    ioGroups: [
+      {
+        id: 'group-A',
+        name: 'A',
+        functionCode: '1',
+        cycleTime: 100,
+        offset: '0x0000',
+        length: 2,
+        errorHandling: 'keep-last-value',
+        ioPoints: [
+          { id: 'p0', name: 'A_0', type: 'Digital Input', iecLocation: '%IX0.0' },
+          { id: 'p1', name: 'A_1', type: 'Digital Input', iecLocation: '%IX0.1' },
+        ],
+      },
+    ],
+    ...overrides,
+  },
+})
+
+const global = (name: string, location: string): PLCVariable =>
+  ({ name, class: 'global', type: { definition: 'base-type', value: 'BOOL' }, location }) as PLCVariable
+
+const rules = (input: { servers?: PLCServer[]; remoteDevices?: PLCRemoteDevice[]; globals?: PLCVariable[] }) =>
+  lintProtocols({
+    servers: input.servers ?? [],
+    remoteDevices: input.remoteDevices ?? [],
+    debugMapContent: '',
+    instances: [],
+    globals: input.globals ?? [],
+  }).map((finding) => finding.rule)
+
+describe('two servers of one protocol', () => {
+  it('reports both enabled, because the runtime takes one config', () => {
+    expect(rules({ servers: [modbusServer('A', true), modbusServer('B', true, 1502)] })).toContain(
+      'duplicate-protocol-server',
+    )
+  })
+
+  it('says nothing when only one is enabled', () => {
+    expect(rules({ servers: [modbusServer('A', true), modbusServer('B', false, 1502)] })).toEqual([])
+  })
+
+  it('reports a port two enabled servers share', () => {
+    const s7: PLCServer = {
+      name: 'S7',
+      protocol: 's7comm',
+      s7commSlaveConfig: {
+        server: {
+          enabled: true,
+          bindAddress: '0.0.0.0',
+          port: 502,
+          maxClients: 8,
+          workIntervalMs: 100,
+          sendTimeoutMs: 3000,
+          recvTimeoutMs: 3000,
+          pingTimeoutMs: 10000,
+          pduSize: 480,
+        },
+        dataBlocks: [],
+      },
+    }
+    expect(rules({ servers: [modbusServer('A', true), s7] })).toContain('server-port-conflict')
+  })
+})
+
+describe('a remote device the generator would drop', () => {
+  it('reports one with no I/O groups', () => {
+    expect(rules({ remoteDevices: [device('Empty', { ioGroups: [] })] })).toContain('modbus-device-without-io-groups')
+  })
+
+  it('reports RTU with no serial port', () => {
+    expect(rules({ remoteDevices: [device('Serial', { transport: 'rtu' })] })).toContain(
+      'modbus-rtu-without-serial-port',
+    )
+  })
+
+  it('says nothing about a complete TCP device', () => {
+    expect(rules({ remoteDevices: [device('Good')] })).toEqual([])
+  })
+})
+
+describe('a located global sharing an address with a device', () => {
+  it('reports a literal address the allocator also handed out', () => {
+    // The allocator's pool is built from the pin mapping, VPP and the remote
+    // devices — never from a global's hand-written location.
+    expect(rules({ remoteDevices: [device('Field')], globals: [global('gStart', '%IX0.0')] })).toContain(
+      'located-global-collides-with-remote-io',
+    )
+  })
+
+  it('does NOT report a global bound to the point by ALIAS', () => {
+    // This is the intended way to read a polled value, and reporting it taught
+    // the linter to be ignored the first time it met a real project.
+    expect(rules({ remoteDevices: [device('Field')], globals: [global('fCoil0', 'fCoil0')] })).toEqual([])
+  })
+
+  it('does NOT report a different storage class at the same index', () => {
+    // `bool_input` and `int_input` are separate arrays in the runtime, so
+    // %IX0.0 and %IW0 are not the same storage.
+    expect(rules({ remoteDevices: [device('Field')], globals: [global('gLevel', '%IW0')] })).toEqual([])
+  })
+
+  it('does NOT report an address no device claims', () => {
+    expect(rules({ remoteDevices: [device('Field')], globals: [global('gSpare', '%IX10.0')] })).toEqual([])
+  })
+
+  it('treats a bitless bit address as bit 0', () => {
+    expect(rules({ remoteDevices: [device('Field')], globals: [global('gStart', '%IX0')] })).toContain(
+      'located-global-collides-with-remote-io',
+    )
+  })
+})
+
+describe('an EtherCAT bus', () => {
+  // The stored shape: the generator dereferences every one of these.
+  const slaveConfig = {
+    startupChecks: { checkVendorId: true, checkProductCode: true },
+    addressing: { ethercatAddress: 1001 },
+    timeouts: { sdoTimeoutMs: 1000, initToPreOpTimeoutMs: 3000, safeOpToOpTimeoutMs: 10000 },
+    watchdog: { smWatchdogEnabled: true, smWatchdogMs: 100, pdiWatchdogEnabled: true, pdiWatchdogMs: 100 },
+    distributedClocks: {
+      dcEnabled: false,
+      dcSyncUnitCycleUs: 0,
+      dcSync0Enabled: false,
+      dcSync0CycleUs: 0,
+      dcSync0ShiftUs: 0,
+      dcSync1Enabled: false,
+      dcSync1CycleUs: 0,
+      dcSync1ShiftUs: 0,
+    },
+  }
+
+  const slave = (name: string, channelMappings: unknown[]) => ({
+    id: name,
+    name,
+    position: 0,
+    esiDeviceRef: { repositoryItemId: 'file', deviceIndex: 0 },
+    vendorId: '0x1',
+    productCode: '0x2',
+    revisionNo: '0x3',
+    addedFrom: 'repository',
+    config: slaveConfig,
+    channelMappings,
+  })
+
+  const bus = (devices: unknown[]): PLCRemoteDevice =>
+    ({
+      name: 'Bus',
+      protocol: 'ethercat',
+      ethercatConfig: { masterConfig: { networkInterface: 'eth0', cycleTimeUs: 1000 }, devices },
+    }) as PLCRemoteDevice
+
+  it('reports a master with no slaves', () => {
+    expect(rules({ remoteDevices: [bus([])] })).toContain('ethercat-master-without-slaves')
+  })
+
+  it('reports a slave with no channel mappings', () => {
+    expect(rules({ remoteDevices: [bus([slave('Axis1', [])])] })).toContain('ethercat-slave-without-channels')
+  })
+
+  it('says nothing about a slave that exchanges data', () => {
+    const wired = bus([slave('Axis1', [{ channelId: 'c0', iecLocation: '%IW4' }])])
+    expect(rules({ remoteDevices: [wired] })).toEqual([])
+  })
+
+  it('reports rather than crashes when the generator cannot build the config', () => {
+    // `check` running the linter must survive a project shape the generator
+    // dereferences without a guard.
+    const broken = bus([{ name: 'NoConfig', channelMappings: [{ channelId: 'c0', iecLocation: '%IW4' }] }])
+    expect(rules({ remoteDevices: [broken] })).toContain('ethercat-config-invalid')
+  })
+})

--- a/src/cli/__tests__/load-hydration.test.ts
+++ b/src/cli/__tests__/load-hydration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * `loadProject` hydrates the library pool, and does it FIRST.
+ *
+ * `handleOpenProjectResponse` reads `libraries.system` and re-stamps every
+ * placed block against it inside the same action, and `setProjectLibraries`
+ * derives the enabled/missing lists from it. A pool hydrated afterwards is a
+ * pool neither of them saw.
+ *
+ * Ordering is the whole assertion. `jest-vi-shim.ts` already hydrates system
+ * libraries for every spec in this repo, so a test that merely checks the pool
+ * is populated passes whether or not `loadProject` does anything at all. The
+ * store is mocked rather than spied on because its real state is immer-frozen
+ * and cannot be instrumented in place.
+ */
+
+import { loadProject } from '../project/load'
+
+const archives = [{ manifest: { name: 'demo', version: '1.0.0' } }]
+
+/** Call order, in the order `loadProject` drives the store. */
+const calls: string[] = []
+const record =
+  (name: string) =>
+  (...args: unknown[]) => {
+    calls.push(name)
+    return args
+  }
+
+let setSystemLibraries: jest.Mock
+let setBundledLibraryNames: jest.Mock
+let canEdit = true
+let isEphemeralProject = false
+
+jest.mock('@root/frontend/store', () => ({
+  openPLCStoreBase: {
+    getState: () => ({
+      deviceActions: { setAvailableOptions: record('setAvailableOptions') },
+      libraryActions: {
+        setSystemLibraries,
+        setBundledLibraryNames,
+      },
+      sharedWorkspaceActions: { handleOpenProjectResponse: record('handleOpenProjectResponse') },
+      project: { meta: { name: 'demo' }, data: {} },
+      projectActions: { getCompileReadyProjectData: () => ({}) },
+      workspace: { canEdit, isEphemeralProject },
+      deviceDefinitions: {
+        configuration: { deviceBoard: 'Uno', vendorScreenData: undefined, communicationPort: undefined },
+      },
+    }),
+  },
+}))
+
+jest.mock('@root/backend/editor/hardware', () => ({
+  HardwareModule: jest.fn().mockImplementation(() => ({ getAvailableBoards: async () => [] })),
+}))
+
+jest.mock('@root/backend/editor/services', () => ({
+  ProjectService: jest.fn().mockImplementation(() => ({
+    readRawProjectFiles: async () => ({
+      success: true,
+      data: { projectPath: '/tmp/p', projectJson: {}, pouFiles: [], dataTypeFiles: [] },
+    }),
+  })),
+}))
+
+jest.mock('@root/backend/shared/utils/parse-project-files', () => ({
+  parseProjectFiles: () => ({ warnings: ['a parse warning'] }),
+}))
+
+jest.mock('@root/backend/editor/library-manager', () => ({
+  LibraryManagerModule: jest.fn().mockImplementation(() => ({
+    loadAll: () => archives,
+    listInstalled: () => [
+      { name: 'bundled-one', bundled: true },
+      { name: 'user-one', bundled: false },
+    ],
+  })),
+}))
+
+jest.mock('@root/frontend/utils/stlib-to-system-library', () => ({
+  stlibsToSystemLibraries: (input: unknown) => input,
+}))
+
+beforeEach(() => {
+  calls.length = 0
+  canEdit = true
+  isEphemeralProject = false
+  setSystemLibraries = jest.fn(record('setSystemLibraries'))
+  setBundledLibraryNames = jest.fn(record('setBundledLibraryNames'))
+})
+
+describe('loadProject library hydration', () => {
+  it('sets the system libraries before opening the project', async () => {
+    await loadProject('/tmp/p')
+
+    expect(calls).toEqual([
+      'setAvailableOptions',
+      'setSystemLibraries',
+      'setBundledLibraryNames',
+      'handleOpenProjectResponse',
+    ])
+  })
+
+  it('passes the installed archives through, and names only the bundled ones', async () => {
+    await loadProject('/tmp/p')
+
+    expect(setSystemLibraries).toHaveBeenCalledWith(archives)
+    expect(setBundledLibraryNames).toHaveBeenCalledWith(['bundled-one'])
+  })
+
+  it('warns rather than failing the load when the library store cannot be read', async () => {
+    setSystemLibraries = jest.fn(() => {
+      throw new Error('registry unreadable')
+    })
+
+    const result = await loadProject('/tmp/p')
+
+    expect(result.success).toBe(true)
+    expect(result.success && result.project.warnings).toEqual([
+      'warning: could not read the installed libraries: registry unreadable',
+      'a parse warning',
+    ])
+  })
+})
+
+describe('loadProject save guards', () => {
+  // `executeSaveProject` refuses on either of these and reports only through a
+  // toast, so a writing command that does not check them exits 0 having written
+  // nothing.
+  it('reports the workspace flags a writing command has to check', async () => {
+    const result = await loadProject('/tmp/p')
+
+    expect(result.success && result.project.canEdit).toBe(true)
+    expect(result.success && result.project.isEphemeral).toBe(false)
+  })
+
+  it('carries a read-only workspace through rather than hiding it', async () => {
+    canEdit = false
+    isEphemeralProject = true
+
+    const result = await loadProject('/tmp/p')
+
+    expect(result.success && result.project.canEdit).toBe(false)
+    expect(result.success && result.project.isEphemeral).toBe(true)
+  })
+})

--- a/src/cli/__tests__/protocol-confs.test.ts
+++ b/src/cli/__tests__/protocol-confs.test.ts
@@ -1,0 +1,101 @@
+/**
+ * `check --protocols` answers "which plugins will be on", and the runtime has
+ * no endpoint that answers it. These assertions are the whole basis for that
+ * claim, so they pin the exact conf set per project shape.
+ */
+
+import type { PLCProjectData, PLCRemoteDevice, PLCServer } from '@root/middleware/shared/ports/types'
+
+import { describeProtocolConfs } from '../check/protocol-confs'
+
+const project = (servers: PLCServer[], remoteDevices: PLCRemoteDevice[] = []): PLCProjectData =>
+  ({
+    servers,
+    remoteDevices,
+    configurations: { resource: { tasks: [], instances: [], globalVariables: [] } },
+    pous: [],
+    dataTypes: [],
+  }) as unknown as PLCProjectData
+
+const modbus = (name: string, enabled: boolean): PLCServer => ({
+  name,
+  protocol: 'modbus-tcp',
+  modbusSlaveConfig: { enabled, networkInterface: '0.0.0.0', port: 502 },
+})
+
+const s7 = (name: string, enabled: boolean): PLCServer => ({
+  name,
+  protocol: 's7comm',
+  s7commSlaveConfig: {
+    server: {
+      enabled,
+      bindAddress: '0.0.0.0',
+      port: 102,
+      maxClients: 8,
+      workIntervalMs: 100,
+      sendTimeoutMs: 3000,
+      recvTimeoutMs: 3000,
+      pingTimeoutMs: 10000,
+      pduSize: 480,
+    },
+    dataBlocks: [],
+  },
+})
+
+const enabledConfs = (data: PLCProjectData) => {
+  const result = describeProtocolConfs(data, '', () => undefined)
+  if (!result.ok) throw new Error(`expected confs, got: ${result.error}`)
+  return Object.entries(result.confs)
+    .filter(([, summary]) => summary.enabled)
+    .map(([name]) => name)
+    .sort()
+}
+
+describe('which conf files an upload would carry', () => {
+  it('carries none for a project with no protocols', () => {
+    expect(enabledConfs(project([]))).toEqual([])
+  })
+
+  it('carries modbus_slave for an enabled Modbus server', () => {
+    expect(enabledConfs(project([modbus('A', true)]))).toEqual(['modbusSlave'])
+  })
+
+  it('carries nothing for a DISABLED Modbus server', () => {
+    // The conf file IS the switch: shipping it opens port 502 on a device
+    // meant to have it closed.
+    expect(enabledConfs(project([modbus('A', false)]))).toEqual([])
+  })
+
+  it('carries s7comm even when the server is disabled', () => {
+    // By design — that plugin reads `enabled` itself and declines to serve.
+    expect(enabledConfs(project([s7('S', false)]))).toEqual(['s7comm'])
+  })
+
+  it('carries no ethercat.json when the project has no EtherCAT devices', () => {
+    // It used to be written unconditionally, which enabled the native plugin
+    // on every upload.
+    expect(enabledConfs(project([modbus('A', true)], []))).not.toContain('ethercat')
+  })
+
+  it('carries no modbus_master for a device with no I/O groups', () => {
+    const empty: PLCRemoteDevice = {
+      name: 'Empty',
+      protocol: 'modbus-tcp',
+      modbusTcpConfig: { transport: 'tcp', host: '10.0.0.1', port: 502, timeout: 1000, ioGroups: [] },
+    }
+    expect(enabledConfs(project([], [empty]))).toEqual([])
+  })
+
+  it('reports the reason instead of throwing when a generator refuses', () => {
+    const broken: PLCRemoteDevice = {
+      name: 'Bus',
+      protocol: 'ethercat',
+      ethercatConfig: {
+        masterConfig: { networkInterface: 'eth0', cycleTimeUs: 1000 },
+        devices: [{ name: 'NoConfig', channelMappings: [] }],
+      },
+    } as unknown as PLCRemoteDevice
+    const result = describeProtocolConfs(project([], [broken]), '', () => undefined)
+    expect(result.ok).toBe(false)
+  })
+})

--- a/src/cli/apply/fbd.ts
+++ b/src/cli/apply/fbd.ts
@@ -136,6 +136,17 @@ export function applyFbdBody(pouName: string, body: SpecFbdBody): string[] {
     })
   }
 
+  // A label is how a connection names a node, so two nodes sharing one makes
+  // every reference to it ambiguous — the graph builder keeps the last and the
+  // earlier node silently loses its wires.
+  const seenLabels = new Set<string>()
+  for (const node of nodes) {
+    if (seenLabels.has(node.label)) {
+      errors.push(`POU "${pouName}": two nodes are both labelled "${node.label}"; a label names one node.`)
+    }
+    seenLabels.add(node.label)
+  }
+
   if (errors.length > 0) return errors
 
   // Every pin a connection names must exist, or be one an extensible block can

--- a/src/cli/apply/fbd.ts
+++ b/src/cli/apply/fbd.ts
@@ -1,0 +1,175 @@
+/**
+ * Spec FBD body -> a placed, wired flow in the store.
+ *
+ * Node construction and layout live in `store/slices/fbd/utils/build-graph`,
+ * because the node builders are component modules the CLI may not import. What
+ * is left here is the part the CLI owns: resolving a block reference to its
+ * signature, and reporting failures in the spec's own vocabulary.
+ */
+
+import { openPLCStoreBase } from '@root/frontend/store'
+import { buildFbdGraph, type FbdGraphNode } from '@root/frontend/store/slices/fbd/utils/build-graph'
+import { buildBlockVariant } from '@root/frontend/utils/PLC/block-variant'
+
+import { unresolvedHandles } from './handles'
+import type { SpecFbdBody } from './schema'
+
+/** Pins the editor adds itself; they are not in a library's declared list. */
+const IMPLICIT_PINS = new Set(['EN', 'ENO'])
+
+/**
+ * Check every `label.PIN` against the block it names, growing an extensible
+ * block to fit.
+ *
+ * ADD, MUL, AND and friends declare `IN1`/`IN2` and accept any number — the GUI
+ * grows them with a `+`. A spec that wires `IN3` is asking for exactly that, so
+ * the pin is appended, typed like the last declared input. MUX is the odd one:
+ * it numbers from zero (`K`, `IN0`, `IN1`), so its next pin is `IN2`. A pin that
+ * is NOT a legal extension is an error, because the alternative is silence.
+ */
+function resolvePins(pouName: string, nodes: FbdGraphNode[], body: SpecFbdBody): string[] {
+  const errors: string[] = []
+  const byLabel = new Map(nodes.map((node) => [node.label, node]))
+
+  for (const connection of body.connections) {
+    for (const [ref, side] of [
+      [connection.from, 'source'],
+      [connection.to, 'target'],
+    ] as const) {
+      const dot = ref.indexOf('.')
+      if (dot < 0) continue
+      const label = ref.slice(0, dot)
+      const pin = ref.slice(dot + 1)
+      const node = byLabel.get(label)
+      if (!node || node.kind !== 'block') continue
+
+      const variant = node.variant as
+        | { name?: string; extensible?: boolean; variables?: Array<{ name: string; class?: string; type?: unknown }> }
+        | undefined
+      const pins = variant?.variables
+      if (!pins) continue
+      if (IMPLICIT_PINS.has(pin) || pins.some((entry) => entry.name === pin)) continue
+
+      const grown = growExtensiblePin(variant, pin)
+      if (grown) continue
+
+      const legal = pins.map((entry) => entry.name).join(', ')
+      errors.push(
+        `POU "${pouName}": block "${variant?.name ?? label}" has no ${side === 'source' ? 'output' : 'input'} pin ` +
+          `"${pin}". Its pins are: ${legal}.`,
+      )
+    }
+  }
+  return errors
+}
+
+/**
+ * Append `IN<n>` to an extensible block, typed like its last declared input.
+ * Returns false when the block is not extensible or the name is not the next
+ * numbered input.
+ */
+function growExtensiblePin(
+  variant: { extensible?: boolean; variables?: Array<{ name: string; class?: string; type?: unknown }> } | undefined,
+  pin: string,
+): boolean {
+  if (!variant?.extensible || !variant.variables) return false
+  const match = /^IN(\d+)$/.exec(pin)
+  if (!match) return false
+
+  const inputs = variant.variables.filter((entry) => entry.class === 'input' && /^IN\d+$/.test(entry.name))
+  const last = inputs[inputs.length - 1]
+  if (!last) return false
+
+  // Count from the HIGHEST existing index, not from how many there are: `MUX`
+  // numbers its inputs from zero (`K`, `IN0`, `IN1`), so a count-based next
+  // index skips `IN2` — accepting it as valid while adding no pin, and leaving
+  // a hole in the argument list if `IN3` is wired later.
+  const highest = Math.max(...inputs.map((entry) => Number(/^IN(\d+)$/.exec(entry.name)?.[1] ?? 0)))
+  const wanted = Number(match[1])
+  if (wanted <= highest) return true
+
+  // Grow one at a time so a jump from IN2 to IN9 does not leave holes the
+  // transpiler would emit as missing arguments.
+  for (let index = highest + 1; index <= wanted; index += 1) {
+    variant.variables.push({ ...last, name: `IN${index}` })
+  }
+  return true
+}
+
+export function applyFbdBody(pouName: string, body: SpecFbdBody): string[] {
+  const errors: string[] = []
+  const state = openPLCStoreBase.getState()
+
+  const nodes: FbdGraphNode[] = []
+  for (const spec of body.nodes) {
+    let variant: unknown
+    if (spec.kind === 'block') {
+      if (!spec.call) {
+        errors.push(`POU "${pouName}": node "${spec.label}" is a block and needs "call".`)
+        continue
+      }
+      const built = buildBlockVariant({
+        blockRef: spec.call,
+        systemLibraries: state.libraries.system,
+        userLibraries: state.libraries.user,
+        pous: state.project.data.pous,
+      })
+      if (!built.ok) {
+        errors.push(`POU "${pouName}": block "${spec.call}" — ${built.reason.replace(/-/g, ' ')}.`)
+        continue
+      }
+      // Cloned: the system branch of `buildBlockVariant` hands back the
+      // library's own `variables` array, which the store has frozen. Growing an
+      // extensible block writes to it, and a placed block should not alias the
+      // library's array in any case.
+      variant = structuredClone(built.variant)
+    }
+
+    nodes.push({
+      label: spec.label,
+      kind: spec.kind,
+      variant,
+      variable: spec.kind === 'block' ? spec.instance : spec.variable,
+      text: spec.text,
+      executionControl: spec.executionControl,
+      executionOrder: spec.executionOrder,
+    })
+  }
+
+  if (errors.length > 0) return errors
+
+  // Every pin a connection names must exist, or be one an extensible block can
+  // grow. A wrong pin name is otherwise dropped in silence: the diagram looks
+  // wired and the transpiler emits the call without it.
+  errors.push(...resolvePins(pouName, nodes, body))
+  if (errors.length > 0) return errors
+
+  const graph = buildFbdGraph(nodes, body.connections)
+  if (graph.errors.length > 0) return graph.errors.map((error) => `POU "${pouName}": ${error}.`)
+
+  // `addFBDFlow` adds nothing, so the built graph is what renders. A pin name
+  // that survived `resolvePins` but is not a declared handle stops here.
+  const dangling = unresolvedHandles(graph.nodes, graph.edges)
+  if (dangling.length > 0) return dangling.map((problem) => `POU "${pouName}": ${problem}.`)
+
+  for (const broken of graph.brokenCycles) {
+    // FBD is a left-to-right data flow: a diagram cannot feed a block from
+    // something downstream of it. Refused rather than placed, because the
+    // layout can only draw such a diagram by ignoring the connection — which
+    // would render as a wire that does not carry anything.
+    errors.push(
+      `POU "${pouName}": "${broken.from}" feeds "${broken.to}", which feeds it back. FBD has no feedback ` +
+        'within one diagram — carry the value in a variable, which holds it to the next scan.',
+    )
+  }
+  if (errors.length > 0) return errors
+
+  state.fbdFlowActions.addFBDFlow({
+    name: pouName,
+    rung: { comment: '', nodes: graph.nodes, edges: graph.edges, selectedNodes: [] },
+  } as never)
+  // `addFBDFlow` forces `updated: false` — it exists for loading a saved flow —
+  // so without this the body would never be written back.
+  state.fbdFlowActions.setFlowUpdated({ editorName: pouName, updated: true } as never)
+  return []
+}

--- a/src/cli/apply/handles.ts
+++ b/src/cli/apply/handles.ts
@@ -1,0 +1,50 @@
+/**
+ * Check that every edge names a handle the node it points at actually declares.
+ *
+ * React Flow drops an edge whose handle id is not on the node, logs a warning
+ * and renders the diagram without that wire. Nothing else catches it: the
+ * transpilers walk node/edge topology rather than handle ids, so the generated
+ * ST is correct while the diagram is visibly broken.
+ */
+
+import type { Edge, Node } from '@xyflow/react'
+
+interface Handle {
+  id?: string | null
+  type?: string
+}
+
+function handlesOf(node: Node): Handle[] {
+  const data = node.data as { handles?: Handle[] } | undefined
+  return data?.handles ?? []
+}
+
+/** One message per unresolved end, in the spec's own vocabulary. */
+export function unresolvedHandles(nodes: readonly Node[], edges: readonly Edge[]): string[] {
+  const byId = new Map(nodes.map((node) => [node.id, node]))
+  const problems: string[] = []
+
+  for (const edge of edges) {
+    for (const [nodeId, handleId, direction] of [
+      [edge.source, edge.sourceHandle, 'source'],
+      [edge.target, edge.targetHandle, 'target'],
+    ] as const) {
+      const node = byId.get(nodeId)
+      if (!node) {
+        problems.push(`edge "${edge.id}" names a node "${nodeId}" that is not in the rung`)
+        continue
+      }
+      const handles = handlesOf(node)
+      // A node builder that declares no handles at all is a different failure —
+      // reporting every edge against it would bury the real one.
+      if (handles.length === 0) continue
+      if (handles.some((handle) => handle.id === handleId)) continue
+
+      const declared = handles.map((handle) => String(handle.id)).join(', ')
+      problems.push(
+        `edge "${edge.id}": ${direction} node "${nodeId}" has no handle "${String(handleId)}" (it has: ${declared})`,
+      )
+    }
+  }
+  return problems
+}

--- a/src/cli/apply/ladder.ts
+++ b/src/cli/apply/ladder.ts
@@ -1,0 +1,227 @@
+/**
+ * Spec ladder body -> a laid-out flow in the store.
+ *
+ * The geometry is not computed here. `buildLadderRung` emits every element at
+ * the origin and `addLadderFlow` runs the editor's own solver over it, so a
+ * CLI-authored rung is placed by exactly the code that places a hand-drawn one.
+ */
+
+import { openPLCStoreBase } from '@root/frontend/store'
+import { needsPositionRecovery } from '@root/frontend/store/slices/ladder/slice'
+import {
+  buildLadderRung,
+  type RungLogic,
+  type RungOutput,
+  type RungVariableResolver,
+} from '@root/frontend/store/slices/ladder/utils/build-rung'
+import { buildBlockVariant } from '@root/frontend/utils/PLC/block-variant'
+import type { Edge, Node } from '@xyflow/react'
+
+import { unresolvedHandles } from './handles'
+import type { SpecLadderBody, SpecLadderOutput } from './schema'
+
+export function applyLadderBody(pouName: string, body: SpecLadderBody): string[] {
+  const errors: string[] = []
+  const state = openPLCStoreBase.getState()
+
+  // Mirrors the editor's own lookup (`ladder/utils/utils.ts`): the POU's own
+  // variables, matched case-insensitively, and a contact or coil will not take a
+  // derived type.
+  const declared = state.project.data.pous.find((pou) => pou.name === pouName)?.interface?.variables ?? []
+  const resolveVariable = (name: string, kind: 'contact' | 'coil' | 'block') =>
+    declared.find(
+      (variable) =>
+        variable.name.toLowerCase() === name.toLowerCase() &&
+        (kind === 'block' || variable.type.definition !== 'derived'),
+    )
+
+  const rungs = body.rungs.map((spec, index) => {
+    const outputs: RungOutput[] = []
+    for (const output of spec.outputs) {
+      const built = toOutput(pouName, output, errors)
+      if (built) outputs.push(built)
+    }
+    return buildLadderRung({
+      rungId: `rung-${index}`,
+      comment: spec.comment,
+      logic: spec.logic as RungLogic | undefined,
+      outputs,
+      resolveVariable,
+    })
+  })
+
+  if (errors.length > 0) return errors
+
+  state.ladderFlowActions.removeLadderFlow(pouName)
+  state.ladderFlowActions.addLadderFlow({ name: pouName, updated: true, rungs } as never)
+
+  // Naming the pins comes AFTER the flow is added, because `addLadderFlow` is
+  // what creates one variable element per block pin. Creating them here too
+  // would leave the rung with two elements on every pin.
+  nameBlockPins(pouName, body, errors, resolveVariable)
+
+  // The solver runs inside a try with guards that silently return the rung
+  // unchanged. The LD walker sorts sinks by y-position, so an unrecovered rung
+  // does not look broken — it transpiles to the wrong statement order.
+  const flow = openPLCStoreBase.getState().ladderFlows.find((entry) => entry.name === pouName)
+  for (const rung of flow?.rungs ?? []) {
+    if (needsPositionRecovery(rung)) {
+      errors.push(`POU "${pouName}" rung "${rung.id}": the editor could not lay this rung out.`)
+    }
+    // Checked on the stored rung, not the built one: `addLadderFlow` adds the
+    // block pin elements and their edges, so this is the only shape the editor
+    // will actually render.
+    for (const problem of unresolvedHandles(rung.nodes as Node[], rung.edges as Edge[])) {
+      errors.push(`POU "${pouName}" rung "${rung.id}": ${problem}.`)
+    }
+  }
+  return errors
+}
+
+/**
+ * Put the requested variable on each block pin the spec named.
+ *
+ * `addLadderFlow` gives every data pin its own variable element, unnamed. The
+ * elements carry `data.block.handleId`, which is the pin's name, so the one to
+ * name is found by that rather than by position.
+ */
+function nameBlockPins(
+  pouName: string,
+  body: SpecLadderBody,
+  errors: string[],
+  resolveVariable: RungVariableResolver,
+): void {
+  const flow = openPLCStoreBase.getState().ladderFlows.find((entry) => entry.name === pouName)
+  const updates: Array<{ node: Node; nodeId: string; rungId: string; editorName: string }> = []
+  /**
+   * What the GUI records on the BLOCK when a pin's variable is named
+   * (`ladder/variable.tsx`'s `updateRelatedNode`). Naming the element is only
+   * half the job: the block's `connectedVariables` is what tells the editor a
+   * pin already shows its own value, and `BlockOutputDebugBadges` skips an
+   * output found there. Leaving it empty drew the value twice on every named
+   * output pin — once from the element, once from the block.
+   */
+  const connections = new Map<string, { rungId: string; block: Node; entries: unknown[] }>()
+
+  for (const [index, spec] of body.rungs.entries()) {
+    const rung = flow?.rungs[index]
+    if (!rung) continue
+
+    const nodes = rung.nodes as Node[]
+    // Paired by position: `buildLadderRung` appends one block per block output,
+    // in order, so the Nth block node in the rung is the Nth block the spec
+    // asked for.
+    const placed = nodes.filter((node) => node.type === 'block')
+    const asked = spec.outputs.filter((output) => 'block' in output)
+
+    for (const [slot, output] of asked.entries()) {
+      if (!('block' in output)) continue
+      const block = placed[slot]
+      if (!block) continue
+
+      const pins = { ...(output.block.inputs ?? {}), ...(output.block.outputs ?? {}) }
+      for (const [pin, source] of Object.entries(pins)) {
+        // Matched on the OWNING BLOCK as well as the pin name. Keying on the pin
+        // alone let three blocks that each declare `POSITION` collide, and the
+        // last one in the document silently won on all of them.
+        const element = nodes.find((node) => {
+          if (node.type !== 'variable') return false
+          const data = node.data as { block?: { id?: string; handleId?: string } }
+          return data.block?.id === block.id && data.block.handleId === pin
+        })
+
+        if (!element) {
+          errors.push(
+            `POU "${pouName}" rung "${rung.id}": pin "${pin}" on "${output.block.call}" has no variable element ` +
+              `to name. A pin carrying rung power is wired to the next element rather than to a variable.`,
+          )
+          continue
+        }
+
+        updates.push({
+          editorName: pouName,
+          rungId: rung.id,
+          nodeId: element.id,
+          node: { ...element, data: { ...element.data, variable: { name: source } } } as Node,
+        })
+
+        const elementData = element.data as { variant?: string; block?: { handleId?: string } }
+        const variant = (block.data as { variant?: { variables?: Array<{ id?: string; name: string }> } }).variant
+        const entry = connections.get(block.id) ?? { rungId: rung.id, block, entries: [] }
+        entry.entries.push({
+          handleId: pin,
+          handleTableId: variant?.variables?.find((declared) => declared.name === pin)?.id,
+          type: elementData.variant,
+          // The resolved declaration when the name is one, and a bare name
+          // otherwise — a pin can carry a literal (`TRUE`, `100`), and the GUI
+          // stores those the same way.
+          variable: resolveVariable(source, 'block') ?? { name: source },
+        })
+        connections.set(block.id, entry)
+      }
+    }
+  }
+
+  // One update per block, not one per pin: each carries the whole list, so
+  // separate updates would each overwrite the last.
+  for (const { rungId, block, entries } of connections.values()) {
+    updates.push({
+      editorName: pouName,
+      rungId,
+      nodeId: block.id,
+      node: { ...block, data: { ...block.data, connectedVariables: entries } } as Node,
+    })
+  }
+
+  if (updates.length > 0) openPLCStoreBase.getState().ladderFlowActions.updateNodes(updates)
+}
+
+function toOutput(pouName: string, output: SpecLadderOutput, errors: string[]): RungOutput | null {
+  if ('coil' in output) return { coil: output.coil }
+
+  const state = openPLCStoreBase.getState()
+  const built = buildBlockVariant({
+    blockRef: output.block.call,
+    systemLibraries: state.libraries.system,
+    userLibraries: state.libraries.user,
+    pous: state.project.data.pous,
+  })
+  if (!built.ok) {
+    errors.push(`POU "${pouName}": block "${output.block.call}" — ${built.reason.replace('-', ' ')}.`)
+    return null
+  }
+  // Cloned for the same reason as in `apply/fbd.ts`: the library's `variables`
+  // array is frozen, and a placed block should carry its own copy.
+  const variant = structuredClone(built.variant)
+
+  // A pin name that is not on the block would otherwise be dropped in silence —
+  // the rung would look wired and the call would go out without it.
+  // An in-out pin — SoftMotion's `AXIS` — sits on the left with the inputs and is
+  // named through `inputs`. It is not optional: the compiler refuses a call that
+  // leaves one unassigned.
+  const accepts: Record<'input' | 'output', readonly string[]> = { input: ['input', 'inOut'], output: ['output'] }
+  for (const [side, pins] of [
+    ['input', output.block.inputs],
+    ['output', output.block.outputs],
+  ] as const) {
+    for (const pin of Object.keys(pins ?? {})) {
+      if (variant.variables.some((entry) => entry.name === pin && accepts[side].includes(entry.class ?? ''))) continue
+      const legal = variant.variables
+        .filter((entry) => accepts[side].includes(entry.class ?? ''))
+        .map((entry) => entry.name)
+        .join(', ')
+      errors.push(`POU "${pouName}": block "${variant.name}" has no ${side} pin "${pin}". Its ${side}s are: ${legal}.`)
+      return null
+    }
+  }
+
+  return {
+    block: {
+      variant,
+      instance: output.block.instance,
+      inputs: output.block.inputs,
+      outputs: output.block.outputs,
+      executionControl: output.block.executionControl,
+    },
+  }
+}

--- a/src/cli/apply/plan.ts
+++ b/src/cli/apply/plan.ts
@@ -1,0 +1,795 @@
+/**
+ * Turn an `apply` spec into store actions, in an order that works.
+ *
+ * The ordering is not cosmetic. Several store actions refuse or silently no-op
+ * when what they reference does not exist yet:
+ *
+ *   - a variable with `scope: 'local'` fails with "POU not found" unless its
+ *     POU is already created;
+ *   - a variable whose type is a user data type needs that type registered, or
+ *     the editor classifies it as unknown;
+ *   - an instance names a task and a program by string and validates neither,
+ *     so a wrong order produces a project that only fails much later, in the
+ *     IEC compiler, with "program not found".
+ *
+ * So: data types, then POUs, then bodies, then variables, then tasks, then
+ * instances. An agent cannot see any of this, which is the whole reason `apply`
+ * takes a declarative document rather than a sequence of commands.
+ */
+
+import { openPLCStoreBase } from '@root/frontend/store'
+import { elementNameCollision } from '@root/frontend/store/slices/shared/name-collision'
+import { isLegalIdentifier } from '@root/frontend/utils/keywords'
+import { baseTypeEnum } from '@root/middleware/shared/ports/plc-schemas'
+import type { PLCDataType, PLCVariable } from '@root/middleware/shared/ports/types'
+
+import { applyFbdBody } from './fbd'
+import { applyLadderBody } from './ladder'
+import { applyRemoteDevices, applyServers, pruneProtocols } from './protocol'
+import type { ApplySpec, SpecDataType, SpecPou, SpecVariable } from './schema'
+
+export interface PlannedChange {
+  kind:
+    | 'data-type'
+    | 'pou'
+    | 'body'
+    | 'variable'
+    | 'task'
+    | 'instance'
+    | 'device'
+    | 'library'
+    | 'gvl'
+    | 'server'
+    | 'remote-device'
+    | 'io-group'
+    | 'ethercat-slave'
+  action: 'create' | 'update' | 'delete'
+  name: string
+}
+
+export interface ApplyOutcome {
+  changes: PlannedChange[]
+  errors: string[]
+}
+
+type Store = ReturnType<typeof openPLCStoreBase.getState>
+
+/** Languages whose body is a plain string. */
+const TEXTUAL = new Set(['st', 'il', 'python', 'cpp'])
+
+/**
+ * `projectPath` is needed only by the EtherCAT section, which reads the
+ * project's own ESI repository off disk — which is also why this is async.
+ */
+export async function applySpec(
+  spec: ApplySpec,
+  options: { prune: boolean; projectPath: string },
+): Promise<ApplyOutcome> {
+  const changes: PlannedChange[] = []
+  const errors: string[] = []
+
+  applyDevice(spec, changes)
+  applyLibraries(spec, changes, errors)
+  applyDataTypes(spec, changes, errors)
+  applyGlobalVariableLists(spec, changes, errors)
+  applyPous(spec, changes, errors)
+  applyVariables(spec, changes, errors)
+  // Bodies LAST, after every POU has its variables. A graphical body placing a
+  // `user/<pou>` block resolves that block's pins from the POU's own variable
+  // list, so a body applied in the same pass that created the POU sees an
+  // interface with no pins at all.
+  applyBodies(spec, changes, errors)
+  applyGlobalVariables(spec, changes, errors)
+  applyTasks(spec, changes, errors)
+  applyInstances(spec, changes, errors)
+  applyServers(spec, changes, errors)
+  await applyRemoteDevices(spec, options.projectPath, changes, errors)
+  if (options.prune) {
+    prune(spec, changes, errors)
+    pruneProtocols(spec, changes)
+  }
+
+  // Any `location` that was bound changes the IEC address map, and nothing
+  // recomputes it on the way out of these actions.
+  if ((spec.globalVariables ?? []).some((variable) => variable.location) || specBindsLocation(spec)) {
+    openPLCStoreBase.getState().projectActions.recalculateIecAddresses()
+  }
+
+  return { changes, errors }
+}
+
+function specBindsLocation(spec: ApplySpec): boolean {
+  return (spec.pous ?? []).some((pou) => (pou.variables ?? []).some((variable) => variable.location))
+}
+
+// ---------------------------------------------------------------------------
+// Device and project settings
+// ---------------------------------------------------------------------------
+
+/**
+ * The build target.
+ *
+ * Written through `setDeviceDefinitions` rather than passed along the side,
+ * because the debug-spec resolver reads `communicationPort` and
+ * `runtimeIpAddress` off the store — the same reason `applyConnectionOverrides`
+ * exists. A project whose board is never set compiles for whatever the scaffold
+ * chose, which is rarely what was asked for.
+ */
+function applyDevice(spec: ApplySpec, changes: PlannedChange[]): void {
+  if (!spec.device) return
+  const configuration: Record<string, string> = {}
+  if (spec.device.board) configuration.deviceBoard = spec.device.board
+  if (spec.device.communicationPort !== undefined) configuration.communicationPort = spec.device.communicationPort
+  if (spec.device.runtimeIpAddress !== undefined) configuration.runtimeIpAddress = spec.device.runtimeIpAddress
+
+  // `setDeviceBoard` first, for the side effects a bulk write does not do: it
+  // swaps the per-board vendor and persistent-storage buckets, clears the
+  // platform options, and recomputes the IEC addresses.
+  if (spec.device.board) {
+    openPLCStoreBase.getState().deviceActions.setDeviceBoard(spec.device.board)
+    changes.push({ kind: 'device', action: 'update', name: `board = ${spec.device.board}` })
+  }
+
+  // Before the bail-out below: a `device` section carrying nothing but
+  // `persistentStorage` still has work to do.
+  applyPersistentStorage(spec, changes)
+
+  const rest = { ...configuration }
+  delete rest.deviceBoard
+  if (Object.keys(rest).length === 0) return
+
+  // Merged onto the CURRENT configuration, not passed as a fragment.
+  // `setDeviceDefinitions` REPLACES the object, filling the rest from defaults —
+  // so a partial `{ runtimeIpAddress }` silently resets the board to the default
+  // and the project saves for the wrong target.
+  const current = openPLCStoreBase.getState().deviceDefinitions.configuration
+  openPLCStoreBase.getState().deviceActions.setDeviceDefinitions({ configuration: { ...current, ...rest } as never })
+  for (const [key, value] of Object.entries(rest)) {
+    changes.push({ kind: 'device', action: 'update', name: `${key} = ${value || '(cleared)'}` })
+  }
+}
+
+/** Libraries the project compiles against. Replaces the list wholesale. */
+/**
+ * The libraries a project enables.
+ *
+ * This list is for libraries INSTALLED through the Library Manager, which the
+ * build resolves to an archive on disk. A library bundled with the editor has no
+ * archive, so naming one here does not "declare a dependency" — it makes the
+ * build stop with "enables libraries that are not installed", pointing at a
+ * Library Manager that has nothing to install. Its blocks are usable either way.
+ *
+ * So a bundled name is refused here, where the message can say that, rather than
+ * saved into a project that only fails at compile time.
+ */
+function applyLibraries(spec: ApplySpec, changes: PlannedChange[], errors: string[]): void {
+  if (!spec.libraries) return
+
+  const state = openPLCStoreBase.getState()
+  const bundled = new Set(state.bundledLibraryNames)
+  const known = new Set(state.libraries.system.map((library) => library.name))
+
+  for (const ref of spec.libraries) {
+    if (bundled.has(ref.name)) {
+      errors.push(
+        `library "${ref.name}" is bundled with the editor and must not be listed in "libraries": ` +
+          'its blocks are available without it, and listing it stops the build with "not installed".',
+      )
+      continue
+    }
+    if (!known.has(ref.name)) {
+      errors.push(`library "${ref.name}" is not installed, so a project enabling it cannot be built.`)
+    }
+  }
+  if (errors.length > 0) return
+
+  state.libraryActions.setProjectLibraries(spec.libraries)
+  for (const ref of spec.libraries) {
+    changes.push({ kind: 'library', action: 'update', name: `${ref.name}@${ref.version}` })
+  }
+}
+
+function applyGlobalVariableLists(spec: ApplySpec, changes: PlannedChange[], errors: string[]): void {
+  for (const wanted of spec.globalVariableLists ?? []) {
+    const state: Store = openPLCStoreBase.getState()
+    const existing = (state.project.data.globalVariableLists ?? []).some((list) => list.name === wanted.name)
+
+    if (!existing) {
+      const response = state.projectActions.createGlobalVariableList(wanted.name)
+      if (!response.ok) {
+        errors.push(`global variable list "${wanted.name}": ${response.message ?? 'could not be created'}`)
+        continue
+      }
+      changes.push({ kind: 'gvl', action: 'create', name: wanted.name })
+    }
+
+    openPLCStoreBase.getState().projectActions.updateGlobalVariableList(
+      wanted.name,
+      wanted.variables.map((variable) => toVariable(variable, 'global')),
+    )
+    if (wanted.qualifier !== undefined) {
+      openPLCStoreBase.getState().projectActions.updateGlobalVariableListQualifier(wanted.name, wanted.qualifier)
+    }
+    if (existing) changes.push({ kind: 'gvl', action: 'update', name: wanted.name })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+function toDataType(spec: SpecDataType): PLCDataType {
+  if (spec.derivation === 'enumerated') {
+    return {
+      name: spec.name,
+      derivation: 'enumerated',
+      initialValue: spec.initialValue ?? '',
+      values: spec.values.map((description) => ({ description })),
+    } as PLCDataType
+  }
+  if (spec.derivation === 'structure') {
+    return {
+      name: spec.name,
+      derivation: 'structure',
+      variable: spec.variables.map((member) => ({
+        name: member.name,
+        // Through the same conversion as a variable: a member declared as an
+        // array carried the spec's `dimensions` into the store, which keeps its
+        // bounds in `data`, so the member silently degraded to a scalar of the
+        // element type — `Trend : INT` where `ARRAY [0..2] OF INT` was asked
+        // for.
+        type: toVariableType(member.type),
+        ...(member.initialValue ? { initialValue: { simpleValue: { value: member.initialValue } } } : {}),
+        documentation: member.documentation ?? '',
+      })),
+    } as unknown as PLCDataType
+  }
+  return {
+    name: spec.name,
+    derivation: 'array',
+    baseType: spec.baseType,
+    initialValue: spec.initialValue ?? '',
+    dimensions: spec.dimensions.map((dimension) => ({ dimension })),
+  } as unknown as PLCDataType
+}
+
+/**
+ * Check every identifier a data type introduces.
+ *
+ * `createDatatype` does not: a structure field named `Label` was accepted, and
+ * the `.dt` written for it then failed to parse on the next load — the editor
+ * preserves the file and warns, but the type is absent from the project and
+ * every reference to it fails to compile as an undefined type. Refusing here
+ * turns that into an error against the document that caused it.
+ */
+function checkDataTypeNames(wanted: SpecDataType): string[] {
+  const problems: string[] = []
+  const check = (name: string, what: string) => {
+    const [legal, reason] = isLegalIdentifier(name)
+    if (!legal) problems.push(`data type "${wanted.name}": ${what} "${name}" ${reason}.`)
+  }
+
+  check(wanted.name, 'the name')
+  if (wanted.derivation === 'structure') for (const member of wanted.variables) check(member.name, 'field')
+  if (wanted.derivation === 'enumerated') for (const value of wanted.values) check(value, 'value')
+  return problems
+}
+
+function applyDataTypes(spec: ApplySpec, changes: PlannedChange[], errors: string[]): void {
+  for (const wanted of spec.dataTypes ?? []) {
+    const problems = checkDataTypeNames(wanted)
+    if (problems.length > 0) {
+      errors.push(...problems)
+      continue
+    }
+
+    const state: Store = openPLCStoreBase.getState()
+    const existing = state.project.data.dataTypes.find((type) => type.name === wanted.name)
+    const data = toDataType(wanted)
+
+    if (existing) {
+      state.projectActions.updateDatatype(wanted.name, data)
+      changes.push({ kind: 'data-type', action: 'update', name: wanted.name })
+      continue
+    }
+
+    const response = state.projectActions.createDatatype({ data })
+    if (!response.ok) {
+      errors.push(`data type "${wanted.name}": ${response.message ?? 'could not be created'}`)
+      continue
+    }
+    changes.push({ kind: 'data-type', action: 'create', name: wanted.name })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POUs and bodies
+// ---------------------------------------------------------------------------
+
+function applyPous(spec: ApplySpec, changes: PlannedChange[], errors: string[]): void {
+  for (const wanted of spec.pous ?? []) {
+    if (wanted.language === 'sfc') {
+      errors.push(`POU "${wanted.name}": SFC bodies cannot be authored — the transpiler does not support them yet.`)
+      continue
+    }
+
+    const state: Store = openPLCStoreBase.getState()
+    const existing = state.project.data.pous.find((pou) => pou.name === wanted.name)
+
+    if (!existing) {
+      // `pouActions.create`, not `projectActions.createPou`: only the shared
+      // action checks the name against every other element and seeds the
+      // ladder/FBD flow. Without that seeding the graphical editor opens empty
+      // and the next save writes that emptiness over the body.
+      const response = state.pouActions.create({
+        type: wanted.kind,
+        name: wanted.name,
+        language: wanted.language,
+      })
+      if (!response.ok) {
+        errors.push(`POU "${wanted.name}": ${response.message ?? 'could not be created'}`)
+        continue
+      }
+      changes.push({ kind: 'pou', action: 'create', name: wanted.name })
+    }
+
+    // A POU's language is fixed once it exists. The upsert path only ever set
+    // it on create, so a spec asking for a different one was ignored in
+    // silence — and worse than ignored: the body is written to a file named
+    // for the NEW language while the old file stays, and the loader reads the
+    // old one. The project then compiles a body the spec no longer describes.
+    if (existing && existing.body.language !== wanted.language) {
+      errors.push(
+        `POU "${wanted.name}" is ${existing.body.language} and the spec asks for ${wanted.language}. ` +
+          "A POU's language cannot be changed in place — its body is stored in a file named for the " +
+          'language. Rename or remove the POU and declare a new one.',
+      )
+      continue
+    }
+
+    if (wanted.kind === 'function' && wanted.returnType) {
+      openPLCStoreBase.getState().projectActions.updatePouReturnType(wanted.name, wanted.returnType)
+    }
+    if (wanted.documentation !== undefined) {
+      openPLCStoreBase.getState().projectActions.updatePouDocumentation(wanted.name, wanted.documentation)
+    }
+  }
+}
+
+/** Second pass: every POU exists and has its variables, so a block resolves. */
+function applyBodies(spec: ApplySpec, changes: PlannedChange[], errors: string[]): void {
+  for (const wanted of spec.pous ?? []) {
+    if (wanted.language === 'sfc') continue
+    if (!openPLCStoreBase.getState().project.data.pous.some((pou) => pou.name === wanted.name)) continue
+    applyBody(wanted, changes, errors)
+  }
+}
+
+function applyBody(wanted: SpecPou, changes: PlannedChange[], errors: string[]): void {
+  if (!wanted.body) return
+
+  if (TEXTUAL.has(wanted.language)) {
+    if (!('text' in wanted.body)) {
+      errors.push(`POU "${wanted.name}": a ${wanted.language} body needs { "text": "..." }.`)
+      return
+    }
+
+    const structural = checkNativeStructure(wanted.language, wanted.body.text)
+    if (structural) {
+      errors.push(`POU "${wanted.name}": ${structural}`)
+      return
+    }
+    openPLCStoreBase.getState().projectActions.updatePou({
+      name: wanted.name,
+      content: { language: wanted.language, value: wanted.body.text } as never,
+    })
+    changes.push({ kind: 'body', action: 'update', name: wanted.name })
+    return
+  }
+
+  if (wanted.language === 'ld') {
+    if (!('rungs' in wanted.body)) {
+      errors.push(`POU "${wanted.name}": a ladder body needs { "rungs": [...] }.`)
+      return
+    }
+    const failures = applyLadderBody(wanted.name, wanted.body)
+    if (failures.length > 0) {
+      errors.push(...failures)
+      return
+    }
+    changes.push({ kind: 'body', action: 'update', name: wanted.name })
+    return
+  }
+
+  if (wanted.language === 'fbd') {
+    if (!('nodes' in wanted.body)) {
+      errors.push(`POU "${wanted.name}": an FBD body needs { "nodes": [...], "connections": [...] }.`)
+      return
+    }
+    const failures = applyFbdBody(wanted.name, wanted.body)
+    if (failures.length > 0) {
+      errors.push(...failures)
+      return
+    }
+    changes.push({ kind: 'body', action: 'update', name: wanted.name })
+    return
+  }
+
+  errors.push(`POU "${wanted.name}": ${wanted.language} bodies are not applied yet.`)
+}
+
+/**
+ * Native blocks are driven by entry points the runtime calls, and nothing else
+ * checks for them at author time.
+ *
+ * The editor injects a Python template when a human opens the POU
+ * (`monaco/index.tsx`), so a hand-written block has them by default. A POU
+ * authored here never sees that template: bare top-level statements run once at
+ * import and then never again, so the block compiles, uploads and silently does
+ * nothing — indistinguishable from a wiring fault.
+ *
+ * C/C++ is checked later by `preprocessPous`, but reporting it here names the
+ * POU while the author still has the spec in front of them.
+ */
+function checkNativeStructure(language: string, text: string): string | null {
+  if (language === 'python') {
+    const hasLoop = /^\s*def\s+block_loop\s*\(/m.test(text)
+    const hasInit = /^\s*def\s+block_init\s*\(/m.test(text)
+    if (!hasLoop || !hasInit) {
+      const missing = [!hasInit ? 'block_init()' : '', !hasLoop ? 'block_loop()' : ''].filter(Boolean).join(' and ')
+      return (
+        `a Python body must define ${missing}. The runtime calls block_init() once and block_loop() about ` +
+        'every 100 ms; top-level statements run once at import and never again.'
+      )
+    }
+  }
+  if (language === 'cpp') {
+    const hasSetup = /\bvoid\s+setup\s*\(/.test(text)
+    const hasLoop = /\bvoid\s+loop\s*\(/.test(text)
+    if (!hasSetup || !hasLoop) {
+      const missing = [!hasSetup ? 'setup()' : '', !hasLoop ? 'loop()' : ''].filter(Boolean).join(' and ')
+      return `a C/C++ body must define ${missing}.`
+    }
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Variables
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the store's array type from the spec's `dimensions`.
+ *
+ * The store keeps an array twice over: `value` as the rendered IEC text and
+ * `data` as the structured bounds. Both are derived here, exactly as the GUI's
+ * array modal builds them (`variables-table/elements/array-modal.tsx`) — asking
+ * a caller for the rendered string as well as the bounds is asking for the two
+ * to disagree.
+ */
+function toVariableType(type: SpecVariable['type']): PLCVariable['type'] {
+  if (type.definition !== 'array' || !type.dimensions) return type as PLCVariable['type']
+
+  const element = type.value.trim()
+  const isBaseType = (baseTypeEnum.options as readonly string[]).includes(element.toUpperCase())
+  return {
+    definition: 'array',
+    value: `ARRAY [${type.dimensions.join(', ')}] OF ${element.toUpperCase()}`,
+    data: {
+      baseType: { definition: isBaseType ? 'base-type' : 'user-data-type', value: element },
+      dimensions: type.dimensions.map((dimension) => ({ dimension })),
+    },
+  } as PLCVariable['type']
+}
+
+function toVariable(spec: SpecVariable, fallbackClass: 'local' | 'global'): PLCVariable {
+  return {
+    name: spec.name,
+    class: spec.class ?? fallbackClass,
+    type: toVariableType(spec.type),
+    location: spec.location ?? '',
+    documentation: spec.documentation ?? '',
+    ...(spec.initialValue !== undefined ? { initialValue: spec.initialValue } : {}),
+    ...(spec.debug !== undefined ? { debug: spec.debug } : {}),
+    ...(spec.flag !== undefined ? { flag: spec.flag } : {}),
+  } as unknown as PLCVariable
+}
+
+/**
+ * Retain settings, written after the board is set.
+ *
+ * `setDeviceBoard` swaps the per-board persistent-storage bucket, so writing
+ * these first would put them on the outgoing board and lose them.
+ */
+function applyPersistentStorage(spec: ApplySpec, changes: PlannedChange[]): void {
+  const wanted = spec.device?.persistentStorage
+  if (!wanted) return
+
+  // `setPersistentStorage`, not a hand-merge through `setDeviceDefinitions`: it
+  // materialises the defaults, keeps `persistentStorageByBoard` in step with the
+  // flat view, and marks the device dirty — without that last part the save
+  // writes the device file without this in it.
+  openPLCStoreBase.getState().deviceActions.setPersistentStorage({
+    enabled: wanted.enabled,
+    ...(wanted.path !== undefined ? { path: wanted.path } : {}),
+    ...(wanted.flushSeconds !== undefined ? { flushSeconds: wanted.flushSeconds } : {}),
+  })
+
+  const applied = openPLCStoreBase.getState().deviceDefinitions.configuration.persistentStorage
+  changes.push({
+    kind: 'device',
+    action: 'update',
+    name: `persistentStorage = ${applied?.enabled ? `every ${applied.flushSeconds}s` : 'off'}`,
+  })
+}
+
+function applyVariables(spec: ApplySpec, changes: PlannedChange[], errors: string[]): void {
+  for (const pou of spec.pous ?? []) {
+    for (const wanted of pou.variables ?? []) {
+      const state: Store = openPLCStoreBase.getState()
+      const target = state.project.data.pous.find((entry) => entry.name === pou.name)
+      if (!target) continue
+
+      const existing = (target.interface?.variables ?? []).findIndex((entry) => entry.name === wanted.name)
+      if (existing >= 0) {
+        state.projectActions.updateVariable({
+          scope: 'local',
+          associatedPou: pou.name,
+          rowId: existing,
+          data: toVariable(wanted, 'local'),
+        })
+        changes.push({ kind: 'variable', action: 'update', name: `${pou.name}.${wanted.name}` })
+        continue
+      }
+
+      const response = state.projectActions.createVariable({
+        scope: 'local',
+        associatedPou: pou.name,
+        data: toVariable(wanted, 'local'),
+      })
+      if (!response.ok) {
+        errors.push(`variable "${pou.name}.${wanted.name}": ${response.message ?? 'could not be created'}`)
+        continue
+      }
+      changes.push(namedChange(response, pou.name, wanted.name, errors))
+    }
+  }
+}
+
+function applyGlobalVariables(spec: ApplySpec, changes: PlannedChange[], errors: string[]): void {
+  for (const wanted of spec.globalVariables ?? []) {
+    const state: Store = openPLCStoreBase.getState()
+    const globals = state.project.data.configurations.resource.globalVariables ?? []
+    const existing = globals.findIndex((entry) => entry.name === wanted.name)
+
+    if (existing >= 0) {
+      state.projectActions.updateVariable({ scope: 'global', rowId: existing, data: toVariable(wanted, 'global') })
+      changes.push({ kind: 'variable', action: 'update', name: wanted.name })
+      continue
+    }
+
+    const response = state.projectActions.createVariable({ scope: 'global', data: toVariable(wanted, 'global') })
+    if (!response.ok) {
+      errors.push(`global variable "${wanted.name}": ${response.message ?? 'could not be created'}`)
+      continue
+    }
+    changes.push(namedChange(response, null, wanted.name, errors))
+  }
+}
+
+/**
+ * Report the name the store actually used.
+ *
+ * `createVariableValidation` auto-increments a colliding name — ask for `Motor`
+ * on a POU that already has one and you get `Motor1`, silently. A spec that
+ * later references `Motor` would then be referencing a variable that does not
+ * exist, so the rename is surfaced rather than swallowed.
+ */
+function namedChange(
+  response: { data?: unknown },
+  pouName: string | null,
+  asked: string,
+  errors: string[],
+): PlannedChange {
+  const actual = (response.data as { name?: string } | undefined)?.name
+  const label = pouName ? `${pouName}.${asked}` : asked
+  if (actual && actual !== asked) {
+    // An error, not a note. A spec is a declaration: if the store cannot give
+    // the name that was asked for, nothing downstream referring to it resolves,
+    // and `--prune` then deletes the renamed variable because the spec never
+    // mentions that name. The combination is silent and destructive.
+    //
+    // `createVariable` throws the REASON away and returns only the new name, so
+    // ask the same gate the store asked and quote what it says. Guessing the
+    // cause sends the reader to the wrong place: a library block, a POU, a
+    // device alias and a reserved word all land here.
+    const why =
+      pouName === null
+        ? elementNameCollision(openPLCStoreBase.getState(), asked, 'resource-global')
+        : `POU "${pouName}" already has a variable called "${asked}"`
+    const reason = (why ?? 'The name is already claimed').replace(/\.?$/, '.')
+    errors.push(
+      `variable "${label}" could not take that name — the store renamed it to "${actual}". ` +
+        `${reason} Rename it in the spec.`,
+    )
+  }
+  return { kind: 'variable', action: 'create', name: label }
+}
+
+// ---------------------------------------------------------------------------
+// Tasks and instances
+// ---------------------------------------------------------------------------
+
+function applyTasks(spec: ApplySpec, changes: PlannedChange[], errors: string[]): void {
+  for (const wanted of spec.tasks ?? []) {
+    const state: Store = openPLCStoreBase.getState()
+    const tasks = state.project.data.configurations.resource.tasks
+    const existing = tasks.findIndex((task) => task.name === wanted.name)
+
+    if (existing >= 0) {
+      state.projectActions.updateTask({ data: wanted, rowId: existing })
+      changes.push({ kind: 'task', action: 'update', name: wanted.name })
+      continue
+    }
+
+    const response = state.projectActions.createTask({ data: wanted })
+    if (!response.ok) {
+      errors.push(`task "${wanted.name}": ${response.message ?? 'could not be created'}`)
+      continue
+    }
+    changes.push({ kind: 'task', action: 'create', name: wanted.name })
+  }
+}
+
+function applyInstances(spec: ApplySpec, changes: PlannedChange[], errors: string[]): void {
+  for (const wanted of spec.instances ?? []) {
+    const state: Store = openPLCStoreBase.getState()
+    const resource = state.project.data.configurations.resource
+
+    // `createInstance` validates neither of these, and a dangling reference
+    // only surfaces much later as an IEC compile error.
+    if (!resource.tasks.some((task) => task.name === wanted.task)) {
+      errors.push(`instance "${wanted.name}": no task named "${wanted.task}".`)
+      continue
+    }
+    const program = state.project.data.pous.find((pou) => pou.name === wanted.program)
+    if (!program || program.pouType !== 'program') {
+      errors.push(`instance "${wanted.name}": "${wanted.program}" is not a program in this project.`)
+      continue
+    }
+
+    const existing = resource.instances.findIndex((instance) => instance.name === wanted.name)
+    if (existing >= 0) {
+      state.projectActions.updateInstance({ data: wanted, rowId: existing })
+      changes.push({ kind: 'instance', action: 'update', name: wanted.name })
+      continue
+    }
+
+    const response = state.projectActions.createInstance({ data: wanted })
+    if (!response.ok) {
+      errors.push(`instance "${wanted.name}": ${response.message ?? 'could not be created'}`)
+      continue
+    }
+    changes.push({ kind: 'instance', action: 'create', name: wanted.name })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Prune
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove what the spec does not mention.
+ *
+ * Only entities the spec's own sections cover: a spec with no `pous` key is not
+ * a request to delete every POU, so a section that is absent prunes nothing.
+ * `pouActions.delete`, never `deleteRequest` — the latter opens a modal and
+ * would hang here forever.
+ */
+function prune(spec: ApplySpec, changes: PlannedChange[], errors: string[]): void {
+  if (spec.pous) {
+    const wanted = new Set(spec.pous.map((pou) => pou.name))
+    for (const pou of [...openPLCStoreBase.getState().project.data.pous]) {
+      if (wanted.has(pou.name)) continue
+      openPLCStoreBase.getState().pouActions.delete(pou.name)
+      changes.push({ kind: 'pou', action: 'delete', name: pou.name })
+    }
+  }
+
+  if (spec.dataTypes) {
+    const wanted = new Set(spec.dataTypes.map((type) => type.name))
+    for (const type of [...openPLCStoreBase.getState().project.data.dataTypes]) {
+      if (wanted.has(type.name)) continue
+      openPLCStoreBase.getState().projectActions.deleteDatatype(type.name)
+      changes.push({ kind: 'data-type', action: 'delete', name: type.name })
+    }
+  }
+
+  if (spec.instances) {
+    const wanted = new Set(spec.instances.map((instance) => instance.name))
+    const resource = openPLCStoreBase.getState().project.data.configurations.resource
+    // Backwards: every delete is by row index, so removing from the end keeps
+    // the remaining indices valid.
+    for (let row = resource.instances.length - 1; row >= 0; row -= 1) {
+      const instance = resource.instances[row]
+      if (wanted.has(instance.name)) continue
+      openPLCStoreBase.getState().projectActions.deleteInstance({ rowId: row })
+      changes.push({ kind: 'instance', action: 'delete', name: instance.name })
+    }
+  }
+
+  if (spec.tasks) {
+    const wanted = new Set(spec.tasks.map((task) => task.name))
+    const resource = openPLCStoreBase.getState().project.data.configurations.resource
+    for (let row = resource.tasks.length - 1; row >= 0; row -= 1) {
+      const task = resource.tasks[row]
+      if (wanted.has(task.name)) continue
+      openPLCStoreBase.getState().projectActions.deleteTask({ rowId: row })
+      changes.push({ kind: 'task', action: 'delete', name: task.name })
+    }
+  }
+
+  pruneVariables(spec, changes, errors)
+}
+
+/**
+ * Drop variables the spec stopped declaring.
+ *
+ * Without this a `describe` -> edit -> `apply` round trip can only ever add:
+ * a variable removed from the document stays in the project, and a renamed one
+ * leaves its old declaration behind.
+ *
+ * Same rule as everything else here — an absent key prunes nothing, so a POU
+ * with no `variables` section keeps the ones it has.
+ */
+function pruneVariables(spec: ApplySpec, changes: PlannedChange[], errors: string[]): void {
+  for (const pou of spec.pous ?? []) {
+    if (!pou.variables) continue
+    const wanted = new Set(pou.variables.map((variable) => variable.name.toLowerCase()))
+    const current = openPLCStoreBase.getState().project.data.pous.find((entry) => entry.name === pou.name)
+    for (const variable of [...(current?.interface?.variables ?? [])]) {
+      if (wanted.has(variable.name.toLowerCase())) continue
+      openPLCStoreBase
+        .getState()
+        .projectActions.deleteVariable({ scope: 'local', associatedPou: pou.name, variableName: variable.name })
+      changes.push({ kind: 'variable', action: 'delete', name: `${pou.name}.${variable.name}` })
+    }
+  }
+
+  if (spec.globalVariables) {
+    const wanted = new Set(spec.globalVariables.map((variable) => variable.name.toLowerCase()))
+    const globals = openPLCStoreBase.getState().project.data.configurations.resource.globalVariables ?? []
+    for (const variable of [...globals]) {
+      if (wanted.has(variable.name.toLowerCase())) continue
+      // Not forced: a global a POU still declares VAR_EXTERNAL would otherwise
+      // be cascade-deleted out of that POU's interface, which the spec did not
+      // ask for. Report the conflict and leave both in place.
+      const response = openPLCStoreBase
+        .getState()
+        .projectActions.deleteVariable({ scope: 'global', variableName: variable.name })
+      if (!response.ok) {
+        const referencing = (response.data as { referencingPous?: string[] } | undefined)?.referencingPous ?? []
+        errors.push(
+          `global variable "${variable.name}" cannot be pruned: ` +
+            `${referencing.join(', ') || 'a POU'} still declares it VAR_EXTERNAL.`,
+        )
+        continue
+      }
+      changes.push({ kind: 'variable', action: 'delete', name: variable.name })
+    }
+  }
+
+  for (const list of spec.globalVariableLists ?? []) {
+    const wanted = new Set(list.variables.map((variable) => variable.name.toLowerCase()))
+    const current = openPLCStoreBase
+      .getState()
+      .project.data.globalVariableLists?.find((entry) => entry.name === list.name)
+    for (const variable of [...(current?.variables ?? [])]) {
+      if (wanted.has(variable.name.toLowerCase())) continue
+      openPLCStoreBase
+        .getState()
+        .projectActions.deleteVariable({ scope: 'global', associatedList: list.name, variableName: variable.name })
+      changes.push({ kind: 'variable', action: 'delete', name: `${list.name}.${variable.name}` })
+    }
+  }
+}

--- a/src/cli/apply/protocol.ts
+++ b/src/cli/apply/protocol.ts
@@ -1,0 +1,338 @@
+/**
+ * `apply`'s protocol section: servers, remote devices and the EtherCAT bus.
+ *
+ * The sequencing here is load-bearing rather than incidental. `deleteRemoteDevice`
+ * recalculates the project's IEC addresses, and so does every `addIOGroup`, so a
+ * per-device create/populate loop costs one project-wide reallocation per group
+ * — and lands on different addresses than the same spec applied in a different
+ * order. Delete everything, create everything, add every group in spec order,
+ * recalculate once at the end.
+ *
+ * Everything below the store boundary goes through the same actions the device
+ * screens use. Nothing here writes `project.data.servers` directly.
+ */
+
+import { ESIService } from '@root/backend/editor/ethercat/esi-service'
+import { normalizeEthercatSlave } from '@root/backend/shared/protocol/normalize-ethercat-slave'
+import type { NormalizedRemoteDevice } from '@root/backend/shared/protocol/normalize-remote-device-spec'
+import { normalizeRemoteDeviceSpec } from '@root/backend/shared/protocol/normalize-remote-device-spec'
+import { normalizeServerSpec } from '@root/backend/shared/protocol/normalize-server-spec'
+import { openPLCStoreBase } from '@root/frontend/store'
+import type { ConfiguredEtherCATDevice } from '@root/middleware/shared/ports/esi-types'
+import type { PLCRemoteDevice, PLCServer } from '@root/middleware/shared/ports/types'
+
+import type { PlannedChange } from './plan'
+import type { ApplySpec, SpecRemoteDevice, SpecServer } from './schema'
+
+/** A server's OPC-UA secrets, kept when the spec omits them. */
+interface PreservedSecrets {
+  serverPrivateKeyCustom?: string | null
+  passwordHashById: Map<string, string | null>
+}
+
+export function applyServers(spec: ApplySpec, changes: PlannedChange[], errors: string[]): void {
+  if (!spec.servers) return
+
+  const state = () => openPLCStoreBase.getState()
+  const existing = state().project.data.servers ?? []
+  const preserved = new Map(existing.map((server) => [server.name, collectSecrets(server)]))
+
+  const wanted = spec.servers.map((server) => server.name.toLowerCase())
+  const duplicate = wanted.find((name, index) => wanted.indexOf(name) !== index)
+  if (duplicate) {
+    errors.push(`Two servers in the spec are both named "${duplicate}".`)
+    return
+  }
+
+  const normalized: PLCServer[] = []
+  for (const server of spec.servers) {
+    const result = normalizeServerSpec(server)
+    if (!result.ok) {
+      errors.push(...result.errors)
+      continue
+    }
+    normalized.push(restoreSecrets(result.value, server, preserved.get(server.name)))
+  }
+  if (errors.length > 0) return
+
+  // Replace rather than patch: `createServer` refuses an existing name, and the
+  // granular update actions each cover one nested slice of one protocol.
+  // `executeSaveProject` filters `pendingDeletions` against the files it is
+  // about to write, so deleting and recreating the same name is not a delete.
+  for (const server of normalized) {
+    const had = existing.some((entry) => entry.name === server.name)
+    if (had) state().projectActions.deleteServer(server.name)
+    const response = state().projectActions.createServer({ data: server })
+    if (!response.ok) {
+      errors.push(`Could not create server "${server.name}": ${response.message ?? 'the store refused it'}`)
+      continue
+    }
+    changes.push({ kind: 'server', action: had ? 'update' : 'create', name: server.name })
+  }
+}
+
+/**
+ * `describe` redacts the private key and every password hash, so a spec that
+ * came from `describe` carries neither. Writing `null` in their place would
+ * destroy the key on the first round trip.
+ */
+function collectSecrets(server: PLCServer): PreservedSecrets {
+  const config = server.opcuaServerConfig
+  return {
+    serverPrivateKeyCustom: config?.security.serverPrivateKeyCustom,
+    passwordHashById: new Map((config?.users ?? []).map((user) => [user.id, user.passwordHash])),
+  }
+}
+
+function restoreSecrets(server: PLCServer, spec: SpecServer, preserved: PreservedSecrets | undefined): PLCServer {
+  if (!server.opcuaServerConfig || !preserved) return server
+
+  const config = server.opcuaServerConfig
+  const keyOmitted = spec.opcua?.security === undefined || !('serverPrivateKeyCustom' in spec.opcua.security)
+
+  return {
+    ...server,
+    opcuaServerConfig: {
+      ...config,
+      security: {
+        ...config.security,
+        serverPrivateKeyCustom: keyOmitted
+          ? (preserved.serverPrivateKeyCustom ?? config.security.serverPrivateKeyCustom)
+          : config.security.serverPrivateKeyCustom,
+      },
+      users: config.users.map((user, index) => {
+        const written = spec.opcua?.users?.[index]
+        if (written && 'passwordHash' in written) return user
+        const kept = preserved.passwordHashById.get(user.id)
+        return kept === undefined ? user : { ...user, passwordHash: kept }
+      }),
+    },
+  }
+}
+
+export async function applyRemoteDevices(
+  spec: ApplySpec,
+  projectPath: string,
+  changes: PlannedChange[],
+  errors: string[],
+): Promise<void> {
+  if (!spec.remoteDevices) return
+
+  const state = () => openPLCStoreBase.getState()
+
+  const wanted = spec.remoteDevices.map((device) => device.name.toLowerCase())
+  const duplicate = wanted.find((name, index) => wanted.indexOf(name) !== index)
+  if (duplicate) {
+    errors.push(`Two remote devices in the spec are both named "${duplicate}".`)
+    return
+  }
+
+  const normalized: NormalizedRemoteDevice[] = []
+  for (const device of spec.remoteDevices) {
+    const result = normalizeRemoteDeviceSpec(device)
+    if (!result.ok) {
+      errors.push(...result.errors)
+      continue
+    }
+    normalized.push(result.value)
+  }
+  if (errors.length > 0) return
+
+  // EtherCAT slaves are built before anything is written: reading an ESI file
+  // can fail, and a half-written bus is worse than an unchanged one.
+  const slavesByDevice = await buildEthercatSlaves(spec.remoteDevices, projectPath, errors)
+  if (errors.length > 0) return
+
+  const existing = state().project.data.remoteDevices ?? []
+
+  // Delete every device first. Each delete recalculates the project's addresses,
+  // so interleaving deletes with creates reallocates repeatedly and lands
+  // somewhere different depending on the order.
+  for (const device of normalized) {
+    if (existing.some((entry) => entry.name === device.device.name)) {
+      state().projectActions.deleteRemoteDevice(device.device.name)
+    }
+  }
+
+  for (const { device } of normalized) {
+    const had = existing.some((entry) => entry.name === device.name)
+    const response = state().projectActions.createRemoteDevice({ data: device })
+    if (!response.ok) {
+      errors.push(`Could not create remote device "${device.name}": ${response.message ?? 'the store refused it'}`)
+      continue
+    }
+    changes.push({ kind: 'remote-device', action: had ? 'update' : 'create', name: device.name })
+  }
+
+  // Groups in spec order, so the addresses a spec produces are a function of
+  // the document rather than of iteration order.
+  for (const { device, ioGroups } of normalized) {
+    for (const group of ioGroups) {
+      const response = state().projectActions.addIOGroup(device.name, group)
+      if (!response.ok) {
+        errors.push(`Could not add I/O group "${group.name}" to "${device.name}": ${response.message ?? 'refused'}`)
+        continue
+      }
+      changes.push({ kind: 'io-group', action: 'create', name: `${device.name}.${group.name}` })
+    }
+  }
+
+  // After the groups exist, so the points they name have been allocated.
+  for (const { device, aliasesByGroupId } of normalized) {
+    for (const [groupId, aliases] of aliasesByGroupId) {
+      const stored = state()
+        .project.data.remoteDevices?.find((entry) => entry.name === device.name)
+        ?.modbusTcpConfig?.ioGroups.find((group) => group.id === groupId)
+      if (!stored) continue
+      aliases.forEach((alias, index) => {
+        const point = stored.ioPoints?.[index]
+        if (!point) return
+        state().projectActions.updateIOPointAlias(device.name, groupId, point.id, alias)
+        changes.push({ kind: 'io-group', action: 'update', name: `${device.name}.${stored.name}[${index}] = ${alias}` })
+      })
+    }
+  }
+
+  for (const { device } of normalized) {
+    const slaves = slavesByDevice.get(device.name)
+    if (!slaves || device.protocol !== 'ethercat') continue
+    const response = state().projectActions.updateEthercatConfig(device.name, {
+      masterConfig: device.ethercatConfig?.masterConfig,
+      devices: slaves,
+    })
+    if (!response.ok) {
+      errors.push(`Could not configure the EtherCAT bus on "${device.name}": ${response.message ?? 'refused'}`)
+      continue
+    }
+    for (const slave of slaves) {
+      changes.push({ kind: 'ethercat-slave', action: 'create', name: `${device.name}.${slave.name}` })
+    }
+  }
+
+  // One recalculation for the whole section. Every action above triggers its
+  // own; this is the one whose result is kept.
+  state().projectActions.recalculateIecAddresses()
+}
+
+/**
+ * Build every EtherCAT slave in the spec, resolving each `repositoryItemId`
+ * against the project's own ESI repository.
+ *
+ * The id may be the repository item's uuid or the file's name. `esi import`
+ * mints the uuid, so requiring it would mean importing, reading the id back and
+ * pasting it into the spec before anything could be authored.
+ */
+async function buildEthercatSlaves(
+  specs: readonly SpecRemoteDevice[],
+  projectPath: string,
+  errors: string[],
+): Promise<Map<string, ConfiguredEtherCATDevice[]>> {
+  const byDevice = new Map<string, ConfiguredEtherCATDevice[]>()
+  const withSlaves = specs.filter((device) => (device.ethercat?.slaves ?? []).length > 0)
+  if (withSlaves.length === 0) return byDevice
+
+  const esi = new ESIService()
+  const index = await esi.loadRepositoryIndex(projectPath)
+  if (!index) {
+    errors.push('This project has no ESI repository — run `openplc-cli esi import` before declaring EtherCAT slaves.')
+    return byDevice
+  }
+
+  const xmlCache = new Map<string, string>()
+  // Claimed by buses this spec is NOT replacing. Counting the ones it IS
+  // replacing would make every re-apply rename `Axis1` to `Axis1_01` and push
+  // its channels to fresh addresses — the spec would never round-trip.
+  const replaced = new Set(specs.map((device) => device.name))
+  const untouched = openPLCStoreBase
+    .getState()
+    .project.data.remoteDevices?.filter((device) => !replaced.has(device.name))
+  const usedAddresses = claimedAddresses(untouched)
+  const takenNames = claimedSlaveNames(untouched)
+
+  for (const device of withSlaves) {
+    const slaves: ConfiguredEtherCATDevice[] = []
+    for (const [position, spec] of (device.ethercat?.slaves ?? []).entries()) {
+      const wanted = spec.esiDeviceRef.repositoryItemId
+      const item = index.items.find((entry) => entry.id === wanted || entry.filename === wanted)
+      if (!item) {
+        errors.push(
+          `EtherCAT slave on "${device.name}": no ESI file "${wanted}" in this project. ` +
+            `Known files: ${index.items.map((entry) => entry.filename).join(', ') || '(none)'}.`,
+        )
+        continue
+      }
+
+      let xml = xmlCache.get(item.id)
+      if (xml === undefined) {
+        const loaded = await esi.loadXmlFile(projectPath, item.id)
+        if (!loaded.success || !loaded.content) {
+          errors.push(`EtherCAT slave on "${device.name}": could not read ${item.filename} — ${loaded.error ?? ''}`)
+          continue
+        }
+        xml = loaded.content
+        xmlCache.set(item.id, xml)
+      }
+
+      const built = normalizeEthercatSlave({
+        spec: { ...spec, esiDeviceRef: { ...spec.esiDeviceRef, repositoryItemId: item.id } },
+        xml,
+        usedAddresses,
+        takenNames,
+        fallbackPosition: position,
+        // Stable across runs, so re-applying the same spec does not rewrite the
+        // file with new ids.
+        id: `${device.name}-${position}`,
+      })
+      if (!built.ok) {
+        errors.push(...built.errors)
+        continue
+      }
+      slaves.push(built.value)
+    }
+    byDevice.set(device.name, slaves)
+  }
+
+  return byDevice
+}
+
+/** IEC addresses held by the given devices. */
+function claimedAddresses(devices: readonly PLCRemoteDevice[] | undefined): Set<string> {
+  const claimed = new Set<string>()
+  for (const device of devices ?? []) {
+    for (const slave of device.ethercatConfig?.devices ?? []) {
+      for (const mapping of slave.channelMappings ?? []) claimed.add(mapping.iecLocation)
+    }
+  }
+  return claimed
+}
+
+function claimedSlaveNames(devices: readonly PLCRemoteDevice[] | undefined): Set<string> {
+  const names = new Set<string>()
+  for (const device of devices ?? []) {
+    for (const slave of device.ethercatConfig?.devices ?? []) names.add(slave.name)
+  }
+  return names
+}
+
+/** Remove servers and remote devices the spec stopped mentioning. */
+export function pruneProtocols(spec: ApplySpec, changes: PlannedChange[]): void {
+  const state = () => openPLCStoreBase.getState()
+
+  if (spec.servers) {
+    const wanted = new Set(spec.servers.map((server) => server.name))
+    for (const server of [...(state().project.data.servers ?? [])]) {
+      if (wanted.has(server.name)) continue
+      state().projectActions.deleteServer(server.name)
+      changes.push({ kind: 'server', action: 'delete', name: server.name })
+    }
+  }
+
+  if (spec.remoteDevices) {
+    const wanted = new Set(spec.remoteDevices.map((device) => device.name))
+    for (const device of [...(state().project.data.remoteDevices ?? [])]) {
+      if (wanted.has(device.name)) continue
+      state().projectActions.deleteRemoteDevice(device.name)
+      changes.push({ kind: 'remote-device', action: 'delete', name: device.name })
+    }
+  }
+}

--- a/src/cli/apply/schema.ts
+++ b/src/cli/apply/schema.ts
@@ -1,0 +1,766 @@
+/**
+ * The `apply` spec — what an agent writes to author a project.
+ *
+ * `.strict()` on every object, deliberately. An agent that writes `"varables"`
+ * gets `pous[0].varables: Unrecognized key` and can fix it; a permissive schema
+ * would accept the typo, produce a POU with no variables, and the mistake would
+ * only surface as a compile error in a file the agent never wrote.
+ *
+ * Shapes mirror the store's own types rather than inventing friendlier ones.
+ * A ladder contact variant is `'risingEdge'`, not `'rising'`, because that is
+ * the literal the ladder node carries — a nicer spelling here would be a second
+ * vocabulary to keep in sync.
+ */
+
+import type { OpcUaFieldConfig } from '@root/middleware/shared/ports/types'
+import { z } from 'zod'
+
+/** Every language the transpiler supports. `sfc` is parsed and then refused. */
+export const bodyLanguageSchema = z.enum(['st', 'il', 'ld', 'fbd', 'python', 'cpp', 'sfc'])
+
+const variableTypeSchema = z
+  .object({
+    definition: z.enum(['base-type', 'user-data-type', 'derived', 'array', 'generic-type']),
+    /**
+     * The type's name — and for `array`, the name of its ELEMENT (`INT`), not
+     * the rendered `ARRAY [0..3] OF INT`. The store keeps both that rendered
+     * text and a structured copy of the bounds; `apply` derives them from
+     * `dimensions` so the two cannot disagree.
+     */
+    value: z.string(),
+    /** `array` only, and required there: `["0..3"]`, one entry per dimension. */
+    dimensions: z.array(z.string().min(1)).min(1).optional(),
+  })
+  .strict()
+  .refine((type) => (type.definition === 'array') === (type.dimensions !== undefined), {
+    message: 'an array type needs "dimensions", and "dimensions" is only valid on an array type',
+  })
+
+const variableSchema = z
+  .object({
+    name: z.string().min(1),
+    /**
+     * Optional: the store itself allows a variable with no class, and a POU's
+     * plain local is the common case. Absent becomes `local` on a POU and
+     * `global` on the resource — see `toVariable` in `apply/plan.ts`.
+     */
+    class: z.enum(['input', 'output', 'inOut', 'local', 'temp', 'external', 'global']).optional(),
+    type: variableTypeSchema,
+    /** Alias name or a literal IEC address (`%IX0.0`). Empty = unlocated. */
+    location: z.string().optional(),
+    initialValue: z.string().nullable().optional(),
+    documentation: z.string().optional(),
+    debug: z.boolean().optional(),
+    /**
+     * The IEC block qualifier — the variables table's **Flags** column.
+     *
+     * Absent is a plain `VAR`, which is IEC's `NON_RETAIN`. `retain` keeps the
+     * value across a power cycle and needs the project's `persistentStorage`
+     * switched on to mean anything. One field because the two are mutually
+     * exclusive; STruC++ rejects the combination.
+     */
+    flag: z.enum(['constant', 'retain']).optional(),
+  })
+  .strict()
+
+// ---------------------------------------------------------------------------
+// Ladder
+// ---------------------------------------------------------------------------
+
+/** The literals the ladder nodes actually carry — see `ladder/utils/types.ts`. */
+const contactVariantSchema = z.enum(['default', 'negated', 'risingEdge', 'fallingEdge'])
+const coilVariantSchema = z.enum(['default', 'negated', 'risingEdge', 'fallingEdge', 'set', 'reset'])
+
+const contactSchema = z
+  .object({ contact: z.object({ variable: z.string().min(1), variant: contactVariantSchema }).strict() })
+  .strict()
+
+/**
+ * A rung is a series-parallel two-terminal network, so a nested expression
+ * describes it completely — no ids, no coordinates. Recursive, hence the
+ * explicit type annotation zod needs for a lazy schema.
+ */
+export type LadderLogic = z.infer<typeof contactSchema> | { series: LadderLogic[] } | { parallel: LadderLogic[] }
+
+const ladderLogicSchema: z.ZodType<LadderLogic> = z.lazy(() =>
+  z.union([
+    contactSchema,
+    z.object({ series: z.array(ladderLogicSchema).min(1) }).strict(),
+    z.object({ parallel: z.array(ladderLogicSchema).min(2) }).strict(),
+  ]),
+)
+
+const ladderOutputSchema = z.union([
+  z.object({ coil: z.object({ variable: z.string().min(1), variant: coilVariantSchema }).strict() }).strict(),
+  z
+    .object({
+      block: z
+        .object({
+          /** `system/<library>/<pou>` or `user/<pou>`. */
+          call: z.string().min(1),
+          /** Instance variable name — required for a function block. */
+          instance: z.string().optional(),
+          /** Literal or variable name per pin, keyed by the pin's own name. */
+          inputs: z.record(z.string(), z.string()).optional(),
+          /**
+           * Variable to receive each output pin. The pin carrying rung power
+           * continues the rung and is not named here.
+           */
+          outputs: z.record(z.string(), z.string()).optional(),
+          /**
+           * Add EN/ENO and pass rung power through them instead of through the
+           * block's first boolean input and output.
+           *
+           * Defaults to false, which is how a timer or counter is drawn — power
+           * drives `IN` and leaves on `Q`. With EN/ENO the rung only gates the
+           * call and `IN` is never driven, so the block does nothing. Forced on
+           * for a block whose first input or output is not BOOL.
+           */
+          executionControl: z.boolean().optional(),
+        })
+        .strict(),
+    })
+    .strict(),
+])
+
+const ladderBodySchema = z
+  .object({
+    rungs: z.array(
+      z
+        .object({
+          comment: z.string().optional(),
+          logic: ladderLogicSchema.optional(),
+          outputs: z.array(ladderOutputSchema).min(1),
+        })
+        .strict(),
+    ),
+  })
+  .strict()
+
+// ---------------------------------------------------------------------------
+// FBD
+// ---------------------------------------------------------------------------
+
+const fbdNodeSchema = z
+  .object({
+    /** Spec-local label. Never a store id — those are minted on apply. */
+    label: z.string().min(1),
+    kind: z.enum(['block', 'input-variable', 'output-variable', 'inout-variable', 'comment']),
+    /** `block` only. */
+    call: z.string().optional(),
+    /** `block` only — the instance variable for a function block. */
+    instance: z.string().optional(),
+    /** Variable nodes only. */
+    variable: z.string().optional(),
+    /** `comment` only. */
+    text: z.string().optional(),
+    /**
+     * `block` only — add EN/ENO so the block's execution can be gated. Forced on
+     * regardless for a block whose first input or output is not BOOL.
+     */
+    executionControl: z.boolean().optional(),
+    /**
+     * `block` only — the order this block is evaluated in, as the Block
+     * Properties dialog sets it. 0 leaves it unordered.
+     */
+    executionOrder: z.number().int().min(0).optional(),
+  })
+  .strict()
+
+const fbdBodySchema = z
+  .object({
+    nodes: z.array(fbdNodeSchema),
+    /** `from`/`to` are `label` or `label.PIN`; PIN is the pin's name verbatim. */
+    connections: z.array(z.object({ from: z.string().min(1), to: z.string().min(1) }).strict()),
+  })
+  .strict()
+
+// ---------------------------------------------------------------------------
+// POUs
+// ---------------------------------------------------------------------------
+
+/** Textual languages carry their body verbatim — including Python and C/C++. */
+const textBodySchema = z.object({ text: z.string() }).strict()
+
+const pouSchema = z
+  .object({
+    name: z.string().min(1),
+    kind: z.enum(['program', 'function', 'function-block']),
+    language: bodyLanguageSchema,
+    /** `function` only. */
+    returnType: z.string().optional(),
+    documentation: z.string().optional(),
+    variables: z.array(variableSchema).optional(),
+    body: z.union([textBodySchema, ladderBodySchema, fbdBodySchema]).optional(),
+  })
+  .strict()
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+const dataTypeSchema = z.discriminatedUnion('derivation', [
+  z
+    .object({
+      derivation: z.literal('enumerated'),
+      name: z.string().min(1),
+      values: z.array(z.string().min(1)).min(1),
+      initialValue: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      derivation: z.literal('structure'),
+      name: z.string().min(1),
+      variables: z
+        .array(
+          z
+            .object({
+              name: z.string().min(1),
+              type: variableTypeSchema,
+              initialValue: z.string().optional(),
+              documentation: z.string().optional(),
+            })
+            .strict(),
+        )
+        .min(1),
+    })
+    .strict(),
+  z
+    .object({
+      derivation: z.literal('array'),
+      name: z.string().min(1),
+      baseType: variableTypeSchema,
+      /** `0..9` per dimension. Empty means a scalar alias of `baseType`. */
+      dimensions: z.array(z.string().min(1)),
+      initialValue: z.string().optional(),
+    })
+    .strict(),
+])
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const taskSchema = z
+  .object({
+    name: z.string().min(1),
+    triggering: z.enum(['Cyclic', 'Interrupt']),
+    /** IEC duration — `T#20ms`. A bare `20ms` produces a project that will not compile. */
+    interval: z.string().min(1),
+    /** 0-100, and LOWER is higher priority. The stored schema leaves it
+     *  unbounded with a TODO; the documented rule is enforced here. */
+    priority: z.number().int().min(0).max(100),
+  })
+  .strict()
+
+const instanceSchema = z
+  .object({ name: z.string().min(1), program: z.string().min(1), task: z.string().min(1) })
+  .strict()
+
+// ---------------------------------------------------------------------------
+// Device and project settings
+// ---------------------------------------------------------------------------
+
+/**
+ * The target a project builds for.
+ *
+ * Not part of `PLCProjectData` — it lives in the device slice and is persisted
+ * separately — but it decides whether the project compiles at all, so a spec
+ * that cannot set it cannot describe a working project.
+ */
+const deviceSchema = z
+  .object({
+    /** Board name exactly as `openplc-cli devices` reports it. */
+    board: z.string().min(1).optional(),
+    /** Serial port for a board flashed over USB. */
+    communicationPort: z.string().optional(),
+    /** Address of a runtime target. */
+    runtimeIpAddress: z.string().optional(),
+    /**
+     * Where `retain` variables are kept, delivered to the device as
+     * `retain.conf` with the program.
+     *
+     * Off by default, and a project that leaves it off uploads no `retain.conf`
+     * at all — so a variable flagged `retain` retains nothing until this is on.
+     */
+    persistentStorage: z
+      .object({
+        enabled: z.boolean(),
+        /** Absolute path ON THE DEVICE. Empty means the runtime's own default. */
+        path: z.string().optional(),
+        /**
+         * Commit period in seconds, 1 to 3600.
+         *
+         * The runtime hands the store its blob every scan; this is what stops it
+         * writing through at scan rate and wearing the flash out. Lower costs
+         * less state on a power cut and works the storage harder. The runtime
+         * refuses a value outside the range at install time.
+         */
+        flushSeconds: z.number().int().min(1).max(3600).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+/** Libraries the project compiles against, by name and version. */
+const libraryRefSchema = z.object({ name: z.string().min(1), version: z.string().min(1) }).strict()
+
+/**
+ * A Global Variable List — what CODESYS calls a GVL.
+ *
+ * Distinct from `globalVariables`: a list carries its own `VAR_GLOBAL`
+ * qualifier (CONSTANT, RETAIN, PERSISTENT) and is referenced as `List.Member`.
+ */
+const globalVariableListSchema = z
+  .object({
+    name: z.string().min(1),
+    qualifier: z.enum(['CONSTANT', 'RETAIN', 'PERSISTENT', 'NON_RETAIN']).optional(),
+    documentation: z.string().optional(),
+    variables: z.array(variableSchema),
+  })
+  .strict()
+
+// ---------------------------------------------------------------------------
+// Protocols
+// ---------------------------------------------------------------------------
+
+/**
+ * Server and remote-device specs mirror what the project stores, with two
+ * differences: one `enabled` per server instead of a different nested flag per
+ * protocol, and everything below the name optional. Derived fields are absent —
+ * `ioPoints` and their IEC addresses are allocated by the editor, so a spec
+ * that named them would fight the allocator.
+ */
+
+const modbusBufferMappingSchema = z
+  .object({
+    holdingRegisters: z
+      .object({
+        qwCount: z.number().int().min(0).optional(),
+        mwCount: z.number().int().min(0).optional(),
+        mdCount: z.number().int().min(0).optional(),
+        mlCount: z.number().int().min(0).optional(),
+      })
+      .strict()
+      .optional(),
+    coils: z
+      .object({ qxBits: z.number().int().min(0).optional(), mxBits: z.number().int().min(0).optional() })
+      .strict()
+      .optional(),
+    discreteInputs: z
+      .object({ ixBits: z.number().int().min(0).optional() })
+      .strict()
+      .optional(),
+    inputRegisters: z
+      .object({ iwCount: z.number().int().min(0).optional() })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+const modbusSlaveSpecSchema = z
+  .object({
+    /** The address the runtime binds to; `0.0.0.0` is every interface. */
+    networkInterface: z.string().optional(),
+    port: z.number().int().min(1).max(65535).optional(),
+    bufferMapping: modbusBufferMappingSchema.optional(),
+  })
+  .strict()
+
+const s7BufferMappingSchema = z
+  .object({
+    type: z.enum([
+      'bool_input',
+      'bool_output',
+      'bool_memory',
+      'byte_input',
+      'byte_output',
+      'int_input',
+      'int_output',
+      'int_memory',
+      'dint_input',
+      'dint_output',
+      'dint_memory',
+      'lint_input',
+      'lint_output',
+      'lint_memory',
+    ]),
+    startBuffer: z.number().int().min(0).max(1023),
+    bitAddressing: z.boolean(),
+  })
+  .strict()
+
+const s7SystemAreaSchema = z
+  .object({
+    enabled: z.boolean(),
+    sizeBytes: z.number().int().min(1).max(65536),
+    mapping: s7BufferMappingSchema.optional(),
+  })
+  .strict()
+
+const s7commSpecSchema = z
+  .object({
+    server: z
+      .object({
+        bindAddress: z.string().optional(),
+        port: z.number().int().min(1).max(65535).optional(),
+        maxClients: z.number().int().min(1).max(1024).optional(),
+        workIntervalMs: z.number().int().min(1).max(10000).optional(),
+        sendTimeoutMs: z.number().int().min(100).max(60000).optional(),
+        recvTimeoutMs: z.number().int().min(100).max(60000).optional(),
+        pingTimeoutMs: z.number().int().min(1000).max(300000).optional(),
+        pduSize: z.number().int().min(240).max(960).optional(),
+      })
+      .strict()
+      .optional(),
+    plcIdentity: z
+      .object({
+        name: z.string().max(64).optional(),
+        moduleType: z.string().max(64).optional(),
+        serialNumber: z.string().max(64).optional(),
+        copyright: z.string().max(64).optional(),
+        moduleName: z.string().max(64).optional(),
+      })
+      .strict()
+      .optional(),
+    dataBlocks: z
+      .array(
+        z
+          .object({
+            dbNumber: z.number().int().min(1).max(65535),
+            description: z.string().max(128),
+            sizeBytes: z.number().int().min(1).max(65536),
+            mapping: s7BufferMappingSchema,
+          })
+          .strict(),
+      )
+      .max(64)
+      .optional(),
+    systemAreas: z
+      .object({
+        peArea: s7SystemAreaSchema.optional(),
+        paArea: s7SystemAreaSchema.optional(),
+        mkArea: s7SystemAreaSchema.optional(),
+      })
+      .strict()
+      .optional(),
+    logging: z
+      .object({
+        logConnections: z.boolean().optional(),
+        logDataAccess: z.boolean().optional(),
+        logErrors: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+const opcUaPermissionsSchema = z
+  .object({ viewer: z.enum(['r', 'w', 'rw']), operator: z.enum(['r', 'w', 'rw']), engineer: z.enum(['r', 'w', 'rw']) })
+  .strict()
+
+/** Recursive: a structure node's fields carry their own fields. */
+const opcUaFieldSchema: z.ZodType<OpcUaFieldConfig> = z.lazy(() =>
+  z
+    .object({
+      fieldPath: z.string().min(1),
+      displayName: z.string(),
+      datatype: z.string().optional(),
+      permissions: opcUaPermissionsSchema,
+      fields: z.array(opcUaFieldSchema).optional(),
+    })
+    .strict(),
+)
+
+const opcUaSpecSchema = z
+  .object({
+    server: z
+      .object({
+        name: z.string().max(128).optional(),
+        applicationUri: z.string().optional(),
+        productUri: z.string().optional(),
+        bindAddress: z.string().optional(),
+        port: z.number().int().min(1).max(65535).optional(),
+        endpointPath: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    securityProfiles: z
+      .array(
+        z
+          .object({
+            /** Defaults to `profile-<name>`, so a round trip is stable. */
+            id: z.string().optional(),
+            name: z.string().min(1).max(64),
+            enabled: z.boolean(),
+            securityPolicy: z.enum(['None', 'Basic128Rsa15', 'Basic256', 'Basic256Sha256']),
+            securityMode: z.enum(['None', 'Sign', 'SignAndEncrypt']),
+            authMethods: z.array(z.enum(['Anonymous', 'Username', 'Certificate'])).min(1),
+          })
+          .strict(),
+      )
+      .optional(),
+    security: z
+      .object({
+        serverCertificateStrategy: z.enum(['auto_self_signed', 'custom']).optional(),
+        serverCertificateCustom: z.string().nullable().optional(),
+        /** Redacted by `describe`; omitting it on apply keeps what is stored. */
+        serverPrivateKeyCustom: z.string().nullable().optional(),
+        trustedClientCertificates: z
+          .array(
+            z
+              .object({
+                id: z.string().min(1).max(64),
+                pem: z.string(),
+                subject: z.string().optional(),
+                validFrom: z.string().optional(),
+                validTo: z.string().optional(),
+                fingerprint: z.string().optional(),
+              })
+              .strict(),
+          )
+          .optional(),
+      })
+      .strict()
+      .optional(),
+    users: z
+      .array(
+        z
+          .object({
+            /** Defaults to `user-<username>`. */
+            id: z.string().optional(),
+            type: z.enum(['password', 'certificate']),
+            username: z.string().nullable(),
+            /** Redacted by `describe`; omitting it on apply keeps what is stored. */
+            passwordHash: z.string().nullable().optional(),
+            certificateId: z.string().nullable(),
+            role: z.enum(['viewer', 'operator', 'engineer']),
+          })
+          .strict(),
+      )
+      .optional(),
+    cycleTimeMs: z.number().int().min(10).max(10000).optional(),
+    addressSpace: z
+      .object({
+        namespaceUri: z.string().optional(),
+        nodes: z
+          .array(
+            z
+              .object({
+                /** Defaults to `<pouName>.<variablePath>`. Internal; not the
+                 *  OPC-UA Node ID. */
+                id: z.string().optional(),
+                pouName: z.string().min(1),
+                variablePath: z.string().min(1),
+                variableType: z.string(),
+                /** The OPC-UA Node ID's IDENTIFIER, not a whole node id: the
+                 *  server prefixes its own namespace. The editor generates
+                 *  `PLC.<POU>.<path>` and caps it at 128 characters. */
+                nodeId: z.string().min(1).max(128),
+                browseName: z.string(),
+                displayName: z.string(),
+                description: z.string(),
+                permissions: opcUaPermissionsSchema,
+                nodeType: z.enum(['variable', 'structure', 'array']),
+                fields: z.array(opcUaFieldSchema).optional(),
+                arrayLength: z.number().int().optional(),
+                elementType: z.string().optional(),
+              })
+              .strict(),
+          )
+          .optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+const serverSchema = z
+  .object({
+    name: z.string().min(1),
+    /** `ethernet-ip` is refused: the editor stores it but nothing generates it. */
+    protocol: z.enum(['modbus-tcp', 's7comm', 'opcua']),
+    /**
+     * One switch per server. Stored, it lives in a different place for each
+     * protocol, which is three chances to set the wrong one. Absent is off,
+     * matching what the GUI creates.
+     */
+    enabled: z.boolean().optional(),
+    modbus: modbusSlaveSpecSchema.optional(),
+    s7comm: s7commSpecSchema.optional(),
+    opcua: opcUaSpecSchema.optional(),
+  })
+  .strict()
+
+const ioGroupSchema = z
+  .object({
+    name: z.string().min(1),
+    /** The Modbus function code, as the string the store keeps. */
+    functionCode: z.enum(['1', '2', '3', '4', '5', '6', '15', '16']),
+    cycleTime: z.number().int().min(1),
+    /** First register/coil address, decimal or `0x`-prefixed. */
+    offset: z.string().min(1),
+    length: z.number().int().min(1),
+    errorHandling: z.enum(['keep-last-value', 'set-to-zero']).optional(),
+    /** One name per point, in order. A variable binds to a point by alias. */
+    aliases: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+
+const modbusMasterSpecSchema = z
+  .object({
+    transport: z.enum(['tcp', 'rtu']).optional(),
+    host: z.string().optional(),
+    port: z.number().int().min(1).max(65535).optional(),
+    /** Required for `rtu`: the generator drops a device without one. */
+    serialPort: z.string().optional(),
+    baudRate: z.number().int().min(1).optional(),
+    parity: z.enum(['N', 'E', 'O']).optional(),
+    stopBits: z.number().int().min(1).max(2).optional(),
+    dataBits: z.number().int().min(7).max(8).optional(),
+    timeout: z.number().int().min(1).optional(),
+    /** 0..255 over TCP, 1..247 over RTU — checked against the transport. */
+    slaveId: z.number().int().min(0).max(255).optional(),
+    ioGroups: z.array(ioGroupSchema).optional(),
+  })
+  .strict()
+
+const ethercatSlaveSchema = z
+  .object({
+    /** Which ESI file, and which device inside it. `esi import` adds files. */
+    esiDeviceRef: z
+      .object({ repositoryItemId: z.string().min(1), deviceIndex: z.number().int().min(0).optional() })
+      .strict(),
+    /** Defaults to the ESI's own short name, made unique across the bus. */
+    name: z.string().min(1).optional(),
+    position: z.number().int().min(0).optional(),
+    config: z
+      .object({
+        startupChecks: z
+          .object({ checkVendorId: z.boolean().optional(), checkProductCode: z.boolean().optional() })
+          .strict()
+          .optional(),
+        addressing: z
+          .object({ ethercatAddress: z.number().int().min(0).max(65535) })
+          .strict()
+          .optional(),
+        timeouts: z
+          .object({
+            sdoTimeoutMs: z.number().int().min(0).optional(),
+            initToPreOpTimeoutMs: z.number().int().min(0).optional(),
+            safeOpToOpTimeoutMs: z.number().int().min(0).optional(),
+          })
+          .strict()
+          .optional(),
+        watchdog: z
+          .object({
+            smWatchdogEnabled: z.boolean().optional(),
+            smWatchdogMs: z.number().int().min(0).optional(),
+            pdiWatchdogEnabled: z.boolean().optional(),
+            pdiWatchdogMs: z.number().int().min(0).optional(),
+          })
+          .strict()
+          .optional(),
+        distributedClocks: z
+          .object({
+            dcEnabled: z.boolean().optional(),
+            dcSyncUnitCycleUs: z.number().int().min(0).optional(),
+            dcSync0Enabled: z.boolean().optional(),
+            dcSync0CycleUs: z.number().int().min(0).optional(),
+            dcSync0ShiftUs: z.number().int().min(0).optional(),
+            dcSync1Enabled: z.boolean().optional(),
+            dcSync1CycleUs: z.number().int().min(0).optional(),
+            dcSync1ShiftUs: z.number().int().min(0).optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
+    /** A CiA 402 drive is recognized from the ESI; this overrides the scaling. */
+    cia402: z
+      .object({
+        enabled: z.boolean().optional(),
+        scaleNum: z.number().optional(),
+        scaleDenom: z.number().optional(),
+        scaleFactor: z.number().optional(),
+      })
+      .strict()
+      .optional(),
+    /** Channel id → alias, for the channels you want named. */
+    aliases: z.record(z.string(), z.string().min(1)).optional(),
+  })
+  .strict()
+
+const ethercatSpecSchema = z
+  .object({
+    master: z
+      .object({
+        enabled: z.boolean().optional(),
+        networkInterface: z.string().optional(),
+        cycleTimeUs: z.number().int().min(100).max(100000).optional(),
+        watchdogTimeoutCycles: z.number().int().min(1).max(100).optional(),
+        taskPriority: z.number().int().min(1).max(31).optional(),
+      })
+      .strict()
+      .optional(),
+    slaves: z.array(ethercatSlaveSchema).optional(),
+  })
+  .strict()
+
+const remoteDeviceSchema = z
+  .object({
+    name: z.string().min(1),
+    /** `ethernet-ip` and `profinet` are refused: neither has a generator. */
+    protocol: z.enum(['modbus-tcp', 'ethercat']),
+    modbus: modbusMasterSpecSchema.optional(),
+    ethercat: ethercatSpecSchema.optional(),
+  })
+  .strict()
+
+export const applySpecSchema = z
+  .object({
+    specVersion: z.literal(1),
+    device: deviceSchema.optional(),
+    libraries: z.array(libraryRefSchema).optional(),
+    dataTypes: z.array(dataTypeSchema).optional(),
+    globalVariableLists: z.array(globalVariableListSchema).optional(),
+    globalVariables: z.array(variableSchema).optional(),
+    pous: z.array(pouSchema).optional(),
+    tasks: z.array(taskSchema).optional(),
+    instances: z.array(instanceSchema).optional(),
+    servers: z.array(serverSchema).optional(),
+    remoteDevices: z.array(remoteDeviceSchema).optional(),
+  })
+  .strict()
+
+export type ApplySpec = z.infer<typeof applySpecSchema>
+export type SpecPou = z.infer<typeof pouSchema>
+export type SpecVariable = z.infer<typeof variableSchema>
+export type SpecDataType = z.infer<typeof dataTypeSchema>
+export type SpecTask = z.infer<typeof taskSchema>
+export type SpecInstance = z.infer<typeof instanceSchema>
+export type SpecLadderBody = z.infer<typeof ladderBodySchema>
+export type SpecFbdBody = z.infer<typeof fbdBodySchema>
+export type SpecLadderOutput = z.infer<typeof ladderOutputSchema>
+export type SpecDevice = z.infer<typeof deviceSchema>
+export type SpecGlobalVariableList = z.infer<typeof globalVariableListSchema>
+export type SpecServer = z.infer<typeof serverSchema>
+export type SpecRemoteDevice = z.infer<typeof remoteDeviceSchema>
+export type SpecIOGroup = z.infer<typeof ioGroupSchema>
+export type SpecEtherCATSlave = z.infer<typeof ethercatSlaveSchema>
+
+/** `path: message`, one per issue — the shape the reporter's `details` renders. */
+export function formatSpecIssues(error: z.ZodError): string[] {
+  return error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '(root)'
+    return `${path}: ${issue.message}`
+  })
+}
+
+export function parseApplySpec(input: unknown): { ok: true; spec: ApplySpec } | { ok: false; issues: string[] } {
+  const parsed = applySpecSchema.safeParse(input)
+  return parsed.success ? { ok: true, spec: parsed.data } : { ok: false, issues: formatSpecIssues(parsed.error) }
+}

--- a/src/cli/check/protocol-confs.ts
+++ b/src/cli/check/protocol-confs.ts
@@ -1,0 +1,64 @@
+/**
+ * Which `conf/*.json` an upload would carry.
+ *
+ * The runtime enables a plugin by the PRESENCE of `core/generated/conf/<name>.json`
+ * — there is no `enabled` key it reads at that level and no endpoint that reports
+ * which plugins are on. So this file set is the enable state, and computing it
+ * with the same function the bundle uses is the only honest way to answer
+ * "will Modbus be listening" without an upload.
+ */
+
+import type { GenerateConfsInput } from '@root/backend/shared/compile/steps/generate-confs'
+import { generateRuntimeConfs } from '@root/backend/shared/compile/steps/generate-confs'
+import type { PLCProjectData } from '@root/middleware/shared/ports/types'
+
+export interface ProtocolConfSummary {
+  /** The file the upload would write, or null when the protocol is off. */
+  confFile: string | null
+  enabled: boolean
+}
+
+export type ProtocolConfs =
+  | { ok: true; confs: Record<string, ProtocolConfSummary> }
+  /** The generators abort the compile rather than emit a bad config. */
+  | { ok: false; error: string }
+
+export function describeProtocolConfs(
+  project: PLCProjectData,
+  debugMapContent: string,
+  log: GenerateConfsInput['log'],
+): ProtocolConfs {
+  let confs: ReturnType<typeof generateRuntimeConfs>
+  try {
+    confs = generateRuntimeConfs({
+      servers: project.servers as GenerateConfsInput['servers'],
+      remoteDevices: project.remoteDevices as GenerateConfsInput['remoteDevices'],
+      instances: (project.configurations?.resource?.instances ?? []).map((instance) => ({
+        name: instance.name,
+        task: instance.task,
+        program: instance.program,
+      })),
+      debugMapContent,
+      log,
+    })
+  } catch (error) {
+    // OPC-UA and EtherCAT both abort the compile from here rather than emitting
+    // a bad config, so a throw is the answer, not a crash.
+    return { ok: false, error: error instanceof Error ? error.message : String(error) }
+  }
+
+  return {
+    ok: true,
+    confs: {
+      modbusSlave: summarize('conf/modbus_slave.json', confs.modbusSlave),
+      modbusMaster: summarize('conf/modbus_master.json', confs.modbusMaster),
+      s7comm: summarize('conf/s7comm.json', confs.s7Comm),
+      opcua: summarize('conf/opcua.json', confs.opcUa),
+      ethercat: summarize('conf/ethercat.json', confs.ethercat),
+    },
+  }
+}
+
+function summarize(confFile: string, content: string | null): ProtocolConfSummary {
+  return content === null ? { confFile: null, enabled: false } : { confFile, enabled: true }
+}

--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -1,0 +1,183 @@
+/**
+ * `openplc-cli apply` — author a project from a declarative spec.
+ *
+ * Declarative rather than a sequence of commands for two reasons. Store actions
+ * are order-dependent in ways a caller cannot see (a local variable needs its
+ * POU first; an instance names a task and a program and validates neither), and
+ * `executeSaveProject` serialises the entire project, so N fine-grained
+ * commands would mean N full rewrites of every file.
+ *
+ * Upsert by name and idempotent: applying the same spec twice leaves the same
+ * project. `--prune` additionally removes what the spec does not mention;
+ * `--dry-run` reports the change list and saves nothing.
+ */
+
+import { readFile } from 'node:fs/promises'
+
+import { executeSaveProject } from '@root/frontend/services/save-actions'
+import { EDITOR_CAPABILITIES } from '@root/middleware/shared/ports/platform-capabilities'
+
+import { applySpec, type PlannedChange } from '../apply/plan'
+import { parseApplySpec } from '../apply/schema'
+import { boolFlag, type ParsedArgs, stringFlag } from '../args'
+import { ErrorCode, ExitCode } from '../exit-codes'
+import type { CliResult, Reporter } from '../output'
+import { loadProject, unreadableProtocolFilesMessage } from '../project/load'
+import { createCliProjectPort } from '../project/project-port'
+
+export async function runApply(args: ParsedArgs, reporter: Reporter): Promise<CliResult> {
+  const specPath = args.positionals[0]
+  if (!specPath) {
+    return reporter.failure(
+      { code: ErrorCode.InvalidArgument, message: 'apply needs a spec file, or - to read one from stdin.' },
+      ExitCode.Usage,
+    )
+  }
+
+  const source = await readSpec(specPath)
+  if (!source.ok) {
+    return reporter.failure({ code: ErrorCode.InvalidArgument, message: source.error }, ExitCode.NotFound)
+  }
+
+  let raw: unknown
+  try {
+    raw = JSON.parse(source.text)
+  } catch (err) {
+    return reporter.failure(
+      { code: ErrorCode.InvalidArgument, message: `${specPath} is not valid JSON: ${describe(err)}` },
+      ExitCode.Usage,
+    )
+  }
+
+  const parsed = parseApplySpec(raw)
+  if (!parsed.ok) {
+    return reporter.failure(
+      {
+        code: ErrorCode.InvalidArgument,
+        message: `${specPath} does not match the spec schema.`,
+        details: parsed.issues,
+      },
+      ExitCode.Usage,
+    )
+  }
+
+  const projectPath = stringFlag(args, 'project') ?? args.positionals[1]
+  if (!projectPath) {
+    return reporter.failure(
+      { code: ErrorCode.InvalidArgument, message: 'apply needs --project <dir>.' },
+      ExitCode.Usage,
+    )
+  }
+
+  const loaded = await loadProject(projectPath)
+  if (!loaded.success) {
+    return reporter.failure({ code: ErrorCode.ProjectNotFound, message: loaded.error }, ExitCode.NotFound)
+  }
+  for (const warning of loaded.project.warnings) reporter.progress(warning)
+
+  const unreadable = unreadableProtocolFilesMessage(loaded.project)
+  if (unreadable) {
+    return reporter.failure(
+      {
+        code: ErrorCode.ProtocolFileUnreadable,
+        message: unreadable,
+        details: loaded.project.unreadableProtocolFiles,
+      },
+      ExitCode.TargetError,
+    )
+  }
+
+  // `executeSaveProject` refuses on either of these and says so only through a
+  // toast, which goes nowhere here — without this check `apply` would report
+  // success having written nothing.
+  if (!loaded.project.canEdit) {
+    return reporter.failure(
+      {
+        code: ErrorCode.TargetError,
+        message: 'This project is read-only — it loaded with errors, so nothing would be saved.',
+      },
+      ExitCode.TargetError,
+    )
+  }
+  if (loaded.project.isEphemeral) {
+    return reporter.failure(
+      { code: ErrorCode.TargetError, message: 'This project has no location on disk, so nothing would be saved.' },
+      ExitCode.TargetError,
+    )
+  }
+
+  const dryRun = boolFlag(args, 'dry-run')
+  const outcome = await applySpec(parsed.spec, { prune: boolFlag(args, 'prune'), projectPath })
+
+  // Errors before the save, always: a half-applied project written to disk is
+  // worse than one not written at all, and the store is discarded on exit.
+  if (outcome.errors.length > 0) {
+    return reporter.partial(
+      { ok: false, project: loaded.project.name, changes: outcome.changes, errors: outcome.errors, saved: false },
+      {
+        code: ErrorCode.InvalidArgument,
+        message: `${outcome.errors.length} problem(s) in the spec — nothing was saved.`,
+        details: outcome.errors,
+      },
+      ExitCode.CompileFailed,
+      () => render(outcome.changes, outcome.errors, false),
+    )
+  }
+
+  if (dryRun) {
+    return reporter.success(
+      { ok: true, project: loaded.project.name, changes: outcome.changes, errors: [], saved: false, dryRun: true },
+      () => `${render(outcome.changes, [], false)}\n\nDry run — nothing written.`,
+    )
+  }
+
+  const saved = await executeSaveProject(createCliProjectPort(), EDITOR_CAPABILITIES, 'user')
+  if (!saved.success) {
+    return reporter.failure({ code: ErrorCode.Internal, message: 'The project could not be saved.' }, ExitCode.Internal)
+  }
+
+  return reporter.success(
+    { ok: true, project: loaded.project.name, changes: outcome.changes, errors: [], saved: true },
+    () => render(outcome.changes, [], true),
+  )
+}
+
+async function readSpec(specPath: string): Promise<{ ok: true; text: string } | { ok: false; error: string }> {
+  if (specPath === '-') {
+    try {
+      let text = ''
+      process.stdin.setEncoding('utf-8')
+      for await (const chunk of process.stdin) text += String(chunk)
+      return { ok: true, text }
+    } catch (err) {
+      return { ok: false, error: `Could not read the spec from stdin: ${describe(err)}` }
+    }
+  }
+  try {
+    return { ok: true, text: await readFile(specPath, 'utf-8') }
+  } catch {
+    return { ok: false, error: `Could not read ${specPath}` }
+  }
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+function render(changes: PlannedChange[], errors: string[], saved: boolean): string {
+  if (changes.length === 0 && errors.length === 0) return 'Nothing to change.'
+
+  const lines: string[] = []
+  for (const change of changes) {
+    lines.push(`  ${change.action} ${change.kind} ${change.name}`)
+  }
+  for (const error of errors) lines.push(`  error: ${error}`)
+
+  const applied = changes.length
+  lines.unshift(
+    errors.length > 0
+      ? `${applied} change(s) attempted, ${errors.length} problem(s)`
+      : `${applied} change(s)${saved ? ' — saved' : ''}`,
+  )
+  return lines.join('\n')
+}

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -31,7 +31,7 @@ import { ErrorCode, ExitCode } from '../exit-codes'
 import { type LintFinding, lintProgram } from '../lint/program'
 import { lintProtocols } from '../lint/protocol'
 import type { CliResult, Reporter } from '../output'
-import { loadProject } from '../project/load'
+import { loadProject, unreadableProtocolFilesMessage } from '../project/load'
 
 export async function runCheck(args: ParsedArgs, reporter: Reporter): Promise<CliResult> {
   const projectPath = args.positionals[0] ?? stringFlag(args, 'project')
@@ -47,6 +47,21 @@ export async function runCheck(args: ParsedArgs, reporter: Reporter): Promise<Cl
     return reporter.failure({ code: ErrorCode.ProjectNotFound, message: loaded.error }, ExitCode.NotFound)
   }
   for (const warning of loaded.project.warnings) reporter.progress(warning)
+
+  // Same refusal `apply` and `describe` make. A skipped server file is absent
+  // from the project, so `--protocols` and the protocol lint would both answer
+  // for a configuration that is not the one on disk — and answer "OK".
+  const unreadable = unreadableProtocolFilesMessage(loaded.project)
+  if (unreadable) {
+    return reporter.failure(
+      {
+        code: ErrorCode.ProtocolFileUnreadable,
+        message: unreadable,
+        details: loaded.project.unreadableProtocolFiles,
+      },
+      ExitCode.TargetError,
+    )
+  }
 
   const target = stringFlag(args, 'target') ?? loaded.project.board
   if (!target) {

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -1,0 +1,282 @@
+/**
+ * `openplc-cli check` — transpile a project to Structured Text and report what
+ * the compiler would say, without building anything.
+ *
+ * A board compile takes tens of seconds and needs a toolchain. Most of what an
+ * agent gets wrong — an undeclared variable, a pin that does not exist, a POU
+ * that will not project — is settled long before a compiler runs. `check`
+ * returns that verdict in well under a second.
+ *
+ * It deliberately runs the SAME preparation a build does
+ * (`prepareProjectForCompile`): board resolution, the library C/C++ graft and
+ * POU preprocessing. A check that skipped those would pass on projects the
+ * compiler rejects, which is worse than no check at all.
+ */
+
+import crypto from 'node:crypto'
+
+import { runProgramBuildPipeline } from '@root/backend/shared/library/program-build-pipeline'
+import type { SchemaProjectData } from '@root/backend/shared/transpilers/st-transpiler'
+import { fromSchemaShape, transpileToSt } from '@root/backend/shared/transpilers/st-transpiler'
+import type { KnownPou } from '@root/backend/shared/utils/PLC/split-program-st'
+import { openPLCStoreBase } from '@root/frontend/store'
+import { prepareProjectForCompile } from '@root/middleware/adapters/editor/compile-program-flow'
+import { toIpcProjectData } from '@root/middleware/adapters/editor/compiler-adapter'
+import type { PLCProjectData } from '@root/middleware/shared/ports/types'
+
+import { boolFlag, type ParsedArgs, stringFlag } from '../args'
+import { describeProtocolConfs, type ProtocolConfs } from '../check/protocol-confs'
+import { createCliCompileTransport } from '../compile/cli-transport'
+import { ErrorCode, ExitCode } from '../exit-codes'
+import { type LintFinding, lintProgram } from '../lint/program'
+import { lintProtocols } from '../lint/protocol'
+import type { CliResult, Reporter } from '../output'
+import { loadProject } from '../project/load'
+
+export async function runCheck(args: ParsedArgs, reporter: Reporter): Promise<CliResult> {
+  const projectPath = args.positionals[0] ?? stringFlag(args, 'project')
+  if (!projectPath) {
+    return reporter.failure(
+      { code: ErrorCode.InvalidArgument, message: 'check needs the path of a project.' },
+      ExitCode.Usage,
+    )
+  }
+
+  const loaded = await loadProject(projectPath)
+  if (!loaded.success) {
+    return reporter.failure({ code: ErrorCode.ProjectNotFound, message: loaded.error }, ExitCode.NotFound)
+  }
+  for (const warning of loaded.project.warnings) reporter.progress(warning)
+
+  const target = stringFlag(args, 'target') ?? loaded.project.board
+  if (!target) {
+    return reporter.failure(
+      {
+        code: ErrorCode.TargetUnknown,
+        message: 'This project names no board — pass --target (see `openplc-cli devices`).',
+      },
+      ExitCode.Usage,
+    )
+  }
+
+  // `runtime: null` — nothing here uploads, so there is no device and no
+  // credentials. Only `getAvailableBoards` and `loadAllLibraries` are reached.
+  const preparation = await prepareProjectForCompile(
+    { projectData: loaded.project.compileReady, boardTarget: target },
+    createCliCompileTransport(null),
+    (event) => {
+      if (event.level === 'error' || event.level === 'warning') {
+        reporter.progress(`  ${event.level}: ${event.message}`)
+      }
+    },
+  )
+  if (!preparation.ok) {
+    return reporter.failure({ code: ErrorCode.CompileFailed, message: preparation.error }, ExitCode.CompileFailed)
+  }
+
+  const projected = projectToTranspiler(preparation.prepared.processedData)
+  if (!projected.ok) {
+    return reporter.failure({ code: ErrorCode.InvalidArgument, message: projected.error }, ExitCode.CompileFailed)
+  }
+
+  const result = transpileToSt(projected.project)
+  const collected = [...result.errors]
+  const collectedWarnings = [...result.warnings]
+
+  // Projection is only half a check. `transpileToSt` turns the project into ST;
+  // it does not compile it, so an undeclared variable — the mistake an agent
+  // makes most — projects perfectly and reports OK. The semantic pass lives in
+  // strucpp, and `runProgramBuildPipeline` runs it in-process with no disk I/O,
+  // no toolchain and no board. Without this, `check` would say OK on a project
+  // `compile` rejects, which is worse than having no check at all.
+  // strucpp emits `debug-map.json` alongside the C++ — the OPC-UA validator
+  // resolves every address-space node through it, so keeping it here is what
+  // lets `--protocols` catch a node naming a variable the program lacks.
+  let debugMapContent = ''
+  if (result.programSt !== null) {
+    const compiled = runProgramBuildPipeline({
+      source: result.programSt,
+      md5: crypto.createHash('md5').update(result.programSt).digest('hex'),
+      pous: knownPous(preparation.prepared.processedData),
+      libraries: preparation.prepared.archives,
+      missingLibraries: [],
+      hasCBlocks: preparation.prepared.processedData.pous.some((pou) => pou.body.language === 'cpp'),
+    })
+    for (const diagnostic of compiled.errors) collected.push(diagnostic.formatted)
+    for (const diagnostic of compiled.warnings) collectedWarnings.push(diagnostic.formatted)
+    debugMapContent = compiled.files.find((file) => file.name === 'debug-map.json')?.content ?? ''
+  }
+
+  // The linter reads the ST the transpiler just produced: `check` answers "does
+  // this compile", and every finding it reports compiles perfectly.
+  const lint: LintFinding[] = []
+  if (boolFlag(args, 'lint') && result.programSt !== null) {
+    lint.push(
+      ...lintProgram({
+        st: result.programSt,
+        pous: preparation.prepared.processedData.pous,
+        systemLibraries: openPLCStoreBase.getState().libraries.system,
+        globals: loaded.project.compileReady.configurations?.resource?.globalVariables ?? [],
+      }),
+    )
+  }
+
+  // Protocol findings are project-wide (`pou: null`), so they survive `--pou`.
+  if (boolFlag(args, 'lint')) {
+    lint.push(
+      ...lintProtocols({
+        servers: loaded.project.compileReady.servers ?? [],
+        remoteDevices: loaded.project.compileReady.remoteDevices ?? [],
+        debugMapContent,
+        instances: (loaded.project.compileReady.configurations?.resource?.instances ?? []).map((instance) => ({
+          name: instance.name,
+          task: instance.task,
+          program: instance.program,
+        })),
+        // STORED globals, not the compile-ready ones: a global bound to a device
+        // point by ALIAS is resolved to that point's address on the way to the
+        // compiler, and comparing that would report every correct binding as a
+        // collision. Only a hand-written literal address can collide.
+        globals: loaded.project.data.configurations?.resource?.globalVariables ?? [],
+      }),
+    )
+  }
+
+  const onlyPou = stringFlag(args, 'pou')
+  const errors = onlyPou ? collected.filter((line) => mentionsPou(line, onlyPou)) : collected
+  const warnings = onlyPou ? collectedWarnings.filter((line) => mentionsPou(line, onlyPou)) : collectedWarnings
+  const lintFindings = onlyPou ? lint.filter((finding) => finding.pou === null || finding.pou === onlyPou) : lint
+  // A lint error fails the command, a warning does not — the same bargain a
+  // compiler strikes, so `--lint` is safe to leave on in a pipeline.
+  const lintErrors = lintFindings.filter((finding) => finding.severity === 'error')
+  const ok = errors.length === 0 && lintErrors.length === 0
+
+  const payload: Record<string, unknown> = {
+    ok,
+    project: loaded.project.name,
+    target,
+    pous: result.pouNames,
+    errors,
+    warnings,
+  }
+  if (boolFlag(args, 'emit-st')) payload.st = result.programSt
+  if (boolFlag(args, 'lint')) payload.lint = lintFindings
+
+  // Which `conf/*.json` the upload would carry. The runtime decides which
+  // plugins to load from exactly that file set and offers no way to read it
+  // back, so this — computed by the same code that produces the bundle — IS the
+  // enable state, with no device needed.
+  if (boolFlag(args, 'protocols')) {
+    payload.protocols = describeProtocolConfs(loaded.project.compileReady, debugMapContent, (message, level) => {
+      if (level === 'error' || level === 'warning') reporter.progress(`  ${level}: ${message}`)
+    })
+  }
+
+  // A failed check is a real result, not a CLI fault: it reports through the
+  // normal payload and a compile-failed exit code, the way `compile` does.
+  if (!ok) {
+    return reporter.partial(
+      payload,
+      {
+        code: ErrorCode.CompileFailed,
+        message:
+          errors.length > 0
+            ? `${errors.length} error(s) in ${loaded.project.name}.`
+            : `${lintErrors.length} lint error(s) in ${loaded.project.name}.`,
+      },
+      ExitCode.CompileFailed,
+      () => renderCheck(payload, errors, warnings),
+    )
+  }
+
+  return reporter.success(payload, () => renderCheck(payload, errors, warnings))
+}
+
+/**
+ * POUs in the order they appear in the generated ST, for the per-POU splitter
+ * that gives strucpp errors a real file name instead of `program.st`.
+ *
+ * Built here rather than through `buildKnownPous`, which takes the backend
+ * schema's nested `{type, data}` POU; this side holds the flat port shape.
+ */
+function knownPous(data: PLCProjectData): KnownPou[] {
+  return data.pous.map((pou) => ({
+    name: pou.name,
+    kind:
+      pou.pouType === 'program'
+        ? ('PROGRAM' as const)
+        : pou.pouType === 'function'
+          ? ('FUNCTION' as const)
+          : ('FUNCTION_BLOCK' as const),
+    language: pou.body.language as KnownPou['language'],
+  }))
+}
+
+/**
+ * Project the prepared data into the transpiler's shape.
+ *
+ * Wrapped because `fromSchemaShape` throws rather than accumulating: an SFC body
+ * raises `SFC support is under development` at projection time, outside the
+ * per-POU try/catch inside `transpileToSt`. One unsupported POU would otherwise
+ * take the whole run down with an internal-error exit code.
+ */
+function projectToTranspiler(
+  data: PLCProjectData,
+): { ok: true; project: ReturnType<typeof fromSchemaShape> } | { ok: false; error: string } {
+  try {
+    // Through `toIpcProjectData` first, exactly as a real build does. That is
+    // not a formality: it renames `configurations` to `configuration` and
+    // reshapes every POU into `{type, data}`, and the transpiler reads both.
+    // Handing it the port shape directly throws on the first POU.
+    //
+    // The cast afterwards is the one every caller of `fromSchemaShape` makes
+    // (`compiler-module.ts:3348`, `desktop-library-build-port.ts:59`,
+    // `editor-compiler-platform-port.ts:187`) — see the note on `IpcProjectData`.
+    const ipc = toIpcProjectData(data)
+    return { ok: true, project: fromSchemaShape(ipc as unknown as SchemaProjectData) }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    const culprit = data.pous.find((pou) => pou.body.language === 'sfc')
+    return {
+      ok: false,
+      error: culprit ? `POU "${culprit.name}" (sfc body): ${message}` : message,
+    }
+  }
+}
+
+/** The transpiler prefixes every diagnostic with `POU "<name>"`. */
+function mentionsPou(line: string, pouName: string): boolean {
+  return line.toLowerCase().includes(`pou "${pouName.toLowerCase()}"`)
+}
+
+function renderCheck(payload: Record<string, unknown>, errors: string[], warnings: string[]): string {
+  const pous = (payload.pous as string[]) ?? []
+  const lint = (payload.lint as LintFinding[] | undefined) ?? []
+  const lintErrors = lint.filter((finding) => finding.severity === 'error').length
+  // Counted together, because a run that failed on lint alone reported
+  // "FAILED — 0 error(s)" and showed nothing that had failed.
+  const failures = errors.length + lintErrors
+  const lines = [
+    payload.ok === true
+      ? `OK — ${pous.length} POU(s) transpiled for ${String(payload.target)}`
+      : `FAILED — ${failures} error(s) in ${pous.length} POU(s) for ${String(payload.target)}`,
+  ]
+  for (const error of errors) lines.push(`  error: ${error}`)
+  for (const warning of warnings) lines.push(`  warning: ${warning}`)
+  for (const finding of lint) {
+    lines.push(`  ${finding.severity}: [${finding.rule}] ${finding.pou ? `${finding.pou}: ` : ''}${finding.message}`)
+  }
+  const protocols = payload.protocols as ProtocolConfs | undefined
+  if (protocols) {
+    lines.push('', 'Protocol configs this project would upload:')
+    if (!protocols.ok) {
+      lines.push(`  error: ${protocols.error}`)
+    } else {
+      for (const [name, summary] of Object.entries(protocols.confs)) {
+        lines.push(`  ${name.padEnd(14)} ${summary.confFile ?? '(not generated — the plugin stays off)'}`)
+      }
+    }
+  }
+  if (typeof payload.st === 'string') lines.push('', payload.st)
+  return lines.join('\n')
+}

--- a/src/cli/commands/describe.ts
+++ b/src/cli/commands/describe.ts
@@ -1,0 +1,256 @@
+/**
+ * `openplc-cli describe` — read a project back out in the shape `apply` takes.
+ *
+ * Round-tripping is the point: an agent reads a project, edits the document it
+ * gets, and applies it. Anything this cannot express is flagged rather than
+ * silently flattened — a body that came back subtly different from what is on
+ * disk would be data loss disguised as a feature.
+ *
+ * `--libraries` emits the block catalogue with exact pin names. That is the
+ * single most valuable payload here: without it an agent guesses whether the
+ * pin is `PT` or `PRESET`, and a guess produces a diagram that looks right and
+ * does not compile.
+ */
+
+import { openPLCStoreBase } from '@root/frontend/store'
+import type { SystemLibrary } from '@root/middleware/shared/ports/library-types'
+import type { PLCDataType, PLCPou, PLCVariable } from '@root/middleware/shared/ports/types'
+
+import { boolFlag, type ParsedArgs, stringFlag } from '../args'
+import { describeFbdBody } from '../describe/fbd'
+import { describeLadderBody } from '../describe/ladder'
+import { describeProtocols } from '../describe/protocol'
+import { ErrorCode, ExitCode } from '../exit-codes'
+import type { CliResult, Reporter } from '../output'
+import { loadProject, unreadableProtocolFilesMessage } from '../project/load'
+
+const TEXTUAL = new Set(['st', 'il', 'python', 'cpp'])
+
+export async function runDescribe(args: ParsedArgs, reporter: Reporter): Promise<CliResult> {
+  const projectPath = args.positionals[0] ?? stringFlag(args, 'project')
+  if (!projectPath) {
+    return reporter.failure(
+      { code: ErrorCode.InvalidArgument, message: 'describe needs the path of a project.' },
+      ExitCode.Usage,
+    )
+  }
+
+  const loaded = await loadProject(projectPath)
+  if (!loaded.success) {
+    return reporter.failure({ code: ErrorCode.ProjectNotFound, message: loaded.error }, ExitCode.NotFound)
+  }
+  for (const warning of loaded.project.warnings) reporter.progress(warning)
+
+  const unreadable = unreadableProtocolFilesMessage(loaded.project)
+  if (unreadable) {
+    return reporter.failure(
+      {
+        code: ErrorCode.ProtocolFileUnreadable,
+        message: unreadable,
+        details: loaded.project.unreadableProtocolFiles,
+      },
+      ExitCode.TargetError,
+    )
+  }
+
+  const state = openPLCStoreBase.getState()
+  const onlyPou = stringFlag(args, 'pou')
+  const pous = state.project.data.pous.filter((pou) => !onlyPou || pou.name === onlyPou)
+  // Every POU in the project, not just the filtered view — a block can call one
+  // this listing leaves out.
+  const userPouNames = new Set(state.project.data.pous.map((pou) => pou.name))
+
+  if (onlyPou && pous.length === 0) {
+    return reporter.failure(
+      { code: ErrorCode.TargetError, message: `This project has no POU named "${onlyPou}".` },
+      ExitCode.NotFound,
+    )
+  }
+
+  // Read-only, and deliberately outside `spec`: allocation decides these, so a
+  // spec carrying them would stop round-tripping whenever allocation differed.
+  let protocolAddresses: Record<string, unknown>[] = []
+
+  const spec: Record<string, unknown> = {
+    specVersion: 1,
+    pous: pous.map((pou) => describePou(pou, state.libraries.system, userPouNames)),
+  }
+
+  // A single-POU view is a lens on one body, not a project document — emitting
+  // the configuration alongside it would invite applying a partial spec with
+  // `--prune` and deleting everything else.
+  if (!onlyPou) {
+    spec.device = {
+      board: loaded.project.board,
+      ...(loaded.project.communicationPort ? { communicationPort: loaded.project.communicationPort } : {}),
+      ...(state.deviceDefinitions.configuration.runtimeIpAddress
+        ? { runtimeIpAddress: state.deviceDefinitions.configuration.runtimeIpAddress }
+        : {}),
+      ...(state.deviceDefinitions.configuration.persistentStorage
+        ? { persistentStorage: state.deviceDefinitions.configuration.persistentStorage }
+        : {}),
+    }
+    spec.libraries = (state.project.data.libraries ?? []).map((ref) => ({ name: ref.name, version: ref.version }))
+    spec.globalVariableLists = (state.project.data.globalVariableLists ?? []).map((list) => ({
+      name: list.name,
+      ...(list.qualifier ? { qualifier: list.qualifier } : {}),
+      ...(list.documentation ? { documentation: list.documentation } : {}),
+      variables: list.variables.map(describeVariable),
+    }))
+    spec.dataTypes = state.project.data.dataTypes.map(describeDataType).filter(Boolean)
+    spec.globalVariables = (state.project.data.configurations.resource.globalVariables ?? []).map(describeVariable)
+    spec.tasks = state.project.data.configurations.resource.tasks
+    spec.instances = state.project.data.configurations.resource.instances
+
+    const protocols = describeProtocols(state.project.data.servers ?? [], state.project.data.remoteDevices ?? [])
+    spec.servers = protocols.servers
+    spec.remoteDevices = protocols.remoteDevices
+    protocolAddresses = protocols.protocolAddresses
+  }
+
+  const payload: Record<string, unknown> = {
+    ok: true,
+    project: loaded.project.name,
+    board: loaded.project.board,
+    spec,
+  }
+  if (protocolAddresses.length > 0) payload.protocolAddresses = protocolAddresses
+  if (boolFlag(args, 'libraries')) payload.libraries = state.libraries.system.map(describeLibrary)
+
+  return reporter.success(payload, () => render(payload))
+}
+
+function describePou(
+  pou: PLCPou,
+  libraries: readonly SystemLibrary[],
+  userPouNames: ReadonlySet<string>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    name: pou.name,
+    kind: pou.pouType,
+    language: pou.body.language,
+  }
+  if (pou.interface?.returnType) out.returnType = pou.interface.returnType
+  if (pou.documentation) out.documentation = pou.documentation
+  out.variables = (pou.interface?.variables ?? []).map(describeVariable)
+
+  if (TEXTUAL.has(pou.body.language)) {
+    out.body = { text: String(pou.body.value ?? '') }
+    return out
+  }
+
+  const described =
+    pou.body.language === 'ld'
+      ? describeLadderBody(pou.body.value, libraries, userPouNames)
+      : pou.body.language === 'fbd'
+        ? describeFbdBody(pou.body.value, libraries, userPouNames)
+        : null
+
+  if (described?.ok) {
+    out.body = described.body
+  } else {
+    // The diagram cannot be written back as this grammar. Saying so is the
+    // whole contract — `apply` refuses to overwrite a body it cannot express,
+    // rather than flattening it on the next round trip.
+    out.bodyLossy = true
+    out.bodyLossyReason = described?.reason ?? `${pou.body.language} bodies cannot be described yet`
+  }
+  return out
+}
+
+function describeVariable(variable: PLCVariable): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    name: variable.name,
+    class: variable.class,
+    type: describeVariableType(variable.type),
+  }
+  if (variable.flag) out.flag = variable.flag
+  if (variable.location) out.location = variable.location
+  if (variable.initialValue !== undefined && variable.initialValue !== null) out.initialValue = variable.initialValue
+  if (variable.documentation) out.documentation = variable.documentation
+  return out
+}
+
+/**
+ * An array reads back as its ELEMENT type plus the bounds, which is what `apply`
+ * takes. Reporting the store's rendered `value` ("ARRAY [0..3] OF INT") would
+ * hand back a document that cannot be applied: `apply` derives that text from
+ * `dimensions`, so it would end up nested inside itself on the next pass.
+ */
+function describeVariableType(type: PLCVariable['type']): Record<string, unknown> {
+  if (type.definition !== 'array' || !type.data) {
+    return { definition: type.definition, value: type.value }
+  }
+  return {
+    definition: 'array',
+    value: type.data.baseType.value,
+    dimensions: type.data.dimensions.map((entry) => entry.dimension),
+  }
+}
+
+function describeDataType(dataType: PLCDataType): Record<string, unknown> | null {
+  if (dataType.derivation === 'enumerated') {
+    return {
+      name: dataType.name,
+      derivation: 'enumerated',
+      values: dataType.values.map((value) => value.description),
+      ...(dataType.initialValue ? { initialValue: dataType.initialValue } : {}),
+    }
+  }
+  if (dataType.derivation === 'structure') {
+    return {
+      name: dataType.name,
+      derivation: 'structure',
+      variables: dataType.variable.map((member) => ({
+        name: member.name,
+        type: { definition: member.type.definition, value: member.type.value },
+        ...(member.documentation ? { documentation: member.documentation } : {}),
+      })),
+    }
+  }
+  return {
+    name: dataType.name,
+    derivation: 'array',
+    baseType: { definition: dataType.baseType.definition, value: dataType.baseType.value },
+    dimensions: dataType.dimensions.map((entry) => entry.dimension),
+    ...(dataType.initialValue ? { initialValue: dataType.initialValue } : {}),
+  }
+}
+
+/** The catalogue an agent needs to place a block without guessing its pins. */
+function describeLibrary(library: SystemLibrary): Record<string, unknown> {
+  return {
+    name: library.name,
+    version: library.version,
+    blocks: library.pous.map((pou) => ({
+      /** Exactly what `apply` wants in `call`. */
+      call: `system/${library.name}/${pou.name}`,
+      name: pou.name,
+      type: pou.type,
+      ...(pou.extensible ? { extensible: true } : {}),
+      ...(pou.documentation ? { documentation: pou.documentation } : {}),
+      pins: pou.variables.map((variable) => ({
+        name: variable.name,
+        class: variable.class,
+        type: variable.type.value,
+      })),
+    })),
+  }
+}
+
+function render(payload: Record<string, unknown>): string {
+  const spec = payload.spec as { pous?: Array<Record<string, unknown>> }
+  const lines = [`${String(payload.project)} (${String(payload.board)})`]
+  for (const pou of spec.pous ?? []) {
+    const variables = (pou.variables as unknown[] | undefined)?.length ?? 0
+    const lossy = pou.bodyLossy ? '  [body not describable]' : ''
+    lines.push(`  ${String(pou.kind)} ${String(pou.name)} (${String(pou.language)}, ${variables} var)${lossy}`)
+  }
+  const libraries = payload.libraries as Array<{ name: string; blocks: unknown[] }> | undefined
+  if (libraries) {
+    lines.push('', 'Libraries')
+    for (const library of libraries) lines.push(`  ${library.name} — ${library.blocks.length} block(s)`)
+  }
+  lines.push('', 'Use --json for the full document.')
+  return lines.join('\n')
+}

--- a/src/cli/commands/esi.ts
+++ b/src/cli/commands/esi.ts
@@ -1,0 +1,133 @@
+/**
+ * `openplc-cli esi import <file.xml>` — add an ESI file to the project's device
+ * repository, so an EtherCAT slave can be declared against it.
+ *
+ * Without this the only way to get an ESI file into a project is the device
+ * screen's file picker, which makes the whole EtherCAT surface unreachable
+ * headless. `esi list` exists because `apply` resolves an `esiDeviceRef` by id
+ * OR filename, and a spec author needs to see which devices a file offers and
+ * at which index.
+ */
+
+import { promises as fs } from 'node:fs'
+import { basename, resolve } from 'node:path'
+
+import { ESIService } from '@root/backend/editor/ethercat/esi-service'
+
+import { type ParsedArgs, stringFlag } from '../args'
+import { ErrorCode, ExitCode } from '../exit-codes'
+import type { CliResult, Reporter } from '../output'
+
+export async function runEsi(args: ParsedArgs, reporter: Reporter): Promise<CliResult> {
+  const action = args.positionals[0]
+  if (action !== 'import' && action !== 'list') {
+    return reporter.failure(
+      { code: ErrorCode.UnknownCommand, message: `Unknown esi action "${action ?? ''}". Use "import" or "list".` },
+      ExitCode.Usage,
+    )
+  }
+
+  const projectPath = stringFlag(args, 'project')
+  if (!projectPath) {
+    return reporter.failure({ code: ErrorCode.InvalidArgument, message: 'esi needs --project <dir>.' }, ExitCode.Usage)
+  }
+
+  const esi = new ESIService()
+  return action === 'import' ? importFile(args, projectPath, esi, reporter) : list(projectPath, esi, reporter)
+}
+
+async function importFile(
+  args: ParsedArgs,
+  projectPath: string,
+  esi: ESIService,
+  reporter: Reporter,
+): Promise<CliResult> {
+  const filePath = args.positionals[1] ?? stringFlag(args, 'file')
+  if (!filePath) {
+    return reporter.failure(
+      { code: ErrorCode.InvalidArgument, message: 'esi import needs the path of an ESI .xml file.' },
+      ExitCode.Usage,
+    )
+  }
+
+  let content: string
+  try {
+    content = await fs.readFile(resolve(filePath), 'utf8')
+  } catch (error) {
+    return reporter.failure(
+      {
+        code: ErrorCode.ProjectNotFound,
+        message: `Could not read "${filePath}": ${error instanceof Error ? error.message : String(error)}`,
+      },
+      ExitCode.NotFound,
+    )
+  }
+
+  const filename = basename(filePath)
+  const result = await esi.parseAndSaveFile(projectPath, filename, content)
+  if (!result.success) {
+    return reporter.failure(
+      { code: ErrorCode.InvalidArgument, message: `"${filename}" is not a usable ESI file: ${result.error ?? ''}` },
+      ExitCode.CompileFailed,
+    )
+  }
+
+  // A re-import is a no-op, not a failure — the same bargain the GUI strikes.
+  if (result.duplicate || !result.item) {
+    const payload = { ok: true, imported: false, filename, reason: 'already in this project' }
+    return reporter.success(payload, () => `${filename} is already in this project — nothing to do.`)
+  }
+
+  const payload = {
+    ok: true,
+    imported: true,
+    filename,
+    repositoryItemId: result.item.id,
+    vendor: result.item.vendor,
+    devices: result.item.devices.map((device, index) => ({
+      deviceIndex: index,
+      name: device.name,
+      productCode: device.type.productCode,
+      revisionNo: device.type.revisionNo,
+    })),
+    ...(result.item.warnings?.length ? { warnings: result.item.warnings } : {}),
+  }
+  return reporter.success(payload, () => renderItem(filename, payload.repositoryItemId, payload.devices))
+}
+
+async function list(projectPath: string, esi: ESIService, reporter: Reporter): Promise<CliResult> {
+  const index = await esi.loadRepositoryIndex(projectPath)
+  // The index carries device summaries only when they were cached at import;
+  // `deviceCount` is always there, so an uncached file still reports its size.
+  const items = (index?.items ?? []).map((item) => ({
+    filename: item.filename,
+    repositoryItemId: item.id,
+    vendor: { id: item.vendorId, name: item.vendorName },
+    deviceCount: item.deviceCount,
+    devices: (item.devices ?? []).map((device, deviceIndex) => ({
+      deviceIndex,
+      name: device.name,
+      productCode: device.type.productCode,
+      revisionNo: device.type.revisionNo,
+    })),
+  }))
+
+  const payload = { ok: true, count: items.length, items }
+  return reporter.success(payload, () =>
+    items.length === 0
+      ? 'This project has no ESI files — add one with `openplc-cli esi import`.'
+      : items.map((item) => renderItem(item.filename, item.repositoryItemId, item.devices)).join('\n\n'),
+  )
+}
+
+function renderItem(
+  filename: string,
+  repositoryItemId: string,
+  devices: { deviceIndex: number; name: string; productCode: string; revisionNo: string }[],
+): string {
+  const lines = [`${filename}  (${repositoryItemId})`]
+  for (const device of devices) {
+    lines.push(`  [${device.deviceIndex}] ${device.name}  ${device.productCode} rev ${device.revisionNo}`)
+  }
+  return lines.join('\n')
+}

--- a/src/cli/commands/install-skill.ts
+++ b/src/cli/commands/install-skill.ts
@@ -1,0 +1,57 @@
+/**
+ * `openplc-cli install-skill` — copy the shipped skill into an agent directory.
+ *
+ * Deliberately not automatic on first run. `install-cli` earns that because
+ * nothing else can put the binary on PATH; writing into `~/.claude/` when
+ * someone launches a PLC editor would be a surprise.
+ */
+
+import { installSkill } from '@root/backend/editor/skill/install-skill'
+import { resolveSkillPath } from '@root/backend/editor/skill/skill-source'
+
+import { type ParsedArgs, stringFlag } from '../args'
+import { ErrorCode, ExitCode } from '../exit-codes'
+import type { CliResult, Reporter } from '../output'
+import { skillEnvironment } from './skill'
+
+export function runInstallSkill(args: ParsedArgs, reporter: Reporter): CliResult {
+  const name = stringFlag(args, 'name') ?? 'openplc'
+  const scope = stringFlag(args, 'scope') === 'user' ? 'user' : 'project'
+  const projectPath = stringFlag(args, 'path') ?? args.positionals[0]
+
+  const source = resolveSkillPath(skillEnvironment(), name)
+  if (!source) {
+    return reporter.failure(
+      { code: ErrorCode.TargetError, message: `This build ships no skill named "${name}".` },
+      ExitCode.NotFound,
+    )
+  }
+
+  // `force` on an explicit invocation: the user asked for this one, so a
+  // same-content file is refreshed rather than reported as a conflict.
+  const result = installSkill({ source, scope, projectPath, name, force: false })
+
+  switch (result.status) {
+    case 'installed':
+      return reporter.success(
+        { ok: true, status: result.status, path: result.path },
+        () => `Installed to ${result.path}`,
+      )
+    case 'unchanged':
+      return reporter.success(
+        { ok: true, status: result.status, path: result.path },
+        () => `Already up to date at ${result.path}`,
+      )
+    case 'skipped':
+      return reporter.failure(
+        { code: ErrorCode.TargetError, message: `Not installed: ${result.reason}` },
+        ExitCode.TargetError,
+      )
+    case 'failed':
+      return reporter.failure({ code: ErrorCode.Internal, message: result.error }, ExitCode.Internal)
+    default: {
+      const unreachable: never = result
+      return reporter.internalError(new Error(`Unhandled install result: ${JSON.stringify(unreachable)}`))
+    }
+  }
+}

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -1,0 +1,114 @@
+/**
+ * `openplc-cli runtime info` — what a device is, before you write to it.
+ *
+ * Everything else that talks to a runtime changes it: `upload` replaces the
+ * program, and `debug open` against a device running something else fails
+ * `md5_mismatch` with `--upload-if-needed` as the only way forward. So the only
+ * way to learn a device's version was to overwrite what it was running — which
+ * is backwards for a box in the field, and it is how a project that needs a
+ * feature the device lacks got as far as a full compile and upload before
+ * anyone found out.
+ *
+ * `/api/capabilities` is unauthenticated by the runtime's own design, so this
+ * needs no credentials. `probeRuntimeVersion` falls back to `/api/version` for
+ * runtimes that predate it.
+ */
+
+import { RuntimeApiClient } from '@root/backend/editor/runtime/runtime-api-client'
+import {
+  isRetainConfigCapableRuntime,
+  isStrucppCompatibleRuntime,
+  isUserManagementCapableRuntime,
+  MIN_RETAIN_CONFIG_RUNTIME_VERSION,
+  MIN_RUNTIME_VERSION,
+} from '@root/backend/shared/firmware/runtime-version-gate'
+import { probeRuntimeVersion } from '@root/backend/shared/library/probe-runtime-version'
+
+import { type ParsedArgs, stringFlag } from '../args'
+import { ErrorCode, ExitCode } from '../exit-codes'
+import type { CliResult, Reporter } from '../output'
+
+export async function runRuntime(args: ParsedArgs, reporter: Reporter): Promise<CliResult> {
+  const action = args.positionals[0]
+  if (action !== undefined && action !== 'info') {
+    return reporter.failure(
+      { code: ErrorCode.UnknownCommand, message: `Unknown runtime action "${action}". The only one is "info".` },
+      ExitCode.Usage,
+    )
+  }
+
+  const host = stringFlag(args, 'host') ?? stringFlag(args, 'address') ?? args.positionals[1]
+  if (!host) {
+    return reporter.failure(
+      { code: ErrorCode.InvalidArgument, message: 'runtime info needs --host <address> (see `openplc-cli devices`).' },
+      ExitCode.Usage,
+    )
+  }
+
+  const client = new RuntimeApiClient()
+  const getJson = async (endpoint: string) => {
+    const result = await client.makeRuntimeApiRequest<unknown>(host, endpoint, (body: string) => JSON.parse(body))
+    if (!result.success) return { success: false as const, error: result.error }
+    return { success: true as const, body: result.data }
+  }
+
+  const probe = await probeRuntimeVersion({
+    fetchCapabilities: () => getJson('/api/capabilities'),
+    fetchVersion: () => getJson('/api/version'),
+    log: () => undefined,
+  })
+
+  if (!probe.version) {
+    return reporter.failure(
+      {
+        code: ErrorCode.NotConnected,
+        message: `No runtime answered at "${host}". It may be unreachable, or too old to report a version.`,
+      },
+      ExitCode.Connection,
+    )
+  }
+
+  const payload = {
+    ok: true,
+    host,
+    runtimeVersion: probe.version,
+    /** The oldest editor this runtime accepts programs from. */
+    minEditorVersion: probe.minEditorVersion ?? null,
+    supportsProjectSnapshot: probe.supportsProjectSnapshot === true,
+    capabilities: {
+      /** Below this the editor cannot build for it at all. */
+      strucppPrograms: isStrucppCompatibleRuntime(probe.version),
+      /** `device.persistentStorage` and `flag: "retain"` do nothing without it. */
+      retainStore: isRetainConfigCapableRuntime(probe.version),
+      userManagement: isUserManagementCapableRuntime(probe.version),
+    },
+  }
+
+  return reporter.success(payload, () => render(payload))
+}
+
+function render(payload: {
+  host: string
+  runtimeVersion: string
+  minEditorVersion: string | null
+  supportsProjectSnapshot: boolean
+  capabilities: { strucppPrograms: boolean; retainStore: boolean; userManagement: boolean }
+}): string {
+  const mark = (on: boolean) => (on ? 'yes' : 'no')
+  const lines = [
+    `${payload.host} — ${payload.runtimeVersion}`,
+    `  accepts programs from editor  ${payload.minEditorVersion ?? '(not reported)'} and newer`,
+    `  builds STruC++ programs       ${mark(payload.capabilities.strucppPrograms)}${
+      payload.capabilities.strucppPrograms ? '' : `  (needs ${MIN_RUNTIME_VERSION})`
+    }`,
+    `  built-in retain store         ${mark(payload.capabilities.retainStore)}${
+      payload.capabilities.retainStore ? '' : `  (needs ${MIN_RETAIN_CONFIG_RUNTIME_VERSION})`
+    }`,
+    `  user management API           ${mark(payload.capabilities.userManagement)}`,
+    `  stores the source project     ${mark(payload.supportsProjectSnapshot)}`,
+  ]
+  if (!payload.capabilities.retainStore) {
+    lines.push('', 'A project using `flag: "retain"` will run here, but retained values reset on restart.')
+  }
+  return lines.join('\n')
+}

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -1,0 +1,61 @@
+/**
+ * `openplc-cli skill` — print the agent skill this build ships.
+ *
+ * Primary over `install-skill` because it needs no filesystem permission, works
+ * in a container or CI, and cannot go stale against the binary: the text comes
+ * out of the same package the commands do.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { resolveSkillPath, resolveSkillRoot } from '@root/backend/editor/skill/skill-source'
+import { app } from 'electron'
+
+import { boolFlag, type ParsedArgs, stringFlag } from '../args'
+import { ErrorCode, ExitCode } from '../exit-codes'
+import type { CliResult, Reporter } from '../output'
+
+export function skillEnvironment() {
+  return { packaged: app.isPackaged, resourcesPath: process.resourcesPath, appPath: app.getAppPath() }
+}
+
+export function runSkill(args: ParsedArgs, reporter: Reporter): CliResult {
+  const environment = skillEnvironment()
+
+  if (boolFlag(args, 'list')) {
+    const root = resolveSkillRoot(environment)
+    const names = root ? readdirSync(root).filter((entry) => statSync(join(root, entry)).isDirectory()) : []
+    return reporter.success({ ok: true, skills: names }, () =>
+      names.length === 0 ? 'This build ships no skills.' : names.join('\n'),
+    )
+  }
+
+  const name = stringFlag(args, 'name') ?? args.positionals[0] ?? 'openplc'
+  const path = resolveSkillPath(environment, name)
+  if (!path) {
+    return reporter.failure(
+      { code: ErrorCode.TargetError, message: `This build ships no skill named "${name}".` },
+      ExitCode.NotFound,
+    )
+  }
+
+  const body = readFileSync(join(path, 'SKILL.md'), 'utf-8')
+  const references = readReferences(path)
+
+  return reporter.success({ ok: true, name, skill: body, references }, () => body)
+}
+
+/** The reference pages, so one call gives an agent everything. */
+function readReferences(skillPath: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  try {
+    const directory = join(skillPath, 'references')
+    for (const entry of readdirSync(directory)) {
+      if (entry.endsWith('.md')) out[entry.replace(/\.md$/, '')] = readFileSync(join(directory, entry), 'utf-8')
+    }
+  } catch {
+    // A skill with no references is legal.
+  }
+  return out
+}

--- a/src/cli/describe/fbd.ts
+++ b/src/cli/describe/fbd.ts
@@ -102,7 +102,18 @@ export function describeFbdBody(
     return out
   })
 
-  const connections = (flow?.rung?.edges ?? []).map((edge) => ({
+  // An edge naming a node the diagram does not hold would render as an empty
+  // `from` or `to` — the silent flattening this describer exists to refuse.
+  const edges = flow?.rung?.edges ?? []
+  const dangling = edges.find((edge) => !labelById.has(edge.source) || !labelById.has(edge.target))
+  if (dangling) {
+    return {
+      ok: false,
+      reason: `a connection names a node the diagram does not hold ("${dangling.source}" -> "${dangling.target}")`,
+    }
+  }
+
+  const connections = edges.map((edge) => ({
     from: pinRef(labelById.get(edge.source), edge.sourceHandle),
     to: pinRef(labelById.get(edge.target), edge.targetHandle),
   }))

--- a/src/cli/describe/fbd.ts
+++ b/src/cli/describe/fbd.ts
@@ -1,0 +1,126 @@
+/**
+ * Reduce an FBD rung back to the node/connection list `apply` takes.
+ *
+ * FBD is the easier direction: the spec's own shape is a node list plus
+ * connections, which is close to what the store holds. What is lost is the
+ * placement, and that is deliberate — `apply` recomputes it, so a round trip
+ * tidies a diagram rather than preserving a hand arrangement.
+ *
+ * That last point is why a described FBD body is still flagged when it carries
+ * anything the grammar has no word for: silently dropping it would make
+ * `describe | apply` destructive.
+ */
+
+import type { SystemLibrary } from '@root/middleware/shared/ports/library-types'
+
+import type { DescribeBodyResult } from './ladder'
+
+interface FbdNode {
+  id: string
+  type?: string
+  data?: Record<string, unknown>
+}
+
+interface FbdEdge {
+  source: string
+  target: string
+  sourceHandle?: string | null
+  targetHandle?: string | null
+}
+
+/** Node types the spec can name. */
+const EXPRESSIBLE = new Set(['block', 'input-variable', 'output-variable', 'inout-variable', 'comment'])
+
+/**
+ * Rebuild a block's `system/<library>/<pou>` reference.
+ *
+ * A placed block records only the block's own name — `variant` carries no
+ * library and no version — so the reference has to be recovered by searching
+ * the installed pool. One match is the answer; none or several is not
+ * guessable, and guessing would put the agent's next `apply` on the wrong
+ * library.
+ */
+function resolveCall(
+  blockName: string,
+  libraries: readonly SystemLibrary[],
+  userPouNames: ReadonlySet<string>,
+): string | null {
+  // A POU of this project wins: `user/<name>` is unambiguous, and the editor
+  // resolves a placed block that way before it looks at any library.
+  if (userPouNames.has(blockName)) return `user/${blockName}`
+  const owners = libraries.filter((library) => library.pous.some((pou) => pou.name === blockName))
+  return owners.length === 1 ? `system/${owners[0].name}/${blockName}` : null
+}
+
+export function describeFbdBody(
+  value: unknown,
+  libraries: readonly SystemLibrary[] = [],
+  userPouNames: ReadonlySet<string> = new Set(),
+): DescribeBodyResult {
+  const flow = value as { rung?: { nodes?: FbdNode[]; edges?: FbdEdge[] } } | undefined
+  const nodes = flow?.rung?.nodes
+  if (!nodes) return { ok: false, reason: 'the body is not an FBD flow' }
+
+  const unknown = nodes.find((node) => !EXPRESSIBLE.has(node.type ?? ''))
+  if (unknown) return { ok: false, reason: `the diagram holds a "${unknown.type ?? 'nameless'}" element` }
+
+  // Labels are spec-local. Store ids are long and regenerated on every apply,
+  // so a readable label keeps the document editable by hand.
+  const labelById = new Map<string, string>()
+  const used = new Set<string>()
+  for (const node of nodes) {
+    const data = node.data as { variable?: { name?: string }; variant?: { name?: string } } | undefined
+    const base = data?.variable?.name || data?.variant?.name || node.type || 'node'
+    let label = base
+    let suffix = 1
+    while (used.has(label)) label = `${base}${(suffix += 1)}`
+    used.add(label)
+    labelById.set(node.id, label)
+  }
+
+  const unresolvedBlocks: string[] = []
+  const describedNodes = nodes.map((node) => {
+    const data = node.data as { variable?: { name?: string }; variant?: { name?: string }; value?: string } | undefined
+    const out: Record<string, unknown> = { label: labelById.get(node.id), kind: node.type }
+    if (node.type === 'block') {
+      const call = data?.variant?.name ? resolveCall(data.variant.name, libraries, userPouNames) : null
+      if (call) out.call = call
+      else unresolvedBlocks.push(data?.variant?.name ?? node.id)
+      if (data?.variable?.name) out.instance = data.variable.name
+      // Only when on: `apply` defaults it off, and the editor turns it on by
+      // itself for a block that cannot go without it.
+      if ((node.data as { executionControl?: boolean } | undefined)?.executionControl === true) {
+        out.executionControl = true
+      }
+      const order = (node.data as { executionOrder?: number } | undefined)?.executionOrder
+      if (order) out.executionOrder = order
+    } else if (node.type === 'comment') {
+      if (data?.value) out.text = data.value
+    } else if (data?.variable?.name) {
+      out.variable = data.variable.name
+    }
+    return out
+  })
+
+  const connections = (flow?.rung?.edges ?? []).map((edge) => ({
+    from: pinRef(labelById.get(edge.source), edge.sourceHandle),
+    to: pinRef(labelById.get(edge.target), edge.targetHandle),
+  }))
+
+  if (unresolvedBlocks.length > 0) {
+    return {
+      ok: false,
+      reason: `no project POU or single installed library provides ${unresolvedBlocks.map((name) => `"${name}"`).join(', ')}`,
+    }
+  }
+
+  return { ok: true, body: { nodes: describedNodes, connections } as never }
+}
+
+function pinRef(label: string | undefined, handle: string | null | undefined): string {
+  if (!label) return ''
+  // A variable node's handle is implied by its direction; only a block's pin
+  // needs naming.
+  if (!handle || handle === 'input-variable' || handle === 'output-variable') return label
+  return `${label}.${handle}`
+}

--- a/src/cli/describe/ladder.ts
+++ b/src/cli/describe/ladder.ts
@@ -1,0 +1,259 @@
+/**
+ * Reduce a ladder rung graph back to the series/parallel expression `apply`
+ * takes.
+ *
+ * Not every rung is expressible. The grammar covers a series-parallel
+ * two-terminal network, which is what the editor's own parallel OPEN/CLOSE
+ * pairs build — but a hand-drawn diagram can contain shapes outside it, and the
+ * rung may hold elements the grammar has no word for.
+ *
+ * When that happens this REFUSES. Emitting a best-effort approximation would
+ * mean `describe | apply` quietly redrew someone's diagram, which is worse than
+ * telling them the round trip is not available for that POU.
+ */
+
+interface RungNode {
+  id: string
+  type?: string
+  data?: Record<string, unknown>
+}
+
+interface RungEdge {
+  source: string
+  target: string
+  sourceHandle?: string | null
+  targetHandle?: string | null
+}
+
+import type { SystemLibrary } from '@root/middleware/shared/ports/library-types'
+
+export type DescribeBodyResult = { ok: true; body: { rungs: unknown[] } } | { ok: false; reason: string }
+
+/**
+ * Node types the grammar can name.
+ *
+ * `variable` is in the list because `addLadderFlow` gives every block data pin
+ * its own variable element. They are not described in their own right — they
+ * are read back as the block's `inputs`.
+ */
+const EXPRESSIBLE = new Set(['powerRail', 'contact', 'coil', 'parallel', 'block', 'variable'])
+
+/** Rebuild a block's `type/library/pou` reference from its placed name. */
+function resolveCall(
+  blockName: string,
+  libraries: readonly SystemLibrary[],
+  userPouNames: ReadonlySet<string>,
+): string | null {
+  if (userPouNames.has(blockName)) return `user/${blockName}`
+  const owners = libraries.filter((library) => library.pous.some((pou) => pou.name === blockName))
+  return owners.length === 1 ? `system/${owners[0].name}/${blockName}` : null
+}
+
+export function describeLadderBody(
+  value: unknown,
+  libraries: readonly SystemLibrary[] = [],
+  userPouNames: ReadonlySet<string> = new Set(),
+): DescribeBodyResult {
+  const flow = value as { rungs?: Array<{ comment?: string; nodes?: RungNode[]; edges?: RungEdge[] }> } | undefined
+  if (!flow?.rungs) return { ok: false, reason: 'the body is not a ladder flow' }
+
+  const rungs: unknown[] = []
+  for (const rung of flow.rungs) {
+    const described = describeRung(rung, libraries, userPouNames)
+    if (!described.ok) return described
+    rungs.push(described.rung)
+  }
+  return { ok: true, body: { rungs } }
+}
+
+function describeRung(
+  rung: { comment?: string; nodes?: RungNode[]; edges?: RungEdge[] },
+  libraries: readonly SystemLibrary[],
+  userPouNames: ReadonlySet<string>,
+): { ok: true; rung: Record<string, unknown> } | { ok: false; reason: string } {
+  const nodes = rung.nodes ?? []
+  const edges = rung.edges ?? []
+
+  const unknown = nodes.find((node) => !EXPRESSIBLE.has(node.type ?? ''))
+  if (unknown) return { ok: false, reason: `the rung holds a "${unknown.type ?? 'nameless'}" element` }
+
+  const byId = new Map(nodes.map((node) => [node.id, node]))
+  const outgoing = new Map<string, RungEdge[]>()
+  for (const edge of edges) {
+    const list = outgoing.get(edge.source) ?? []
+    list.push(edge)
+    outgoing.set(edge.source, list)
+  }
+
+  const leftRail = nodes.find((node) => node.type === 'powerRail' && node.id.startsWith('left-rail'))
+  if (!leftRail) return { ok: false, reason: 'the rung has no left power rail' }
+
+  const logic: unknown[] = []
+  const outputs: unknown[] = []
+  const seen = new Set<string>()
+
+  /**
+   * Walk a straight run from `startId` until `stopId` (or the right rail),
+   * collecting contacts and following any parallel pair whole.
+   */
+  function walk(
+    startId: string,
+    stopId: string | null,
+  ): { ok: true; parts: unknown[] } | { ok: false; reason: string } {
+    const parts: unknown[] = []
+    let cursor: string | undefined = startId
+
+    while (cursor && cursor !== stopId) {
+      if (seen.has(cursor)) return { ok: false, reason: 'the rung contains a loop' }
+      seen.add(cursor)
+
+      const next = outgoing.get(cursor) ?? []
+      if (next.length === 0) break
+
+      const node = byId.get(cursor)
+      if (node?.type === 'parallel' && (node.data as { type?: string })?.type === 'open') {
+        const built = describeParallel(node)
+        if (!built.ok) return built
+        parts.push(built.logic)
+        cursor = built.closeId
+        continue
+      }
+
+      // A block has one edge per output pin; the rest go off to their own
+      // variable elements. The one that continues the rung is whichever pin the
+      // node carries as its output connector — ENO with execution control, the
+      // first boolean output without it.
+      const power =
+        node?.type === 'block'
+          ? next.find(
+              (edge) => edge.sourceHandle === (node.data as { outputConnector?: { id?: string } })?.outputConnector?.id,
+            )
+          : next[0]
+      if (!power) return { ok: false, reason: 'a block in this rung does not pass power through' }
+      if (node?.type !== 'block' && next.length > 1) {
+        return { ok: false, reason: 'the rung branches outside a parallel pair' }
+      }
+
+      const target = byId.get(power.target)
+      if (!target) break
+
+      if (target.type === 'contact') parts.push({ contact: describeElement(target) })
+      else if (target.type === 'coil') outputs.push({ coil: describeElement(target) })
+      else if (target.type === 'block') {
+        const built = describeBlock(target)
+        if (!built.ok) return built
+        outputs.push(built.output)
+      }
+
+      cursor = target.id
+    }
+
+    return { ok: true, parts }
+  }
+
+  /**
+   * A block as a rung output, with the variables sitting on its data pins.
+   *
+   * Those variables are separate elements carrying `data.block.handleId` — the
+   * pin's name — so the map is rebuilt by reading them rather than by position.
+   * An unnamed one means the pin was left blank, which is not the same as a pin
+   * wired to nothing and is simply omitted.
+   */
+  function describeBlock(block: RungNode): { ok: true; output: unknown } | { ok: false; reason: string } {
+    const data = block.data as { variable?: { name?: string }; variant?: { name?: string } } | undefined
+    const blockName = data?.variant?.name
+    if (!blockName) return { ok: false, reason: 'a placed block carries no type name' }
+
+    const call = resolveCall(blockName, libraries, userPouNames)
+    if (!call) {
+      return { ok: false, reason: `no project POU or single installed library provides "${blockName}"` }
+    }
+
+    const inputs: Record<string, string> = {}
+    const outputs: Record<string, string> = {}
+    for (const node of nodes) {
+      if (node.type !== 'variable') continue
+      const variableData = node.data as
+        | {
+            block?: { id?: string; handleId?: string; variableType?: { class?: string } }
+            variable?: { name?: string }
+          }
+        | undefined
+      if (variableData?.block?.id !== block.id) continue
+      const side = variableData.block.variableType?.class
+      if (side !== 'input' && side !== 'output') continue
+      const pin = variableData.block.handleId
+      const name = variableData.variable?.name
+      if (pin && name) (side === 'input' ? inputs : outputs)[pin] = name
+    }
+
+    // Only worth stating when it is on: `apply` defaults it off, and the editor
+    // turns it on by itself for a block that cannot go without it.
+    const executionControl = (block.data as { executionControl?: boolean } | undefined)?.executionControl === true
+
+    return {
+      ok: true,
+      output: {
+        block: {
+          call,
+          ...(data?.variable?.name ? { instance: data.variable.name } : {}),
+          ...(executionControl ? { executionControl: true } : {}),
+          ...(Object.keys(inputs).length > 0 ? { inputs } : {}),
+          ...(Object.keys(outputs).length > 0 ? { outputs } : {}),
+        },
+      },
+    }
+  }
+
+  /** An OPEN node and its CLOSE bracket two branches; both are walked whole. */
+  function describeParallel(
+    open: RungNode,
+  ): { ok: true; logic: unknown; closeId: string } | { ok: false; reason: string } {
+    const data = open.data as { parallelCloseReference?: string; parallelOutputConnector?: { id?: string } } | undefined
+    const closeId = data?.parallelCloseReference
+    if (!closeId || !byId.has(closeId)) {
+      return { ok: false, reason: 'a parallel branch is missing its closing element' }
+    }
+
+    const out = outgoing.get(open.id) ?? []
+    const downHandle = data?.parallelOutputConnector?.id
+    const straight = out.find((edge) => edge.sourceHandle === 'output-right')
+    const down = out.find((edge) => edge.sourceHandle === downHandle)
+    if (!straight || !down) return { ok: false, reason: 'a parallel branch is wired in a shape this cannot read' }
+
+    const branches: unknown[] = []
+    for (const entry of [straight, down]) {
+      const branch = walk(entry.target, closeId)
+      if (!branch.ok) return branch
+      const node = byId.get(entry.target)
+      // `walk` starts AT the branch's first element, so that element is not in
+      // its own output — collect it here.
+      const head = node?.type === 'contact' ? [{ contact: describeElement(node) }] : node?.type === 'parallel' ? [] : []
+      const parts = [...head, ...branch.parts]
+      if (parts.length === 0) return { ok: false, reason: 'a parallel branch is empty' }
+      branches.push(parts.length === 1 ? parts[0] : { series: parts })
+    }
+
+    return { ok: true, logic: { parallel: branches }, closeId }
+  }
+
+  const walked = walk(leftRail.id, null)
+  if (!walked.ok) return walked
+  logic.push(...walked.parts)
+
+  if (outputs.length === 0) return { ok: false, reason: 'the rung drives nothing the grammar can name' }
+
+  return {
+    ok: true,
+    rung: {
+      ...(rung.comment ? { comment: rung.comment } : {}),
+      ...(logic.length === 1 ? { logic: logic[0] } : logic.length > 1 ? { logic: { series: logic } } : {}),
+      outputs,
+    },
+  }
+}
+
+function describeElement(node: RungNode): { variable: string; variant: string } {
+  const data = node.data as { variable?: { name?: string }; variant?: string } | undefined
+  return { variable: data?.variable?.name ?? '', variant: data?.variant ?? 'default' }
+}

--- a/src/cli/describe/protocol.ts
+++ b/src/cli/describe/protocol.ts
@@ -1,0 +1,171 @@
+/**
+ * Servers and remote devices as `apply` would accept them back.
+ *
+ * Two rules decide what is left out.
+ *
+ * **Secrets are redacted.** `security.serverPrivateKeyCustom` and every
+ * `users[].passwordHash` are dropped rather than printed, because `describe`
+ * output ends up in logs and diffs. `apply` preserves the stored value when the
+ * key is absent, so a round trip keeps them.
+ *
+ * **Allocated addresses are not part of the spec.** `ioPoints[].iecLocation`
+ * and the EtherCAT channel locations are decided by the allocator from the
+ * whole project. A spec containing them would stop round-tripping the moment
+ * allocation differed, so they go under a sibling `protocolAddresses` key —
+ * still answering "what address did my point get", without pretending to be
+ * an input.
+ */
+
+import type { PLCRemoteDevice, PLCServer } from '@root/middleware/shared/ports/types'
+
+export interface DescribedProtocols {
+  servers: Record<string, unknown>[]
+  remoteDevices: Record<string, unknown>[]
+  /** Read-only: what the allocator decided. Never part of `spec`. */
+  protocolAddresses: Record<string, unknown>[]
+}
+
+export function describeProtocols(
+  servers: readonly PLCServer[],
+  remoteDevices: readonly PLCRemoteDevice[],
+): DescribedProtocols {
+  return {
+    servers: servers.map(describeServer),
+    remoteDevices: remoteDevices.map(describeRemoteDevice),
+    protocolAddresses: describeAddresses(remoteDevices),
+  }
+}
+
+function describeServer(server: PLCServer): Record<string, unknown> {
+  const out: Record<string, unknown> = { name: server.name, protocol: server.protocol }
+
+  if (server.protocol === 'modbus-tcp') {
+    const config = server.modbusSlaveConfig
+    if (!config) return out
+    out.enabled = config.enabled
+    out.modbus = {
+      networkInterface: config.networkInterface,
+      port: config.port,
+      ...(config.bufferMapping ? { bufferMapping: config.bufferMapping } : {}),
+    }
+    return out
+  }
+
+  if (server.protocol === 's7comm') {
+    const config = server.s7commSlaveConfig
+    if (!config) return out
+    const { enabled, ...server7 } = config.server
+    out.enabled = enabled
+    out.s7comm = {
+      server: server7,
+      ...(config.plcIdentity ? { plcIdentity: config.plcIdentity } : {}),
+      dataBlocks: config.dataBlocks,
+      ...(config.systemAreas ? { systemAreas: config.systemAreas } : {}),
+      ...(config.logging ? { logging: config.logging } : {}),
+    }
+    return out
+  }
+
+  const config = server.opcuaServerConfig
+  if (!config) return out
+  const { enabled, ...settings } = config.server
+  out.enabled = enabled
+  out.opcua = {
+    server: settings,
+    securityProfiles: config.securityProfiles,
+    security: {
+      serverCertificateStrategy: config.security.serverCertificateStrategy,
+      serverCertificateCustom: config.security.serverCertificateCustom,
+      trustedClientCertificates: config.security.trustedClientCertificates,
+    },
+    users: config.users.map(({ passwordHash: _redacted, ...user }) => user),
+    cycleTimeMs: config.cycleTimeMs,
+    addressSpace: config.addressSpace,
+  }
+  return out
+}
+
+function describeRemoteDevice(device: PLCRemoteDevice): Record<string, unknown> {
+  const out: Record<string, unknown> = { name: device.name, protocol: device.protocol }
+
+  if (device.protocol === 'modbus-tcp') {
+    const config = device.modbusTcpConfig
+    if (!config) return out
+    const { ioGroups, ...connection } = config
+    out.modbus = {
+      ...connection,
+      ioGroups: ioGroups.map(({ id: _derived, ioPoints, ...group }) => {
+        // Aliases are authored, not allocated, so they belong in the spec —
+        // unlike the addresses beside them.
+        const aliases = (ioPoints ?? []).map((point) => point.alias ?? '')
+        const named = aliases.filter((alias) => alias.length > 0).length
+        return { ...group, ...(named > 0 ? { aliases: aliases.slice(0, lastNamed(aliases) + 1) } : {}) }
+      }),
+    }
+    return out
+  }
+
+  const config = device.ethercatConfig
+  if (!config) return out
+  out.ethercat = {
+    ...(config.masterConfig ? { master: config.masterConfig } : {}),
+    slaves: config.devices.map((slave) => ({
+      esiDeviceRef: slave.esiDeviceRef,
+      name: slave.name,
+      ...(slave.position === undefined ? {} : { position: slave.position }),
+      config: slave.config,
+      ...(slave.cia402 ? { cia402: slave.cia402 } : {}),
+      ...aliasesOf(slave.channelMappings),
+    })),
+  }
+  return out
+}
+
+/** Index of the last named point, so trailing unnamed points are not emitted. */
+function lastNamed(aliases: readonly string[]): number {
+  for (let index = aliases.length - 1; index >= 0; index -= 1) {
+    if (aliases[index].length > 0) return index
+  }
+  return -1
+}
+
+function aliasesOf(mappings: readonly { channelId: string; alias?: string }[] | undefined): Record<string, unknown> {
+  const aliases: Record<string, string> = {}
+  for (const mapping of mappings ?? []) {
+    if (mapping.alias) aliases[mapping.channelId] = mapping.alias
+  }
+  return Object.keys(aliases).length > 0 ? { aliases } : {}
+}
+
+/** Every IEC address the allocator handed a remote device's points and channels. */
+function describeAddresses(remoteDevices: readonly PLCRemoteDevice[]): Record<string, unknown>[] {
+  const rows: Record<string, unknown>[] = []
+
+  for (const device of remoteDevices) {
+    for (const group of device.modbusTcpConfig?.ioGroups ?? []) {
+      for (const point of group.ioPoints ?? []) {
+        rows.push({
+          device: device.name,
+          group: group.name,
+          point: point.name,
+          type: point.type,
+          iecLocation: point.iecLocation,
+          ...(point.alias ? { alias: point.alias } : {}),
+        })
+      }
+    }
+    for (const slave of device.ethercatConfig?.devices ?? []) {
+      for (const mapping of slave.channelMappings ?? []) {
+        rows.push({
+          device: device.name,
+          slave: slave.name,
+          channel: mapping.channelId,
+          iecLocation: mapping.iecLocation,
+          ...(mapping.alias ? { alias: mapping.alias } : {}),
+        })
+      }
+    }
+  }
+
+  return rows
+}

--- a/src/cli/exit-codes.ts
+++ b/src/cli/exit-codes.ts
@@ -45,6 +45,8 @@ export const ErrorCode = {
   InvalidArgument: 'invalid_argument',
   ProjectNotFound: 'project_not_found',
   ProjectInvalid: 'project_invalid',
+  /** A `devices/servers` or `devices/remote` file on disk could not be read. */
+  ProtocolFileUnreadable: 'protocol_file_unreadable',
   TargetUnknown: 'target_unknown',
   CompileFailed: 'compile_failed',
   SessionNotFound: 'session_not_found',

--- a/src/cli/lint/program.ts
+++ b/src/cli/lint/program.ts
@@ -1,0 +1,277 @@
+/**
+ * Read the generated ST and say whether the program does anything.
+ *
+ * `check` answers "does this compile". Every one of these findings compiles
+ * perfectly, which is the point: a timer whose input is never driven, a coil
+ * written by two rungs, a program that touches no I/O. A graphical body makes
+ * all of them easy to draw and impossible to see.
+ *
+ * The ST is the subject rather than the diagram because the ST is what runs. A
+ * rung can look wired and still transpile to a call with the pin missing — that
+ * is exactly the shape of the bug this exists to catch.
+ *
+ * Conservative by construction: every rule here is one that cannot fire on
+ * correct code, because a linter an agent learns to ignore is worse than none.
+ * Anything ambiguous is left alone.
+ */
+
+import type { SystemLibrary } from '@root/middleware/shared/ports/library-types'
+import type { PLCPou, PLCVariable } from '@root/middleware/shared/ports/types'
+
+export interface LintFinding {
+  severity: 'error' | 'warning'
+  /** The POU it was found in, or null for a project-wide finding. */
+  pou: string | null
+  /** Stable slug, so a caller can filter without matching prose. */
+  rule: string
+  message: string
+}
+
+export interface LintInput {
+  st: string
+  pous: readonly PLCPou[]
+  systemLibraries: readonly SystemLibrary[]
+  /** Resource globals, for the I/O reachability rules. */
+  globals: readonly PLCVariable[]
+}
+
+/** One POU's statements, with its declarations stripped. */
+interface PouBody {
+  name: string
+  statements: string
+}
+
+/** `EN`/`ENO` are the editor's, not the block's — they are never the subject. */
+const IMPLICIT = new Set(['EN', 'ENO'])
+
+/**
+ * Split the ST into POU bodies.
+ *
+ * `FUNCTION_BLOCK` is matched before `FUNCTION` deliberately: the shorter
+ * keyword is a prefix of the longer one, so the other order ends every function
+ * block at its first `END_FUNCTION`.
+ */
+function splitPous(st: string): PouBody[] {
+  const bodies: PouBody[] = []
+  const pattern = /\b(FUNCTION_BLOCK|PROGRAM|FUNCTION)\s+(\w+)([\s\S]*?)\bEND_\1\b/g
+  for (const match of st.matchAll(pattern)) {
+    bodies.push({ name: match[2], statements: stripDeclarations(match[3]) })
+  }
+  return bodies
+}
+
+/** Drop every `VAR… END_VAR` block, so a declaration never reads as a use. */
+function stripDeclarations(body: string): string {
+  return body.replace(/\bVAR(?:_INPUT|_OUTPUT|_IN_OUT|_EXTERNAL|_GLOBAL|_TEMP)?\b[\s\S]*?\bEND_VAR\b/g, '')
+}
+
+/** Strip comments so a name mentioned in prose is not counted as a use. */
+function stripComments(text: string): string {
+  return text.replace(/\(\*[\s\S]*?\*\)/g, ' ').replace(/\/\/[^\n]*/g, ' ')
+}
+
+function mentions(text: string, name: string): boolean {
+  return new RegExp(`\\b${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(text)
+}
+
+/** The argument list of `name(...)`, scanned for balance so nesting is safe. */
+function callArguments(statements: string, name: string): string | null {
+  const opener = new RegExp(`\\b${name}\\s*\\(`, 'i')
+  const found = opener.exec(statements)
+  if (!found) return null
+
+  let depth = 0
+  const from = found.index + found[0].length - 1
+  for (let at = from; at < statements.length; at += 1) {
+    if (statements[at] === '(') depth += 1
+    else if (statements[at] === ')') {
+      depth -= 1
+      if (depth === 0) return statements.slice(from + 1, at)
+    }
+  }
+  return null
+}
+
+/** The pins a call assigns, by name. */
+function assignedPins(argumentList: string): Set<string> {
+  const pins = new Set<string>()
+  for (const match of argumentList.matchAll(/(\w+)\s*:?=>?/g)) pins.add(match[1].toUpperCase())
+  return pins
+}
+
+/** Pins whose value the call sends OUT, `pin => target`. */
+function outputPins(argumentList: string): Set<string> {
+  const pins = new Set<string>()
+  for (const match of argumentList.matchAll(/(\w+)\s*=>/g)) pins.add(match[1].toUpperCase())
+  return pins
+}
+
+/** A block's declared pins, from the installed libraries or the project's own POUs. */
+function pinsOf(
+  blockType: string,
+  systemLibraries: readonly SystemLibrary[],
+  pous: readonly PLCPou[],
+): { inputs: string[]; outputs: string[] } | null {
+  const own = pous.find((pou) => pou.name.toLowerCase() === blockType.toLowerCase())
+  if (own) {
+    const variables = own.interface?.variables ?? []
+    return {
+      inputs: variables.filter((v) => v.class === 'input').map((v) => v.name),
+      outputs: variables.filter((v) => v.class === 'output').map((v) => v.name),
+    }
+  }
+
+  for (const library of systemLibraries) {
+    const block = library.pous.find((pou) => pou.name.toLowerCase() === blockType.toLowerCase())
+    if (!block) continue
+    return {
+      inputs: block.variables.filter((v) => v.class === 'input').map((v) => v.name),
+      outputs: block.variables.filter((v) => v.class === 'output').map((v) => v.name),
+    }
+  }
+  return null
+}
+
+/**
+ * Names assigned by an UNCONDITIONAL statement, and how often.
+ *
+ * Depth matters: a SET and a RESET coil on one variable are two assignments and
+ * entirely correct, and they transpile to `IF <edge> THEN x := …; END_IF;`. Only
+ * assignments at the top level are the double-drive this rule is about.
+ */
+function unconditionalAssignments(statements: string): Map<string, number> {
+  const counts = new Map<string, number>()
+  let depth = 0
+  // A call's named arguments are written one per line often enough that this
+  // is not an edge case — the editor's own SoftMotion bridge does it — and
+  // `wStatusWord := x,` inside one reads exactly like an assignment.
+  let parenDepth = 0
+
+  for (const rawLine of statements.split('\n')) {
+    const line = rawLine.trim()
+    const lineStartedInsideCall = parenDepth > 0
+    parenDepth += (line.match(/\(/g) ?? []).length - (line.match(/\)/g) ?? []).length
+    if (parenDepth < 0) parenDepth = 0
+    if (line.length === 0 || lineStartedInsideCall) continue
+
+    const closes = (line.match(/\bEND_(IF|CASE|WHILE|FOR|REPEAT)\b/g) ?? []).length
+    depth -= closes
+    if (depth < 0) depth = 0
+
+    if (depth === 0) {
+      const assignment = /^(\w+(?:\.\w+)*)\s*:=/.exec(line)
+      // `inst(…)` is a call, not an assignment, and `a.b := …` writes a member
+      // rather than the variable — neither is a double drive.
+      if (assignment && !assignment[1].includes('.')) {
+        const name = assignment[1].toUpperCase()
+        counts.set(name, (counts.get(name) ?? 0) + 1)
+      }
+    }
+
+    const opens = (line.match(/\b(IF|CASE|WHILE|FOR|REPEAT)\b/g) ?? []).length
+    const elses = (line.match(/\bELSIF\b/g) ?? []).length
+    depth += opens - elses
+  }
+  return counts
+}
+
+export function lintProgram(input: LintInput): LintFinding[] {
+  const findings: LintFinding[] = []
+  const bodies = splitPous(stripComments(input.st))
+
+  for (const body of bodies) {
+    const pou = input.pous.find((entry) => entry.name.toLowerCase() === body.name.toLowerCase())
+    const instances = (pou?.interface?.variables ?? []).filter((variable) => variable.type.definition === 'derived')
+
+    for (const instance of instances) {
+      const pins = pinsOf(instance.type.value, input.systemLibraries, input.pous)
+      if (!pins) continue
+
+      const argumentList = callArguments(body.statements, instance.name)
+      if (argumentList === null) continue
+
+      const assigned = assignedPins(argumentList)
+      const inputs = pins.inputs.filter((pin) => !IMPLICIT.has(pin.toUpperCase()))
+      const outputs = pins.outputs.filter((pin) => !IMPLICIT.has(pin.toUpperCase()))
+
+      // The block's FIRST declared input is the one that drives it — `IN` on a
+      // timer, `EXECUTE` on a motion block. Leaving it open while calling the
+      // block is the EN/ENO trap: the rung gates the call and nothing drives it.
+      const primary = inputs[0]
+      if (primary && !assigned.has(primary.toUpperCase())) {
+        const gated = assigned.has('EN') ? ' The rung is wired to EN/ENO, which only gates the call.' : ''
+        findings.push({
+          severity: 'error',
+          pou: body.name,
+          rule: 'block-primary-input-unassigned',
+          message:
+            `"${instance.name}" (${instance.type.value}) is called but its "${primary}" input is never assigned, ` +
+            `so the block never does anything.${gated}`,
+        })
+      }
+
+      // An output is read either as `inst.PIN` or by being sent somewhere in the
+      // call itself (`PIN => target`), which is the form the editor generates.
+      const sent = outputPins(argumentList)
+      const anyRead = outputs.some(
+        (pin) => sent.has(pin.toUpperCase()) || mentions(body.statements, `${instance.name}.${pin}`),
+      )
+      if (outputs.length > 0 && !anyRead) {
+        findings.push({
+          severity: 'warning',
+          pou: body.name,
+          rule: 'block-outputs-unread',
+          message:
+            `Nothing reads any output of "${instance.name}" (${instance.type.value}); ` +
+            `its result goes nowhere. Its outputs are: ${outputs.join(', ')}.`,
+        })
+      }
+    }
+
+    for (const [name, count] of unconditionalAssignments(body.statements)) {
+      if (count < 2) continue
+      findings.push({
+        severity: 'error',
+        pou: body.name,
+        rule: 'variable-driven-twice',
+        message:
+          `"${name}" is assigned by ${count} unconditional statements; only the last one survives the scan. ` +
+          'In ladder this is a double coil.',
+      })
+    }
+  }
+
+  findings.push(...lintIo(input, bodies))
+  return findings
+}
+
+/** Does the program reach the outside world at all? */
+function lintIo(input: LintInput, bodies: PouBody[]): LintFinding[] {
+  const located = input.globals.filter((global) => (global.location ?? '').trim().length > 0)
+  if (located.length === 0) return []
+
+  const everything = bodies.map((body) => body.statements).join('\n')
+  const unreferenced = located.filter((global) => !mentions(everything, global.name))
+
+  // Every located global unread AND unwritten means the program cannot see an
+  // input or move an output, whatever else it computes.
+  if (unreferenced.length === located.length) {
+    return [
+      {
+        severity: 'error',
+        pou: null,
+        rule: 'no-io-referenced',
+        message:
+          `No POU references any of the ${located.length} global(s) bound to an IEC address, ` +
+          'so this program reads no inputs and drives no outputs.',
+      },
+    ]
+  }
+
+  return unreferenced.map((global) => ({
+    severity: 'warning' as const,
+    pou: null,
+    rule: 'located-global-unreferenced',
+    message: `Global "${global.name}" is bound to ${global.location ?? ''} but no POU references it.`,
+  }))
+}

--- a/src/cli/lint/program.ts
+++ b/src/cli/lint/program.ts
@@ -70,13 +70,20 @@ function stripComments(text: string): string {
   return text.replace(/\(\*[\s\S]*?\*\)/g, ' ').replace(/\/\/[^\n]*/g, ' ')
 }
 
+/** Regex-safe form of a name read from project data, which is not validated. */
+function escapeForRegex(name: string): string {
+  return name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 function mentions(text: string, name: string): boolean {
-  return new RegExp(`\\b${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(text)
+  return new RegExp(`\\b${escapeForRegex(name)}\\b`, 'i').test(text)
 }
 
 /** The argument list of `name(...)`, scanned for balance so nesting is safe. */
 function callArguments(statements: string, name: string): string | null {
-  const opener = new RegExp(`\\b${name}\\s*\\(`, 'i')
+  // Escaped: a legacy JSON project can carry an instance name the editor would
+  // refuse, and a raw metacharacter here either throws or matches the wrong call.
+  const opener = new RegExp(`\\b${escapeForRegex(name)}\\s*\\(`, 'i')
   const found = opener.exec(statements)
   if (!found) return null
 

--- a/src/cli/lint/protocol.ts
+++ b/src/cli/lint/protocol.ts
@@ -234,6 +234,31 @@ function lintOpcUa(input: ProtocolLintInput): LintFinding[] {
       })
     }
 
+    // The shipped default profile is `None`/`None` with Anonymous auth, and it
+    // is inert in the editor because a new server starts disabled. A spec that
+    // says `enabled: true` without naming a profile inherits it and opens an
+    // unauthenticated server on every interface. A warning, not an error: this
+    // is a legitimate choice on a closed network, and a rule that fails a
+    // correct configuration teaches the reader to stop reading.
+    const open = config.securityProfiles.filter(
+      (profile) =>
+        profile.enabled &&
+        profile.securityPolicy === 'None' &&
+        profile.securityMode === 'None' &&
+        profile.authMethods.includes('Anonymous'),
+    )
+    if (open.length > 0 && config.securityProfiles.every((profile) => !profile.enabled || open.includes(profile))) {
+      findings.push({
+        severity: 'warning',
+        pou: null,
+        rule: 'opcua-server-unauthenticated',
+        message:
+          `OPC-UA server "${server.name}" is enabled on ${config.server.bindAddress}:${config.server.port} and ` +
+          'every enabled security profile is None/None with Anonymous auth, so any client that can reach it can ' +
+          'read and write. Add a profile with a policy and an authentication method, or bind it to one interface.',
+      })
+    }
+
     // `nodeId` is the IDENTIFIER, which the plugin wraps as `ns=<idx>;s=<id>`
     // (`opcua/address_space.py`). Writing a whole node id here produces
     // `ns=2;s=ns=1;s=Thing`, which browses fine and cannot be read by the id

--- a/src/cli/lint/protocol.ts
+++ b/src/cli/lint/protocol.ts
@@ -1,0 +1,309 @@
+/**
+ * Protocol configurations that save, upload, and then half-exist.
+ *
+ * Same bargain as the program linter: every finding here is a project the
+ * compiler accepts. The generators are forgiving by design — a Modbus device
+ * with no I/O groups and an RTU device with no serial port are both dropped and
+ * the compile succeeds, so the runtime simply never polls them. Nothing else in
+ * the toolchain says so before a technician is standing next to the panel.
+ *
+ * Where a real validator already exists it is delegated to rather than
+ * reimplemented: `validateOpcUaConfig` resolves every address-space node against
+ * the debug map, which is the highest-value check in the set and impossible to
+ * approximate.
+ */
+
+import { generateEthercatConfig } from '@root/backend/shared/ethercat/generate-ethercat-config'
+import { validateEthercatConfig } from '@root/backend/shared/ethercat/validate-ethercat-config'
+import { validateOpcUaConfig } from '@root/frontend/utils/opcua/generate-opcua-config'
+import type { PLCInstanceInfo } from '@root/frontend/utils/opcua/types'
+import type { PLCRemoteDevice, PLCServer, PLCVariable } from '@root/middleware/shared/ports/types'
+
+import type { LintFinding } from './program'
+
+export interface ProtocolLintInput {
+  servers: readonly PLCServer[]
+  remoteDevices: readonly PLCRemoteDevice[]
+  /** STruC++'s `debug-map.json`; OPC-UA node resolution needs it. */
+  debugMapContent: string
+  instances: PLCInstanceInfo[]
+  /** Resource globals, for the address-collision rule. */
+  globals: readonly PLCVariable[]
+}
+
+/** The port each protocol listens on, for the conflict check. */
+function serverPort(server: PLCServer): number | undefined {
+  if (server.protocol === 'modbus-tcp') return server.modbusSlaveConfig?.port
+  if (server.protocol === 's7comm') return server.s7commSlaveConfig?.server.port
+  if (server.protocol === 'opcua') return server.opcuaServerConfig?.server.port
+  return undefined
+}
+
+function isEnabled(server: PLCServer): boolean {
+  if (server.protocol === 'modbus-tcp') return server.modbusSlaveConfig?.enabled === true
+  if (server.protocol === 's7comm') return server.s7commSlaveConfig?.server.enabled === true
+  if (server.protocol === 'opcua') return server.opcuaServerConfig?.server.enabled === true
+  return false
+}
+
+export function lintProtocols(input: ProtocolLintInput): LintFinding[] {
+  const findings: LintFinding[] = []
+  const enabled = input.servers.filter(isEnabled)
+
+  // Each generator takes ONE server of its protocol; a second is dropped, and
+  // which one survives is decided by array order.
+  const byProtocol = new Map<string, PLCServer[]>()
+  for (const server of enabled) {
+    byProtocol.set(server.protocol, [...(byProtocol.get(server.protocol) ?? []), server])
+  }
+  for (const [protocol, servers] of byProtocol) {
+    if (servers.length < 2) continue
+    findings.push({
+      severity: 'error',
+      pou: null,
+      rule: 'duplicate-protocol-server',
+      message:
+        `${servers.length} enabled "${protocol}" servers (${servers.map((s) => s.name).join(', ')}). ` +
+        `The runtime takes one config per protocol, so only "${servers[0].name}" would be used.`,
+    })
+  }
+
+  // Two servers on one port bind in an order nothing here decides; the loser
+  // fails at runtime, not at compile.
+  const byPort = new Map<number, PLCServer[]>()
+  for (const server of enabled) {
+    const port = serverPort(server)
+    if (port === undefined) continue
+    byPort.set(port, [...(byPort.get(port) ?? []), server])
+  }
+  for (const [port, servers] of byPort) {
+    if (servers.length < 2) continue
+    findings.push({
+      severity: 'error',
+      pou: null,
+      rule: 'server-port-conflict',
+      message: `${servers.map((s) => `"${s.name}"`).join(' and ')} both listen on port ${port}.`,
+    })
+  }
+
+  findings.push(...lintRemoteDevices(input.remoteDevices))
+  findings.push(...lintOpcUa(input))
+  findings.push(...lintEthercat(input.remoteDevices))
+  findings.push(...lintAddressCollisions(input.remoteDevices, input.globals))
+  return findings
+}
+
+/**
+ * A global whose address a remote device also got.
+ *
+ * The allocator builds its pool from the pin mapping, the VPP entries and the
+ * remote devices — never from a global's hand-written `location`. So a project
+ * that writes `gRunCmd AT %IX0.0` and then adds a Modbus master gets the
+ * master's first coil at `%IX0.0` too, and the poll overwrites the input every
+ * scan. Both halves compile, save and upload.
+ *
+ * Only same-class addresses collide: the runtime keeps `bool_input`,
+ * `int_input`, `dint_input` and `lint_input` as separate arrays
+ * (`core/src/plc_app/image_tables.h`), so `%IX0.0` and `%IW0` are different
+ * storage and not a conflict.
+ */
+function lintAddressCollisions(
+  remoteDevices: readonly PLCRemoteDevice[],
+  /** As STORED. A global bound by alias carries the alias name here, which
+   *  `normalizeAddress` rejects — a deliberate binding is not a collision. */
+  globals: readonly PLCVariable[],
+): LintFinding[] {
+  const byAddress = new Map<string, string>()
+  for (const global of globals) {
+    const address = normalizeAddress(global.location)
+    if (address) byAddress.set(address, global.name)
+  }
+  if (byAddress.size === 0) return []
+
+  const findings: LintFinding[] = []
+  const report = (address: string, claimant: string) => {
+    const global = byAddress.get(address)
+    if (!global) return
+    findings.push({
+      severity: 'error',
+      pou: null,
+      rule: 'located-global-collides-with-remote-io',
+      message:
+        `Global "${global}" is bound to ${address}, and ${claimant} was allocated the same address. ` +
+        'The device overwrites the global every poll — move the global to an address no device claims.',
+    })
+  }
+
+  for (const device of remoteDevices) {
+    for (const group of device.modbusTcpConfig?.ioGroups ?? []) {
+      for (const point of group.ioPoints ?? []) {
+        const address = normalizeAddress(point.iecLocation)
+        if (address) report(address, `"${device.name}.${group.name}"`)
+      }
+    }
+    for (const slave of device.ethercatConfig?.devices ?? []) {
+      for (const mapping of slave.channelMappings ?? []) {
+        const address = normalizeAddress(mapping.iecLocation)
+        if (address) report(address, `EtherCAT slave "${device.name}.${slave.name}"`)
+      }
+    }
+  }
+
+  return findings
+}
+
+/** `%IX0.0` → `%IX0.0`; a bitless bit address is bit 0. Anything else is an alias. */
+function normalizeAddress(location: string | undefined): string | null {
+  const match = /^%([IQM])([XBWDL])(\d+)(?:\.(\d+))?$/i.exec((location ?? '').trim())
+  if (!match) return null
+  const [, space, width, index, bit] = match
+  const upper = `%${space.toUpperCase()}${width.toUpperCase()}${index}`
+  return width.toUpperCase() === 'X' ? `${upper}.${bit ?? '0'}` : upper
+}
+
+function lintRemoteDevices(remoteDevices: readonly PLCRemoteDevice[]): LintFinding[] {
+  const findings: LintFinding[] = []
+
+  for (const device of remoteDevices) {
+    if (device.protocol !== 'modbus-tcp') continue
+    const config = device.modbusTcpConfig
+    if (!config) continue
+
+    if ((config.ioGroups ?? []).length === 0) {
+      findings.push({
+        severity: 'error',
+        pou: null,
+        rule: 'modbus-device-without-io-groups',
+        message:
+          `Remote device "${device.name}" has no I/O groups, so the generator drops it: ` +
+          'it uploads cleanly and then polls nothing.',
+      })
+    }
+
+    if ((config.transport ?? 'tcp') === 'rtu' && !config.serialPort) {
+      findings.push({
+        severity: 'error',
+        pou: null,
+        rule: 'modbus-rtu-without-serial-port',
+        message: `Remote device "${device.name}" uses RTU with no serial port, so the generator drops it.`,
+      })
+    }
+  }
+
+  // Two Modbus masters on one serial line cannot both drive it.
+  const bySerialPort = new Map<string, string[]>()
+  for (const device of remoteDevices) {
+    const port = device.modbusTcpConfig?.serialPort
+    if (!port || (device.modbusTcpConfig?.transport ?? 'tcp') !== 'rtu') continue
+    bySerialPort.set(port, [...(bySerialPort.get(port) ?? []), device.name])
+  }
+  for (const [port, names] of bySerialPort) {
+    if (names.length < 2) continue
+    findings.push({
+      severity: 'warning',
+      pou: null,
+      rule: 'modbus-rtu-serial-port-shared',
+      message: `${names.map((name) => `"${name}"`).join(' and ')} share serial port ${port}.`,
+    })
+  }
+
+  return findings
+}
+
+/**
+ * Every enabled OPC-UA server, through the generator's own validator.
+ *
+ * This is the one rule that needs the debug map: a node naming a variable the
+ * program does not have resolves to nothing, and the server serves an address
+ * space with a hole in it.
+ */
+function lintOpcUa(input: ProtocolLintInput): LintFinding[] {
+  const findings: LintFinding[] = []
+
+  for (const server of input.servers) {
+    const config = server.opcuaServerConfig
+    if (!config?.server.enabled) continue
+
+    const result = validateOpcUaConfig(config, input.debugMapContent, input.instances)
+    for (const error of result.errors) {
+      findings.push({
+        severity: 'error',
+        pou: null,
+        rule: 'opcua-config-invalid',
+        message: `OPC-UA server "${server.name}": ${error}`,
+      })
+    }
+
+    // `nodeId` is the IDENTIFIER, which the plugin wraps as `ns=<idx>;s=<id>`
+    // (`opcua/address_space.py`). Writing a whole node id here produces
+    // `ns=2;s=ns=1;s=Thing`, which browses fine and cannot be read by the id
+    // the author wrote.
+    for (const node of config.addressSpace.nodes) {
+      if (!/^ns=\d+;[isgb]=/i.test(node.nodeId)) continue
+      findings.push({
+        severity: 'error',
+        pou: null,
+        rule: 'opcua-node-id-is-an-identifier',
+        message:
+          `OPC-UA server "${server.name}": node "${node.browseName}" has nodeId "${node.nodeId}". ` +
+          'That field is the identifier only — the server adds its own namespace, so this becomes ' +
+          `"ns=<n>;s=${node.nodeId}". Use just the identifier (e.g. "${node.pouName}.${node.variablePath}").`,
+      })
+    }
+  }
+
+  return findings
+}
+
+function lintEthercat(remoteDevices: readonly PLCRemoteDevice[]): LintFinding[] {
+  const findings: LintFinding[] = []
+
+  for (const device of remoteDevices) {
+    if (device.protocol !== 'ethercat') continue
+    const config = device.ethercatConfig
+    if (!config || config.masterConfig?.enabled === false) continue
+
+    if ((config.devices ?? []).length === 0) {
+      findings.push({
+        severity: 'warning',
+        pou: null,
+        rule: 'ethercat-master-without-slaves',
+        message: `EtherCAT master "${device.name}" has no slaves, so no config is generated for it.`,
+      })
+      continue
+    }
+
+    for (const slave of config.devices) {
+      if ((slave.channelMappings ?? []).length > 0) continue
+      findings.push({
+        severity: 'warning',
+        pou: null,
+        rule: 'ethercat-slave-without-channels',
+        message: `EtherCAT slave "${device.name}.${slave.name}" has no channel mappings, so it exchanges no data.`,
+      })
+    }
+  }
+
+  // The generator's own validator, against the JSON it produces — it takes the
+  // generated string, not the project. The cast is the one `generateRuntimeConfs`
+  // makes: the generator's shape requires fields the port type leaves optional.
+  //
+  // Wrapped because the generator dereferences a slave's `config` without a
+  // guard: a project missing one takes `check` down with a TypeError instead of
+  // reporting anything. A linter that crashes is worse than one that misses.
+  try {
+    const generated = generateEthercatConfig([...remoteDevices] as Parameters<typeof generateEthercatConfig>[0])
+    for (const error of validateEthercatConfig(generated)) {
+      findings.push({ severity: 'error', pou: null, rule: 'ethercat-config-invalid', message: error })
+    }
+  } catch (error) {
+    findings.push({
+      severity: 'error',
+      pou: null,
+      rule: 'ethercat-config-invalid',
+      message: `The EtherCAT config could not be generated: ${error instanceof Error ? error.message : String(error)}`,
+    })
+  }
+
+  return findings
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -30,11 +30,18 @@ import { app } from 'electron'
 
 import { boolFlag, parseArgs, type ParsedArgs, stringFlag } from './args'
 import { cliArgv } from './argv'
+import { runApply } from './commands/apply'
 import { buildProject, runBuild } from './commands/build'
+import { runCheck } from './commands/check'
 import { runCreate } from './commands/create'
 import { type DebugContext, runDebug } from './commands/debug'
+import { runDescribe } from './commands/describe'
 import { runDevices } from './commands/devices'
+import { runEsi } from './commands/esi'
 import { runInstallCli } from './commands/install-cli'
+import { runInstallSkill } from './commands/install-skill'
+import { runRuntime } from './commands/runtime'
+import { runSkill } from './commands/skill'
 import { runDaemonFromStdin } from './daemon-entry'
 import { ErrorCode, ExitCode, type ExitCodeValue } from './exit-codes'
 import { createProcessReporter, Reporter } from './output'
@@ -63,6 +70,23 @@ const BOOLEAN_FLAGS = [
   'force-new',
   // `create --force`: overwrite an existing destination instead of refusing it.
   'force',
+  // `upload --create-user`: bootstrap the first account on a fresh runtime.
+  // Unregistered it consumed the next token, so `--create-user ./project` ate
+  // the project path and the command failed asking for one.
+  'create-user',
+  // `check --protocols`: which conf/*.json the upload would carry.
+  'protocols',
+  // `check --emit-st`: include the generated ST in the result.
+  'emit-st',
+  // `check --lint`: report logic that compiles and does nothing.
+  'lint',
+  // `apply`: validate without writing, and delete what the spec omits.
+  'dry-run',
+  'prune',
+  // `describe --libraries`: include the block catalogue.
+  'libraries',
+  // `skill --list`.
+  'list',
   'keep-forces',
   'keep-going',
   'all',
@@ -79,8 +103,16 @@ Usage
   openplc-cli create --from-json <file>                     (fixture-friendly form)
   openplc-cli install-cli                                   (put openplc-cli on your PATH)
   openplc-cli devices [--timeout <ms>]
+  openplc-cli runtime info --host <address>                 (version and capabilities; no login)
+  openplc-cli skill   [--list] [--name <skill>]            (the agent skill this build ships)
+  openplc-cli install-skill [--scope project|user] [--path <dir>]
+  openplc-cli describe <project> [--libraries] [--pou <name>]
+  openplc-cli apply   <spec.json>|- --project <dir> [--dry-run] [--prune]
+  openplc-cli check   <project> [--target <board>] [--pou <name>] [--emit-st] [--lint] [--protocols]
+  openplc-cli esi import <file.xml> --project <dir>         (add an ESI file for EtherCAT)
+  openplc-cli esi list --project <dir>                      (ids and device indices to reference)
   openplc-cli compile <project> [--target <board>] [--port <serial>] [--clean]
-  openplc-cli upload  <project> (--host <address> | --port <serial>) [--target <board>] [--clean] [-y|--yes]
+  openplc-cli upload  <project> (--host <address> | --port <serial>) [--target <board>] [--clean] [-y|--yes] [--create-user]
   openplc-cli debug open <project> --target <board> (--host <address> | --port <serial>) [--upload-if-needed]
   openplc-cli debug list
   openplc-cli debug status | list-vars | read | force | unforce | start | stop | watch | poll | unwatch
@@ -193,8 +225,22 @@ async function dispatch(args: ParsedArgs, reporter: Reporter): Promise<ExitCodeV
       return (await runCreate(args, reporter)).exitCode
     case 'devices':
       return (await runDevices(args, reporter)).exitCode
+    case 'runtime':
+      return (await runRuntime(args, reporter)).exitCode
+    case 'esi':
+      return (await runEsi(args, reporter)).exitCode
     case 'install-cli':
       return (await runInstallCli(args, reporter)).exitCode
+    case 'apply':
+      return (await runApply(args, reporter)).exitCode
+    case 'describe':
+      return (await runDescribe(args, reporter)).exitCode
+    case 'skill':
+      return runSkill(args, reporter).exitCode
+    case 'install-skill':
+      return runInstallSkill(args, reporter).exitCode
+    case 'check':
+      return (await runCheck(args, reporter)).exitCode
     case 'compile':
       return (await runBuild(args, reporter, { withUpload: false })).exitCode
     case 'upload':
@@ -282,7 +328,13 @@ function daemonSpawnArgs(): string[] {
 
   // Dev: Electron was handed this bundle's path, and webpack leaves __filename
   // as the real runtime path (`node: { __filename: false }`).
-  const script = process.argv[1] ?? __filename
+  //
+  // NOT `process.argv[1]`: on Linux `main/entry.ts` re-execs with
+  // `--ozone-platform=headless --disable-gpu` in front of the script, so argv[1]
+  // is a switch there — truthy, so `?? __filename` never fired and every
+  // `debug open` on Linux died on it. Take the first argument that looks like a
+  // bundle instead.
+  const script = process.argv.slice(1).find((argument) => argument.endsWith('.js')) ?? __filename
   if (!script.endsWith('.js')) {
     throw new Error(
       `Cannot locate the CLI bundle to spawn a debug session (resolved "${script}"). ` +

--- a/src/cli/project/load.ts
+++ b/src/cli/project/load.ts
@@ -18,9 +18,11 @@
  */
 
 import { HardwareModule } from '@root/backend/editor/hardware'
+import { LibraryManagerModule } from '@root/backend/editor/library-manager'
 import { ProjectService } from '@root/backend/editor/services'
 import { parseProjectFiles } from '@root/backend/shared/utils/parse-project-files'
 import { openPLCStoreBase } from '@root/frontend/store'
+import { stlibsToSystemLibraries } from '@root/frontend/utils/stlib-to-system-library'
 import type { PLCProjectData } from '@root/middleware/shared/ports/types'
 
 export interface LoadedProject {
@@ -35,9 +37,69 @@ export interface LoadedProject {
   vendorScreenData: Record<string, unknown> | undefined
   communicationPort: string | undefined
   warnings: string[]
+  /**
+   * `executeSaveProject` refuses silently on either of these — `canEdit` false
+   * (set when the open response carried fatal errors) returns `{success:false}`
+   * through a toast that goes nowhere headless, and an ephemeral project refuses
+   * a `'user'` save. A writing command must check them rather than exit 0 having
+   * written nothing.
+   */
+  canEdit: boolean
+  isEphemeral: boolean
+  /**
+   * Server / remote-device files on disk that failed to load.  Their configs
+   * are absent from `data`, so `describe` under-reports the project and an
+   * `apply` naming the same server would overwrite a file it never read.
+   * Writing and reporting commands must refuse rather than warn.
+   */
+  unreadableProtocolFiles: { relativePath: string; reason: string }[]
 }
 
 export type LoadProjectResult = { success: true; project: LoadedProject } | { success: false; error: string }
+
+/**
+ * The message for a project holding a protocol file that would not load, or
+ * null when every one was read.
+ *
+ * A skipped file is silent: the server is simply absent from the store, so
+ * `describe` reports a project that is not the one on disk, and an `apply`
+ * declaring that same name writes over a config nobody read. Both refuse.
+ */
+export function unreadableProtocolFilesMessage(project: LoadedProject): string | null {
+  if (project.unreadableProtocolFiles.length === 0) return null
+  const listed = project.unreadableProtocolFiles.map((file) => `  ${file.relativePath} — ${file.reason}`).join('\n')
+  return (
+    `${project.unreadableProtocolFiles.length} protocol file(s) in this project could not be read, ` +
+    `so its configuration is not what is on disk:\n${listed}\n` +
+    'Fix or remove the file(s) first — continuing would overwrite them.'
+  )
+}
+
+/**
+ * Load the installed libraries into the store, returning any warning rather
+ * than throwing: a project that references no library still compiles, so a
+ * damaged library store must not stop the build.
+ *
+ * Two reads, as the renderer does: `loadAll` carries the POU lists the pool is
+ * built from, `listInstalled` carries the bundled flag the archive shape has no
+ * room for.
+ */
+function hydrateLibraries(): string[] {
+  try {
+    const libraries = new LibraryManagerModule()
+    const actions = openPLCStoreBase.getState().libraryActions
+    actions.setSystemLibraries(stlibsToSystemLibraries(libraries.loadAll()))
+    actions.setBundledLibraryNames(
+      libraries
+        .listInstalled()
+        .filter((library) => library.bundled)
+        .map((library) => library.name),
+    )
+    return []
+  } catch (err) {
+    return [`warning: could not read the installed libraries: ${err instanceof Error ? err.message : String(err)}`]
+  }
+}
 
 export async function loadProject(projectPath: string): Promise<LoadProjectResult> {
   // The main process's own reader, so the CLI sees exactly the file set the
@@ -79,6 +141,13 @@ export async function loadProject(projectPath: string): Promise<LoadProjectResul
   // leave those resolvers looking at an empty one, and the CLI would have to
   // reimplement them. One project per process is the same assumption the editor
   // makes, and a CLI invocation is one project.
+  // The library pool, BEFORE the project opens. `handleOpenProjectResponse`
+  // reads `libraries.system` and re-stamps every placed block against it in the
+  // same call, and `setProjectLibraries` derives the enabled/missing lists from
+  // it — both see an empty pool if this runs after. Mirrors `hydrateLibraries`
+  // in App.tsx, which is the renderer's equivalent.
+  const libraryWarnings = hydrateLibraries()
+
   openPLCStoreBase.getState().sharedWorkspaceActions.handleOpenProjectResponse(parsed)
 
   const state = openPLCStoreBase.getState()
@@ -92,7 +161,10 @@ export async function loadProject(projectPath: string): Promise<LoadProjectResul
       board: state.deviceDefinitions.configuration.deviceBoard,
       vendorScreenData: state.deviceDefinitions.configuration.vendorScreenData,
       communicationPort: state.deviceDefinitions.configuration.communicationPort,
-      warnings: parsed.warnings ?? [],
+      warnings: [...libraryWarnings, ...(parsed.warnings ?? [])],
+      canEdit: state.workspace.canEdit,
+      isEphemeral: state.workspace.isEphemeralProject,
+      unreadableProtocolFiles: parsed.unreadableProtocolFiles ?? [],
     },
   }
 }

--- a/src/cli/project/project-port.ts
+++ b/src/cli/project/project-port.ts
@@ -1,0 +1,76 @@
+/**
+ * A `ProjectPort` that works in the CLI's process.
+ *
+ * The editor's own adapter reaches the filesystem through `window.bridge`
+ * (`project-adapter.ts`), which is renderer-only — there is no window here. But
+ * `executeSaveProject` calls exactly ONE member, `saveProject(files)`, so the
+ * shim implements that for real against the same `ProjectService` the main
+ * process uses, and refuses the rest.
+ *
+ * Refusals are structured, never thrown. A dialog has no meaning without a user
+ * in front of it, and a CLI that crashed on one would turn "this command cannot
+ * pick a file for you" into a stack trace. Modelled on `headless-bridge.ts`'s
+ * `noRuntime()`.
+ */
+
+import { readFile } from 'node:fs/promises'
+
+import { ProjectService } from '@root/backend/editor/services'
+import type { ProjectPort } from '@root/middleware/shared/ports/project-port'
+import type { WriteProjectFiles } from '@root/middleware/shared/ports/project-port'
+
+/** One refusal shape, so every unsupported member reads the same. */
+function notInCli(what: string): { success: false; error: string } {
+  return { success: false, error: `${what} needs the editor's UI and is not available from the CLI.` }
+}
+
+export function createCliProjectPort(): ProjectPort {
+  const service = new ProjectService()
+
+  const port = {
+    // The one member `executeSaveProject` actually calls.
+    saveProject: (files: WriteProjectFiles) => service.writeProjectFiles(files),
+
+    saveFile: async (filePath: string, content: unknown) => {
+      // `saveProject` covers the whole project; a single-file write is only
+      // reached by the surgical save paths, which the CLI does not use.
+      void filePath
+      void content
+      return notInCli('Saving one file')
+    },
+
+    readFileContent: async (filePath: string) => {
+      // `ProjectService` has no single-file read; the surgical save paths that
+      // use this read plain text off disk, which is all this needs to be.
+      try {
+        return { success: true, content: await readFile(filePath, 'utf-8') }
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+    readProjectFiles: (projectPath: string) => service.readRawProjectFiles(projectPath),
+
+    createProject: async () => notInCli('Creating a project through the project port'),
+    openProject: async () => notInCli('Opening a project through a dialog'),
+    openProjectByPath: async () => notInCli('Opening a project through the project port'),
+    createPou: async () => notInCli('Creating a POU file through the project port'),
+    deletePou: async () => notInCli('Deleting a POU file through the project port'),
+    renamePou: async () => notInCli('Renaming a POU file through the project port'),
+    renameProject: async () => notInCli('Renaming a project'),
+    pickPath: async () => notInCli('Choosing a path'),
+    getRecentProjects: async () => [],
+    removeRecentProject: async () => notInCli('Editing the recent-projects list'),
+    deleteProject: async () => notInCli('Deleting a project'),
+    pickPlcopenImportFile: async () => notInCli('Choosing a file to import'),
+    exportPlcopenFile: async () => notInCli('Exporting through a save dialog'),
+    exportPdfFile: async () => notInCli('Exporting a PDF'),
+    renderPdf: async () => {
+      // Typed as returning bytes rather than a result object, so there is no
+      // refusal shape to return — an empty document is the honest answer.
+      return new Uint8Array()
+    },
+    preparePdfPreviewWorker: async () => undefined,
+  } as unknown as ProjectPort
+
+  return port
+}

--- a/src/cli/session/registry.ts
+++ b/src/cli/session/registry.ts
@@ -21,7 +21,7 @@
 
 import { randomBytes } from 'node:crypto'
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 /** What a one-shot client needs in order to reach a session. */
 export interface SessionRecord {
@@ -170,7 +170,10 @@ export class SessionRegistry {
    * looks like a bare timeout while a perfectly good session sits idle.
    */
   findReusable(projectPath: string, target: string): SessionRecord | undefined {
-    return this.list().find((record) => record.projectPath === projectPath && record.target === target)
+    // Resolved, not compared raw: `./proj` and `/abs/proj` name one project, and
+    // a raw compare opened a second session against a device that answers one.
+    const wanted = resolve(projectPath)
+    return this.list().find((record) => resolve(record.projectPath) === wanted && record.target === target)
   }
 
   private readRecord(path: string): SessionRecord | undefined {

--- a/src/cli/session/session-core.ts
+++ b/src/cli/session/session-core.ts
@@ -648,7 +648,15 @@ function writeHasSettled(value: VariableValue, requested: string): boolean {
     const parsed = Number(wanted.replace(/^16#/, '0x'))
     return Number.isNaN(parsed) ? true : Math.abs(value.value - parsed) < 1e-6
   }
-  if (typeof value.value === 'string') return value.value.toUpperCase() === wanted
+  if (typeof value.value === 'string') {
+    // A duration is requested as an IEC literal (`T#1s`) and reads back
+    // formatted (`1s`), and the two do not agree as text even when the write
+    // landed — `T#1500ms` comes back as `1s500ms`. This is the "cannot be
+    // compared" case the doc above describes, so give up rather than spin to the
+    // timeout and report a write that actually succeeded as a failure.
+    if (/^L?(TIME)?#/.test(wanted) || /^L?T#/.test(wanted)) return true
+    return value.value.toUpperCase() === wanted
+  }
   return true
 }
 

--- a/src/cli/session/session-core.ts
+++ b/src/cli/session/session-core.ts
@@ -650,14 +650,56 @@ function writeHasSettled(value: VariableValue, requested: string): boolean {
   }
   if (typeof value.value === 'string') {
     // A duration is requested as an IEC literal (`T#1s`) and reads back
-    // formatted (`1s`), and the two do not agree as text even when the write
-    // landed — `T#1500ms` comes back as `1s500ms`. This is the "cannot be
-    // compared" case the doc above describes, so give up rather than spin to the
-    // timeout and report a write that actually succeeded as a failure.
-    if (/^L?(TIME)?#/.test(wanted) || /^L?T#/.test(wanted)) return true
+    // formatted (`1s`), so the two never agree as text even when the write
+    // landed — `T#1500ms` comes back as `1s500ms`. Compare what they MEAN:
+    // accepting any read-back would report a force that landed on the wrong
+    // value as settled.
+    const wantedNs = durationNanoseconds(wanted)
+    if (wantedNs !== null) {
+      const actualNs = durationNanoseconds(value.value)
+      // A read-back that will not parse is the "cannot be compared" case the
+      // doc above describes — give up rather than spin to the timeout.
+      return actualNs === null ? true : actualNs === wantedNs
+    }
     return value.value.toUpperCase() === wanted
   }
   return true
+}
+
+/**
+ * An IEC duration in nanoseconds, or null when the text is not one.
+ *
+ * Accepts the literal a caller writes (`T#1s`, `TIME#1h30m`, `LT#…`) and the
+ * form the runtime reads back (`1s500ms`). `ms`, `us` and `ns` are matched
+ * before `m` and `s` so `500ms` is not read as 500 minutes.
+ */
+function durationNanoseconds(text: string): number | null {
+  const body = text
+    .trim()
+    .toUpperCase()
+    .replace(/^L?(TIME)?#/, '')
+    .replace(/^L?T#/, '')
+  if (body.length === 0) return null
+
+  const unit: Record<string, number> = {
+    D: 86_400e9,
+    H: 3_600e9,
+    M: 60e9,
+    S: 1e9,
+    MS: 1e6,
+    US: 1e3,
+    NS: 1,
+  }
+
+  let total = 0
+  let matched = 0
+  for (const part of body.matchAll(/(\d+(?:\.\d+)?)(MS|US|NS|D|H|M|S)/g)) {
+    total += Number(part[1]) * unit[part[2]]
+    matched += part[0].length
+  }
+  // Every character has to belong to a value/unit pair, or this is not a
+  // duration and comparing it as one would be worse than not comparing.
+  return matched === body.replace(/[\s_]/g, '').length && matched > 0 ? total : null
 }
 
 function delay(ms: number): Promise<void> {

--- a/src/frontend/components/_molecules/graphical-editor/fbd/index.tsx
+++ b/src/frontend/components/_molecules/graphical-editor/fbd/index.tsx
@@ -32,9 +32,9 @@ import { getFbdBlockType, isFbdBlockDrag } from '../../../../utils/graphical/dra
 import { getFunctionBlockVariablesToCleanup } from '../../../../utils/graphical/get-function-block-variables-to-cleanup'
 import { findOccupiedInOutPin } from '../../../../utils/graphical/in-out-pin-rules'
 import { newGraphicalEditorNodeID } from '../../../../utils/new-graphical-editor-node-id'
+import { buildBlockVariant } from '../../../../utils/PLC/block-variant'
 import { CustomFbdNodeTypes, customNodeTypes } from '../../../_atoms/graphical-editor/fbd'
 import { BlockNode } from '../../../_atoms/graphical-editor/fbd/utils/types'
-import { getVariableRestrictionType } from '../../../_atoms/graphical-editor/utils'
 import { ReactFlowPanel } from '../../../_atoms/react-flow'
 import { toast } from '../../../_features/[app]/toast/use-toast'
 import { useBoundEditorModel, useBoundPou } from '../../../_features/[workspace]/editor/graphical/active-context'
@@ -428,65 +428,17 @@ export const FBDBody = ({ rung, nodeDivergences = [], isDebuggerActive = false }
     const { libraries } = useOpenPLCStore.getState()
     let pouLibrary = undefined
     if (library) {
-      const [blockLibraryType, blockLibrary, pouName] = library.split('/')
+      const built = buildBlockVariant({
+        blockRef: library,
+        systemLibraries: libraries.system,
+        userLibraries: libraries.user,
+        pous,
+      })
 
-      if (blockLibraryType === 'system') {
-        const libraryPou = libraries.system
-          .find((Library) => Library.name === blockLibrary)
-          ?.pous.find((p) => p.name === pouName)
-        // Copy the signature, not the library entry. That entry also carries
-        // `body` (the authored source, which for a native C/C++ or Python block
-        // is the entire file) and `language`, and passing the object straight
-        // through froze a copy of the library's source into every project that
-        // placed the block. Nothing ever reads either field back off a placed
-        // variant, and the embedded VAR ... END_VAR broke the POU parser badly
-        // enough that the project would not open (DOPE-592). The user-library
-        // branch below has always built a curated object this way.
-        pouLibrary = libraryPou
-          ? {
-              name: libraryPou.name,
-              type: libraryPou.type,
-              variables: libraryPou.variables,
-              documentation: libraryPou.documentation,
-              extensible: libraryPou.extensible ?? false,
-            }
-          : undefined
-      }
-
-      if (blockLibraryType === 'user') {
-        const library = libraries.user.find((library) => library.name === blockLibrary)
-        const pou = pous.find((pou) => pou.name === library?.name)
-        if (!pou) return
-        const variables = (pou.interface?.variables ?? []).map((variable) => ({
-          id: variable.id,
-          name: variable.name,
-          class: variable.class,
-          type: { definition: variable.type.definition, value: variable.type.value.toUpperCase() },
-        }))
-
-        if (pou.pouType === 'function') {
-          const variable = getVariableRestrictionType(pou.interface?.returnType ?? '')
-          variables.push({
-            id: 'OUT',
-            name: 'OUT',
-            class: 'output',
-            type: {
-              definition: (variable.definition as 'array' | 'base-type' | 'user-data-type' | 'derived') ?? 'derived',
-              value: (pou.interface?.returnType ?? '').toUpperCase(),
-            },
-          })
-        }
-
-        pouLibrary = {
-          name: pou.name,
-          type: pou.pouType,
-          variables: variables,
-          documentation: pou.documentation,
-          extensible: false,
-        }
-      }
-
-      if (!pouLibrary) {
+      // A user block that cannot be resolved has always dropped out silently —
+      // the block is simply not added. Only a system block explains itself.
+      if (!built.ok && built.libraryType === 'user') return
+      if (!built.ok) {
         toast({
           title: 'Can not add block',
           description: `The block type ${library} does not exist in the library`,
@@ -494,6 +446,7 @@ export const FBDBody = ({ rung, nodeDivergences = [], isDebuggerActive = false }
         })
         return
       }
+      pouLibrary = built.variant
     }
 
     const newNode = buildGenericNode({

--- a/src/frontend/components/_molecules/graphical-editor/ladder/rung/body.tsx
+++ b/src/frontend/components/_molecules/graphical-editor/ladder/rung/body.tsx
@@ -21,9 +21,9 @@ import { cn } from '../../../../../utils/cn'
 import { getLadderBlockType, isLadderBlockDrag } from '../../../../../utils/graphical/drag-detection'
 import { getFunctionBlockVariablesToCleanup } from '../../../../../utils/graphical/get-function-block-variables-to-cleanup'
 import { syncNodesWithVariables } from '../../../../../utils/graphical/sync-nodes-with-variables'
+import { buildBlockVariant } from '../../../../../utils/PLC/block-variant'
 import { customNodeTypes } from '../../../../_atoms/graphical-editor/ladder'
 import type { BasicNodeData } from '../../../../_atoms/graphical-editor/ladder/utils/types'
-import { getVariableRestrictionType } from '../../../../_atoms/graphical-editor/utils'
 import { ReactFlowPanel } from '../../../../_atoms/react-flow'
 import { toast } from '../../../../_features/[app]/toast/use-toast'
 import { useBoundEditorModel, useBoundPou } from '../../../../_features/[workspace]/editor/graphical/active-context'
@@ -501,64 +501,17 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
     const { libraries, ladderFlows } = useOpenPLCStore.getState()
     let pouLibrary = undefined
     if (blockType) {
-      const [blockLibraryType, blockLibrary, pouName] = blockType.split('/')
+      const built = buildBlockVariant({
+        blockRef: blockType,
+        systemLibraries: libraries.system,
+        userLibraries: libraries.user,
+        pous,
+      })
 
-      if (blockLibraryType === 'system') {
-        const libraryPou = libraries.system
-          .find((Library) => Library.name === blockLibrary)
-          ?.pous.find((p) => p.name === pouName)
-        // Copy the signature, not the library entry. That entry also carries
-        // `body` (the authored source, which for a native C/C++ or Python block
-        // is the entire file) and `language`, and passing the object straight
-        // through froze a copy of the library's source into every project that
-        // placed the block. Nothing ever reads either field back off a placed
-        // variant, and the embedded VAR ... END_VAR broke the POU parser badly
-        // enough that the project would not open (DOPE-592). The user-library
-        // branch below has always built a curated object this way.
-        pouLibrary = libraryPou
-          ? {
-              name: libraryPou.name,
-              type: libraryPou.type,
-              variables: libraryPou.variables,
-              documentation: libraryPou.documentation,
-              extensible: libraryPou.extensible ?? false,
-            }
-          : undefined
-      }
-
-      if (blockLibraryType === 'user') {
-        const library = libraries.user.find((library) => library.name === blockLibrary)
-        const pou = pous.find((pou) => pou.name === library?.name)
-        if (!pou) return
-        const variables = (pou.interface?.variables ?? []).map((variable) => ({
-          id: variable.id,
-          name: variable.name,
-          class: variable.class,
-          type: { definition: variable.type.definition, value: variable.type.value.toUpperCase() },
-        }))
-        if (pou.pouType === 'function') {
-          const variable = getVariableRestrictionType(pou.interface?.returnType ?? '')
-          variables.push({
-            id: 'OUT',
-            name: 'OUT',
-            class: 'output',
-            type: {
-              definition: (variable.definition as 'array' | 'base-type' | 'user-data-type' | 'derived') ?? 'derived',
-              value: (pou.interface?.returnType ?? '').toUpperCase(),
-            },
-          })
-        }
-
-        pouLibrary = {
-          name: pou.name,
-          type: pou.pouType,
-          variables: variables,
-          documentation: pou.documentation,
-          extensible: false,
-        }
-      }
-
-      if (!pouLibrary) {
+      // A user block that cannot be resolved has always dropped out silently —
+      // the block is simply not added. Only a system block explains itself.
+      if (!built.ok && built.libraryType === 'user') return
+      if (!built.ok) {
         const nodes = removePlaceholderElements(rungLocal.nodes)
         setRungLocal((rung) => ({ ...rung, nodes }))
         toast({
@@ -568,6 +521,7 @@ export const RungBody = ({ rung, className, nodeDivergences = [], isDebuggerActi
         })
         return
       }
+      pouLibrary = built.variant
     }
 
     const { nodes, edges, newNode, handleBranches } = addNewElement(rungLocal, {

--- a/src/frontend/store/slices/device/slice.ts
+++ b/src/frontend/store/slices/device/slice.ts
@@ -839,6 +839,12 @@ function mergeDeviceConfigWithDefaults(
     // every selector falling back to `?? {}` returns a fresh literal that
     // triggers an infinite Zustand re-render loop (blank device screen).
     selectedPlatformOptions: provided.selectedPlatformOptions ?? defaults.selectedPlatformOptions,
+    // Carried through, not dropped. This returns a WHOLE configuration, so a
+    // field left out here is erased on every project open — which is what was
+    // happening to the retain settings: saved to `configuration.json`, gone from
+    // the store the moment the project was reopened.
+    ...(provided.persistentStorage ? { persistentStorage: provided.persistentStorage } : {}),
+    ...(provided.persistentStorageByBoard ? { persistentStorageByBoard: provided.persistentStorageByBoard } : {}),
   }
 }
 

--- a/src/frontend/store/slices/fbd/utils/__tests__/build-graph.test.ts
+++ b/src/frontend/store/slices/fbd/utils/__tests__/build-graph.test.ts
@@ -1,0 +1,173 @@
+/**
+ * `buildFbdGraph` is the seam a headless caller goes through to get the diagram
+ * the editor would have drawn, and none of it was covered.
+ *
+ * The node BUILDER is mocked, not because mocking is convenient but because
+ * importing it pulls the whole editor component tree in behind it — autocomplete
+ * → the ST language service → `vscode-languageserver-protocol`, which ships ESM
+ * that this jest config does not transform. The CLI's own tests mock
+ * `apply/fbd` for the same reason.
+ *
+ * So what is under test here is this module's own work: where nodes land, which
+ * handle a pin reference resolves to, the exact edge id, and what it does with
+ * input it cannot use. The stand-in mirrors the real builder's one contract that
+ * matters to this file — a known kind yields a node with a `data` object, an
+ * unknown kind yields `undefined`.
+ */
+
+import type { Edge, Node } from '@xyflow/react'
+
+jest.mock('../../../../../components/_molecules/graphical-editor/fbd/fbd-utils/nodes', () => ({
+  buildGenericNode: ({ id, position, nodeType }: { id: string; position: unknown; nodeType: string }) =>
+    ['block', 'input-variable', 'output-variable', 'inout-variable', 'comment', 'connector', 'continuation'].includes(
+      nodeType,
+    )
+      ? { id, position, type: nodeType, data: {} }
+      : undefined,
+}))
+
+import { buildFbdGraph, splitPinRef } from '../build-graph'
+
+const AND: unknown = { name: 'AND', type: 'function' }
+
+const build = (nodes: Parameters<typeof buildFbdGraph>[0], connections: Parameters<typeof buildFbdGraph>[1] = []) =>
+  buildFbdGraph(nodes, connections)
+
+describe('splitPinRef', () => {
+  it('reads a bare label as a whole node', () => {
+    expect(splitPinRef('start')).toEqual({ label: 'start' })
+  })
+
+  it('splits a pin reference at the first dot', () => {
+    expect(splitPinRef('gate.IN1')).toEqual({ label: 'gate', pin: 'IN1' })
+  })
+
+  it('keeps later dots in the pin, which is how a member path arrives', () => {
+    expect(splitPinRef('gate.Cfg.MinLevel')).toEqual({ label: 'gate', pin: 'Cfg.MinLevel' })
+  })
+})
+
+describe('building a graph', () => {
+  it('places every node and gives each one its own id', () => {
+    const result = build([
+      { label: 'start', kind: 'input-variable', variable: 'gStart' },
+      { label: 'gate', kind: 'block', variant: AND },
+      { label: 'pump', kind: 'output-variable', variable: 'gPump' },
+    ])
+
+    expect(result.errors).toEqual([])
+    expect(result.nodes).toHaveLength(3)
+    expect(new Set(result.nodes.map((node) => node.id)).size).toBe(3)
+  })
+
+  it('lays the graph out along signal flow', () => {
+    const result = build(
+      [
+        { label: 'start', kind: 'input-variable', variable: 'gStart' },
+        { label: 'gate', kind: 'block', variant: AND },
+        { label: 'pump', kind: 'output-variable', variable: 'gPump' },
+      ],
+      [
+        { from: 'start', to: 'gate.IN1' },
+        { from: 'gate.OUT', to: 'pump' },
+      ],
+    )
+
+    const [start, gate, pump] = result.nodes as Node[]
+    expect(start.position.x).toBeLessThan(gate.position.x)
+    expect(gate.position.x).toBeLessThan(pump.position.x)
+  })
+
+  it('carries the variable name onto a variable node', () => {
+    const result = build([{ label: 'start', kind: 'input-variable', variable: 'gStart' }])
+    expect((result.nodes[0].data as { variable?: { name: string } }).variable?.name).toBe('gStart')
+  })
+
+  it('carries a comment body and an execution order', () => {
+    const result = build([
+      { label: 'note', kind: 'comment', text: 'why this rung exists' },
+      { label: 'gate', kind: 'block', variant: AND, executionOrder: 3 },
+    ])
+
+    expect((result.nodes[0].data as { value?: string }).value).toBe('why this rung exists')
+    expect((result.nodes[1].data as { executionOrder?: number }).executionOrder).toBe(3)
+  })
+})
+
+describe('wiring', () => {
+  const wired = () =>
+    build(
+      [
+        { label: 'start', kind: 'input-variable', variable: 'gStart' },
+        { label: 'gate', kind: 'block', variant: AND },
+        { label: 'pump', kind: 'output-variable', variable: 'gPump' },
+      ],
+      [
+        { from: 'start', to: 'gate.IN1' },
+        { from: 'gate.OUT', to: 'pump' },
+      ],
+    )
+
+  it('uses the pin name as the handle on a block, and the fixed handle on a variable', () => {
+    const [toGate, toPump] = wired().edges
+    expect(toGate.targetHandle).toBe('IN1')
+    expect(toGate.sourceHandle).toBe('output-variable')
+    expect(toPump.sourceHandle).toBe('OUT')
+    expect(toPump.targetHandle).toBe('input-variable')
+  })
+
+  it('mints the edge id React Flow and the XML parser both expect', () => {
+    // `xy-edge__<source><sourceHandle>-<target><targetHandle>` — a different
+    // shape loads as a diagram with no wires rather than as an error.
+    const edge = wired().edges[0] as Edge
+    expect(edge.id).toBe(`xy-edge__${edge.source}${edge.sourceHandle}-${edge.target}${edge.targetHandle}`)
+    expect(edge.id.startsWith('xy-edge__')).toBe(true)
+  })
+
+  it('reports a connection naming a node that is not there, and drops only that edge', () => {
+    const result = build(
+      [
+        { label: 'start', kind: 'input-variable', variable: 'gStart' },
+        { label: 'gate', kind: 'block', variant: AND },
+      ],
+      [
+        { from: 'start', to: 'gate.IN1' },
+        { from: 'gate.OUT', to: 'ghost' },
+      ],
+    )
+
+    expect(result.edges).toHaveLength(1)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toContain('unknown node')
+  })
+
+  it('reports a node kind it cannot build, and keeps the rest', () => {
+    const result = build([
+      { label: 'start', kind: 'input-variable', variable: 'gStart' },
+      { label: 'odd', kind: 'not-a-kind' as never },
+    ])
+
+    expect(result.nodes).toHaveLength(1)
+    expect(result.errors[0]).toContain('unknown kind')
+  })
+
+  it('reports the cycles the layout had to break, keeping both edges', () => {
+    // Layout is not policy: it cannot rank a cycle, so it reports which
+    // connection it ignored rather than looping forever, and leaves both edges
+    // alone. Refusing the diagram is `apply/fbd`'s job — FBD has no feedback
+    // within one diagram.
+    const result = build(
+      [
+        { label: 'a', kind: 'block', variant: AND },
+        { label: 'b', kind: 'block', variant: AND },
+      ],
+      [
+        { from: 'a.OUT', to: 'b.IN1' },
+        { from: 'b.OUT', to: 'a.IN1' },
+      ],
+    )
+
+    expect(result.brokenCycles).toHaveLength(1)
+    expect(result.edges).toHaveLength(2)
+  })
+})

--- a/src/frontend/store/slices/fbd/utils/__tests__/layout.test.ts
+++ b/src/frontend/store/slices/fbd/utils/__tests__/layout.test.ts
@@ -1,0 +1,105 @@
+import { layoutFbdGraph } from '../layout'
+
+// FBD has no recovery pass — whatever this produces is where the diagram sits
+// when someone opens it. The rule is signal flow: a node stands to the right of
+// everything that feeds it.
+
+const nodes = (...ids: string[]) => ids.map((id) => ({ id }))
+const x = (result: ReturnType<typeof layoutFbdGraph>, id: string) => result.positions.get(id)?.x
+const y = (result: ReturnType<typeof layoutFbdGraph>, id: string) => result.positions.get(id)?.y
+
+describe('layoutFbdGraph', () => {
+  it('puts an unconnected graph in one column', () => {
+    const result = layoutFbdGraph(nodes('a', 'b', 'c'), [])
+
+    expect([x(result, 'a'), x(result, 'b'), x(result, 'c')]).toEqual([0, 0, 0])
+    expect(y(result, 'a')).toBeLessThan(y(result, 'b')!)
+  })
+
+  it('moves each node right of what feeds it', () => {
+    const result = layoutFbdGraph(nodes('in', 'blk', 'out'), [
+      { from: 'in', to: 'blk' },
+      { from: 'blk', to: 'out' },
+    ])
+
+    expect(x(result, 'in')).toBeLessThan(x(result, 'blk')!)
+    expect(x(result, 'blk')).toBeLessThan(x(result, 'out')!)
+  })
+
+  it('waits for the deepest input, not the first', () => {
+    // `deep` arrives two hops later than `shallow`; `sink` must clear both.
+    const result = layoutFbdGraph(nodes('shallow', 'a', 'deep', 'sink'), [
+      { from: 'a', to: 'deep' },
+      { from: 'shallow', to: 'sink' },
+      { from: 'deep', to: 'sink' },
+    ])
+
+    expect(x(result, 'sink')).toBeGreaterThan(x(result, 'deep')!)
+    expect(x(result, 'sink')).toBeGreaterThan(x(result, 'shallow')!)
+  })
+
+  it('stacks a fan-in into separate rows of the same column', () => {
+    const result = layoutFbdGraph(nodes('a', 'b', 'sink'), [
+      { from: 'a', to: 'sink' },
+      { from: 'b', to: 'sink' },
+    ])
+
+    expect(x(result, 'a')).toBe(x(result, 'b'))
+    expect(y(result, 'a')).not.toBe(y(result, 'b'))
+  })
+
+  it('spreads a fan-out across rows', () => {
+    const result = layoutFbdGraph(nodes('src', 'one', 'two'), [
+      { from: 'src', to: 'one' },
+      { from: 'src', to: 'two' },
+    ])
+
+    expect(x(result, 'one')).toBe(x(result, 'two'))
+    expect(y(result, 'one')).not.toBe(y(result, 'two'))
+  })
+
+  it('breaks a feedback loop and reports it, rather than throwing', () => {
+    // A latch feeding its own reset is an ordinary FBD diagram.
+    const result = layoutFbdGraph(nodes('a', 'b'), [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'a' },
+    ])
+
+    expect(result.positions.size).toBe(2)
+    expect(result.brokenCycles.length).toBeGreaterThan(0)
+  })
+
+  it('survives a self-loop', () => {
+    const result = layoutFbdGraph(nodes('a'), [{ from: 'a', to: 'a' }])
+
+    expect(result.positions.get('a')).toEqual({ x: 0, y: 0 })
+  })
+
+  it('is deterministic — the same graph lays out the same way twice', () => {
+    const graph = nodes('a', 'b', 'c')
+    const edges = [
+      { from: 'a', to: 'c' },
+      { from: 'b', to: 'c' },
+    ]
+
+    expect([...layoutFbdGraph(graph, edges).positions]).toEqual([...layoutFbdGraph(graph, edges).positions])
+  })
+
+  it('ignores a connection naming a node that is not in the graph', () => {
+    const result = layoutFbdGraph(nodes('a'), [{ from: 'ghost', to: 'a' }])
+
+    expect(result.positions.get('a')).toEqual({ x: 0, y: 0 })
+  })
+
+  it('honours the pitch and origin it is given', () => {
+    const result = layoutFbdGraph(nodes('a', 'b'), [{ from: 'a', to: 'b' }], {
+      columnPitch: 10,
+      rowPitch: 5,
+      originX: 100,
+      originY: 50,
+    })
+
+    expect(result.positions.get('a')).toEqual({ x: 100, y: 50 })
+    expect(result.positions.get('b')).toEqual({ x: 110, y: 50 })
+  })
+})

--- a/src/frontend/store/slices/fbd/utils/build-graph.ts
+++ b/src/frontend/store/slices/fbd/utils/build-graph.ts
@@ -1,0 +1,132 @@
+/**
+ * Build an FBD rung from a description: place the nodes, then wire them.
+ *
+ * Hosted in the store rather than beside the editor because the node builders
+ * are component modules the CLI may not import, and this is the seam that lets
+ * a headless caller produce the same diagram the editor would.
+ *
+ * FBD gets neither of the things ladder gets for free — `addFBDFlow` never
+ * touches geometry and `fbd-utils/edges.ts` is empty — so both the placement and
+ * the edge ids are produced here.
+ */
+
+import type { Edge, Node } from '@xyflow/react'
+
+import { buildGenericNode } from '../../../../components/_molecules/graphical-editor/fbd/fbd-utils/nodes'
+import { newGraphicalEditorNodeID } from '../../../../utils/new-graphical-editor-node-id'
+import { type LayoutConnection, layoutFbdGraph } from './layout'
+
+export type FbdNodeKind = 'block' | 'input-variable' | 'output-variable' | 'inout-variable' | 'comment'
+
+export interface FbdGraphNode {
+  /** Caller-local name. Store ids are minted here. */
+  label: string
+  kind: FbdNodeKind
+  /** Block signature, already resolved. */
+  variant?: unknown
+  /** Variable name, or a function block's instance name. */
+  variable?: string
+  /** `comment` only. */
+  text?: string
+  /** Add EN/ENO to a block. */
+  executionControl?: boolean
+  /** Evaluation order for a block; 0 leaves it unordered. */
+  executionOrder?: number
+}
+
+export interface FbdGraphConnection {
+  /** `label` or `label.PIN`. */
+  from: string
+  to: string
+}
+
+export interface BuildFbdGraphResult {
+  nodes: Node[]
+  edges: Edge[]
+  brokenCycles: LayoutConnection[]
+  errors: string[]
+}
+
+/** React Flow's own edge id — the form the XML parser writes and reads. */
+function edgeId(source: string, sourceHandle: string, target: string, targetHandle: string): string {
+  return `xy-edge__${source}${sourceHandle}-${target}${targetHandle}`
+}
+
+/** `label` or `label.PIN`. A variable node's pin follows from its direction. */
+export function splitPinRef(ref: string): { label: string; pin?: string } {
+  const dot = ref.indexOf('.')
+  return dot < 0 ? { label: ref } : { label: ref.slice(0, dot), pin: ref.slice(dot + 1) }
+}
+
+export function buildFbdGraph(
+  specNodes: readonly FbdGraphNode[],
+  connections: readonly FbdGraphConnection[],
+): BuildFbdGraphResult {
+  const errors: string[] = []
+
+  const placed = layoutFbdGraph(
+    specNodes.map((node) => ({ id: node.label })),
+    connections.map((connection) => ({
+      from: splitPinRef(connection.from).label,
+      to: splitPinRef(connection.to).label,
+    })),
+  )
+
+  const idByLabel = new Map<string, string>()
+  const nodes: Node[] = []
+
+  for (const spec of specNodes) {
+    const position = placed.positions.get(spec.label) ?? { x: 0, y: 0 }
+    const id = newGraphicalEditorNodeID(spec.kind.toUpperCase())
+    const node = buildGenericNode({
+      id,
+      position,
+      nodeType: spec.kind,
+      blockType: spec.variant,
+      executionControl: spec.executionControl,
+    }) as Node | undefined
+    if (!node) {
+      errors.push(`node "${spec.label}" has an unknown kind "${spec.kind}"`)
+      continue
+    }
+
+    const data = node.data as {
+      variable?: { id: string; name: string }
+      value?: string
+      executionOrder?: number
+    }
+    if (spec.variable) data.variable = { id: '', name: spec.variable }
+    if (spec.kind === 'comment' && spec.text) data.value = spec.text
+    if (spec.executionOrder !== undefined) data.executionOrder = spec.executionOrder
+
+    idByLabel.set(spec.label, id)
+    nodes.push(node)
+  }
+
+  const edges: Edge[] = []
+  for (const connection of connections) {
+    const from = splitPinRef(connection.from)
+    const to = splitPinRef(connection.to)
+    const sourceId = idByLabel.get(from.label)
+    const targetId = idByLabel.get(to.label)
+    if (!sourceId || !targetId) {
+      errors.push(`connection "${connection.from}" -> "${connection.to}" names an unknown node`)
+      continue
+    }
+
+    // On a block the pin name IS the handle id; a variable node carries one
+    // fixed handle per direction.
+    const sourceHandle = from.pin ?? 'output-variable'
+    const targetHandle = to.pin ?? 'input-variable'
+
+    edges.push({
+      id: edgeId(sourceId, sourceHandle, targetId, targetHandle),
+      source: sourceId,
+      sourceHandle,
+      target: targetId,
+      targetHandle,
+    })
+  }
+
+  return { nodes, edges, brokenCycles: placed.brokenCycles, errors }
+}

--- a/src/frontend/store/slices/fbd/utils/layout.ts
+++ b/src/frontend/store/slices/fbd/utils/layout.ts
@@ -1,0 +1,108 @@
+/**
+ * Place an FBD graph on the canvas.
+ *
+ * Unlike ladder, FBD has no recovery path: `addFBDFlow` never touches geometry,
+ * and there is no solver to hand the job to. On a free-form canvas that is the
+ * right default — "arranged differently" is a legitimate state for a diagram a
+ * person laid out — but it means a caller building a graph from a description
+ * has to place it, and a graph with everything at the origin is unreadable.
+ *
+ * The rule is signal flow: a node sits to the right of everything that feeds it.
+ * Column is the longest path from a source, so a block waits for its deepest
+ * input rather than its first; row is order of appearance, which keeps the
+ * result stable and predictable for the caller that wrote the list.
+ *
+ * Pure: no store, no React, no measurement.
+ */
+
+/** A node to place. Only its identity and its edges matter here. */
+export interface LayoutNode {
+  id: string
+}
+
+export interface LayoutConnection {
+  from: string
+  to: string
+}
+
+export interface LayoutOptions {
+  /** Horizontal distance between columns. */
+  columnPitch?: number
+  /** Vertical distance between rows. */
+  rowPitch?: number
+  originX?: number
+  originY?: number
+}
+
+export interface LayoutResult {
+  positions: Map<string, { x: number; y: number }>
+  /** Edges dropped from the depth walk to break a cycle. */
+  brokenCycles: LayoutConnection[]
+}
+
+const DEFAULT_COLUMN_PITCH = 260
+const DEFAULT_ROW_PITCH = 120
+
+export function layoutFbdGraph(
+  nodes: readonly LayoutNode[],
+  connections: readonly LayoutConnection[],
+  options: LayoutOptions = {},
+): LayoutResult {
+  const columnPitch = options.columnPitch ?? DEFAULT_COLUMN_PITCH
+  const rowPitch = options.rowPitch ?? DEFAULT_ROW_PITCH
+  const originX = options.originX ?? 0
+  const originY = options.originY ?? 0
+
+  const known = new Set(nodes.map((node) => node.id))
+  const incoming = new Map<string, string[]>()
+  for (const node of nodes) incoming.set(node.id, [])
+  for (const connection of connections) {
+    if (!known.has(connection.from) || !known.has(connection.to)) continue
+    incoming.get(connection.to)?.push(connection.from)
+  }
+
+  const column = new Map<string, number>()
+  const brokenCycles: LayoutConnection[] = []
+  const visiting = new Set<string>()
+
+  /**
+   * Longest path back to a source.
+   *
+   * Feedback is legal in FBD — a latch feeding its own reset is an ordinary
+   * diagram, not an error — so a cycle is broken at the edge that closes it and
+   * reported, never thrown.
+   */
+  const depthOf = (id: string): number => {
+    const cached = column.get(id)
+    if (cached !== undefined) return cached
+    if (visiting.has(id)) return 0
+
+    visiting.add(id)
+    let deepest = 0
+    for (const producer of incoming.get(id) ?? []) {
+      if (visiting.has(producer)) {
+        brokenCycles.push({ from: producer, to: id })
+        continue
+      }
+      deepest = Math.max(deepest, depthOf(producer) + 1)
+    }
+    visiting.delete(id)
+
+    column.set(id, deepest)
+    return deepest
+  }
+
+  for (const node of nodes) depthOf(node.id)
+
+  // Row is first appearance within a column, so the caller's ordering survives.
+  const nextRow = new Map<number, number>()
+  const positions = new Map<string, { x: number; y: number }>()
+  for (const node of nodes) {
+    const col = column.get(node.id) ?? 0
+    const row = nextRow.get(col) ?? 0
+    nextRow.set(col, row + 1)
+    positions.set(node.id, { x: originX + col * columnPitch, y: originY + row * rowPitch })
+  }
+
+  return { positions, brokenCycles }
+}

--- a/src/frontend/store/slices/ladder/utils/__tests__/build-rung-roundtrip.test.ts
+++ b/src/frontend/store/slices/ladder/utils/__tests__/build-rung-roundtrip.test.ts
@@ -1,0 +1,76 @@
+import type { Node } from '@xyflow/react'
+
+import { openPLCStoreBase } from '../../../../index'
+import { needsPositionRecovery } from '../../slice'
+import { buildLadderRung, type RungLogic } from '../build-rung'
+
+/**
+ * The handoff, end to end: a rung built with no geometry goes through
+ * `addLadderFlow` and comes back laid out by the editor's own solver.
+ *
+ * This is the post-condition that matters most. `updateDiagramElementsPosition`
+ * runs inside a try with guards that silently return the rung unchanged, and the
+ * LD walker sorts sinks by y-position — so a rung that quietly failed to lay out
+ * does not look broken, it transpiles to the wrong statement order.
+ */
+
+const contact = (variable: string): RungLogic => ({ contact: { variable, variant: 'default' } })
+const coil = (variable: string) => ({ coil: { variable, variant: 'default' as const } })
+
+function addAndRead(name: string, rungs: ReturnType<typeof buildLadderRung>[]) {
+  openPLCStoreBase.getState().ladderFlowActions.addLadderFlow({ name, updated: true, rungs } as never)
+  return openPLCStoreBase.getState().ladderFlows.find((flow) => flow.name === name)
+}
+
+describe('buildLadderRung through addLadderFlow', () => {
+  it('is laid out by the store, not left at the origin', () => {
+    const rung = buildLadderRung({ rungId: 'r1', logic: contact('Start'), outputs: [coil('Run')] })
+    expect(needsPositionRecovery(rung)).toBe(true)
+
+    const flow = addAndRead('LaidOut', [rung])
+
+    expect(flow).toBeDefined()
+    expect(flow?.rungs).toHaveLength(1)
+    // The whole point: the solver ran, so nothing is at the origin any more.
+    expect(needsPositionRecovery(flow!.rungs[0])).toBe(false)
+  })
+
+  it('lays out a rung carrying a parallel branch', () => {
+    const rung = buildLadderRung({
+      rungId: 'r1',
+      logic: { series: [{ parallel: [contact('Start'), contact('Run')] }, contact('Stop')] },
+      outputs: [coil('Run')],
+    })
+
+    const flow = addAndRead('WithBranch', [rung])
+
+    expect(needsPositionRecovery(flow!.rungs[0])).toBe(false)
+  })
+
+  it('orders the elements left to right, which is what the walker reads', () => {
+    const rung = buildLadderRung({
+      rungId: 'r1',
+      logic: { series: [contact('A'), contact('B'), contact('C')] },
+      outputs: [coil('Run')],
+    })
+
+    const flow = addAndRead('Ordered', [rung])
+    const placed = (flow!.rungs[0].nodes as Node[]).filter((node) => node.type === 'contact')
+    const xs = placed.map((node) => node.position.x)
+
+    expect(xs).toEqual([...xs].sort((a, b) => a - b))
+    expect(new Set(xs).size).toBe(3)
+  })
+
+  it('keeps every rung of a multi-rung flow laid out', () => {
+    const rungs = [
+      buildLadderRung({ rungId: 'r1', logic: contact('A'), outputs: [coil('X')] }),
+      buildLadderRung({ rungId: 'r2', logic: contact('B'), outputs: [coil('Y')] }),
+    ]
+
+    const flow = addAndRead('TwoRungs', rungs)
+
+    expect(flow?.rungs).toHaveLength(2)
+    for (const rung of flow!.rungs) expect(needsPositionRecovery(rung)).toBe(false)
+  })
+})

--- a/src/frontend/store/slices/ladder/utils/__tests__/build-rung.test.ts
+++ b/src/frontend/store/slices/ladder/utils/__tests__/build-rung.test.ts
@@ -1,0 +1,402 @@
+import type { Node } from '@xyflow/react'
+
+import { needsPositionRecovery } from '../../slice'
+import { buildLadderRung, type RungLogic } from '../build-rung'
+
+// A rung built from a description carries no geometry. That is the contract
+// with `addLadderFlow`, which runs the editor's real layout solver over any
+// rung where `needsPositionRecovery` fires — and that predicate keys on an
+// element sitting at the origin. Emitting no `position` at all would NOT
+// trigger it, so these tests pin the origin rather than the absence.
+
+const contact = (variable: string): RungLogic => ({ contact: { variable, variant: 'default' } })
+const coil = (variable: string) => ({ coil: { variable, variant: 'default' as const } })
+
+const nodesOfType = (nodes: Node[], type: string) => nodes.filter((node) => node.type === type)
+
+describe('buildLadderRung — shape', () => {
+  it('brackets the rung with a left and right rail the store can find', () => {
+    // `setRungs` silently does nothing unless the ids start this way.
+    const rung = buildLadderRung({ rungId: 'r1', outputs: [coil('Run')] })
+
+    expect(rung.nodes[0].id).toBe('left-rail-r1')
+    expect(rung.nodes[rung.nodes.length - 1].id).toBe('right-rail-r1')
+  })
+
+  it('wires a single contact between the rails', () => {
+    const rung = buildLadderRung({ rungId: 'r1', logic: contact('Start'), outputs: [coil('Run')] })
+
+    expect(nodesOfType(rung.nodes as Node[], 'contact')).toHaveLength(1)
+    expect(nodesOfType(rung.nodes as Node[], 'coil')).toHaveLength(1)
+    // rail -> contact -> coil -> rail
+    expect(rung.edges).toHaveLength(3)
+  })
+
+  it('carries the variable names onto the nodes', () => {
+    const rung = buildLadderRung({ rungId: 'r1', logic: contact('Start'), outputs: [coil('Run')] })
+    const names = (rung.nodes as Node[])
+      .filter((node) => node.type === 'contact' || node.type === 'coil')
+      .map((node) => (node.data as { variable: { name: string } }).variable.name)
+
+    expect(names).toEqual(['Start', 'Run'])
+  })
+
+  it('chains a series left to right', () => {
+    const rung = buildLadderRung({
+      rungId: 'r1',
+      logic: { series: [contact('A'), contact('B'), contact('C')] },
+      outputs: [coil('Run')],
+    })
+
+    expect(nodesOfType(rung.nodes as Node[], 'contact')).toHaveLength(3)
+    // rail->A, A->B, B->C, C->coil, coil->rail
+    expect(rung.edges).toHaveLength(5)
+  })
+})
+
+describe('buildLadderRung — parallels', () => {
+  it('brackets two branches with a linked OPEN/CLOSE pair', () => {
+    const rung = buildLadderRung({
+      rungId: 'r1',
+      logic: { parallel: [contact('Start'), contact('Run')] },
+      outputs: [coil('Run')],
+    })
+
+    const parallels = nodesOfType(rung.nodes as Node[], 'parallel')
+    expect(parallels).toHaveLength(2)
+
+    const open = parallels.find((node) => (node.data as { type: string }).type === 'open')
+    const close = parallels.find((node) => (node.data as { type: string }).type === 'close')
+    // The pair is found by id at layout time; an unlinked pair lays out wrong.
+    expect((open?.data as { parallelCloseReference?: string }).parallelCloseReference).toBe(close?.id)
+    expect((close?.data as { parallelOpenReference?: string }).parallelOpenReference).toBe(open?.id)
+  })
+
+  it('routes one branch straight through and the other down', () => {
+    const rung = buildLadderRung({
+      rungId: 'r1',
+      logic: { parallel: [contact('A'), contact('B')] },
+      outputs: [coil('Run')],
+    })
+
+    const handles = rung.edges.map((edge) => `${edge.sourceHandle}->${edge.targetHandle}`)
+    expect(handles).toContain('output-right->input')
+    expect(handles).toContain('output-down->input')
+    expect(handles).toContain('output->input-down')
+  })
+
+  it('nests three or more branches, since a pair carries only two', () => {
+    const rung = buildLadderRung({
+      rungId: 'r1',
+      logic: { parallel: [contact('A'), contact('B'), contact('C')] },
+      outputs: [coil('Run')],
+    })
+
+    expect(nodesOfType(rung.nodes as Node[], 'parallel')).toHaveLength(4)
+    expect(nodesOfType(rung.nodes as Node[], 'contact')).toHaveLength(3)
+  })
+})
+
+describe('buildLadderRung — geometry handoff', () => {
+  it.each([
+    ['a plain rung', { logic: contact('A'), outputs: [coil('Run')] }],
+    ['a series', { logic: { series: [contact('A'), contact('B')] } as RungLogic, outputs: [coil('Run')] }],
+    ['a parallel', { logic: { parallel: [contact('A'), contact('B')] } as RungLogic, outputs: [coil('Run')] }],
+  ])('asks the store to lay out %s', (_label, input) => {
+    const rung = buildLadderRung({ rungId: 'r1', ...input })
+
+    expect(needsPositionRecovery(rung)).toBe(true)
+  })
+
+  it('puts every non-rail element at the origin, never leaves position absent', () => {
+    const rung = buildLadderRung({
+      rungId: 'r1',
+      logic: { parallel: [contact('A'), contact('B')] },
+      outputs: [coil('Run')],
+    })
+
+    for (const node of rung.nodes as Node[]) {
+      expect(node.position).toBeDefined()
+      if (node.type === 'powerRail') continue
+      expect(node.position).toEqual({ x: 0, y: 0 })
+    }
+  })
+
+  it('gives every edge both handles, which the flow schema requires', () => {
+    // `buildEdge` writes `undefined` when a handle is omitted, and that
+    // stringifies into the edge id as the literal "undefined".
+    const rung = buildLadderRung({
+      rungId: 'r1',
+      logic: { parallel: [contact('A'), contact('B')] },
+      outputs: [coil('Run')],
+    })
+
+    for (const edge of rung.edges) {
+      expect(typeof edge.sourceHandle).toBe('string')
+      expect(typeof edge.targetHandle).toBe('string')
+      expect(edge.id).not.toContain('undefined')
+    }
+  })
+})
+
+describe('buildLadderRung — every edge resolves to a real handle', () => {
+  // React Flow drops an edge whose handle id is not declared on the node it
+  // names, and drops it silently apart from a console warning. The rung still
+  // transpiles — the LD walker reads node/edge topology, not handles — so
+  // nothing but this catches a wrong id.
+  const handlesOf = (node: Node) => (node.data as { handles: { id: string; type: string }[] }).handles
+
+  const ton = {
+    name: 'TON',
+    type: 'function-block',
+    variables: [
+      { name: 'IN', class: 'input', type: { definition: 'base-type', value: 'BOOL' } },
+      { name: 'PT', class: 'input', type: { definition: 'base-type', value: 'TIME' } },
+      { name: 'Q', class: 'output', type: { definition: 'base-type', value: 'BOOL' } },
+      { name: 'ET', class: 'output', type: { definition: 'base-type', value: 'TIME' } },
+    ],
+  }
+
+  it.each([
+    ['a plain rung', { logic: contact('A'), outputs: [coil('Run')] }],
+    ['a series', { logic: { series: [contact('A'), contact('B')] } as RungLogic, outputs: [coil('Run')] }],
+    ['a parallel', { logic: { parallel: [contact('A'), contact('B')] } as RungLogic, outputs: [coil('Run')] }],
+    [
+      'a nested parallel',
+      {
+        logic: { parallel: [contact('A'), { parallel: [contact('B'), contact('C')] }] } as RungLogic,
+        outputs: [coil('Run')],
+      },
+    ],
+    ['no logic at all', { outputs: [coil('Run')] }],
+    ['two outputs', { logic: contact('A'), outputs: [coil('Run'), coil('Alarm')] }],
+    ['a block sink', { logic: contact('A'), outputs: [{ block: { variant: ton, instance: 'delay' } }] }],
+  ])('resolves both ends of every edge in %s', (_label, input) => {
+    const rung = buildLadderRung({ rungId: 'r1', ...input })
+    const byId = new Map((rung.nodes as Node[]).map((node) => [node.id, node]))
+
+    for (const edge of rung.edges) {
+      const source = byId.get(edge.source)
+      const target = byId.get(edge.target)
+      expect(source).toBeDefined()
+      expect(target).toBeDefined()
+
+      expect(handlesOf(source as Node).map((handle) => handle.id)).toContain(edge.sourceHandle)
+      expect(handlesOf(target as Node).map((handle) => handle.id)).toContain(edge.targetHandle)
+
+      const out = handlesOf(source as Node).find((handle) => handle.id === edge.sourceHandle)
+      const into = handlesOf(target as Node).find((handle) => handle.id === edge.targetHandle)
+      expect(out?.type).toBe('source')
+      expect(into?.type).toBe('target')
+    }
+  })
+
+  it('wires the rails by the handle they actually carry, not by their name', () => {
+    // A rail's handle id is the opposite of its `connector`: the left rail
+    // carries `left-rail`, built with `connector: 'right'`.
+    const rung = buildLadderRung({ rungId: 'r1', logic: contact('A'), outputs: [coil('Run')] })
+    const nodes = rung.nodes as Node[]
+    const left = nodes.find((node) => node.id === 'left-rail-r1') as Node
+    const right = nodes.find((node) => node.id === 'right-rail-r1') as Node
+
+    expect(handlesOf(left)[0].id).toBe('left-rail')
+    expect(handlesOf(right)[0].id).toBe('right-rail')
+
+    const fromLeft = rung.edges.find((edge) => edge.source === left.id)
+    const toRight = rung.edges.find((edge) => edge.target === right.id)
+    expect(fromLeft?.sourceHandle).toBe('left-rail')
+    expect(toRight?.targetHandle).toBe('right-rail')
+  })
+})
+
+describe('buildLadderRung — declared variables', () => {
+  // The editor stores the whole declared variable on an element and checks the
+  // two agree; a block whose instance does not resolve is ringed red in the
+  // diagram. A name on its own is not enough.
+  const declared = [
+    { name: 'Start', class: 'local', type: { definition: 'base-type', value: 'BOOL' } },
+    { name: 'Run', class: 'local', type: { definition: 'base-type', value: 'BOOL' } },
+    { name: 'holdOff', class: 'local', type: { definition: 'derived', value: 'TON' } },
+  ]
+  const resolveVariable = (name: string, kind: 'contact' | 'coil' | 'block') =>
+    declared.find(
+      (variable) =>
+        variable.name.toLowerCase() === name.toLowerCase() &&
+        (kind === 'block' || variable.type.definition !== 'derived'),
+    )
+
+  const variableOf = (nodes: Node[], type: string) =>
+    (nodes.find((node) => node.type === type)?.data as { variable: Record<string, unknown> }).variable
+
+  it('carries the declared variable onto a contact and a coil, not just the name', () => {
+    const rung = buildLadderRung({
+      rungId: 'r1',
+      logic: contact('Start'),
+      outputs: [coil('Run')],
+      resolveVariable,
+    })
+
+    expect(variableOf(rung.nodes as Node[], 'contact')).toEqual(declared[0])
+    expect(variableOf(rung.nodes as Node[], 'coil')).toEqual(declared[1])
+  })
+
+  it('carries the instance variable onto a block', () => {
+    const rung = buildLadderRung({
+      rungId: 'r1',
+      outputs: [{ block: { variant: { name: 'TON', type: 'function-block', variables: [] }, instance: 'holdOff' } }],
+      resolveVariable,
+    })
+
+    expect(variableOf(rung.nodes as Node[], 'block')).toEqual(declared[2])
+  })
+
+  it('leaves a name that resolves to nothing as a bare name', () => {
+    const rung = buildLadderRung({ rungId: 'r1', logic: contact('Nope'), outputs: [coil('Run')], resolveVariable })
+
+    expect(variableOf(rung.nodes as Node[], 'contact')).toEqual({ name: 'Nope' })
+  })
+
+  it('refuses a derived type on a contact, as the editor does', () => {
+    const rung = buildLadderRung({ rungId: 'r1', logic: contact('holdOff'), outputs: [coil('Run')], resolveVariable })
+
+    expect(variableOf(rung.nodes as Node[], 'contact')).toEqual({ name: 'holdOff' })
+  })
+})
+
+describe('buildLadderRung — where rung power enters a block', () => {
+  // A block wired EN/ENO is only gated by the rung: its own inputs stay open,
+  // so a timer never times. Power has to go through the block's first boolean
+  // input and out its first boolean output, which is how the editor draws one.
+  const ton = {
+    name: 'TON',
+    type: 'function-block',
+    variables: [
+      { name: 'IN', class: 'input', type: { definition: 'base-type', value: 'BOOL' } },
+      { name: 'PT', class: 'input', type: { definition: 'base-type', value: 'TIME' } },
+      { name: 'Q', class: 'output', type: { definition: 'base-type', value: 'BOOL' } },
+      { name: 'ET', class: 'output', type: { definition: 'base-type', value: 'TIME' } },
+    ],
+  }
+  // ADD's first input is not BOOL, so the editor forces EN/ENO on regardless.
+  const add = {
+    name: 'ADD',
+    type: 'function',
+    variables: [
+      { name: 'IN1', class: 'input', type: { definition: 'base-type', value: 'INT' } },
+      { name: 'IN2', class: 'input', type: { definition: 'base-type', value: 'INT' } },
+      { name: 'OUT', class: 'output', type: { definition: 'base-type', value: 'INT' } },
+    ],
+  }
+
+  const blockEdges = (rung: ReturnType<typeof buildLadderRung>) => {
+    const block = (rung.nodes as Node[]).find((node) => node.type === 'block') as Node
+    return {
+      into: rung.edges.find((edge) => edge.target === block.id)?.targetHandle,
+      outOf: rung.edges.find((edge) => edge.source === block.id)?.sourceHandle,
+      handles: (block.data as { handles: { id: string }[] }).handles.map((handle) => handle.id),
+    }
+  }
+
+  it('drives the first boolean input and leaves on the first boolean output', () => {
+    const rung = buildLadderRung({
+      rungId: 'r1',
+      logic: contact('Run'),
+      outputs: [{ block: { variant: ton, instance: 'holdOff' } }, coil('Settled')],
+    })
+
+    const { into, outOf, handles } = blockEdges(rung)
+    expect(into).toBe('IN')
+    expect(outOf).toBe('Q')
+    expect(handles).not.toContain('EN')
+    expect(handles).not.toContain('ENO')
+  })
+
+  it('uses EN/ENO when the caller asks for execution control', () => {
+    const rung = buildLadderRung({
+      rungId: 'r1',
+      logic: contact('Run'),
+      outputs: [{ block: { variant: ton, instance: 'holdOff', executionControl: true } }],
+    })
+
+    const { into, outOf } = blockEdges(rung)
+    expect(into).toBe('EN')
+    expect(outOf).toBe('ENO')
+  })
+
+  it('still gets EN/ENO when the block cannot carry power itself', () => {
+    const rung = buildLadderRung({ rungId: 'r1', logic: contact('Permit'), outputs: [{ block: { variant: add } }] })
+
+    const { into, outOf, handles } = blockEdges(rung)
+    expect(handles).toContain('EN')
+    expect(into).toBe('EN')
+    expect(outOf).toBe('ENO')
+  })
+})
+
+describe('buildLadderRung — a parallel nested in a parallel', () => {
+  // A pair carries a SECOND set of connectors, `input-top` and `output-top`,
+  // that exist only for nesting: they sit a connector's height above the
+  // ordinary ones, which is what makes concentric brackets draw as brackets.
+  // `startParallelConnection` overrides the handles for exactly this case;
+  // wiring the inner pair by its plain `input`/`output-right` instead drew the
+  // branch verticals in a staircase.
+  const nested = buildLadderRung({
+    rungId: 'r1',
+    logic: { parallel: [contact('A'), contact('B'), contact('C')] },
+    outputs: [coil('Run')],
+  })
+
+  /**
+   * Resolved by the pair's own cross-references, not by position: nodes are
+   * pushed `[open, …straight, …down, close]`, so the INNER close precedes the
+   * outer one and an index would name the wrong node.
+   */
+  const pairs = (rung: typeof nested) => {
+    const nodes = rung.nodes as Node[]
+    const opens = nodes.filter((node) => node.type === 'parallel' && (node.data as { type: string }).type === 'open')
+    const closeOf = (open: Node) =>
+      nodes.find((node) => node.id === (open.data as { parallelCloseReference?: string }).parallelCloseReference)
+    const innerOpen = opens.find((open) =>
+      rung.edges.some((edge) => edge.target === open.id && edge.sourceHandle === 'output-down'),
+    )
+    const outerOpen = opens.find((open) => open.id !== innerOpen?.id)
+    return {
+      outerOpen,
+      innerOpen,
+      outerClose: outerOpen && closeOf(outerOpen),
+      innerClose: innerOpen && closeOf(innerOpen),
+    }
+  }
+
+  it('enters the inner pair by its top connector', () => {
+    const { outerOpen, innerOpen } = pairs(nested)
+    const down = nested.edges.find((edge) => edge.source === outerOpen?.id && edge.sourceHandle === 'output-down')
+
+    expect(down?.target).toBe(innerOpen?.id)
+    expect(down?.targetHandle).toBe('input-top')
+  })
+
+  it('leaves the inner pair by its top connector', () => {
+    const { outerClose, innerClose } = pairs(nested)
+    const up = nested.edges.find((edge) => edge.target === outerClose?.id && edge.targetHandle === 'input-down')
+
+    expect(up?.source).toBe(innerClose?.id)
+    expect(up?.sourceHandle).toBe('output-top')
+  })
+
+  it('still wires a plain two-branch pair by its ordinary connectors', () => {
+    // The override is for nesting only — a contact on the down path is entered
+    // at its own input, as before.
+    const flat = buildLadderRung({
+      rungId: 'r1',
+      logic: { parallel: [contact('A'), contact('B')] },
+      outputs: [coil('Run')],
+    })
+    const open = (flat.nodes as Node[]).find(
+      (node) => node.type === 'parallel' && (node.data as { type: string }).type === 'open',
+    )
+    const down = flat.edges.find((edge) => edge.source === open?.id && edge.sourceHandle === 'output-down')
+
+    expect(down?.targetHandle).toBe('input')
+  })
+})

--- a/src/frontend/store/slices/ladder/utils/build-rung.ts
+++ b/src/frontend/store/slices/ladder/utils/build-rung.ts
@@ -1,0 +1,353 @@
+/**
+ * Build a ladder rung from a series/parallel description, with no coordinates.
+ *
+ * A rung is a series-parallel two-terminal network, so a nested expression
+ * describes it completely — which is what lets a caller author one without
+ * knowing anything about React Flow, handle ids or pixel geometry.
+ *
+ * Geometry is deliberately left at `{x: 0, y: 0}` on every element. That is not
+ * a placeholder: `needsPositionRecovery` treats any element at the origin as a
+ * signal, and `addLadderFlow` then runs the editor's real layout solver over the
+ * rung (`ladder/slice.ts:222-272`). Omitting `position` entirely would NOT
+ * trigger it — an absent position is explicitly not a signal — so every node
+ * must carry `{0, 0}` and let the store place it.
+ *
+ * This lives in the store layer because `nodesBuilder` is a component module the
+ * CLI may not import; `ladder/utils/index.ts` already carries that exception.
+ */
+
+import type { Edge, Node } from '@xyflow/react'
+
+import {
+  defaultCustomNodesStyles,
+  nodesBuilder,
+} from '../../../../components/_atoms/graphical-editor/ladder/node-builders'
+import { newGraphicalEditorNodeID } from '../../../../utils/new-graphical-editor-node-id'
+import type { RungLadderState } from '../types'
+
+/** The literals the ladder nodes carry — see `ladder/utils/types.ts`. */
+export type ContactVariant = 'default' | 'negated' | 'risingEdge' | 'fallingEdge'
+export type CoilVariant = ContactVariant | 'set' | 'reset'
+
+/** A leaf: one contact. */
+export interface RungContact {
+  contact: { variable: string; variant: ContactVariant }
+}
+
+/** The series-parallel expression describing a rung's condition. */
+export type RungLogic = RungContact | { series: RungLogic[] } | { parallel: RungLogic[] }
+
+/** What the rung drives. */
+export type RungOutput =
+  | { coil: { variable: string; variant: CoilVariant } }
+  | {
+      block: {
+        variant: unknown
+        instance?: string
+        /**
+         * Variable or literal per data pin, keyed by the pin's own name.
+         * Applied AFTER the flow is added — `addLadderFlow` creates one
+         * variable element per pin itself, so these name the elements it made
+         * rather than adding a second set.
+         */
+        inputs?: Record<string, string>
+        outputs?: Record<string, string>
+        /**
+         * Add EN/ENO and run rung power through them.
+         *
+         * Off by default, which is how a timer or counter is drawn: power goes
+         * in the first boolean input and out the first boolean output, so the
+         * block is actually driven. With EN/ENO the rung only gates the call and
+         * `IN` is left open — the timer never runs. The editor forces this on
+         * anyway for a block whose first input or output is not BOOL.
+         */
+        executionControl?: boolean
+      }
+    }
+
+/**
+ * Resolve an element's variable name to the POU's declared variable.
+ *
+ * Returning `undefined` leaves the element carrying just the name, which is what
+ * the editor shows for a name that matches nothing.
+ */
+export type RungVariableResolver = (name: string, kind: 'contact' | 'coil' | 'block') => { name: string } | undefined
+
+export interface BuildLadderRungInput {
+  rungId: string
+  comment?: string
+  logic?: RungLogic
+  outputs: RungOutput[]
+  /** Without this, elements carry a bare name and the editor rings them red. */
+  resolveVariable?: RungVariableResolver
+  /** Canvas the rails span. Defaults to the size the editor starts a rung at. */
+  defaultBounds?: [number, number]
+}
+
+/** One built fragment and the two terminals the caller wires it by. */
+interface Fragment {
+  nodes: Node[]
+  edges: Edge[]
+  entry: { nodeId: string; handleId: string }
+  exit: { nodeId: string; handleId: string }
+  /**
+   * The terminals to use when this fragment hangs off a parallel's DOWN path.
+   *
+   * A parallel pair carries a second set of connectors — `input-top` on the open
+   * and `output-top` on the close — that exist only for nesting: they sit a
+   * connector's height above the others, which is what makes concentric
+   * brackets draw as brackets. `startParallelConnection` overrides the handles
+   * for exactly this case ("Detect nested parallel for handle overrides"), and
+   * wiring the inner pair by its ordinary `input`/`output-right` instead put the
+   * verticals in a staircase.
+   *
+   * Only set by a fragment that begins/ends with a parallel pair.
+   */
+  nestedEntry?: { nodeId: string; handleId: string }
+  nestedExit?: { nodeId: string; handleId: string }
+}
+
+/** Ladder's own edge-id form — see `ladder-utils/edges.ts`. */
+function edgeId(source: string, target: string, sourceHandle: string, targetHandle: string): string {
+  return `e_${source}_${target}__${sourceHandle}_${targetHandle}`
+}
+
+function connect(from: { nodeId: string; handleId: string }, to: { nodeId: string; handleId: string }): Edge {
+  return {
+    id: edgeId(from.nodeId, to.nodeId, from.handleId, to.handleId),
+    source: from.nodeId,
+    sourceHandle: from.handleId,
+    target: to.nodeId,
+    targetHandle: to.handleId,
+    type: 'smoothstep',
+  }
+}
+
+/** Every element starts at the origin so the solver knows to place it. */
+const ORIGIN = { posX: 0, posY: 0, handleX: 0, handleY: 0 }
+
+/** A power rail carries exactly one handle. */
+function railHandleId(rail: Node): string {
+  return (rail.data as { handles: { id: string }[] }).handles[0].id
+}
+
+function buildContact(spec: RungContact): Fragment {
+  const id = newGraphicalEditorNodeID('CONTACT')
+  const node = nodesBuilder.contact({ id, ...ORIGIN, variant: spec.contact.variant }) as unknown as Node
+  const data = node.data as { variable: { name: string } }
+  data.variable = { name: spec.contact.variable }
+  return {
+    nodes: [node],
+    edges: [],
+    entry: { nodeId: id, handleId: 'input' },
+    exit: { nodeId: id, handleId: 'output' },
+  }
+}
+
+function buildSeries(parts: RungLogic[]): Fragment {
+  const built = parts.map(buildLogic)
+  const nodes = built.flatMap((part) => part.nodes)
+  const edges = built.flatMap((part) => part.edges)
+  for (let index = 0; index < built.length - 1; index += 1) {
+    edges.push(connect(built[index].exit, built[index + 1].entry))
+  }
+  const last = built[built.length - 1]
+  return {
+    nodes,
+    edges,
+    entry: built[0].entry,
+    exit: last.exit,
+    // Carried from the ends: a series that STARTS with a parallel is still a
+    // nested parallel as far as the enclosing pair's down path is concerned.
+    nestedEntry: built[0].nestedEntry,
+    nestedExit: last.nestedExit,
+  }
+}
+
+/**
+ * A parallel pair wraps exactly two branches — that is what the node model
+ * carries, one straight-through path and one "down" path. Three or more nest,
+ * which is also how the editor builds them when a branch is added to a branch.
+ */
+function buildParallel(branches: RungLogic[]): Fragment {
+  if (branches.length > 2) {
+    return buildParallel([branches[0], { parallel: branches.slice(1) }])
+  }
+
+  const openId = newGraphicalEditorNodeID('PARALLEL_OPEN')
+  const closeId = newGraphicalEditorNodeID('PARALLEL_CLOSE')
+  const open = nodesBuilder.parallel({ id: openId, ...ORIGIN, type: 'open' }) as unknown as Node
+  const close = nodesBuilder.parallel({ id: closeId, ...ORIGIN, type: 'close' }) as unknown as Node
+
+  // The pair is linked by id; the layout and wiring code both follow these.
+  const openData = open.data as {
+    parallelCloseReference?: string
+    parallelOutputConnector: { id: string }
+    parallelInputConnector: { id: string }
+  }
+  const closeData = close.data as {
+    parallelOpenReference?: string
+    parallelInputConnector: { id: string }
+    parallelOutputConnector: { id: string }
+  }
+  openData.parallelCloseReference = closeId
+  closeData.parallelOpenReference = openId
+
+  const [first, second] = branches.map(buildLogic)
+  const nodes = [open, ...first.nodes, ...second.nodes, close]
+  const edges = [...first.edges, ...second.edges]
+
+  // Straight through: OPEN's output to the first branch, on to CLOSE's input.
+  edges.push(connect({ nodeId: openId, handleId: 'output-right' }, first.entry))
+  edges.push(connect(first.exit, { nodeId: closeId, handleId: 'input' }))
+  // The branch below: OPEN's down pin to the second branch, on to CLOSE's. A
+  // nested pair is entered by its top connectors, not its ordinary ones.
+  edges.push(
+    connect({ nodeId: openId, handleId: openData.parallelOutputConnector.id }, second.nestedEntry ?? second.entry),
+  )
+  edges.push(
+    connect(second.nestedExit ?? second.exit, { nodeId: closeId, handleId: closeData.parallelInputConnector.id }),
+  )
+
+  return {
+    nodes,
+    edges,
+    entry: { nodeId: openId, handleId: 'input' },
+    exit: { nodeId: closeId, handleId: 'output-right' },
+    nestedEntry: { nodeId: openId, handleId: openData.parallelInputConnector.id },
+    nestedExit: { nodeId: closeId, handleId: closeData.parallelOutputConnector.id },
+  }
+}
+
+function buildLogic(logic: RungLogic): Fragment {
+  if ('contact' in logic) return buildContact(logic)
+  if ('series' in logic) return buildSeries(logic.series)
+  return buildParallel(logic.parallel)
+}
+
+function buildOutput(output: RungOutput): Fragment {
+  if ('coil' in output) {
+    const id = newGraphicalEditorNodeID('COIL')
+    const node = nodesBuilder.coil({ id, ...ORIGIN, variant: output.coil.variant }) as unknown as Node
+    const data = node.data as { variable: { name: string } }
+    data.variable = { name: output.coil.variable }
+    return {
+      nodes: [node],
+      edges: [],
+      entry: { nodeId: id, handleId: 'input' },
+      exit: { nodeId: id, handleId: 'output' },
+    }
+  }
+
+  const id = newGraphicalEditorNodeID('BLOCK')
+  const node = nodesBuilder.block({
+    id,
+    ...ORIGIN,
+    variant: output.block.variant as never,
+    executionControl: output.block.executionControl ?? false,
+  }) as unknown as Node
+  const data = node.data as {
+    variable: { name: string }
+    inputConnector?: { id: string }
+    outputConnector?: { id: string }
+  }
+  if (output.block.instance) data.variable = { name: output.block.instance }
+
+  // Read the power pins off the built node rather than naming them. The builder
+  // decides whether the block gets EN/ENO, and its first left/right connector is
+  // whichever pin ends up carrying rung power — EN/ENO when execution control is
+  // on, the first boolean input and output when it is not.
+  return {
+    nodes: [node],
+    edges: [],
+    entry: { nodeId: id, handleId: data.inputConnector?.id ?? 'EN' },
+    exit: { nodeId: id, handleId: data.outputConnector?.id ?? 'ENO' },
+  }
+}
+
+/**
+ * What the editor starts every rung at (`graphical/ladder/index.tsx`).
+ *
+ * The value matters beyond the initial canvas: `changeRailBounds` only moves the
+ * right rail when content is WIDER than this, so a generous bound leaves the
+ * rail parked out at its full width with the coil stranded mid-rung. At 300 any
+ * real rung overflows, and the rail is pulled in to sit just past the last
+ * element — which is where a hand-drawn rung puts it.
+ */
+const EDITOR_RUNG_BOUNDS: [number, number] = [300, 100]
+
+export function buildLadderRung(input: BuildLadderRungInput): RungLadderState {
+  const defaultBounds = input.defaultBounds ?? EDITOR_RUNG_BOUNDS
+  const { powerRail } = defaultCustomNodesStyles
+
+  // Rails keep real coordinates — `needsPositionRecovery` ignores them, and the
+  // solver measures the span it has to lay the rung out across from them.
+  const leftRail = nodesBuilder.powerRail({
+    id: `left-rail-${input.rungId}`,
+    posX: 0,
+    posY: defaultBounds[1] / 2 - powerRail.height / 2,
+    connector: 'right',
+    handleX: powerRail.width,
+    handleY: defaultBounds[1] / 2,
+  }) as unknown as Node
+  const rightRail = nodesBuilder.powerRail({
+    id: `right-rail-${input.rungId}`,
+    posX: defaultBounds[0],
+    posY: defaultBounds[1] / 2 - powerRail.height / 2,
+    connector: 'left',
+    handleX: defaultBounds[0] - powerRail.width,
+    handleY: defaultBounds[1] / 2,
+  }) as unknown as Node
+
+  // Read the handle id off the built rail: it is the opposite of the node's
+  // `connector`, so naming it here gets it backwards. `startLadderRung` reads
+  // it the same way.
+  const leftExit = { nodeId: leftRail.id, handleId: railHandleId(leftRail) }
+  const rightEntry = { nodeId: rightRail.id, handleId: railHandleId(rightRail) }
+
+  const nodes: Node[] = [leftRail]
+  const edges: Edge[] = []
+  let power = leftExit
+
+  if (input.logic) {
+    const condition = buildLogic(input.logic)
+    nodes.push(...condition.nodes)
+    edges.push(...condition.edges)
+    edges.push(connect(power, condition.entry))
+    power = condition.exit
+  }
+
+  for (const output of input.outputs) {
+    const built = buildOutput(output)
+    nodes.push(...built.nodes)
+    edges.push(...built.edges)
+    edges.push(connect(power, built.entry))
+    power = built.exit
+  }
+
+  edges.push(connect(power, rightEntry))
+  nodes.push(rightRail)
+
+  // The editor stores the whole declared variable on an element, not just its
+  // name, and checks the two agree — a block whose instance does not resolve is
+  // ringed red. Placing the name alone produced exactly that.
+  if (input.resolveVariable) {
+    for (const node of nodes) {
+      const kind = node.type
+      if (kind !== 'contact' && kind !== 'coil' && kind !== 'block') continue
+      const data = node.data as { variable: { name: string } }
+      const resolved = input.resolveVariable(data.variable.name, kind)
+      if (resolved) data.variable = resolved
+    }
+  }
+
+  return {
+    id: input.rungId,
+    comment: input.comment ?? '',
+    defaultBounds,
+    reactFlowViewport: defaultBounds,
+    selectedNodes: [],
+    nodes,
+    edges,
+  } as unknown as RungLadderState
+}

--- a/src/frontend/store/slices/project/slice.ts
+++ b/src/frontend/store/slices/project/slice.ts
@@ -2,15 +2,7 @@ import { produce } from 'immer'
 import type { StoreApi } from 'zustand'
 import { StateCreator } from 'zustand'
 
-import type {
-  ModbusIOPoint,
-  OpcUaServerConfig,
-  PLCServer,
-  PLCVariable,
-  S7CommLogging,
-  S7CommPlcIdentity,
-  S7CommServerSettings,
-} from '../../../../middleware/shared/ports/types'
+import type { ModbusIOPoint, PLCServer, PLCVariable } from '../../../../middleware/shared/ports/types'
 import {
   type AddressPool,
   buildAddressPool,
@@ -56,6 +48,12 @@ import { renameGlobalVariableListInPou } from '../../../utils/PLC/global-variabl
 import { serializeGlobalVariableListToText } from '../../../utils/PLC/global-variable-list-serializer'
 import { parseGlobalVariableListFromText } from '../../../utils/PLC/global-variable-list-text-parser'
 import { getExtensionFromLanguage, getFolderFromPouType } from '../../../utils/PLC/pou-file-extensions'
+import {
+  DEFAULT_OPCUA_SERVER_CONFIG,
+  DEFAULT_S7COMM_LOGGING,
+  DEFAULT_S7COMM_PLC_IDENTITY,
+  DEFAULT_S7COMM_SERVER_SETTINGS,
+} from '../../../utils/protocol/server-defaults'
 import { elementNameCollision } from '../shared/name-collision'
 import type { ProjectResponse, ProjectSlice, ProjectSliceRoot, VariableScope } from './types'
 import { getVariableBasedOnRowIdOrVariableId } from './utils'
@@ -66,68 +64,6 @@ const fail = (message: string, title?: string): ProjectResponse => ({ ok: false,
 
 /** IEC identifiers are case-insensitive — the rule every element-name lookup folds by. */
 const nameMatches = (a: string, b: string): boolean => a.toLowerCase() === b.toLowerCase()
-
-// Default S7Comm configurations
-const DEFAULT_S7COMM_SERVER_SETTINGS: S7CommServerSettings = {
-  enabled: false,
-  bindAddress: '0.0.0.0',
-  port: 102,
-  maxClients: 32,
-  workIntervalMs: 100,
-  sendTimeoutMs: 3000,
-  recvTimeoutMs: 3000,
-  pingTimeoutMs: 10000,
-  pduSize: 480,
-}
-
-const DEFAULT_S7COMM_PLC_IDENTITY: S7CommPlcIdentity = {
-  name: 'OpenPLC Runtime',
-  moduleType: 'CPU 315-2 PN/DP',
-  serialNumber: 'S C-OPENPLC01',
-  copyright: 'OpenPLC Project',
-  moduleName: 'OpenPLC',
-}
-
-const DEFAULT_S7COMM_LOGGING: S7CommLogging = {
-  logConnections: true,
-  logDataAccess: false,
-  logErrors: true,
-}
-
-// Default OPC-UA configuration
-const DEFAULT_OPCUA_SERVER_CONFIG: OpcUaServerConfig = {
-  server: {
-    enabled: false,
-    name: 'OpenPLC OPC UA Server',
-    applicationUri: 'urn:openplc:opcua:server',
-    productUri: 'urn:openplc:runtime',
-    bindAddress: '0.0.0.0',
-    port: 4840,
-    endpointPath: '/openplc/opcua',
-  },
-  securityProfiles: [
-    {
-      id: 'default-insecure',
-      name: 'insecure',
-      enabled: true,
-      securityPolicy: 'None',
-      securityMode: 'None',
-      authMethods: ['Anonymous'],
-    },
-  ],
-  security: {
-    serverCertificateStrategy: 'auto_self_signed',
-    serverCertificateCustom: null,
-    serverPrivateKeyCustom: null,
-    trustedClientCertificates: [],
-  },
-  users: [],
-  cycleTimeMs: 100,
-  addressSpace: {
-    namespaceUri: 'urn:openplc:opcua:namespace',
-    nodes: [],
-  },
-}
 
 function initializeServerProtocolConfig(serverData: PLCServer): PLCServer {
   if (serverData.protocol === 'modbus-tcp' && !serverData.modbusSlaveConfig) {

--- a/src/frontend/utils/PLC/__tests__/block-variant.test.ts
+++ b/src/frontend/utils/PLC/__tests__/block-variant.test.ts
@@ -1,0 +1,192 @@
+import type { SystemLibrary, UserLibrary } from '../../../../middleware/shared/ports/library-types'
+import type { PLCPou } from '../../../../middleware/shared/ports/types'
+import { buildBlockVariant } from '../block-variant'
+
+// `node.data.variant` is the only durable record of a placed block's signature —
+// the transpiler and the PLCopen exporter read it off the node rather than
+// re-resolving the library. Anything wrong here is wrong in the project forever.
+
+const systemLibraries = [
+  {
+    name: 'standard',
+    version: '1.0.0',
+    author: '',
+    stPath: '',
+    cPath: '',
+    pous: [
+      {
+        name: 'TON',
+        type: 'function-block',
+        documentation: 'On-delay timer',
+        extensible: true,
+        language: 'st',
+        body: 'FUNCTION_BLOCK TON ... END_FUNCTION_BLOCK',
+        variables: [
+          { name: 'IN', class: 'input', type: { definition: 'base-type', value: 'BOOL' } },
+          { name: 'PT', class: 'input', type: { definition: 'base-type', value: 'TIME' } },
+          { name: 'Q', class: 'output', type: { definition: 'base-type', value: 'BOOL' } },
+        ],
+      },
+      {
+        name: 'CTU',
+        type: 'function-block',
+        language: 'st',
+        body: '',
+        variables: [],
+      },
+    ],
+  },
+] as unknown as SystemLibrary[]
+
+const userLibraries = [{ name: 'Latch' }, { name: 'Scale' }, { name: 'Ghost' }] as unknown as UserLibrary[]
+
+const pous = [
+  {
+    name: 'Latch',
+    pouType: 'function-block',
+    documentation: 'Set-dominant latch',
+    interface: {
+      variables: [
+        { id: 'v1', name: 'S', class: 'input', type: { definition: 'base-type', value: 'bool' } },
+        { id: 'v2', name: 'Q', class: 'output', type: { definition: 'base-type', value: 'bool' } },
+      ],
+    },
+  },
+  {
+    name: 'Scale',
+    pouType: 'function',
+    interface: {
+      returnType: 'real',
+      variables: [{ id: 'v3', name: 'Raw', class: 'input', type: { definition: 'base-type', value: 'int' } }],
+    },
+  },
+] as unknown as PLCPou[]
+
+const build = (blockRef: string) => buildBlockVariant({ blockRef, systemLibraries, userLibraries, pous })
+
+describe('buildBlockVariant — system library branch', () => {
+  it('copies the signature', () => {
+    const result = build('system/standard/TON')
+
+    expect(result).toEqual({
+      ok: true,
+      variant: {
+        name: 'TON',
+        type: 'function-block',
+        documentation: 'On-delay timer',
+        extensible: true,
+        variables: [
+          { name: 'IN', class: 'input', type: { definition: 'base-type', value: 'BOOL' } },
+          { name: 'PT', class: 'input', type: { definition: 'base-type', value: 'TIME' } },
+          { name: 'Q', class: 'output', type: { definition: 'base-type', value: 'BOOL' } },
+        ],
+      },
+    })
+  })
+
+  it('never carries the library entry body or language', () => {
+    // DOPE-592: spreading the entry froze a copy of the library's source into
+    // every project that placed the block, and the embedded VAR…END_VAR broke
+    // the POU parser badly enough that the project would not open.
+    const result = build('system/standard/TON')
+    const variant: Record<string, unknown> = result.ok ? { ...result.variant } : {}
+
+    expect(variant.body).toBeUndefined()
+    expect(variant.language).toBeUndefined()
+    expect(Object.keys(variant).sort()).toEqual(['documentation', 'extensible', 'name', 'type', 'variables'])
+  })
+
+  it('defaults extensible to false when the library omits it', () => {
+    expect(build('system/standard/CTU')).toMatchObject({ ok: true, variant: { extensible: false } })
+  })
+
+  it('reports an unknown block', () => {
+    expect(build('system/standard/NOPE')).toEqual({
+      ok: false,
+      reason: 'unknown-pou',
+      libraryType: 'system',
+      blockRef: 'system/standard/NOPE',
+    })
+  })
+
+  it('reports an unknown library', () => {
+    expect(build('system/nope/TON')).toEqual({
+      ok: false,
+      reason: 'unknown-pou',
+      libraryType: 'system',
+      blockRef: 'system/nope/TON',
+    })
+  })
+
+  it('reports a reference missing its POU segment', () => {
+    expect(build('system/standard')).toEqual({
+      ok: false,
+      reason: 'malformed-ref',
+      libraryType: 'system',
+      blockRef: 'system/standard',
+    })
+  })
+})
+
+describe('buildBlockVariant — user POU branch', () => {
+  it('rebuilds each pin and upper-cases its type', () => {
+    expect(build('user/Latch')).toEqual({
+      ok: true,
+      variant: {
+        name: 'Latch',
+        type: 'function-block',
+        documentation: 'Set-dominant latch',
+        extensible: false,
+        variables: [
+          { id: 'v1', name: 'S', class: 'input', type: { definition: 'base-type', value: 'BOOL' } },
+          { id: 'v2', name: 'Q', class: 'output', type: { definition: 'base-type', value: 'BOOL' } },
+        ],
+      },
+    })
+  })
+
+  it('synthesizes the OUT pin for a function from its return type', () => {
+    // A function's return is a pin on the diagram but not a declared variable,
+    // so nothing else would produce it.
+    const result = build('user/Scale')
+    const variables = result.ok ? result.variant.variables : []
+
+    expect(variables).toHaveLength(2)
+    expect(variables[1]).toEqual({
+      id: 'OUT',
+      name: 'OUT',
+      class: 'output',
+      type: { definition: 'base-type', value: 'REAL' },
+    })
+  })
+
+  it('does not synthesize OUT for a function block', () => {
+    const result = build('user/Latch')
+
+    expect(result.ok && result.variant.variables.some((pin) => pin.name === 'OUT')).toBe(false)
+  })
+
+  it('reports a library entry with no matching POU', () => {
+    expect(build('user/Ghost')).toEqual({
+      ok: false,
+      reason: 'unknown-pou',
+      libraryType: 'user',
+      blockRef: 'user/Ghost',
+    })
+  })
+
+  it('reports a name that is in no user library', () => {
+    expect(build('user/Nope')).toEqual({
+      ok: false,
+      reason: 'unknown-library',
+      libraryType: 'user',
+      blockRef: 'user/Nope',
+    })
+  })
+})
+
+describe('buildBlockVariant — malformed references', () => {
+  it.each([['TON'], ['weird/standard/TON'], ['']])('rejects %p', (blockRef) => {
+    expect(build(blockRef)).toEqual({ ok: false, reason: 'malformed-ref', libraryType: 'unknown', blockRef })
+  })
+})

--- a/src/frontend/utils/PLC/block-variant.ts
+++ b/src/frontend/utils/PLC/block-variant.ts
@@ -70,7 +70,17 @@ export interface BuildBlockVariantInput {
 }
 
 export function buildBlockVariant(input: BuildBlockVariantInput): BuildBlockVariantResult {
-  const [blockLibraryType, blockLibrary, pouName] = input.blockRef.split('/')
+  const segments = input.blockRef.split('/')
+  const [blockLibraryType, blockLibrary, pouName] = segments
+
+  // Destructuring ignores anything past the third segment, so `system/lib/TON/x`
+  // would resolve as `system/lib/TON`. The two shapes have exact lengths.
+  if (blockLibraryType === 'system' && segments.length !== 3) {
+    return { ok: false, reason: 'malformed-ref', libraryType: 'system', blockRef: input.blockRef }
+  }
+  if (blockLibraryType === 'user' && segments.length !== 2) {
+    return { ok: false, reason: 'malformed-ref', libraryType: 'user', blockRef: input.blockRef }
+  }
 
   if (blockLibraryType === 'system') {
     if (!blockLibrary || !pouName)

--- a/src/frontend/utils/PLC/block-variant.ts
+++ b/src/frontend/utils/PLC/block-variant.ts
@@ -1,0 +1,145 @@
+/**
+ * Build the `variant` a placed block carries, from a `type/library/pou` block
+ * reference.
+ *
+ * `node.data.variant` is the only durable record of a block's signature — the
+ * transpiler and the PLCopen exporter both read it off the placed node rather
+ * than re-resolving the library, so whatever this produces is what the project
+ * compiles against forever.
+ *
+ * Lives in `utils/` because three layers need it: the two graphical editors
+ * (`components`), and the CLI, which may not import `components` at all. It was
+ * previously ~70 lines duplicated near-verbatim between `ladder/rung/body.tsx`
+ * and `fbd/index.tsx`.
+ *
+ * Pure: state arrives as arguments rather than being read from the store, so
+ * the same call works in a renderer, a test and a headless process.
+ */
+
+// From `ports`, not the store's re-export: `utils` may not import `store`.
+import type { SystemLibrary, UserLibrary } from '../../../middleware/shared/ports/library-types'
+import type { PLCPou } from '../../../middleware/shared/ports/types'
+import { getVariableRestrictionType } from './validate-variable-type'
+
+/**
+ * One pin on a placed block.
+ *
+ * Structural and permissive on purpose. The two sources disagree: a system
+ * library pin carries a narrow class enum, while a user POU's variable may have
+ * no class at all, and a synthesised function return can be `derived` — which
+ * the strict `blockVariantVariableSchema` union does not admit. Both editors
+ * accept this through a generic parameter today; widening here keeps that
+ * behaviour rather than forcing a cast at three call sites.
+ */
+export interface BlockVariantVariable {
+  id?: string
+  name: string
+  class?: string
+  type: { definition: string; value: string }
+}
+
+/** The curated signature a placed block keeps. Deliberately not the library entry. */
+export interface BlockVariantShape {
+  name: string
+  type: string
+  variables: BlockVariantVariable[]
+  documentation?: string
+  extensible: boolean
+}
+
+export type BuildBlockVariantResult =
+  | { ok: true; variant: BlockVariantShape }
+  | {
+      ok: false
+      reason: 'unknown-library' | 'unknown-pou' | 'malformed-ref'
+      /**
+       * Which half of the reference failed. The two editors report a failed
+       * `system` lookup with a toast but drop a failed `user` lookup silently,
+       * so a caller has to be able to tell them apart.
+       */
+      libraryType: 'system' | 'user' | 'unknown'
+      blockRef: string
+    }
+
+export interface BuildBlockVariantInput {
+  /** `system/<library>/<pou>` or `user/<pou>` — the form the editors split on. */
+  blockRef: string
+  systemLibraries: readonly SystemLibrary[]
+  userLibraries: readonly UserLibrary[]
+  pous: readonly PLCPou[]
+}
+
+export function buildBlockVariant(input: BuildBlockVariantInput): BuildBlockVariantResult {
+  const [blockLibraryType, blockLibrary, pouName] = input.blockRef.split('/')
+
+  if (blockLibraryType === 'system') {
+    if (!blockLibrary || !pouName)
+      return { ok: false, reason: 'malformed-ref', libraryType: 'system', blockRef: input.blockRef }
+    const libraryPou = input.systemLibraries
+      .find((library) => library.name === blockLibrary)
+      ?.pous.find((pou) => pou.name === pouName)
+    if (!libraryPou) return { ok: false, reason: 'unknown-pou', libraryType: 'system', blockRef: input.blockRef }
+
+    // Copy the signature, not the library entry. That entry also carries `body`
+    // (the authored source, which for a native C/C++ or Python block is the
+    // entire file) and `language`, and passing the object straight through froze
+    // a copy of the library's source into every project that placed the block.
+    // Nothing ever reads either field back off a placed variant, and the
+    // embedded VAR ... END_VAR broke the POU parser badly enough that the
+    // project would not open (DOPE-592).
+    return {
+      ok: true,
+      variant: {
+        name: libraryPou.name,
+        type: libraryPou.type,
+        variables: libraryPou.variables,
+        documentation: libraryPou.documentation,
+        extensible: libraryPou.extensible ?? false,
+      },
+    }
+  }
+
+  if (blockLibraryType === 'user') {
+    if (!blockLibrary) return { ok: false, reason: 'malformed-ref', libraryType: 'user', blockRef: input.blockRef }
+    const library = input.userLibraries.find((entry) => entry.name === blockLibrary)
+    if (!library) return { ok: false, reason: 'unknown-library', libraryType: 'user', blockRef: input.blockRef }
+    const pou = input.pous.find((entry) => entry.name === library.name)
+    if (!pou) return { ok: false, reason: 'unknown-pou', libraryType: 'user', blockRef: input.blockRef }
+
+    const variables: BlockVariantVariable[] = (pou.interface?.variables ?? []).map((variable) => ({
+      id: variable.id,
+      name: variable.name,
+      class: variable.class,
+      type: { definition: variable.type.definition, value: variable.type.value.toUpperCase() },
+    }))
+
+    // A function's return value is a pin on the diagram but not a declared
+    // variable, so it is synthesised here. System library POUs already declare
+    // their outputs, which is why that branch never does this.
+    if (pou.pouType === 'function') {
+      const restriction = getVariableRestrictionType(pou.interface?.returnType ?? '')
+      variables.push({
+        id: 'OUT',
+        name: 'OUT',
+        class: 'output',
+        type: {
+          definition: restriction.definition ?? 'derived',
+          value: (pou.interface?.returnType ?? '').toUpperCase(),
+        },
+      })
+    }
+
+    return {
+      ok: true,
+      variant: {
+        name: pou.name,
+        type: pou.pouType,
+        variables,
+        documentation: pou.documentation,
+        extensible: false,
+      },
+    }
+  }
+
+  return { ok: false, reason: 'malformed-ref', libraryType: 'unknown', blockRef: input.blockRef }
+}

--- a/src/frontend/utils/modbus/__tests__/generate-modbus-slave-config.test.ts
+++ b/src/frontend/utils/modbus/__tests__/generate-modbus-slave-config.test.ts
@@ -31,6 +31,73 @@ describe('generateModbusSlaveConfig', () => {
     expect(generateModbusSlaveConfig(servers)).toBeNull()
   })
 
+  /**
+   * Enable state is the presence of `conf/modbus_slave.json` — the runtime
+   * has no `enabled` key to read.  A disabled server that still emits a
+   * config opens port 502 on a device meant to have it closed.
+   */
+  describe('the enabled switch', () => {
+    it('returns null when the only modbus-tcp server is disabled', () => {
+      const disabled = makeModbusServer({
+        modbusSlaveConfig: { enabled: false, networkInterface: '0.0.0.0', port: 502 },
+      })
+      expect(generateModbusSlaveConfig([disabled])).toBeNull()
+    })
+
+    it('takes the enabled server when a disabled one comes first', () => {
+      const disabled = makeModbusServer({
+        name: 'Off',
+        modbusSlaveConfig: { enabled: false, networkInterface: '10.0.0.1', port: 1502 },
+      })
+      const result = generateModbusSlaveConfig([disabled, makeModbusServer({ name: 'On' })])
+
+      expect(result).not.toBeNull()
+      expect(JSON.parse(result!).network_configuration.port).toBe(5020)
+    })
+
+    it('reports the servers it ignores when two are enabled', () => {
+      const messages: string[] = []
+      const result = generateModbusSlaveConfig(
+        [makeModbusServer({ name: 'First' }), makeModbusServer({ name: 'Second' })],
+        (message) => messages.push(message),
+      )
+
+      expect(result).not.toBeNull()
+      expect(messages).toHaveLength(1)
+      expect(messages[0]).toContain('Using "First"')
+      expect(messages[0]).toContain('ignoring Second')
+    })
+
+    it('does not log when only one server is enabled', () => {
+      const messages: string[] = []
+      generateModbusSlaveConfig([makeModbusServer()], (message) => messages.push(message))
+      expect(messages).toEqual([])
+    })
+  })
+
+  /**
+   * A partial mapping must survive the round trip: `ModbusBufferMapping`
+   * makes every group and count optional, so each missing value falls back
+   * to the runtime default rather than reaching the conf as undefined.
+   */
+  it('defaults every count a partial bufferMapping omits', () => {
+    const partial = makeModbusServer({
+      modbusSlaveConfig: {
+        enabled: true,
+        networkInterface: '0.0.0.0',
+        port: 502,
+        bufferMapping: { coils: { qxBits: 16 } },
+      },
+    })
+    const parsed = JSON.parse(generateModbusSlaveConfig([partial])!)
+
+    expect(parsed.buffer_mapping.coils.qx_bits).toBe(16)
+    expect(parsed.buffer_mapping.coils.mx_bits).toBe(DEFAULT_BUFFER_MAPPING.coils.mxBits)
+    expect(parsed.buffer_mapping.holding_registers.qw_count).toBe(DEFAULT_BUFFER_MAPPING.holdingRegisters.qwCount)
+    expect(parsed.buffer_mapping.discrete_inputs.ix_bits).toBe(DEFAULT_BUFFER_MAPPING.discreteInputs.ixBits)
+    expect(parsed.buffer_mapping.input_registers.iw_count).toBe(DEFAULT_BUFFER_MAPPING.inputRegisters.iwCount)
+  })
+
   it('generates config with correct network configuration', () => {
     const result = generateModbusSlaveConfig([makeModbusServer()])
 

--- a/src/frontend/utils/modbus/generate-modbus-slave-config.ts
+++ b/src/frontend/utils/modbus/generate-modbus-slave-config.ts
@@ -45,21 +45,49 @@ interface ModbusSlaveConfig {
   buffer_mapping: ModbusSlaveBufferMapping
 }
 
+/** Sink for non-fatal diagnostics, wired to the build console. */
+type ModbusSlaveConfigLog = (message: string) => void
+
 /**
  * Generates the Modbus Slave plugin configuration JSON from the project's servers.
  * Returns null if there are no enabled Modbus TCP servers configured.
  *
+ * The runtime enables the plugin by the presence of `conf/modbus_slave.json`,
+ * so a disabled server must produce null — shipping the file opens the port.
+ *
  * @param servers - Array of PLCServer from the project data
+ * @param log - Optional sink for non-fatal diagnostics (e.g. a second Modbus server)
  * @returns The Modbus Slave configuration as a JSON string, or null if no servers are configured
  */
-export const generateModbusSlaveConfig = (servers: PLCServer[] | undefined): string | null => {
+export const generateModbusSlaveConfig = (
+  servers: PLCServer[] | undefined,
+  log?: ModbusSlaveConfigLog,
+): string | null => {
   if (!servers || servers.length === 0) {
     return null
   }
 
-  const modbusServer = servers.find((server) => server.protocol === 'modbus-tcp' && server.modbusSlaveConfig)
+  const enabledServers = servers.filter(
+    (server) => server.protocol === 'modbus-tcp' && server.modbusSlaveConfig?.enabled,
+  )
 
-  if (!modbusServer || !modbusServer.modbusSlaveConfig) {
+  // The runtime takes one Modbus slave config. A second enabled server is
+  // dropped rather than merged, so say which one won instead of picking
+  // silently by array order.
+  if (enabledServers.length > 1) {
+    const dropped = enabledServers
+      .slice(1)
+      .map((server) => server.name)
+      .join(', ')
+    log?.(
+      `Modbus slave: more than one enabled Modbus TCP server (${enabledServers.map((s) => s.name).join(', ')}). ` +
+        `Using "${enabledServers[0].name}"; ignoring ${dropped}.`,
+    )
+  }
+
+  const modbusServer = enabledServers[0]
+
+  if (!modbusServer?.modbusSlaveConfig) {
     return null
   }
 
@@ -100,6 +128,7 @@ export type {
   ModbusSlaveBufferMapping,
   ModbusSlaveCoils,
   ModbusSlaveConfig,
+  ModbusSlaveConfigLog,
   ModbusSlaveDiscreteInputs,
   ModbusSlaveHoldingRegisters,
   ModbusSlaveInputRegisters,

--- a/src/frontend/utils/protocol/server-defaults.ts
+++ b/src/frontend/utils/protocol/server-defaults.ts
@@ -1,0 +1,92 @@
+/**
+ * The values a newly created server starts with.
+ *
+ * Here rather than in the store slice because both the store's `createServer`
+ * and the CLI's spec normalizer need them, and they sit in layers that cannot
+ * import each other. A second copy would drift.
+ *
+ * Every protocol defaults to `enabled: false` — a server appears in the project
+ * before it is switched on, and for Modbus and OPC-UA the enable flag decides
+ * whether the runtime gets a config file at all.
+ */
+
+import type {
+  OpcUaServerConfig,
+  S7CommLogging,
+  S7CommPlcIdentity,
+  S7CommServerSettings,
+} from '../../../middleware/shared/ports/types'
+
+export const DEFAULT_MODBUS_SLAVE_CONFIG = {
+  enabled: false,
+  networkInterface: '0.0.0.0',
+  port: 502,
+} as const
+
+export const DEFAULT_S7COMM_SERVER_SETTINGS: S7CommServerSettings = {
+  enabled: false,
+  bindAddress: '0.0.0.0',
+  port: 102,
+  maxClients: 32,
+  workIntervalMs: 100,
+  sendTimeoutMs: 3000,
+  recvTimeoutMs: 3000,
+  pingTimeoutMs: 10000,
+  pduSize: 480,
+}
+
+export const DEFAULT_S7COMM_PLC_IDENTITY: S7CommPlcIdentity = {
+  name: 'OpenPLC Runtime',
+  moduleType: 'CPU 315-2 PN/DP',
+  serialNumber: 'S C-OPENPLC01',
+  copyright: 'OpenPLC Project',
+  moduleName: 'OpenPLC',
+}
+
+export const DEFAULT_S7COMM_LOGGING: S7CommLogging = {
+  logConnections: true,
+  logDataAccess: false,
+  logErrors: true,
+}
+
+export const DEFAULT_OPCUA_SERVER_CONFIG: OpcUaServerConfig = {
+  server: {
+    enabled: false,
+    name: 'OpenPLC OPC UA Server',
+    applicationUri: 'urn:openplc:opcua:server',
+    productUri: 'urn:openplc:runtime',
+    bindAddress: '0.0.0.0',
+    port: 4840,
+    endpointPath: '/openplc/opcua',
+  },
+  securityProfiles: [
+    {
+      id: 'default-insecure',
+      name: 'insecure',
+      enabled: true,
+      securityPolicy: 'None',
+      securityMode: 'None',
+      authMethods: ['Anonymous'],
+    },
+  ],
+  security: {
+    serverCertificateStrategy: 'auto_self_signed',
+    serverCertificateCustom: null,
+    serverPrivateKeyCustom: null,
+    trustedClientCertificates: [],
+  },
+  users: [],
+  cycleTimeMs: 100,
+  addressSpace: {
+    namespaceUri: 'urn:openplc:opcua:namespace',
+    nodes: [],
+  },
+}
+
+/** What `createRemoteDevice` seeds a Modbus TCP device with. */
+export const DEFAULT_MODBUS_TCP_DEVICE_CONFIG = {
+  host: '127.0.0.1',
+  port: 502,
+  slaveId: 1,
+  timeout: 1000,
+} as const

--- a/src/middleware/adapters/editor/compile-program-flow.ts
+++ b/src/middleware/adapters/editor/compile-program-flow.ts
@@ -22,7 +22,13 @@ import {
 import { preprocessPous } from '../../../backend/shared/utils/PLC/preprocess-pous'
 import type { CompileProgramArgs } from '../../shared/ports/compiler-port'
 import type { StlibArchiveDTO } from '../../shared/ports/library-port'
-import type { BoardInfo, CompileProgressEvent, CompileResult, StructuredCompileError } from '../../shared/ports/types'
+import type {
+  BoardInfo,
+  CompileProgressEvent,
+  CompileResult,
+  PLCProjectData,
+  StructuredCompileError,
+} from '../../shared/ports/types'
 import { resolveTargetCapabilities } from '../../shared/utils/target-capabilities'
 import type { IpcProjectData } from './compiler-adapter'
 import { decodeMessage, inferStage, toIpcProjectData } from './compiler-adapter'
@@ -86,11 +92,40 @@ export interface CompileProgramTransport {
   runCompileProgram: (compileArgs: CompileProgramIpcArgs, onMessage: (data: Record<string, unknown>) => void) => void
 }
 
-export async function compileProgramFlow(
-  args: CompileProgramArgs,
-  transport: CompileProgramTransport,
+/**
+ * What a compile needs resolved before the pipeline is touched.
+ *
+ * Split out so `openplc-cli check` can transpile a project without building it
+ * and still see exactly what a build would see. Re-deriving these steps would
+ * mean a check that passes on a project the compiler rejects, which is worse
+ * than no check.
+ */
+export interface PreparedProject {
+  /** POUs after the library graft and preprocessing — schema shape. */
+  processedData: PLCProjectData
+  boardInfo: BoardInfo | undefined
+  boardCore: string | null
+  isSimulator: boolean
+  pythonSupport: { supported: boolean; targetLabel: string } | undefined
+  archives: StlibArchiveDTO[]
+}
+
+export type PrepareProjectResult = { ok: true; prepared: PreparedProject } | { ok: false; error: string }
+
+/**
+ * Board resolution, capability gating, the library C/C++ graft and POU
+ * preprocessing — everything `compileProgramFlow` does before it builds the IPC
+ * argument tuple.
+ *
+ * Needs only two of the transport's three calls; `runCompileProgram` is not
+ * reached, which is what lets a non-building caller pass a transport with no
+ * runtime behind it.
+ */
+export async function prepareProjectForCompile(
+  args: Pick<CompileProgramArgs, 'projectData' | 'boardTarget' | 'isSimulator'>,
+  transport: Pick<CompileProgramTransport, 'getAvailableBoards' | 'loadAllLibraries'>,
   onProgress: (event: CompileProgressEvent) => void,
-): Promise<CompileResult> {
+): Promise<PrepareProjectResult> {
   const boards = await transport.getAvailableBoards()
   const boardInfo = boards.get(args.boardTarget)
   const boardCore = boardInfo?.core ?? null
@@ -124,7 +159,7 @@ export async function compileProgramFlow(
       `These libraries ship C/C++ or Python blocks without their source, so they cannot be built: ${missingSources.join(', ')}. ` +
       'Reinstall them from a build that includes sources.'
     onProgress({ stage: 'st', message: error, level: 'error' })
-    return { success: false, error }
+    return { ok: false, error }
   }
 
   const dataWithLibCpp = injectLibraryBlocks(args.projectData, archives)
@@ -149,10 +184,25 @@ export async function compileProgramFlow(
 
   if (validationFailed) {
     return {
-      success: false,
+      ok: false,
       error: validationError ?? 'POU validation failed. Check C/C++ code for missing setup()/loop() functions.',
     }
   }
+
+  return {
+    ok: true,
+    prepared: { processedData, boardInfo, boardCore, isSimulator, pythonSupport, archives },
+  }
+}
+
+export async function compileProgramFlow(
+  args: CompileProgramArgs,
+  transport: CompileProgramTransport,
+  onProgress: (event: CompileProgressEvent) => void,
+): Promise<CompileResult> {
+  const preparation = await prepareProjectForCompile(args, transport, onProgress)
+  if (!preparation.ok) return { success: false, error: preparation.error }
+  const { processedData, boardCore } = preparation.prepared
 
   const ipcData = toIpcProjectData(processedData)
 

--- a/src/middleware/shared/utils/library/__tests__/compose-runtime-v4-bundle.test.ts
+++ b/src/middleware/shared/utils/library/__tests__/compose-runtime-v4-bundle.test.ts
@@ -24,7 +24,7 @@ function baseInput(overrides: Partial<ComposeRuntimeV4BundleInput> = {}): Compos
       modbusMaster: null,
       s7Comm: null,
       opcUa: null,
-      ethercat: '{"masters":[]}',
+      ethercat: null,
     },
     ...overrides,
   }
@@ -77,14 +77,29 @@ describe('composeRuntimeV4Bundle', () => {
     expect(files['c_blocks_code.cpp']).toBe('// code for MyBlock\n')
   })
 
-  it('omits each conf/*.json that is null (project does not use that protocol)', () => {
-    const files = composeRuntimeV4Bundle(baseInput())
-    expect('conf/modbus_slave.json' in files).toBe(false)
-    expect('conf/modbus_master.json' in files).toBe(false)
-    expect('conf/s7comm.json' in files).toBe(false)
-    expect('conf/opcua.json' in files).toBe(false)
-    // ethercat is always emitted (always non-null on input).
+  /**
+   * The runtime decides which plugins to load from which `conf/*.json`
+   * files are present, so this key set IS the enable state.  Assert the
+   * whole set, not individual keys: an extra file switches a plugin on.
+   */
+  const confKeys = (files: Record<string, string>) =>
+    Object.keys(files)
+      .filter((p) => p.startsWith('conf/'))
+      .sort()
+
+  it('writes no conf/*.json when the project uses no protocol', () => {
+    expect(confKeys(composeRuntimeV4Bundle(baseInput()))).toEqual([])
+  })
+
+  it('writes only ethercat.json when the project has EtherCAT devices', () => {
+    const files = composeRuntimeV4Bundle(baseInput({ confs: { ...baseInput().confs, ethercat: '{"masters":[]}' } }))
+    expect(confKeys(files)).toEqual(['conf/ethercat.json'])
     expect(files['conf/ethercat.json']).toBe('{"masters":[]}')
+  })
+
+  it('writes only modbus_slave.json when a Modbus server is enabled', () => {
+    const files = composeRuntimeV4Bundle(baseInput({ confs: { ...baseInput().confs, modbusSlave: '{"slaves":[]}' } }))
+    expect(confKeys(files)).toEqual(['conf/modbus_slave.json'])
   })
 
   it('writes each conf/*.json that is provided', () => {
@@ -104,6 +119,13 @@ describe('composeRuntimeV4Bundle', () => {
     expect(files['conf/s7comm.json']).toBe('{"servers":[]}')
     expect(files['conf/opcua.json']).toBe('{"endpoints":[]}')
     expect(files['conf/ethercat.json']).toBe('{"masters":[]}')
+    expect(confKeys(files)).toEqual([
+      'conf/ethercat.json',
+      'conf/modbus_master.json',
+      'conf/modbus_slave.json',
+      'conf/opcua.json',
+      'conf/s7comm.json',
+    ])
   })
 
   it('produces the file set runtime compile.sh check_required_files asserts', () => {

--- a/src/middleware/shared/utils/library/compose-runtime-v4-bundle.ts
+++ b/src/middleware/shared/utils/library/compose-runtime-v4-bundle.ts
@@ -88,8 +88,9 @@ export interface ComposeRuntimeV4BundleInput {
     opcUa: string | null
     /** From `generateEthercatConfig(remoteDevices)`.  Caller should
      *  run `validateEthercatConfig` first and abort the compile (not
-     *  call the composer) when validation produces errors. */
-    ethercat: string
+     *  call the composer) when validation produces errors.  `null`
+     *  when the project has no EtherCAT devices. */
+    ethercat: string | null
   }
 }
 
@@ -142,7 +143,7 @@ export function composeRuntimeV4Bundle(input: ComposeRuntimeV4BundleInput): Reco
   if (input.confs.modbusMaster) files['conf/modbus_master.json'] = input.confs.modbusMaster
   if (input.confs.s7Comm) files['conf/s7comm.json'] = input.confs.s7Comm
   if (input.confs.opcUa) files['conf/opcua.json'] = input.confs.opcUa
-  files['conf/ethercat.json'] = input.confs.ethercat
+  if (input.confs.ethercat) files['conf/ethercat.json'] = input.confs.ethercat
 
   return files
 }


### PR DESCRIPTION
# Pull request info

## Description of the changes proposed

### New commands

| Command | What it does |
| --- | --- |
| `apply <spec.json> --project <dir>` | Writes a whole project from one strict JSON document. `--dry-run` plans without writing; `--prune` deletes what the document stops mentioning. |
| `describe <project>` | Emits the project as that same document. `--pou <name>` for a single body, `--libraries` for the block catalogue with exact pin names and a ready-to-paste `call`. |
| `check <project>` | Transpiles and runs the compiler's semantic pass in-process — seconds, no toolchain, no board. `--lint` adds the logic and protocol rules, `--emit-st` prints the generated ST, `--protocols` lists the `conf/*.json` an upload would carry. |
| `runtime info --host <address>` | Version and capabilities over the unauthenticated endpoint — no login, and nothing is written to the device. |
| `esi import <file.xml>` / `esi list` | Adds a vendor ESI file to the project's repository and lists the ids and device indices an EtherCAT slave is declared against. |
| `skill` | Prints the bundled agent skill and its references. |
| `install-skill` | Installs that skill into a project or user scope. |

Existing commands (`create`, `devices`, `compile`, `upload`, `debug`, `install-cli`) keep their behaviour; `check` and `apply` add the flags above.

### What the spec covers

POUs in every supported language (ST, IL, LD, FBD, Python, C/C++), data types (structure, enumerated, array), variables and their flags, global variable lists, tasks and instances, device and persistent-storage settings, servers and remote devices. `describe → apply → describe` is byte-stable.

- **Ladder and FBD authoring** — rung and diagram construction moved into the store so the CLI can reach it without importing component modules; two architecture exceptions recorded. No coordinates in the spec: a rung is a series-parallel expression, a diagram is placed by signal flow.
- **`check --lint`** — reports what compiles and still does nothing: unassigned block inputs, double drives, programs touching no I/O, and eleven protocol rules.
- **Protocols** — Modbus slave/master (TCP and RTU), S7comm, OPC-UA, EtherCAT with slave authoring from a vendor ESI file. `check --protocols` reports which `conf/*.json` an upload would carry, which *is* the runtime's enable state — there is no endpoint that reads it back.
- **Secrets** — `describe` redacts the OPC-UA private key and password hashes; `apply` preserves them when omitted, so a round trip cannot destroy a credential.
- **Agent skill** — `resources/skills/openplc`, packaged with the app.

### Bug fixes

- `conf/ethercat.json` was written unconditionally and empty — every upload enabled the native EtherCAT plugin with no EtherCAT devices.
- The Modbus slave generator ignored `enabled`; a disabled server shipped its config and opened port 502.
- `ModbusSlaveBufferMappingSchema` required fields the interface made optional, so a partial mapping silently dropped the whole server file on load.
- A protocol file that failed to parse was only a progress line, so `describe` under-reported the project and `apply` could overwrite a config nobody had read. Both now refuse.

## DOD checklist

- [x] The code is complete and according to developers’ standards.
- [x] I have performed a self-review of my code.
- [ ] Meet the acceptance criteria.
- [x] Unit tests are written and green.
- [x] Test coverage: **91.22 %** lines (all four configured thresholds met).
- [x] Integration tests are written and green.
- [ ] Changes were communicated and updated in the ticket description.
- [ ] Reviewed and accepted by the Product Owner.
- [x] End-to-end test are successful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CLI commands for applying, describing, checking, linting, runtime inspection, reserved keywords, and EtherCAT ESI management.
  - Added declarative configuration for Modbus, S7Comm, OPC UA, and EtherCAT, with optional pruning.
  - Added graphical ladder and FBD authoring and round-trip description.
  - Added board-aware protocol validation, skill viewing/installation, and clearer build diagnostics.
- **Bug Fixes**
  - Improved duration-force validation, session matching, retain settings, and partial Modbus mappings.
  - Unreadable protocol files now produce clear diagnostics.
- **Documentation**
  - Expanded CLI command, option, exit-code, and protocol guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->