### PR TITLE
fix(iec-address): scope every address pool by the producer resolver

### DIFF
--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/components/pin-mapping-table.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/components/pin-mapping-table.tsx
@@ -8,7 +8,7 @@ import {
   describeSource,
   validateAliasEdit,
 } from '@root/middleware/shared/utils/iec-address'
-import { resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
+import { resolveAddressProducerCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 import { createColumnHelper } from '@tanstack/react-table'
 
 import { GenericTable } from '../../../../../../_atoms/generic-table'
@@ -72,7 +72,7 @@ const PinMappingTable = ({ pins, selectedRowId, handleRowClick }: PinMappingTabl
           vendorIoMapping: { entries: ioMapping },
           remoteDevices: state.project.data.remoteDevices,
         },
-        resolveTargetCapabilities(boardInfo),
+        resolveAddressProducerCapabilities(boardInfo),
       )
       const registry = buildAliasRegistry(pool)
       const validation = validateAliasEdit(registry, value, sourceRef)

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/io-table-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/io-table-layout.tsx
@@ -11,7 +11,7 @@ import {
   validateAliasEdit,
 } from '@root/middleware/shared/utils/iec-address'
 import { vppMemoryKey } from '@root/middleware/shared/utils/iec-address/registry'
-import { resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
+import { resolveAddressProducerCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { ModuleSystem, ScreenSection } from '../index'
@@ -72,7 +72,7 @@ function IoTableLayout({ section, moduleSystem }: IoTableLayoutProps) {
       remoteDevices: state.project.data.remoteDevices ?? [],
       pinMappingPins:
         state.deviceDefinitions.pinMapping.pinsByBoard[state.deviceDefinitions.configuration.deviceBoard] ?? [],
-      capabilities: resolveTargetCapabilities(boardInfo),
+      capabilities: resolveAddressProducerCapabilities(boardInfo),
     }
   }, [persistenceKey])
 
@@ -201,7 +201,7 @@ function IoTableLayout({ section, moduleSystem }: IoTableLayoutProps) {
         vendorIoMapping: { entries },
         remoteDevices: state.project.data.remoteDevices,
       },
-      resolveTargetCapabilities(boardInfo),
+      resolveAddressProducerCapabilities(boardInfo),
     )
     const registry = buildAliasRegistry(pool)
     const validation = validateAliasEdit(registry, alias, sourceRef)

--- a/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/configuration/vendor-screen/layouts/module-slots-layout.tsx
@@ -24,7 +24,7 @@ import {
   validateAliasEdit,
 } from '@root/middleware/shared/utils/iec-address'
 import { vppMemoryKey } from '@root/middleware/shared/utils/iec-address/registry'
-import { resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
+import { resolveAddressProducerCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { ModuleDefinition, ModuleSystem, ScreenSection } from '../index'
@@ -447,7 +447,7 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
     const boardInfo = state.deviceAvailableOptions.availableBoards.get(
       state.deviceDefinitions.configuration.deviceBoard,
     )
-    const capabilities = resolveTargetCapabilities(boardInfo)
+    const capabilities = resolveAddressProducerCapabilities(boardInfo)
 
     const existingAliases = new Map<string, string>()
     for (const entry of storedMapping?.entries ?? []) {
@@ -690,7 +690,7 @@ function ModuleSlotsLayout({ section, moduleSystem }: ModuleSlotsLayoutProps) {
         vendorIoMapping: { entries: currentEntries },
         remoteDevices: state.project.data.remoteDevices,
       },
-      resolveTargetCapabilities(boardInfo),
+      resolveAddressProducerCapabilities(boardInfo),
     )
     const registry = buildAliasRegistry(pool)
     const validation = validateAliasEdit(registry, alias, sourceRef)

--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/ethercat-device-editor.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/ethercat-device-editor.tsx
@@ -14,7 +14,7 @@ import type {
 } from '@root/middleware/shared/ports/esi-types'
 import { useEsi } from '@root/middleware/shared/providers/platform-context'
 import { buildAddressPool } from '@root/middleware/shared/utils/iec-address'
-import { resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
+import { resolveAddressProducerCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Cia402AxisTab } from './components/cia402-axis-tab'
@@ -138,7 +138,7 @@ const EtherCATDeviceEditor = ({ busName: propBusName, deviceId: propDeviceId }: 
         vendorIoMapping: { entries: ioMapping },
         remoteDevices: project.data.remoteDevices,
       },
-      resolveTargetCapabilities(boardInfo),
+      resolveAddressProducerCapabilities(boardInfo),
     )
     return new Set(pool.byAddress.keys())
   }, [project.data.remoteDevices, vendorScreenData])

--- a/src/frontend/components/_features/[workspace]/editor/device/ethercat/index.tsx
+++ b/src/frontend/components/_features/[workspace]/editor/device/ethercat/index.tsx
@@ -19,7 +19,7 @@ import type { EtherCATDevice, NetworkInterface } from '@root/middleware/shared/p
 import { useEsi, useRuntime } from '@root/middleware/shared/providers/platform-context'
 import { sanitizeAxisName } from '@root/middleware/shared/utils/ethercat'
 import { buildAddressPool } from '@root/middleware/shared/utils/iec-address'
-import { resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
+import { resolveAddressProducerCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -61,7 +61,7 @@ function buildClaimedAddressSet(
       vendorIoMapping: { entries: ioMapping },
       remoteDevices,
     },
-    resolveTargetCapabilities(boardInfo),
+    resolveAddressProducerCapabilities(boardInfo),
   )
   return new Set(pool.byAddress.keys())
 }

--- a/src/frontend/hooks/use-alias-registry.ts
+++ b/src/frontend/hooks/use-alias-registry.ts
@@ -11,18 +11,16 @@
  */
 
 import { useOpenPLCStore } from '@root/frontend/store'
-import type { DevicePin, PLCRemoteDevice } from '@root/middleware/shared/ports/types'
+import type { BoardInfo, DevicePin, PLCRemoteDevice } from '@root/middleware/shared/ports/types'
 import type { AliasRegistry } from '@root/middleware/shared/utils/iec-address'
 import { buildAddressPool, buildAliasRegistry } from '@root/middleware/shared/utils/iec-address'
-import type { TargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
-
-import { useTargetCapabilities } from './use-target-capabilities'
+import { resolveAddressProducerCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 
 interface RegistryCache {
   pins: DevicePin[]
   vsd: Record<string, unknown> | undefined
   remoteDevices: PLCRemoteDevice[] | undefined
-  capabilities: TargetCapabilities
+  boardInfo: BoardInfo | undefined
   registry: AliasRegistry
 }
 
@@ -44,14 +42,26 @@ export function useAliasRegistry(): AliasRegistry {
   const pins = pinsByBoard[deviceBoard] ?? []
   const vsd = useOpenPLCStore((s) => s.deviceDefinitions.configuration.vendorScreenData)
   const remoteDevices = useOpenPLCStore((s) => s.project.data.remoteDevices)
-  const capabilities = useTargetCapabilities()
+  // NOT `useTargetCapabilities`, which answers "no producers at all" for a
+  // board that does not resolve — the VPP package is not installed, the
+  // project came from another machine, or the catalogue has not loaded yet.
+  // That answer is right for gating a UI element and wrong for scoping a
+  // pool: an empty pool makes every claimed address look free, so the alias
+  // registry stops seeing the conflicts it exists to report (DOPE-615, C1).
+  //
+  // Cached on the BOARD INFO rather than on the resolved block, because the
+  // resolver spreads a board's own capability object and so returns a fresh
+  // reference every call. Comparing that would miss the cache on every render
+  // and rebuild the registry for every cell consuming it.
+  const availableBoards = useOpenPLCStore((s) => s.deviceAvailableOptions.availableBoards)
+  const boardInfo = availableBoards.get(deviceBoard)
 
   if (
     cache &&
     cache.pins === pins &&
     cache.vsd === vsd &&
     cache.remoteDevices === remoteDevices &&
-    cache.capabilities === capabilities
+    cache.boardInfo === boardInfo
   ) {
     return cache.registry
   }
@@ -68,10 +78,10 @@ export function useAliasRegistry(): AliasRegistry {
       vendorIoMapping: { entries: ioMapping },
       remoteDevices,
     },
-    capabilities,
+    resolveAddressProducerCapabilities(boardInfo),
   )
   const registry = buildAliasRegistry(pool)
 
-  cache = { pins, vsd, remoteDevices, capabilities, registry }
+  cache = { pins, vsd, remoteDevices, boardInfo, registry }
   return registry
 }

--- a/src/frontend/hooks/use-device-configuration.ts
+++ b/src/frontend/hooks/use-device-configuration.ts
@@ -18,7 +18,7 @@ import {
   describeSource,
   validateAliasEdit,
 } from '@root/middleware/shared/utils/iec-address'
-import { resolveTargetCapabilities } from '@root/middleware/shared/utils/target-capabilities'
+import { resolveAddressProducerCapabilities } from '@root/middleware/shared/utils/target-capabilities'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 type UseDeviceConfigurationParams = {
@@ -148,7 +148,7 @@ export function useDeviceConfiguration({
           vendorIoMapping: { entries: ioMapping },
           remoteDevices: state.project.data.remoteDevices,
         },
-        resolveTargetCapabilities(boardInfo),
+        resolveAddressProducerCapabilities(boardInfo),
       )
       const registry = buildAliasRegistry(pool)
       const validation = validateAliasEdit(registry, alias, sourceRef)

--- a/src/middleware/shared/utils/target-capabilities/__tests__/producer-capabilities-agreement.test.ts
+++ b/src/middleware/shared/utils/target-capabilities/__tests__/producer-capabilities-agreement.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Whatever builds an address pool must scope it with the PRODUCER resolver
+ * (DOPE-615, C1).
+ *
+ * Nine places built a pool through `resolveTargetCapabilities` while the
+ * store's allocation used `resolveAddressProducerCapabilities`. The two
+ * answer differently in exactly one state: a board that does not resolve —
+ * its VPP package is not installed, the project came from another machine, or
+ * the catalogue has not finished loading. There the strict resolver says "no
+ * producers at all".
+ *
+ * A pool scoped that way is EMPTY, so every address already claimed looks
+ * free. The screen allocates from index zero on top of them, and the alias
+ * registry stops reporting the conflicts it exists to report — while the
+ * store and the compiler believe every producer is active. The addresses go
+ * into the project and the damage is found much later.
+ *
+ * This reads the sources rather than exercising the screens, deliberately.
+ * The defect is not a wrong value a component test would catch; it is the
+ * WRONG FUNCTION being called, in a state that needs a board missing from the
+ * catalogue to reproduce. Reading the import is what actually fails when
+ * someone adds a tenth pool and reaches for the resolver they saw next door.
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { execSync } from 'node:child_process'
+
+const STRICT = 'resolveTargetCapabilities'
+const PRODUCER = 'resolveAddressProducerCapabilities'
+
+/** Every source file that builds an address pool, found rather than listed:
+ *  a hard-coded list is the thing that goes stale. */
+function filesThatBuildAPool(): string[] {
+  const out = execSync(
+    "grep -rl --include='*.ts' --include='*.tsx' -e 'buildAddressPool(' -e 'allocateAddresses(' src || true",
+    { encoding: 'utf-8' },
+  )
+  return out
+    .split('\n')
+    .filter(Boolean)
+    .filter((path) => !path.includes('__tests__'))
+    // The pool machinery itself, which takes capabilities as an argument and
+    // resolves nothing.
+    .filter((path) => !path.includes('utils/iec-address/'))
+}
+
+describe('address pools are scoped by the producer resolver', () => {
+  it('finds the pool builders at all', () => {
+    // A guard on the guard: a rename that makes the grep match nothing would
+    // otherwise turn this whole suite into a silent pass.
+    expect(filesThatBuildAPool().length).toBeGreaterThanOrEqual(8)
+  })
+
+  it.each(filesThatBuildAPool())('%s does not resolve capabilities strictly', (path) => {
+    const source = readFileSync(join(process.cwd(), path), 'utf-8')
+    const strictCalls = source.split(`${STRICT}(`).length - 1
+    expect(strictCalls).toBe(0)
+  })
+
+  it('at least one of them resolves producers, so the check is not vacuous', () => {
+    const resolving = filesThatBuildAPool().filter((path) =>
+      readFileSync(join(process.cwd(), path), 'utf-8').includes(`${PRODUCER}(`),
+    )
+    expect(resolving.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
Stacked on #1093 — targets that branch, so the diff here is only C1's own commit. GitHub retargets it to `development` when the parent merges.

Screens built their address pool through `resolveTargetCapabilities` while the store's allocation used `resolveAddressProducerCapabilities`. The two agree everywhere except one state, and it is not a rare one: **a board that does not resolve** — its VPP package is not installed, the project came from another machine, or the catalogue has not finished loading. There the strict resolver answers "no producers at all".

A pool scoped that way is **empty**, so every address already claimed looks free. The screen allocates from index zero on top of them, and the alias registry stops reporting the conflicts it exists to report — while the store and the compiler believe every producer is active. The overlapping addresses go into the project and are found much later.

Both resolvers stay. The strict one is right for gating a UI element (do not offer EtherCAT on a board that may not have it) and wrong for scoping an allocation, where the safe direction is permissive.

### Nine sites, not seven

The audit this came from listed seven. Two more only appear by asking which files build a pool:

- `use-device-configuration.ts` — the same alias-validation shape as the rest
- `use-alias-registry.ts` — indirectly, through `useTargetCapabilities`. That hook is shared with genuine gating surfaces (create-element dialog, variables table, explorer), so it keeps the strict resolver and the registry resolves producers itself

That last one also changed how it caches: the resolver spreads a board's own capability object and so returns a fresh reference every call, which would have missed the cache on every render and rebuilt the registry for every cell consuming it. It keys on the board info instead.

The narrower return type makes the switch self-checking — a site reading `debuggerTransports` or any gating field fails `tsc`. None did.

### Tests

An invariant rather than an example: every file that builds a pool is found by grep and asserted not to resolve strictly, because the defect is the wrong **function** being called in a state that needs a board missing from the catalogue to reproduce. It has a guard against a rename making the grep vacuous, and was verified to fail by reverting one site.

`tsc` clean, `validate:arch` passes, 255 tests in the areas touched (107 on web), `compare-surfaces` `"match": true` over 1115 files, lint unchanged at 12 warnings.

Pre-existing and made visible by this work rather than introduced by it, which is why it carries its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
